### PR TITLE
Framework req test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/html
+docs/doctrees
 
 # PyBuilder
 target/
@@ -108,6 +110,5 @@ ENV/
 # IDE related settings
 .vscode
 
-resource 
+ 
 .pytest_cache
-KPF-Pipeline-TestData

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,12 @@ RUN mkdir /code && \
     apt-get --yes update && \
     apt install build-essential -y --no-install-recommends && \
     apt-get install --yes git && \
-    cd /code && \
-    # Clone the KeckDRPFramework repository 
-    git clone https://github.com/Keck-DataReductionPipelines/KeckDRPFramework.git && \
-    # Current branch only run on develop branch of KeckDRPFramewke
-    cd KeckDRPFramework && \
-    git checkout develop
+    cd /code
+    # # Clone the KeckDRPFramework repository 
+    # git clone https://github.com/Keck-DataReductionPipelines/KeckDRPFramework.git && \
+    # # Current branch only run on develop branch of KeckDRPFramewke
+    # cd KeckDRPFramework && \
+    # git checkout develop
 
 # Set the working directory to KPF-Pipeline
 WORKDIR /code/KPF-Pipeline

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,6 @@ sphinx-rtd-theme
 sphinxcontrib-napoleon
 
 # Framework
+# --TODO-- tracking master for now. Need to settle on a release in the future 
 git+https://github.com/Keck-DataReductionPipelines/KeckDRPFramework.git@master
 


### PR DESCRIPTION
Framework package dependency is now tracked through the requirement.txt by `pip install`, and Docker no longer builds the Framework manually. Currently, the most recent commit on the master branch is pulled. We will need to establish a specific release version later.