### PR TITLE
feature/recipes_on_3_modules remove redundant documentation 

### DIFF
--- a/modules/optimal_extraction/src/optimal_extraction.py
+++ b/modules/optimal_extraction/src/optimal_extraction.py
@@ -93,39 +93,6 @@ DEFAULT_CFG_PATH = 'modules/optimal_extraction/configs/default.cfg'
 
 
 class OptimalExtraction(KPF0_Primitive):
-    """ Optimal extraction primitive
-
-    This module defines class `OptimalExtraction` and methods to perform optimal extraction for KPF pipeline.
-
-    Args:
-        action (Action): action.args contains positional arguments and named arguments passed to the pipeline action,
-
-            - action.args[0] (KPF0): Instance of KPF0 containing spectrum data for optimal extraction.
-            - action.args[1] (KPF0): Instance of KPF0 containing flat data and order trace result.
-            - action.args[2] (str):  File path for the file containing optimal extraction results in terms of
-              level 1 data.
-            - action.args['order_name'] (str, optional): Name of the order to be processed. Default to 'SCI1'.
-            - action.args['start_order'] (int, optional): First order to be processed. Defaults to 0.
-            - action.args['max_result_order']: (int, optional): Total orders to be processed, Defaults to -1.
-            - action.args['rectification_method']: (str, optional): Rectification method for rectifying the curved
-              order. Defaults to 'norect', meaning no rectification.
-            - action.args['wavecal_fits']: (str, optional): Path of the fits file containing wavelength calibration
-              data. Defaults to None.
-
-        context (ProcessingContext): context.config_path contains the path of the config file defined for the module.
-
-    Attributes:
-        input_spectrum (KPF0): Instance of KPF0 data for processing.
-        input_flat (KPF0):  Instance of KPF0 containing flat data and order trace result.
-        ouput_data_file (str): File path for the output.
-        order_name (str): Name of the order to be processed.
-        start_order (int): Index of first order to be processed.
-        max_result_order (int): total orders to be processed.
-        rectification_method (int): Rectification method.
-        wavecal_fits (str): Path of the fits file with wavelength calibration data.
-        alg (modules.order_trace.src.alg.OptimalExtractionAlg): Instance of `OptimalExtractionAlg` which
-             has operation codes for the computation of optimal extraction.
-    """
 
     OrderMap = {
                     'PARAS': {

--- a/modules/order_trace/src/order_trace.py
+++ b/modules/order_trace/src/order_trace.py
@@ -77,29 +77,6 @@ DEFAULT_CFG_PATH = 'modules/order_trace/configs/default.cfg'
 
 
 class OrderTrace(KPF0_Primitive):
-    """class OrderTrace.
-
-        Args:
-            action (Action): action.args contains positional arguments and named arguments as follows,
-
-                - action.args[0] (kpfpipe.models.level0.KPF0): Instance of KPF0 containing image data for order trace
-                  extraction.
-                - action.args['data_row_range'] (list, optional): Row range of the level 0 data to be processed.
-                  Defaults to None.
-
-            context (ProcessingContext): context.config_path contains the path of the config file defined for the module.
-
-        Attributes:
-            input (KPF0): Instance of KPF0 data from flat fits for order trace processing.
-            flat_data (numpy.array):  2D spectral data.
-            row_range (list): Row range of the data to be processed.
-            config_path (str): Path of config file for order trace.
-            config (configparser.ConfigParser): Config context.
-            logger (logging.Logger): Instance of logging.Logger.
-            alg (OrderTraceAlg): Instance of OrderTraceAlg.
-
-
-    """
     def __init__(self, 
                  action: Action,
                  context: ProcessingContext) -> None:

--- a/modules/radial_velocity/src/radial_velocity.py
+++ b/modules/radial_velocity/src/radial_velocity.py
@@ -87,40 +87,6 @@ DEFAULT_CFG_PATH = 'modules/optimal_extraction/configs/default.cfg'
 
 
 class RadialVelocity(KPF1_Primitive):
-    """Radial velocity primitive.
-
-    This module defines class RadialVelocity and methods to perform radial velocity calculation for KPF pipeline.
-
-    Args:
-        action (Action): action.args contains the positional and named arguments passed in the pipeline action:
-
-            - action.args[0] (KPF1): Instance of KPF1 containing data from optimal extraction.
-            - action.args[1] (dict): Result from the init work made by RadialVelocityInit which makes mask lines
-              and velocity steps based on star and module associated configuration for further radial velocity
-              computation.
-            - action.args['input_ref']: (???, optional): level 2 data model containing cross correlation values as a
-              reference for scaling the result of cross correlation in radial velocity computation.
-            - action.args['order_name']: (str, optional): Order name for level 1 data.
-            - action.args['start_order']: (int, optional): Start order of the data. Defaults to None.
-            - action.args['end_order']: (int, optional): End order of the data. Defaults to None.
-
-        context (ProcessingContext): context.config_path contains the path of the config file defined for the module.
-
-    Attributes:
-        input (KPF1): Instance of KPF1 containing data from optimal extraction.
-        rv_init (dict): Result from radial velocity init.
-        sci (str): name of the order to be processed.
-        start_order (int): Index of first order to be processed.
-        end_order (int): Index of last order to be processed.
-        config_path (str): Path of config file for radial velocity module.
-        config (configparser.ConfigParser): Config context.
-        logger (logging.Logger): Instance of logging.Logger.
-        spectrum_data (numpy.ndarray): Reduced 1D data of all orders from optimal extraction.
-        wave_cal (numpy.ndarray): wavelength calibration data.
-        header (fits.header.Header): Fits header of HDU associated with `spectrum_data`
-        ref_ccf (numpy.ndarray): Reference of cross correlation values for scaling the computation of cross correlation.
-        alg (RadialVelocityAlg): Instance of RadialVelocityAlg.
-    """
 
     default_agrs_val = {
         'order_name': 'SCI1'

--- a/modules/radial_velocity/src/radial_velocity_init.py
+++ b/modules/radial_velocity/src/radial_velocity_init.py
@@ -63,18 +63,7 @@ DEFAULT_CFG_PATH = 'modules/radial_velocity/configs/default.cfg'
 
 
 class RadialVelocityInit(KPF_Primitive):
-    """ Radial velocity init primitive
 
-    This module defines class RadialVelocityInit and methods to perform the initial setting for the radial velocity
-    computation.
-
-    Attributes:
-        config_path (str): Path of config file for order trace.
-        config (configparser.ConfigParser): Config context.
-        logger (logging.Logger): Instance of logging.Logger.
-        alg_rv_init (RadialVelocityAlgInit): Instance of RadialVelocityAlgInit.
-
-    """
     def __init__(self,
                  action: Action,
                  context: ProcessingContext) -> None:


### PR DESCRIPTION
Remove the redundant documentation made in primitives of order trace, optimal extraction, and radial velocity. 