### PR TITLE
Feature/add keyword to ccf hdu header 

### DIFF
--- a/modules/radial_velocity/src/radial_velocity_reweighting.py
+++ b/modules/radial_velocity/src/radial_velocity_reweighting.py
@@ -215,6 +215,10 @@ class RadialVelocityReweighting(KPF1_Primitive):
         ccf_df.attrs['ENDORDER'] = str(self.ccf_start_index+self.total_order-1)
 
         self.lev1_input.extension['CCF'] = ccf_df
+
+        for att in ccf_df.attrs:
+            self.lev1_input.header['CCF'][att] = ccf_df.attrs[att]
+
         self.lev1_input.receipt_add_entry('RadialVelocityReweighting',
                                     self.__module__, f'config_path={self.config_path}', 'PASS')
         if self.logger:


### PR DESCRIPTION
This development adds the keywords to the header of CCF HDU created for the fits containing reweighted CCF orders. 