### PR TITLE
feature/fixing_plot_on_recipe_results fixing the output filename pattern for the file made to show the recipe results in Jupyter notebook

### DIFF
--- a/tests/notebooks/recipe_results.ipynb
+++ b/tests/notebooks/recipe_results.ipynb
@@ -167,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "recipe_lev2 = {'RecipeA':'norect_sum_all_L1_L2', \\\n",
+    "recipe_lev2 = {'RecipeA':'norect_optimal_all_L1_L2', \\\n",
     "               'RecipeB': 'vertical_sum_all_L1_L2', \\\n",
     "               'RecipeC': 'norect_sum_all_L1_wave_L2', \\\n",
     "               'RecipeD': 'vertical_sum_all_L1_wave_L2', \\\n",
@@ -216,7 +216,7 @@
     "    print(\"rv: \", rv_neid_stats['values'], \" mean: \", rv_neid_stats[\"mean\"])\n",
     "    plot_velocity_time(rv_stats, \"rv stats from \"+ridx, \\\n",
     "                       {'neid': \"\"}, \\\n",
-    "                       {'neid': 'cyan'}, time_unit='day')\n",
+    "                       {'neid': 'cyan'}, time_unit='hrs')\n",
     "        "
    ]
   },


### PR DESCRIPTION
Before the Bootcamp, I had prepared a Jupyter notebook test file, tests/notebook/recipe_results.ipynb, to show the plot on RVs (the time axis could be days, hours, or minutes) and the standard deviation for the running results of each recipe. 

Just found that the spectrum extraction method in Recipe A was mistakenly set as 'optimal' instead of 'sum', therefore the file name pattern of level 2 fits used in 'recipe_results.ipynb' needs to be fixed accordingly. 

This notebook test file is made informally and simple and could be used to show the plot on RVs from a set of leve2 fits in case Jupyter Notebook is the choice.