### PR TITLE
Output Directory in Docker

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,6 @@
 init: 
 	mkdir -p logs
+	mkdir -p outputs
 	pip3 install -r requirements.txt -e .
 
 update: 


### PR DESCRIPTION
An `outputs` directory is now created as part of the `make init` command. This directory (and anything else put inside the repo directory can be accessed outside of the container.