### PR TITLE
Fixing the bug and enhancing the features for order trace, optimal extraction and radial velocity modules

### DIFF
--- a/modules/barycentric_correction/src/alg_barycentric_corr.py
+++ b/modules/barycentric_correction/src/alg_barycentric_corr.py
@@ -268,6 +268,7 @@ class BarycentricCorrectionAlg:
 
         """
 
+        # bc_obj = get_BC_vel(JDUTC=Time(jd, format='jd', scale='utc'),
         bc_obj = get_BC_vel(JDUTC=jd,
                             ra=obs_config[BarycentricCorrectionAlg.RA],
                             dec=obs_config[BarycentricCorrectionAlg.DEC],

--- a/modules/order_trace/configs/default.cfg
+++ b/modules/order_trace/configs/default.cfg
@@ -41,10 +41,11 @@ fitting_poly_degree = 3
 filter_par = 20
 locate_cluster_noise = 0.0
 cluster_mask = 1
-order_width_th = 7
-width_default = 12
+order_width_th = 10
+width_default = 11
 fit_error_threshold = 3.8
 sigma_for_width_estimation = 2.8
+max_order_distance = 22
 
 ## debug related configurations
 [DEBUG]


### PR DESCRIPTION
The development includes, 
1.  for optimal extraction module,  fixing computation bug due to uneqaul upper width and lower width among orders. 
2. for order trace module,  enhance the method to compute the  order upper width and lower width especially when the gap between the traces doesn't vary smoothly (such as the gap between the different order set are much larger than that between the traces of different fibers in KPF data case)
3. For radial velocity module, update the method of CCF computation to work for the wavelength calibration data in either increasing or decreasing mode. (KPF data has the wavelength calibration data decreases as position x increases).

The development is made to work in generic way, though the code change is inspired by KPF simulated data. 