### PR TITLE
Fix some file paths defined in kpf recipes.

### DIFF
--- a/examples/default_kpf.cfg
+++ b/examples/default_kpf.cfg
@@ -7,11 +7,13 @@ log_verbose = True
 
 [ARGUMENT]
 #data_type = KPF
-#output_dir = ./test_results/kpf/
+output_dir = ./test_results/kpf/
 #test_data_dir = KPFPIPE_TEST_DATA + '/'
-output_dir = '/KPF_Simulated_Data/test_endtoend_files/'
-input_flat_file_pattern = kpf_green_red_flat.fits
-input_lev0_file_prefix = kpf_green_red_lev0.fits
+#output_dir = '/KPF_Simulated_Data/test_endtoend_files/'
+#input_flat_file_pattern = kpf_green_red_flat.fits
+#input_lev0_file_prefix = kpf_green_red_lev0.fits
+input_flat_file_pattern = /KPF_Simulated_Data/test_biasflats/kpf_green_red_flat.fits
+input_lev0_file_prefix = /KPF_Simulated_Data/test_biasflats/kpf_green_red_lev0.fits
 
 output_flat_suffix = _L0
 output_lev1_suffix = _L1
@@ -33,8 +35,8 @@ orderlet_names = [['GREEN_CAL_FLUX', 'GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREE
 # orderlet_names_rv = [['GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3'], ['RED_SCI_FLUX1', 'RED_SCI_FLUX2', 'RED_SCI_FLUX3']]
 orderlet_names_rv = [['GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3']]
 
-wave_fits = ['kpf_green_wave.fits',None]
-#wave_fits = ['science/kpf_green_wave.fits', None]
+#wave_fits = ['kpf_green_wave.fits',None]
+wave_fits = ['/KPF_Simulated_Data/science/kpf_green_wave.fits', None]
 reweighting_method = ccf_max
 op_tag = '_all'
 

--- a/examples/test_kpf.recipe
+++ b/examples/test_kpf.recipe
@@ -1,7 +1,8 @@
 test_data_dir = KPFPIPE_TEST_DATA
 
 data_type = config.ARGUMENT.data_type
-output_dir = KPFPIPE_TEST_DATA+config.ARGUMENT.output_dir
+#output_dir = KPFPIPE_TEST_DATA+config.ARGUMENT.output_dir
+output_dir = config.ARGUMENT.output_dir
 
 input_flat_pattern = config.ARGUMENT.input_flat_file_pattern
 input_lev0_prefix = config.ARGUMENT.input_lev0_file_prefix


### PR DESCRIPTION
This PR includes, 
- update some file paths defined in test_kpf.recipe & default_kpf.cfg for accurate file access. 
- redirect the recipe output from order trace, spectral extraction and rv computation to  KPF-Pipeline/test_resuts/kpf instead of the directory under ownCloud in order to avoid the data output confliction from different running sources. 
