### PR TITLE
suggested update to "getting started"

### DIFF
--- a/docs/source/intro/start.rst
+++ b/docs/source/intro/start.rst
@@ -12,6 +12,8 @@ Then clone the repository and navigate into it::
 
     git clone https://github.com/California-Planet-Search/KPF-Pipeline.git
     cd KPF-Pipeline
+    chmod +x drp_setup
+    ./drp_setup
 
 .. warning:: Refer to :doc:`install_develop` for setting up other branches
 


### PR DESCRIPTION
If `drp_setup` is not run, `test_data` might be generated under a docker instance, which automatically seems to assign it root permissions (making it potentially un-editable to a user).  This edit suggests executing the `drp_setup` script as part of the "Getting Started" file.