### PR TITLE
Integrate QLP to the main recipe

### DIFF
--- a/examples/kpf_ait/kpf.cfg
+++ b/examples/kpf_ait/kpf.cfg
@@ -11,11 +11,8 @@ overwrite = False
 
 output_dir = /data/
 output_dir_flat = /data/
-#output_dir = ./test_data/data/kpf/
-#output_dir_flat = ./test_data/data/kpf/
 
 input_dir_root = /data/2D/
-#input_dir_root = ./test_data/data/kpf/2D/
 
 # need to define the subdirectory to contain order trace result
 output_trace = order_trace/
@@ -24,8 +21,9 @@ output_rv = L2/
 output_rv_reweighting = reweighting/
 # temporary location for Ca H&K sample file
 output_hk = ca_hk/
+output_qlp = QLP/
 
-flat_file = KP.20220512.05655.54
+flat_file = KP.20220601.37734.61
 
 # output_clip is no use when rectification_method = norect
 output_clip = clip_np/
@@ -78,14 +76,15 @@ hk_wavelength_path = ["masters/kpfMaster_HKwave20220812_sci.csv", "masters/kpfMa
 do_order_trace = True
 do_spectral_extraction = True
 do_rv = True
-do_rv_reweighting = True
-do_hk = True
+do_rv_reweighting = False
+do_hk = False
 do_wavecopy_in_sp = False
+do_qlp = True
 
 [MODULE_CONFIGS]
 order_trace = modules/order_trace/configs/default_recipe_kpf_20220505.cfg
 spectral_extraction = modules/spectral_extraction/configs/default_recipe_kpf_20220505.cfg
 radial_velocity = modules/radial_velocity/configs/default_recipe_kpf.cfg
 hk_spectral_extraction = modules/ca_hk/configs/default_hk.cfg
-
+quicklook = modules/quicklook/configs/default.cfg
 

--- a/examples/kpf_ait/kpf.recipe
+++ b/examples/kpf_ait/kpf.recipe
@@ -6,6 +6,7 @@ from modules.radial_velocity.src.radial_velocity import RadialVelocity
 from modules.radial_velocity.src.radial_velocity_reweighting_ref import RadialVelocityReweightingRef
 from modules.radial_velocity.src.radial_velocity_reweighting import RadialVelocityReweighting
 from modules.ca_hk.src.ca_hk_extraction import CaHKExtraction
+from modules.quicklook.src.quick_prim import Quicklook
 from modules.Utils.string_proc import str_replace
 from modules.Utils.string_proc import date_from_kpffile
 from modules.Utils.data_handler import ExtCopy
@@ -18,6 +19,7 @@ do_spectral_extraction = config.ARGUMENT.do_spectral_extraction
 do_rv = config.ARGUMENT.do_rv
 do_rv_reweighting = config.ARGUMENT.do_rv_reweighting
 do_hk = config.ARGUMENT.do_hk
+do_qlp = config.ARGUMENT.do_qlp
 
 overwrite = config.ARGUMENT.overwrite
 
@@ -39,7 +41,7 @@ if context.watch:
 		do_order_trace = False
 		do_spectral_extraction = True
 		do_rv = True
-		do_rv_reweighting = True
+		# do_rv_reweighting = True
 
 	# do rv if L1 data is watched
 	if 'L1' in file_path:
@@ -48,8 +50,7 @@ if context.watch:
 		do_order_trace = False
 		do_spectral_extraction = False
 		do_rv = True
-		do_rv_reweighting = True
-
+		# do_rv_reweighting = True
 else:   
 	sel_obsid = context.date_dir
 	file_path = context.file_path
@@ -60,21 +61,21 @@ else:
 		do_order_trace = False
 		do_spectral_extraction = True
 		do_rv = True
-		do_rv_reweighting = True
+		# do_rv_reweighting = True
 
 	# if including L1, do l1->l2
 	if 'L1' in file_path:
 		do_order_trace = False
 		do_spectral_extraction = False
 		do_rv = True
-		do_rv_reweighting = True
+		# do_rv_reweighting = True
 
 	# if doing reweighted L2
 	if 'L2' in file_path:
 		do_order_trace = False
 		do_spectral_extraction = False
 		do_rv = False
-		do_rv_reweighting = True
+		# do_rv_reweighting = True
 
 date_dir = sel_obsid + '/'
 
@@ -117,10 +118,12 @@ origin = [data_col_range[0], data_row_range[0]]
 fits_ext = '.fits'
 csv_ext = '.csv'
 
+## for order trace
 # order trace I/O
 lev0_flat_pattern = input_2d_dir_flat + flat_file_pattern + fits_ext
 output_order_trace = output_dir + config.ARGUMENT.output_trace + date_dir_flat
 
+## for spectral extraction
 # spectra extraction I/O
 # a single watched L0 file or a group of lev0 files
 if lev0_file_path:
@@ -136,6 +139,7 @@ else:
 	output_clip = None
 orders_per_ccd = config.ARGUMENT.orders_per_ccd
 
+## for rv
 # rv I/O, cheek if single L1 file is watched
 if lev1_file_path:
 	input_lev1_pattern = lev1_file_path
@@ -148,15 +152,16 @@ wave_from_ext = config.ARGUMENT.wave_from_ext
 wave_to_ext = config.ARGUMENT.wave_to_ext
 lev2_pattern = output_rv + '*' + lev2_stem_suffix + fits_ext
 
-## path to ouput L1 containing ca_hk extraction
+## for ca_hk
+# path to ouput L1 containing ca_hk extraction
 output_hk_dir = output_dir + "ca_hk/"
 #output_hk_dir = output_dir + config.ARGUMENT.output_extraction + date_dir
 
-## path containing L0 with ca_hk data, the L0 data sample is temporarily put at output_dir+'ca_hk/'
+# path containing L0 with ca_hk data, the L0 data sample is temporarily put at output_dir+'ca_hk/'
 input_hk_pattern = output_hk_dir + config.ARGUMENT.hk_data_fits
 #input_hk_pattern = lev0_science_pattern
 
-## path containing ca_hk trace file and wavelength table => masters/
+# path containing ca_hk trace file and wavelength table => masters/
 input_hk_data_dir = output_dir
 
 hk_fiber_list = config.ARGUMENT.hk_fiber_list
@@ -168,6 +173,10 @@ hk_wavelength_csvs = config.ARGUMENT.hk_wavelength_path
 hk_wavelength_tables = []
 for hk_w in hk_wavelength_csvs:
 	hk_wavelength_tables = hk_wavelength_tables + [input_hk_data_dir + hk_w]
+
+## for qlp 
+output_qlp =  output_dir + config.ARGUMENT.output_qlp + date_dir
+end_of_night_summary = False
 
 input_flat_file = lev0_flat_pattern
 _, short_flat_file = split(input_flat_file)
@@ -230,7 +239,7 @@ if do_rv or do_rv_reweighting:
 	rv_init = RadialVelocityInit(start_time="2021-03-01", bc_corr_path=bc_path, test_data_path=rv_star_dir)
 	area_def = [[2, 33, 500, -500], [2, 30, 500, -500]]
 
-
+invoke_subrecipe("./examples/kpf_ait/test_kpf_qlp.recipe")
 lev1_list = []
 if do_spectral_extraction:
 	output_lev0_flat_rect = output_order_trace + flat_stem + flat_rect + fits_ext
@@ -294,6 +303,8 @@ if do_spectral_extraction:
 		if b_level1:
 			lev1_list = lev1_list + [output_lev1_file]
 
+invoke_subrecipe("./examples/kpf_ait/test_kpf_qlp.recipe")
+
 if do_hk:
 	hk_lev0_list = find_files(input_hk_pattern)
 	hk_dark_data = config.ARGUMENT.hk_dark_fits
@@ -331,7 +342,8 @@ if do_rv or do_rv_reweighting:
 		lev1_list = find_files(input_lev1_pattern)
 
 	if do_rv:
-		list_socal = output_dir + config.ARGUMENT.output_rv + "List_KPF_observations_using_SoCal.csv"
+		# list_socal = output_dir + config.ARGUMENT.output_rv + "List_KPF_observations_using_SoCal.csv"
+		list_socal = None
 		selected_lev1_files = SelectObs(lev1_list, selection_ref=list_socal, observation_id=sel_obsid)
 	else:
 		selected_lev1_files = []
@@ -343,7 +355,7 @@ if do_rv or do_rv_reweighting:
 		output_lev2_file = output_rv + short_lev2
 
 		if overwrite or not exists(output_lev2_file):
-			lev1_data = kpf1_from_fits(input_lev1_file, data_type='KPF')
+			lev1_data = kpf1_from_fits(input_lev1_file, data_type=data_type)
 			obstime = None
 			exptime = None
 
@@ -371,5 +383,5 @@ if do_rv or do_rv_reweighting:
 	if not context.watch and do_rv_reweighting:
 		invoke_subrecipe("./examples/kpf_ait/test_kpf_rvreweighting.recipe")
 
-
+invoke_subrecipe("./examples/kpf_ait/test_kpf_qlp.recipe")
 

--- a/examples/kpf_ait/test_kpf_qlp.recipe
+++ b/examples/kpf_ait/test_kpf_qlp.recipe
@@ -1,0 +1,4 @@
+if do_qlp:
+	for input_lev0_file in find_files(lev0_science_pattern):
+		open_file = kpf0_from_fits(input_lev0_file,data_type=data_type)
+		Quicklook(open_file, output_qlp, end_of_night_summary)


### PR DESCRIPTION
This PR integrate quicklook tot he main recipe:
- invoke quicklook at 3 points in the main recipe: 
      before spectral extraction (L1), after L1 and before RV (L2) and after RV. 
- update the setting for quicklook in the config file and recipe file. 

test:
(prepare a few L0 data to be under ./test_data/data/kpf/2D/20220516, and map ./test_data/data/kpf to be /data in the docker enviroment.) 
 
watch mode:
kpf -r examples/kpf_ait/kpf.recipe -c examples/kpf_ait/kpf.cfg --watch /data/2D/20220516/

non-watch mode:
kpf -r examples/kpf_ait/kpf.recipe -c examples/kpf_ait/kpf.cfg --date /data/2D/20220516/