### PR TITLE
recipe/config uses order trace from L0  KP.20221001.00105.59.fit

### DIFF
--- a/examples/kpf_ait/kpf.cfg
+++ b/examples/kpf_ait/kpf.cfg
@@ -23,7 +23,8 @@ output_rv_reweighting = reweighting/
 output_hk = ca_hk/
 output_qlp = QLP/
 
-flat_file = KP.20220601.37734.61
+#flat_file = KP.20220601.37734.61
+flat_file = KP.20221001.00105.59
 
 # output_clip is no use when rectification_method = norect
 output_clip = clip_np/

--- a/examples/kpf_ait/kpf_ot.cfg
+++ b/examples/kpf_ait/kpf_ot.cfg
@@ -11,24 +11,25 @@ overwrite = False
 
 output_dir = /data/
 output_dir_flat = /data/
-#output_dir = ./test_data/data/kpf/
-#output_dir_flat = ./test_data/data/kpf/
 
 input_dir_root = /data/2D/
-#input_dir_root = ./test_data/data/kpf/2D/
 
 # need to define the subdirectory to contain order trace result
 output_trace = order_trace/
 output_extraction = L1/
 output_rv = L2/
 output_rv_reweighting = reweighting/
-flat_file = KP.20220512.05655.54
+# temporary location for Ca H&K sample file
+output_hk = ca_hk/
+output_qlp = QLP/
+
+#flat_file = KP.20220601.37734.61
+flat_file = KP.20221001.00105.59
 
 # output_clip is no use when rectification_method = norect
 output_clip = clip_np/
 # need to define the subdirectory to contain barycorrection data and hk output
 output_barycorr = bary/
-output_hk = output_cahk/
 output_lev1_suffix = _L1
 output_lev2_suffix = _L2
 ccd_list = ['GREEN_CCD', 'RED_CCD']
@@ -64,21 +65,27 @@ reweighting_method = ccf_max
 ccf_ext = ['GREEN_CCF', 'RED_CCF']
 rv_ext = RV
 
-hk_fiber_list = ['sky', 'science']
-hk_output_exts = ['CA_HK_SKY', 'CA_HK_SCI']
-hk_trace_path = HK_extraction_locs.txt
+hk_fiber_list = ['sci', 'sky']
+hk_extract_exts = ['CA_HK_SCI', 'CA_HK_SKY']
+hk_wave_exts = ['CA_HK_SCI_WAVE', 'CA_HK_SKY_WAVE']
+hk_data_fits = sci_U_final_0003.fits
+hk_dark_fits = masters/sci_dark_final_0006.fits
+hk_trace_path = masters/kpfMaster_HKOrderBounds20220812.csv
+hk_wavelength_path = ["masters/kpfMaster_HKwave20220812_sci.csv", "masters/kpfMaster_HKwave20220812_sky.csv"]
 
 # module on/off
 do_order_trace = True
 do_spectral_extraction = False
 do_rv = False
 do_rv_reweighting = False
+do_hk = False
 do_wavecopy_in_sp = False
+do_qlp = False
 
 [MODULE_CONFIGS]
 order_trace = modules/order_trace/configs/default_recipe_kpf_20220505.cfg
 spectral_extraction = modules/spectral_extraction/configs/default_recipe_kpf_20220505.cfg
 radial_velocity = modules/radial_velocity/configs/default_recipe_kpf.cfg
-#hk_spectral_extraction = modules/ca_hk/configs/default_hk.cfg
-
+hk_spectral_extraction = modules/ca_hk/configs/default_hk.cfg
+quicklook = modules/quicklook/configs/default.cfg
 


### PR DESCRIPTION
This PR updates the config (examples/kpf_ait/kpf.cfg) for the recipe (examples/kpf_ait/kpf.recipe) to use the order trace result from L0 KP.20221001.00105.59.fit.


to create the order trace from the new flat file:
kpf -r examples/kpf_ait/kpf.recipe -c examples/kpf_ait/kpf_ot.cfg  
(ps. kpf_ot.cfg has the same setting as those in kpf.cfg except it turns off all process except do_order_trace.)