### PR TITLE
Add more columns to RV table in L2 files

### DIFF
--- a/modules/radial_velocity/src/alg.py
+++ b/modules/radial_velocity/src/alg.py
@@ -38,7 +38,7 @@ class RadialVelocityAlg(RadialVelocityBase):
         reweighting_method (string): reweighting method, ccf_max or ccf_mean, of ccf_steps. Defaults to None.
         segment_list (pandas.DataFrame): Table containing segment list containing segment index, start wavelength,
             and end wavelength. Defaults to None.
-        order_limits_mask (pandas.DataFrame): Table containing order index the and the left and right limits of the
+        order_limits_mask (pandas.DataFrame): Table containing order index and the left and right limits of the
             order. Defaults to None.
 
     Attributes:
@@ -178,31 +178,31 @@ class RadialVelocityAlg(RadialVelocityBase):
 
     def get_segment_limits(self, seg_idx=0):
         if self.segment_limits_table is None:
-            segment_list = []   # segment_index, start_wavelength, end_wavelength, start_x, end_x, order_index
+            segment_list = []   # segment_index,  start_x, end_x, start_wavelength, end_wavelength, order_index
 
-            idx = 0
-            if self.segment_limits is not None:
+            seg_idx = 0
+            if self.segment_limits is not None:   # per what segment limits define
                 seg_total, col_num = np.shape(self.segment_limits)
                 col_num = min(col_num-2, 2)
                 for s in range(seg_total):
                     wlen = [self.segment_limits[s, 1], self.segment_limits[s, col_num]]
                     sel_w = np.where((self.wave_cal >= wlen[0]) & (self.wave_cal <= wlen[1]))
                     if np.size(sel_w[0]) > 0:
-                        sel_order = self.segment_limits[s, -1] if self.segment_limits[s, -1] in sel_w[0] else sel_w[0][0]                              # order index
+                        sel_order = self.segment_limits[s, -1] if self.segment_limits[s, -1] in sel_w[0] else sel_w[0][0]
                         sel_pixel = sel_w[1][np.where(sel_w[0] == sel_order)[0]]
                         sel_pixel.sort()
-                        segment_list.append([idx, sel_pixel[0], sel_pixel[-1], wlen[0], wlen[1], int(sel_order)])
-                        idx += 1
-            elif self.order_limits_mask is not None:
+                        segment_list.append([seg_idx, sel_pixel[0], sel_pixel[-1], wlen[0], wlen[1], int(sel_order)])
+                        seg_idx += 1
+            elif self.order_limits_mask is not None:  # 1-1 between segments and orders
                 order_total, col_num = np.shape(self.order_limits_mask)
                 num_limits = min(col_num - 1, 2)  # 1 or 2 limit columns
-                for r in range(order_total):
+                for r in range(order_total):    # per what order limit mask defines [order_idx, left_mask, right_mask]
                     ord_idx = self.order_limits_mask[r, 0]
                     limits = [self.order_limits_mask[r, 1], self.end_x_pos - self.order_limits_mask[r, num_limits]]
                     segment_list.append([ord_idx, limits[0], limits[1],
                                          self.wave_cal[ord_idx, limits[0]],
                                          self.wave_cal[ord_idx, limits[1]], ord_idx])
-            elif self.area_limits is not None:
+            elif self.area_limits is not None:     # all orders are counted, 1-1 between segments and orders
                 order_range = [self.area_limits[i] if self.area_limits[i] >= 0
                                else self.end_order + self.area_limits[i] for i in [0, 1]]
 
@@ -217,7 +217,7 @@ class RadialVelocityAlg(RadialVelocityBase):
                     else:
                         segment_list.append([r, self.start_x_pos, self.end_x_pos,
                                              self.wave_cal[r, 0], self.wave_cal[r, -1], r])
-            else:
+            else:         # order between start_order and end_order are counted, 1-1 between segments and orders
                 for r in range(self.start_order, self.end_order+1):
                     segment_list.append([r, self.start_x_pos, self.end_x_pos,
                                          self.wave_cal[r, self.start_x_pos],
@@ -225,7 +225,7 @@ class RadialVelocityAlg(RadialVelocityBase):
             self.total_segments = len(segment_list)
             self.segment_limits_table = np.array(segment_list)
 
-        idx = np.where(self.segment_limits_table[:, self.SEGMENT_IDX]==seg_idx)[0][0]
+        idx = np.where(self.segment_limits_table[:, self.SEGMENT_IDX] == seg_idx)[0][0]
         return self.segment_limits_table[idx]
 
     def set_order_range(self, lower_order=None, upper_order=None):
@@ -449,7 +449,7 @@ class RadialVelocityAlg(RadialVelocityBase):
         if zb is None:
             return None, 'redshift value error'
         else:
-            self.zb = zb
+            self.zb = zb     # barycentric correction in unit of
 
         self.set_x_range()
         self.set_order_range()
@@ -915,6 +915,7 @@ class RadialVelocityAlg(RadialVelocityBase):
             results.attrs['ENDORDER'] = self.end_order
             results.attrs['TOTALORD'] = self.end_order - self.start_order+1
             results.attrs['ZB'] = self.zb    # remove later
+            results.attrs['BARY'] = self.zb * 1.0e-3  # from m/sec to km/sec
         return results
 
     def compute_rv_by_cc(self, start_seg=None, end_seg=None, ref_ccf=None, print_progress=None):

--- a/modules/radial_velocity/src/radial_velocity.py
+++ b/modules/radial_velocity/src/radial_velocity.py
@@ -117,12 +117,14 @@ class RadialVelocity(KPF1_Primitive):
     RV_COL_START_W = 's_wavelength'
     RV_COL_END_W = 'e_wavelength'
     RV_COL_SEG_NO = 'segment no.'
+    RV_COL_ORD_NO = 'order no.'
     RV_COL_RV = 'RV'
     RV_COL_RV_ERR = 'RV error'
     RV_COL_CCFJD = 'CCFJD'
+    RV_COL_BARY = 'Bary_RVC'
     RV_COL_SOURCE = 'source'
-    rv_col_names = [RV_COL_ORDERLET, RV_COL_START_W, RV_COL_END_W, RV_COL_SEG_NO, RV_COL_RV, RV_COL_RV_ERR,
-                    RV_COL_CCFJD, RV_COL_SOURCE]
+    rv_col_names = [RV_COL_ORDERLET, RV_COL_START_W, RV_COL_END_W, RV_COL_SEG_NO, RV_COL_ORD_NO,
+                    RV_COL_RV, RV_COL_RV_ERR, RV_COL_CCFJD, RV_COL_BARY, RV_COL_SOURCE]
     rv_col_on_orderlet = [RV_COL_ORDERLET, RV_COL_SOURCE]
 
     def __init__(self,
@@ -382,9 +384,11 @@ class RadialVelocity(KPF1_Primitive):
         rv_table[self.RV_COL_START_W] = segment_table[s_seg:e_seg, RadialVelocityAlg.SEGMENT_W1]
         rv_table[self.RV_COL_END_W] = segment_table[s_seg:e_seg, RadialVelocityAlg.SEGMENT_W2]
         rv_table[self.RV_COL_SEG_NO] = segment_table[s_seg:e_seg, RadialVelocityAlg.SEGMENT_IDX].astype(int)
+        rv_table[self.RV_COL_ORD_NO] = segment_table[s_seg:e_seg,  RadialVelocityAlg.SEGMENT_ORD].astype(int)
         rv_table[self.RV_COL_RV] = col_rv
         rv_table[self.RV_COL_RV_ERR] =  np.zeros(total_segment)
         rv_table[self.RV_COL_CCFJD] = np.ones(total_segment) * output_df[0].attrs['CCFJDSUM']
+        rv_table[self.RV_COL_BARY] = np.ones(total_segment) * output_df[0].attrs['BARY']
 
         for o in range(total_orderlet):
             rv_table[self.RV_COL_SOURCE+str(o+1)] = col_sources[:, o]


### PR DESCRIPTION
This PR has the development to add coloumns, 
'order no.' and 'Bary_RVC' to the RV table (extension RV) in L2 file. 