### PR TITLE
fix bug for reading CA H&K wls file

### DIFF
--- a/modules/ca_hk/src/alg.py
+++ b/modules/ca_hk/src/alg.py
@@ -355,7 +355,7 @@ class CaHKAlg(ModuleAlgBase):
         if not exists(wave_table_file):
             return None
 
-        wave_result = pd.read_csv(wave_table_file, header=None, sep=' ', comment='#')
+        wave_result = pd.read_csv(wave_table_file, header=None, sep=' ', comment='#', engine='python')
         wave_vals = np.array(wave_result.values)
         if fiber in self.trace_location and self.trace_location[fiber] is not None:
             total_order = len(self.trace_location[fiber].keys())


### PR DESCRIPTION
This PR has the fix about reading the wls file for CA H&K extraction. 
The wls file is assumed to start with no head but a comment line like `# 0 1 2 3 4 5`