### PR TITLE
Revert the setting of some pararmeters in the config file

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -8,7 +8,7 @@ log_directory = /data/logs/
 
 [ARGUMENT]
 data_type = KPF
-overwrite = False
+overwrite = True
 
 # path to input and output data
 output_dir = /data/
@@ -104,7 +104,7 @@ do_rv = True
 do_rv_reweighting = True
 do_hk = True
 do_wavecopy_in_sp = True
-do_qlp = False
+do_qlp = True
 do_bk_subtraction = True
 do_bc = True
 


### PR DESCRIPTION
This PR reverts the setting of `overwrite` and `do_qlp` in kpf_drp.cfg back to the original value (True). 