### PR TITLE
loop over different WLS solution options

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -70,7 +70,7 @@ do_db_query_for_one_nearest_wls_master_file = True
 cal_file_level = 1
 # contentbitmask = 3 means require at least GREEN and RED CCDs in the WLS master file database-queried nearest in time.
 contentbitmask = 3
-cal_type_pair = ['WLS','cal-lfc-morn']
+cal_type_pairs = [['WLS','cal-lfc-morn'], ['WLS', 'cal-lfc-eve'], ['WLS', 'autocal-thar-all']]
 
 # for rv:
 #    o/ou/outtrderlet_names_rv: [<extensions of L1 for radial velocity process, a subset of orderlet_names for each ccd>]

--- a/kpfpipe/cli.py
+++ b/kpfpipe/cli.py
@@ -199,11 +199,6 @@ def main():
         observer.schedule(al, path=args.watch, recursive=True)
         observer.start()
 
-        if args.ncpus > 1:
-            framework.start(qm_only=True)
-        else:
-            framework.start(wait_for_event=True, continuous=True)
-
         if args.reprocess:
             framework.pipeline.logger.info("Found {:d} files to process.".format(len(infiles)))
 
@@ -219,6 +214,11 @@ def main():
                 time.sleep(3)
 
             framework.append_event('exit', arg)
+
+        if args.ncpus > 1:
+            framework.start(qm_only=True)
+        else:
+            framework.start(wait_for_event=True, continuous=True)
 
     else:
         arg.watch = False

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -164,31 +164,35 @@ do_db_query_for_one_nearest_wls_master_file = config.ARGUMENT.do_db_query_for_on
 date_dir_db_query = context.date_dir
 cal_file_level = config.ARGUMENT.cal_file_level
 contentbitmask = config.ARGUMENT.contentbitmask
-cal_type_pair = config.ARGUMENT.cal_type_pair
+cal_type_pairs = config.ARGUMENT.cal_type_pairs
 
 do_db_query_for_one_nearest_wls_master_file = True
 
 if do_db_query_for_one_nearest_wls_master_file:
+	db_wls_exit_code = 1
+	for cal_type_pair in cal_type_pairs:
+		if db_wls_exit_code != 0:
+			query_one_nearest_master_file_list = QueryDBOneNearestMasterFileFramework(data_type,
+																					date_dir_db_query,
+																					cal_file_level,
+																					contentbitmask,
+																					cal_type_pair)
 
-    query_one_nearest_master_file_list = QueryDBOneNearestMasterFileFramework(data_type,
-                                                                              date_dir_db_query,
-                                                                              cal_file_level,
-                                                                              contentbitmask,
-                                                                              cal_type_pair)
+			db_wls_exit_code = query_one_nearest_master_file_list[0]
 
-    db_wls_exit_code = query_one_nearest_master_file_list[0]
+			if db_wls_exit_code == 0:
 
-    if db_wls_exit_code == 0:
+				db_wls_rec = query_one_nearest_master_file_list[1]
+				db_wls_master_file = db_wls_rec[6]
+				wave_fits = []
+				for wls in wls_list:
+					wave_fits = wave_fits + [output_dir + db_wls_master_file]
 
-        db_wls_rec = query_one_nearest_master_file_list[1]
-        db_wls_master_file = db_wls_rec[6]
-        wave_fits = []
-        for wls in wls_list:
-            wave_fits = wave_fits + [output_dir + db_wls_master_file]
+				wave_fits = []
+				for wls in wls_list:
+					wave_fits = wave_fits + [output_dir + db_wls_master_file]
 
-        wave_fits = []
-        for wls in wls_list:
-	          wave_fits = wave_fits + [output_dir + db_wls_master_file]
+				
 
 #### variables related to input/output and process conditions for order_trace, spectral extraction, CA-HK, rv and qlp
 


### PR DESCRIPTION
@RussLaher I requested your review because I messed with the part of the recipe you worked on most recently involving DB queries for the WLS solution. You'll see that I now loop over a few different WLS options in case the LFC-morn stack is not available.

Could you add a parameter to the DB query that is the maximum number of days old for the calibration file? I'd like to only use wavelength solutions 2 days old or newer. If there isn't an LFC solution in that timespan then try the next cal_pair type until you find one. If none are found after all of those options are considered then fallback on the static solution defined in the config.