### PR TITLE
fix the computation on weighted mean of rv

### DIFF
--- a/modules/radial_velocity/src/radial_velocity.py
+++ b/modules/radial_velocity/src/radial_velocity.py
@@ -563,12 +563,13 @@ class RadialVelocity(KPF1_Primitive):
                                              sci_mask,
                                              rv_guess_on_ccf=(ins == 'kpf'),
                                              vel_span_pixel=self.alg.get_vel_span_pixel())
-            final_rv = sum(rv_table[self.RV_COL_RV])/len(rv_table[self.RV_COL_RV])   # mean of rv column
+            t_avg = np.sum(rv_table[self.RV_COL_RV] != 0.0)
+            final_rv = sum(rv_table[self.RV_COL_RV])/t_avg if t_avg != 0.0 else 0.0     # mean
 
         # ccd1rv, ccd2rv, ccd1erv ccd2erv, cal rv
 
         results.attrs['rv'] = (f_decimal(final_rv - cal_rv), 'BaryC RV (km/s)') \
-            if do_corr else (f_decimal(final_rv), 'BaryC RV (km/s)')
+            if do_corr and final_rv != 0.0 else (f_decimal(final_rv), 'BaryC RV (km/s)')
         results.attrs['rverr'] = f_decimal(final_rv_err)
         results.attrs['ccd_jd'] = ccfjd
         results.attrs['star_rv'] = starrv

--- a/modules/radial_velocity/src/radial_velocity_init.py
+++ b/modules/radial_velocity/src/radial_velocity_init.py
@@ -161,11 +161,16 @@ class RadialVelocityInit(KPF_Primitive):
 
         init_result = self.alg_rv_init.start()
 
-        assert(init_result['status'] and 'data' in init_result)
+        if init_result['status'] and 'data' in init_result:
+            if self.logger:
+                self.logger.info("RadialVelocityInit: Init for radial velocity is done")
 
-        if self.logger:
-            self.logger.info("RadialVelocityInit: Init for radial velocity is done")
+            return Arguments(init_result)
+        else:
+            if self.logger:
+                self.logger.info("RadialVelocityInit: Init for radial velocity fails - " + init_result['msg'])
 
-        return Arguments(init_result)
+            return Arguments(None)
+
 
 

--- a/modules/radial_velocity/src/radial_velocity_reweighting.py
+++ b/modules/radial_velocity/src/radial_velocity_reweighting.py
@@ -236,7 +236,6 @@ class RadialVelocityReweighting(KPF2_Primitive):
         last_sci_idx = self.last_sci_idx
         sci_ccf_ref = None
 
-
         # do cal rv col first
         ccf_ref_list = list()
         for o in range(total_orderlet-1, -1, -1):
@@ -272,7 +271,6 @@ class RadialVelocityReweighting(KPF2_Primitive):
                                                                    self.reweighting_method, s_seg=self.ccf_start_index,
                                                                    do_analysis=True, velocities=velocities)
             self.ccf_data[o, 0:new_total_seg, :] = rw_ccf[0:new_total_seg, :]     # update ccf value for each orderlet
-
 
             # if existing ccf table with summary row
             if np.shape(self.ccf_data)[1] >= new_total_seg + RadialVelocityAlg.ROWS_FOR_ANALYSIS and not is_rv_ext:
@@ -317,10 +315,11 @@ class RadialVelocityReweighting(KPF2_Primitive):
         #                            velocities, self.s_mask_type,
         #                            rv_guess_on_ccf=(self.instrument == 'kpf'),
         #                            vel_span_pixel=self.vel_span_pixel)
+
         ccd_rv = self.reweight_rv(self.RV_COL_RV, sci_ccf_ref)
         if is_rv_ext:
             rv_ext_header['ccd' + str(self.rv_ext_idx+1) + 'rv'] = ccd_rv - cal_rv if do_corr else ccd_rv  # ccdnrv
-        rv_ext_header['rwccfrv'] = 'T';
+        rv_ext_header['rwccfrv'] = 'T'
 
         self.lev2_obj.receipt_add_entry('RadialVelocityReweighting on '+ self.ccf_ext,
                                     self.__module__, f'config_path={self.config_path}', 'PASS')
@@ -383,7 +382,6 @@ class RadialVelocityReweighting(KPF2_Primitive):
                                                                 rv_guess_on_ccf=(self.instrument=='kpf'))
                 rv_ext_values[s+rv_start_idx, sci_idx[o]] = orderlet_rv
                 sum_rv.append(orderlet_rv)
-
             # update orderletn column at segment s
             # _, seg_rv, _, _, _ = RadialVelocityAlg.fit_ccf(sum_segment,
             #                                RadialVelocityAlg.get_rv_estimation(rv_ext_header),

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -590,13 +590,14 @@ if do_rv or do_rv_reweighting:
 			lev1_data = kpf1_from_fits(input_lev1_file, data_type=data_type)
 			rv_init = RadialVelocityInit(start_time="2021-03-01", l1_data=lev1_data, bc_corr_path=bc_path, test_data_path=rv_star_dir)
 
-			for idx in ccd_idx:
-				rv_data = RadialVelocity(lev1_data, rv_init, rv_data,
+			if rv_init != None:
+				for idx in ccd_idx:
+					rv_data = RadialVelocity(lev1_data, rv_init, rv_data,
 						data_ext_rv[idx], ccf_ext=ccf_ext_names[idx], rv_ext=rv_ext,
 						area_def=area_def[idx], start_seg=area_def[idx][0], end_seg=area_def[idx][1],
 						rv_set=idx, ccf_engine='c', start_bary_index=s_bary_idx[idx], rv_correction_by_cal=is_rv_cal)
-			if rv_data != None:
-				result = to_fits(rv_data, output_lev2_file)
+				if rv_data != None:
+					result = to_fits(rv_data, output_lev2_file)
 
 		if do_qlp:
 			# get lev0 w/o _2D suffix


### PR DESCRIPTION
This PR has the development to 
- fix the compuation of weighted mean RV by integrating predefined weighting numbers and zeroing out the zero rv. 
- tune amplitude, mean and stddev while using Gaussian fitting to compute RV per the condition of mask source and ccf value ranges. 
