### PR TITLE
 Add parameter option to OrderMask to adjust order trace upper and lower widths

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -51,11 +51,14 @@ ccd_idx = [0, 1]
 #        if all traces for green (or red)  are identified by order trace process, start_order[0] ( or start_order[1]) is 0.
 #        if the first n traces for green (or red) are not in the order trace result,  then start_order[0] (or start_order[1]) is -n.
 #        ex: start_order = [-1, -1] means the traces of sky fiber of first order for both green and red are missing in the order trace result.
-#    - note: order_per_ccd, start_order, orderlet_names should have size as that of ccd_list.
+#      orderlet_widths_ccds: trace widths per orderlet per ccd to replace the trace widths from the order trace process
+#    - note: order_per_ccd, start_order, orderlet_names should (the outer list), orderlet_widths_ccds (the outer list) have size as that of ccd_list.
+#            the inner lists of orderlet_names and orderlet_widths_ccds are with the same size.
 orders_per_ccd=[35,32]
 start_order = [-1, -1]
 orderlet_names = [['GREEN_SKY_FLUX', 'GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3', 'GREEN_CAL_FLUX'], ['RED_SKY_FLUX', 'RED_SCI_FLUX1', 'RED_SCI_FLUX2', 'RED_SCI_FLUX3', 'RED_CAL_FLUX']]
-
+#orderlet_widths_ccds = [[],[]]
+orderlet_widths_ccds = [[-1, -1, -1, 1, -1],[-1, -1, -1, -1, -1]]
 #    rectification_method: norect|vertical|normal, method to rectify the trace.
 #    extraction_method:    summ|optimal, method to do spectral extraction.
 rectification_method = norect

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -217,6 +217,7 @@ output_order_trace = output_dir + config.ARGUMENT.output_trace + date_dir_flat
 #                          if non-watch mode => a path pattern of 2D files => /data/2D/<date_dir>/*.fits
 #    output_extraction: output path => /data/L1/<date_dir>/
 #    wave_to_ext: extensions in L1 containing wavelength solution data for each fiber.
+#    orderlet_widths_ccds: trace widths per orderlet per ccd to replace the trace widths from the order trace process
 
 if lev0_file_path:
     lev0_science_pattern = lev0_file_path
@@ -224,6 +225,7 @@ else:
     lev0_science_pattern = input_2d_dir + '*' + fits_ext
 output_extraction = output_dir + config.ARGUMENT.output_extraction + date_dir
 wave_to_ext = config.ARGUMENT.wave_to_ext
+orderlet_widths_ccds = config.ARGUMENT.orderlet_widths_ccds
 
 #    output_clip: only needed when rect_method != norect: directory containing files with polygon clipping information
 #                  for faster vertical or normal rectification => /data/L1/clip_np/vertical(or normal)/
@@ -466,9 +468,14 @@ if do_spectral_extraction or do_hk or do_bc:
 					order_mask = None
 					# create order mask for background subtraction
 					for idx in ccd_idx:
+						if orderlet_widths_ccds:
+							orderlet_widths = orderlet_widths_ccds[idx]
+						else:
+							orderlet_widths = []
 						order_mask = OrderMask(lev0_data, order_mask, orderlet_names=orderlet_names[idx],
 								start_order=start_order[idx], trace_file=trace_list[idx],
-								data_extension=ccd_list[idx])
+								data_extension=ccd_list[idx],
+								orderlet_widths=orderlet_widths)
 					# update L0 by background subtraction
 					if order_mask != None:
 						lev0_data = ImageProcessing(lev0_data, order_mask, ccd_list, data_type, None)


### PR DESCRIPTION
This PR has the implementation to 
Add argument option to OrderMask to adjust order trace widths per orderlet based on the upper and lower widths from the order trace file.

Usage: 
Define the orderlet width adjustment based on the orderlet name defined in the config file, 
(or the orderlet width adjustment can be directly defined in the recipe)

in config: 
orderlet_names = 
   [['GREEN_SKY_FLUX', 'GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3', 'GREEN_CAL_FLUX'], 
    ['RED_SKY_FLUX', 'RED_SCI_FLUX1', 'RED_SCI_FLUX2', 'RED_SCI_FLUX3', 'RED_CAL_FLUX']]
orderlet_widths_ccds = 
    [[<widths_green_sky>, <widths_green_sci1>, <widths_green_sci2>, <widths_green_sci3>, <widths_green_cal>], 
      [<widths_green_sky>, <widths_green_sci1>, <widths_green_sci2>, <widths_green_sci3>, <widths_green_cal>]]
      
In the recipe: 
orderlet_widths_ccds = config.ARGUMENT.orderlet_widths_ccds
  ;
 for idx in ccd_idx:
  ;
                  if orderlet_widths_ccds:
                         orderlet_widths = orderlet_widths_ccds[idx]
                  else:
                          orderlet_widths = []
                  order_mask = OrderMask(...,   orderlet_widths=orderlet_widths)
  ; 
    
For each <widths_ccd_orderlet>  
- a number or a list with 2 numbers which is (are) greater than or equal to 0.0
- a negative number or empty list means no adjument to the widths from the order trace file. 

Here are the valid setting for the orderlet widths
orderlet_widths_ccds = []       # no adjustment
orderlet_widths_ccds = [[-1, -1, -1, -1, -1], [-1, -1, -1, -1, -1]]       # no adjustment

orderlet_widths_ccds = [[-1, [2, 3.4], 3, [2, -1], []], []]      # reduce lower width by 2 and upper width by 3.4 for green sci1 
                                                                                                # reduce lower width and upper width by 3 for green sci2
                                                                                                # no adjustment for other orderlets. 

