### PR TITLE
Add CCF weights column in the RV table to record static weights for rv CCF reweighting

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -14,9 +14,11 @@ overwrite = True
 output_dir = /data/
 output_dir_flat = /data/
 input_dir_root = /data/2D/
+masters_dir = /data/masters/
 
 # the subdirectory containing order trace result, L1 data, L2 data, L2 reweighted data, qlp, bary data
-output_trace = order_trace/
+# output_trace = order_trace/
+output_trace = masters/
 output_extraction = L1/
 output_rv = L2/
 output_rv_reweighting = ''
@@ -39,7 +41,8 @@ ccd_list = ['GREEN_CCD', 'RED_CCD']
 # for order trace:
 #    flat_file: flat file for order trace process. updated upon new flat file.
 #    ccd_idx: index in ccd_list for the ccd to be processed in DRP recipe
-flat_file = KP.20221107.04689.77
+#flat_file = KP.20221107.04689.77
+flat_file = kpf_20230411_master_flat
 fitting_poly_degree = 3
 ccd_idx = [0, 1]
 
@@ -55,10 +58,11 @@ ccd_idx = [0, 1]
 #    - note: order_per_ccd, start_order, orderlet_names should (the outer list), orderlet_widths_ccds (the outer list) have size as that of ccd_list.
 #            the inner lists of orderlet_names and orderlet_widths_ccds are with the same size.
 orders_per_ccd=[35,32]
-start_order = [-1, -1]
+start_order = [-1, 0]
 orderlet_names = [['GREEN_SKY_FLUX', 'GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3', 'GREEN_CAL_FLUX'], ['RED_SKY_FLUX', 'RED_SCI_FLUX1', 'RED_SCI_FLUX2', 'RED_SCI_FLUX3', 'RED_CAL_FLUX']]
 #orderlet_widths_ccds = [[],[]]
 orderlet_widths_ccds = [[-1, -1, -1, 1, -1],[-1, -1, -1, -1, -1]]
+
 #    rectification_method: norect|vertical|normal, method to rectify the trace.
 #    extraction_method:    summ|optimal, method to do spectral extraction.
 rectification_method = norect
@@ -88,7 +92,8 @@ rv_correct_by_cal = False
 reweighting_method = ccf_static
 ccf_ext = ['GREEN_CCF', 'RED_CCF']
 rv_ext = RV
-static_ccf_ratio = ['masters/static_green_ccf_ratio.csv', 'masters/static_red_ccf_ratio.csv']
+#static_ccf_ratio = ['masters/static_green_ccf_ratio_2.csv', 'masters/static_red_ccf_ratio_2.csv']
+static_ccf_ratio = ['masters/static_green_ccf_ratio_2.csv', 'masters/static_red_ccf_ratio_2.csv']
 
 # for ca_hk:
 #    hk_fiber_list: [<CA-HK spectrometer fibers>]

--- a/modules/Utils/string_proc.py
+++ b/modules/Utils/string_proc.py
@@ -57,6 +57,12 @@ class date_from_kpffile(KPF_Primitive):
                  action: Action,
                  context: ProcessingContext) -> None:
         KPF_Primitive.__init__(self, action, context)
+        args_keys = [item for item in action.args.iter_kw() if item != "name"]
+        if 'startswith' in args_keys and action.args['startswith']:
+            self.filenamestartwith = action.args['startswith']
+        else:
+            self.filenamestartwith = ''
+
         self.logger = self.context.logger
 
     def _pre_condition(self) -> bool:
@@ -68,10 +74,10 @@ class date_from_kpffile(KPF_Primitive):
 
     def _perform(self):
         f_name = self.action.args[0]
-        first_key = 'KP.'
+        first_key = self.filenamestartwith or 'KP.'
         date_format = 'YYYYMMDD'
         first_idx = f_name.find(first_key)
-        date_str = ""
+        date_str = None
         if first_idx >= 0:
             start_idx = first_idx + len(first_key)
             date_str = f_name[start_idx:start_idx+len(date_format)]

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -119,15 +119,15 @@ date_dir = sel_obsid + '/'
 
 flat_file_pattern = config.ARGUMENT.flat_file
 # date dir for flat file
-date_dir_flat = date_from_kpffile(flat_file_pattern)
-if date_dir_flat == None or date_dir_flat == '':
+date_dir_flat = date_from_kpffile(flat_file_pattern, startswith='kpf_')
+if date_dir_flat == None:
 	date_dir_flat = date_dir
 else:
 	date_dir_flat = date_dir_flat + '/'
 
 output_dir = config.ARGUMENT.output_dir
 input_2d_dir = config.ARGUMENT.input_dir_root + date_dir
-input_2d_dir_flat = config.ARGUMENT.input_dir_root + date_dir_flat
+input_2d_dir_flat = config.ARGUMENT.masters_dir + date_dir_flat
 test_data_dir = output_dir + "masters/"
 
 ## general purpose variables


### PR DESCRIPTION
This PR includes the development, 
- add `CCF Weights`  column to record the static weights for CCF reweighting
- change the static weights csv files for green and red CCD to include columns for masks of `G2[F9 | G8 | G9 | K2 | K6 | M6]_espresso`, `lfc` and `thar` (weights files, /data/masters/ static_green[red]_ccf_ratio_2.csv, are set for DRP running)
- update the method to compute weighted RV. 
- change the flat file to be `kpf_20230411_master_flat` and the location to be under `/data/masters` in the main config file. Make relevant changes in the main recipes accordingly. 

