### PR TITLE
RV module updates

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -21,7 +21,7 @@ masters_dir = /data/masters/
 output_trace = masters/
 output_extraction = L1/
 output_rv = L2/
-output_rv_reweighting = ''
+output_rv_reweighting=''
 output_qlp = QLP/
 output_barycorr = bary/
 
@@ -90,6 +90,8 @@ max_cal_file_age = '2 days'
 orderlet_names_rv = [['GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3', 'GREEN_CAL_FLUX', 'GREEN_SKY_FLUX'],['RED_SCI_FLUX1', 'RED_SCI_FLUX2', 'RED_SCI_FLUX3', 'RED_CAL_FLUX', 'RED_SKY_FLUX']]
 rv_correct_by_cal = False
 reweighting_method = ccf_static
+#reweighting_enable_masks = [['espresso', 'lfc', 'thar', 'etalon'], ['espresso', 'lfc', 'thar', 'etalon']]
+reweighting_enable_masks = [['espresso'], ['espresso']]
 ccf_ext = ['GREEN_CCF', 'RED_CCF']
 rv_ext = RV
 #static_ccf_ratio = ['masters/static_green_ccf_ratio_2.csv', 'masters/static_red_ccf_ratio_2.csv']

--- a/kpfpipe/models/metadata/KPF_definitions.py
+++ b/kpfpipe/models/metadata/KPF_definitions.py
@@ -108,6 +108,9 @@ LEVEL2_EXTENSIONS = {'PRIMARY': fits.PrimaryHDU,
                      'GREEN_CCF': fits.ImageHDU,                     
                      'RED_CCF': fits.ImageHDU,
 
+                     'GREEN_CCF_RW': fits.ImageHDU,
+                     'RED_CCF_RW': fits.ImageHDU,
+
                      'RV': fits.BinTableHDU,
                      'ACTIVITY': fits.BinTableHDU}
 

--- a/modules/radial_velocity/configs/default_recipe_kpf_targ.cfg
+++ b/modules/radial_velocity/configs/default_recipe_kpf_targ.cfg
@@ -38,4 +38,4 @@ ccf_engine = c
 reweighting_ccf_method = ccf_max
 
 # km/s/pixel
-veloctity_span_pixel = 0.87
+vel_span_pixel = 0.87

--- a/modules/radial_velocity/src/alg_rv_init.py
+++ b/modules/radial_velocity/src/alg_rv_init.py
@@ -30,7 +30,6 @@ mask_file_map = {
                  'lfc': ('kpf_lfc_mask_1025.mas', 'vac'),
                  'etalon': ('kpf_etalon_masks_11may2023.csv', 'vac')}
 
-
 class RadialVelocityAlgInit(RadialVelocityBase):
     """ Radial velocity Init.
 
@@ -116,6 +115,8 @@ class RadialVelocityAlgInit(RadialVelocityBase):
     KEY_SCI_OBJ = 'SCI-OBJ'
     KEY_SKY_OBJ = 'SKY-OBJ'
     KEY_CAL_OBJ = 'CAL-OBJ'
+
+    non_espresso_vel_range = [-10, 10]
 
     def __init__(self, config=None, logger=None, l1_data=None, bc_time=None,  bc_period=380, bc_corr_path=None, bc_corr_output=None,
                 test_data=None):
@@ -251,7 +252,8 @@ class RadialVelocityAlgInit(RadialVelocityBase):
         if stellar_dir is None:
             return self.ret_status(self.STELLAR_DIR + not_defined)
 
-        for fobj in [RadialVelocityAlgInit.KEY_SKY_OBJ, RadialVelocityAlgInit.KEY_SCI_OBJ, RadialVelocityAlgInit.KEY_CAL_OBJ]:
+        sci_mask = None
+        for fobj in [RadialVelocityAlgInit.KEY_SCI_OBJ, RadialVelocityAlgInit.KEY_CAL_OBJ, RadialVelocityAlgInit.KEY_SKY_OBJ]:
             try:
                 fiber_obj = self.pheader[fobj]
             except KeyError:
@@ -283,6 +285,11 @@ class RadialVelocityAlgInit(RadialVelocityBase):
             if default_mask not in mask_file_map:
                 return self.ret_status('default mask of ' + default_mask + ' is not defined')
 
+            if fobj ==  RadialVelocityAlgInit.KEY_SCI_OBJ:
+                sci_mask = default_mask
+            if fobj == RadialVelocityAlgInit.KEY_SKY_OBJ and sci_mask is not None and 'espresso' in sci_mask.lower():
+                default_mask = 'G2_espresso'
+
             self.mask_path = self.test_data_dir + stellar_dir + mask_file_map[default_mask][0]
             self.mask_type = default_mask
             self.mask_wavelengths = mask_file_map[default_mask][1]
@@ -290,6 +297,7 @@ class RadialVelocityAlgInit(RadialVelocityBase):
                                         "mask_path": self.mask_path,
                                         "mask_type": self.mask_type,
                                         "mask_wavelengths": self.mask_wavelengths}
+
 
         self.d_print("RadialVelocityAlgInit: mask orderlet: ", self.mask_orderlet)
 
@@ -514,7 +522,7 @@ class RadialVelocityAlgInit(RadialVelocityBase):
             self.reweighting_ccf_method = self.get_value_from_config(self.REWEIGHTING_CCF, default=default_method)
         return self.reweighting_ccf_method
 
-    def get_velocity_width_per_pixel(self, default=0.87):
+    def get_velocity_width_per_pixel(self, default=None):
         """Get velocity span per ccd pixel
         Args:
             default (float): default velocity span per pixel.
@@ -525,6 +533,8 @@ class RadialVelocityAlgInit(RadialVelocityBase):
         """
         if self.vel_span_pixel is None:
             self.vel_span_pixel = self.get_value_from_config(self.VEL_SPAN_PIXEL, default=default)
+            if self.vel_span_pixel is not None:
+                self.vel_span_pixel = float(self.vel_span_pixel)
 
         return self.vel_span_pixel
 
@@ -539,7 +549,20 @@ class RadialVelocityAlgInit(RadialVelocityBase):
 
         """
         if self.STEP_RANGE not in self.rv_config:
-            self.rv_config[self.STEP_RANGE] = self.get_rv_config_value(self.STEP_RANGE, default=default)
+            srange = self.get_rv_config_value(self.STEP_RANGE, default=default)
+            if self.rv_config[self.START_VEL] is not None:
+                srange = [0, (srange[1]-srange[0])]
+                v_loop = np.array(srange) * self.rv_config[self.STEP] + self.rv_config[self.START_VEL]
+            else:
+                v_loop = np.array(srange) * self.rv_config[self.STEP] + self.rv_config[self.STAR_RV]
+            vel_range = self.non_espresso_vel_range
+            left_dis = vel_range[0] - v_loop[0]
+            right_dis = v_loop[-1] - vel_range[-1]
+            left_inc = int((-left_dis + 0.5) / self.rv_config[self.STEP]) if left_dis < 0 else 0
+            right_inc = int((-right_dis + 0.5) / self.rv_config[self.STEP]) if right_dis < 0 else 0
+            inc = max(left_inc, right_inc)
+            self.rv_config[self.STEP_RANGE] = [srange[0]-inc, srange[1]+inc]
+
         return self.rv_config[self.STEP_RANGE]
 
     def get_velocity_loop(self):

--- a/modules/radial_velocity/src/radial_velocity.py
+++ b/modules/radial_velocity/src/radial_velocity.py
@@ -141,13 +141,13 @@ class RadialVelocity(KPF1_Primitive):
     rv_col_on_orderlet = [RV_COL_ORDERLET, RV_COL_SOURCE]
 
     orderlet_key_map = {'kpf':{
-        'sci_flux1': {'ccf': {'mask': 'sci_mask', 'name': 'ccf1'}, 'rv': {'rv':'rv1', 'erv':'erv1'}},
-        'sci_flux2': {'ccf': {'mask': 'sci_mask', 'name': 'ccf2'}, 'rv': {'rv': 'rv2', 'erv': 'erv2'}},
-        'sci_flux3': {'ccf': {'mask': 'sci_mask', 'name': 'ccf3'}, 'rv': {'rv': 'rv3', 'erv': 'erv3'}},
-        'sky_flux': {'ccf': {'mask': 'sky_mask', 'name': 'ccf5'}, 'rv': {'rv': 'rvs', 'erv': 'ervs'}},
-        'cal_flux': {'ccf': {'mask': 'cal_mask', 'name': 'ccf4'}, 'rv': {'rv': 'rvc', 'erv': 'ervc'}}},
+        'sci_flux1': {'ccf': {'mask': 'sci_mask', 'name': 'ccf1'}, 'rv': {'rv':'rv1', 'erv':'erv1', 'ccf':'ccf1'}},
+        'sci_flux2': {'ccf': {'mask': 'sci_mask', 'name': 'ccf2'}, 'rv': {'rv': 'rv2', 'erv': 'erv2', 'ccf':'ccf2'}},
+        'sci_flux3': {'ccf': {'mask': 'sci_mask', 'name': 'ccf3'}, 'rv': {'rv': 'rv3', 'erv': 'erv3', 'ccf':'ccf3'}},
+        'sky_flux': {'ccf': {'mask': 'sky_mask', 'name': 'ccf5'}, 'rv': {'rv': 'rvs', 'erv': 'ervs', 'ccf':'ccfs'}},
+        'cal_flux': {'ccf': {'mask': 'cal_mask', 'name': 'ccf4'}, 'rv': {'rv': 'rvc', 'erv': 'ervc', 'ccf':'ccfc'}}},
         'neid': {
-            'sci': {'ccf': {'mask': 'sci_mask', 'name': 'ccf1'}, 'rv': {'rv': 'rv1', 'erv': 'erv1'}}
+            'sci': {'ccf': {'mask': 'sci_mask', 'name': 'ccf1'}, 'rv': {'rv': 'rv1', 'erv': 'erv1', 'ccf':'ccf1'}}
         }
     }
     orderlet_rv_col_map = {'kpf':{
@@ -205,6 +205,13 @@ class RadialVelocity(KPF1_Primitive):
             self.ins = p_header['INSTRUME'].lower()
         else:
             self.ins = None
+
+        self.reweighting_masks = action.args['reweighting_masks'] if 'reweighting_masks' in args_keys else None
+        if self.reweighting_masks is None or not self.reweighting_masks:
+            if self.ins.lower() == 'kpf':
+                self.reweighting_masks = ['espresso', 'lfc', 'thar', 'etalon']
+            else:
+                self.reweighting_masks = None
 
         # input configuration
         self.config = configparser.ConfigParser()
@@ -269,7 +276,8 @@ class RadialVelocity(KPF1_Primitive):
             if not self.rv_init['data'][mod]:
                 self.input.header[sci]['MASK'] = self.rv_init['data'][mtype]
             elif self.ins is not None:
-                self.rv_init['data'][mod][RadialVelocityAlg.get_fiber_object_in_header(self.ins, sci)][mtype]
+                self.input.header[sci]['MASK'] = \
+                    self.rv_init['data'][mod][RadialVelocityAlg.get_fiber_object_in_header(self.ins, sci)][mtype]
 
         self.total_orderlet = len(self.spectrum_data_set)
         do_rv_corr = False
@@ -297,7 +305,7 @@ class RadialVelocity(KPF1_Primitive):
                     self.mask_collection.append(m_type)
 
         vel_span_pixel = action.args['vel_span_pixel'] if 'vel_span_pixel' in args_keys else None
-        self.reweighted = 'F'
+        self.reweighted = {}
 
         try:
             if self.ins is None:
@@ -315,7 +323,6 @@ class RadialVelocity(KPF1_Primitive):
         except Exception as e:
             self.alg = None
 
-
     def _pre_condition(self) -> bool:
         """
         Check for some necessary pre conditions
@@ -330,31 +337,50 @@ class RadialVelocity(KPF1_Primitive):
         """
         return True
 
-    @staticmethod
-    def is_sci(sci_name):
+    def is_sci(self, sci_name):
         return 'sci' in sci_name.lower()
 
-    @staticmethod
-    def is_cal(sci_name):
+    def is_cal(self, sci_name):
         return 'cal' in sci_name.lower()
 
-    @staticmethod
-    def is_sky(sci_name):
+    def is_sky(self, sci_name):
         return 'sky' in sci_name.lower()
 
-    def get_ratio_ccf(self, od_name):
+    def get_ratio_ccf(self,  od_name):
         ratio_ccf = None
+
+        def is_mask_enable(mask):
+            return mask is not None and \
+                   (self.reweighting_masks is None or any([m.lower() in mask.lower() for m in self.reweighting_masks]))
+
         if self.ref_ccf is not None:
             if self.reweighting_method.lower() == 'ccf_static':
-                for idx, r_col in enumerate(self.ref_ccf.columns):
-                    m_type = self.input.header[od_name]['MASK']
-                    if m_type is not None and r_col.lower() == m_type.lower():
+                m_type = self.input.header[od_name]['MASK']
+                if is_mask_enable(m_type):
+                    idx = [c.lower() for c in self.ref_ccf.columns].index(m_type.lower())
+                    if idx >= 0:
                         col_idx = np.array([0, idx], dtype=int)
                         ratio_ccf = self.ref_ccf.values[:, col_idx]
-                        break
             else:
                 ratio_ccf = self.ref_ccf.values if isinstance(self.ref_ccf, pd.DataFrame) else self.ref_ccf
         return ratio_ccf
+
+    def get_rv_unit(self, od_name, is_final=False):
+        rv_unit = 'Bary-corrected RV (km/s)'
+        rvc_unit = 'Cal fiber RV (km/s)'
+        rvs_unit = 'Sky fiber RV (km/s)'
+        sky_note = ', including SKY RV ' if self.is_solar_data else ''
+
+        if self.is_cal(od_name):
+            unit = rvc_unit
+        elif self.is_sky(od_name):
+            unit = rvs_unit
+        else:
+            if is_final:
+                unit = rv_unit + sky_note
+            else:
+                unit = rv_unit
+        return unit
 
     def _perform(self):
         """
@@ -385,8 +411,7 @@ class RadialVelocity(KPF1_Primitive):
                     self.logger.info('RadialVelocity: computing radial velocity on orderlet '+ self.od_names[i] + '...')
 
                 ratio_ccf = self.get_ratio_ccf(self.od_names[i])
-                if ratio_ccf is not None:
-                    self.reweighted = 'T'
+                self.reweighted[self.od_names[i]] = 'T' if ratio_ccf is not None else 'F'
                 rv_results = self.alg.compute_rv_by_cc(start_seg=self.start_seg, end_seg=self.end_seg, ref_ccf=ratio_ccf)
                 one_df = rv_results['ccf_df']
                 if one_df is None or one_df.empty or not one_df.values.any():
@@ -401,7 +426,6 @@ class RadialVelocity(KPF1_Primitive):
             if self.logger:
                 self.logger.info("RadialVelocity: no L2 produced")
             return Arguments(None)
-
         self.construct_level2_data(output_df)
         self.output_level2.receipt_add_entry('RadialVelocity', self.__module__, f'config_path={self.config_path}', 'PASS')
 
@@ -419,6 +443,12 @@ class RadialVelocity(KPF1_Primitive):
                 return k
         return ''
 
+    def add_ext_key(self, ext, key, key_val):
+        KEY8 = 8
+        key_name = key[0:KEY8] if len(key) > KEY8 else key
+        if key_name not in ext:
+            ext[key_name] = key_val
+
     def construct_level2_data(self, output_df):
         if self.output_level2 is None:
             self.output_level2 = KPF2.from_l1(self.input)
@@ -430,13 +460,24 @@ class RadialVelocity(KPF1_Primitive):
         # make new rv table and append the new one to the existing one if there is
         new_rv_table = self.make_rv_table(output_df)
         self.output_level2.header[self.rv_ext]['star_rv'] = new_rv_table.attrs['star_rv']
+
+        # ccfxrw: if rw is done on ccfx
+        for od_name in self.od_names:
+            od_key = self.get_map_key(od_name)
+            ccf_key = self.orderlet_key_map[self.ins][od_key]['rv']['ccf']
+            if 'rw'+ccf_key not in self.output_level2.header[self.rv_ext]:
+                self.output_level2.header[self.rv_ext]['rw'+ccf_key] = self.reweighted[od_name]
+
+        # velocity range for non espresso mask
+        for m in RadialVelocityAlg.vel_range_per_mask.keys():
+            if m in self.mask_collection:
+                self.add_ext_key(self.output_level2.header[self.rv_ext], 'vr_' + m,
+                                 RadialVelocityAlg.vel_range_per_mask[m])
+
         crt_rv_ext = self.output_level2[self.rv_ext] if hasattr(self.output_level2, self.rv_ext) else None
         if crt_rv_ext is None or np.shape(crt_rv_ext)[0] == 0:
             self.output_level2[self.rv_ext] = new_rv_table
             self.output_level2.header[self.rv_ext]['ccd'+str(self.rv_set_idx+1)+'row'] = 0
-            for m in RadialVelocityAlg.vel_range_per_mask.keys():
-                if m in self.mask_collection:
-                    self.output_level2.header[self.rv_ext]['vr_' + m] = RadialVelocityAlg.vel_range_per_mask[m]
         else:
             first_row = np.shape(crt_rv_ext)[0]
             new_table_list = {}
@@ -460,53 +501,73 @@ class RadialVelocity(KPF1_Primitive):
             od_key = self.get_map_key(od_name)
             rv_key = self.orderlet_key_map[self.ins][od_key]['rv']['rv']
             erv_key = self.orderlet_key_map[self.ins][od_key]['rv']['erv']
-
             self.output_level2.header[self.rv_ext][ccd_p+rv_key] = new_rv_table.attrs[ccd_+rv_key]
             self.output_level2.header[self.rv_ext][ccd_p+erv_key] = new_rv_table.attrs[ccd_+erv_key]
+
 
         self.output_level2.header[self.rv_ext][ccd_p+'rv'] = new_rv_table.attrs[ccd_+'rv']
         self.output_level2.header[self.rv_ext][ccd_p+'erv'] = new_rv_table.attrs[ccd_+'erv']
         self.output_level2.header[self.rv_ext][ccd_p+'jd'] = new_rv_table.attrs[ccd_+'jd']
         self.output_level2.header[self.rv_ext]['rv'+str(self.rv_set_idx+1)+'corr'] = 'T' \
             if new_rv_table.attrs['do_rv_corr'] else 'F'
-        self.output_level2.header[self.rv_ext]['rwccfrv']= self.reweighted       # raw ccf and rv, before reweighting
+
         return True
 
     def make_ccf_table(self, output_df):
         total_orderlet = len(output_df.keys())
+        total_segment = 0
         for o_name, o_df in output_df.items():
             if o_df is not None:
                 total_segment = np.shape(o_df.values)[0] - self.alg.ROWS_FOR_ANALYSIS
                 break
 
-        all_ccf = np.zeros((self.total_orderlet, total_segment,
+        if total_segment == 0:
+            return True
+        original_ccf = np.zeros((self.total_orderlet, total_segment,
+                            self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_STEPS]))
+        reweight_ccf = np.zeros((self.total_orderlet, total_segment,
                             self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_STEPS]))
         for i in range(total_orderlet):      # make ccf in 3d format, each ccf layer is for one SCI orderlet
             if output_df[self.od_names[i]] is not None:
-                all_ccf[i, :, :] = output_df[self.od_names[i]].values[0:total_segment, :]
+                reweight_ccf[i, :, :] = output_df[self.od_names[i]].values[0:total_segment, :]
+                if self.reweighted[self.od_names[i]] == 'T':
+                    original_ccf[i, :, :] = output_df[self.od_names[i]].attrs['ORI_CCF'][0:total_segment, :]
+                else:
+                    original_ccf[i, :, :] = output_df[self.od_names[i]].values[0:total_segment, :]
 
-        self.output_level2[self.ccf_ext] = all_ccf
-        self.output_level2.header[self.ccf_ext]['startseg'] = self.start_seg
-        self.output_level2.header[self.ccf_ext]['startv'] = \
-            (self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_LOOP][0], 'km/sec')
-        self.output_level2.header[self.ccf_ext]['stepv'] = \
-            (self.rv_init['data']['rv_config'][RadialVelocityAlgInit.STEP], 'km/sec')
-        self.output_level2.header[self.ccf_ext]['totalv'] = self.rv_init['data']['velocity_steps']
-        self.output_level2.header[self.ccf_ext]['totalsci'] = len(self.sci_names)
+        # extension xxx_RW to contain reweighted ccf for kpf case
+        if self.ins.lower() == 'kpf':
+            ccf_exts = [self.ccf_ext, self.ccf_ext+'_RW']
+            # if any(x == 'T' for x in self.reweighted.values()) else [self.ccf_ext]
+            self.output_level2[ccf_exts[0]] = original_ccf
+            if len(ccf_exts) > 1:     # only assign reweighted ccf if reweighting is done on some orderlet
+                self.output_level2[ccf_exts[1]] = reweight_ccf
+        else:
+            ccf_exts = [self.ccf_ext]
+            self.output_level2[ccf_exts[0]] = reweight_ccf[i, :, :]
+        for ext in ccf_exts:
+            self.output_level2.header[ext]['startseg'] = self.start_seg
+            self.output_level2.header[ext]['startv'] = \
+                (self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_LOOP][0], 'km/sec')
+            self.output_level2.header[ext]['stepv'] = \
+                (self.rv_init['data']['rv_config'][RadialVelocityAlgInit.STEP], 'km/sec')
+            self.output_level2.header[ext]['totalv'] = self.rv_init['data']['velocity_steps']
+            self.output_level2.header[ext]['totalsci'] = len(self.sci_names)
+
+        for i in range(total_orderlet):
+            map_key = self.get_map_key(self.od_names[i])
+            for ext in ccf_exts:
+                self.output_level2.header[ext][self.orderlet_key_map[self.ins][map_key]['ccf']['name']] = \
+                    self.od_names[i]
 
         for i in range(total_orderlet):
             map_key = self.get_map_key(self.od_names[i])
             ccf_key = self.orderlet_key_map[self.ins][map_key]['ccf']['mask']
 
-            if ccf_key not in self.output_level2.header[self.ccf_ext]:
-                self.output_level2.header[self.ccf_ext][ccf_key] = \
-                    RadialVelocityAlg.get_orderlet_masktype(self.ins, self.od_names[i], self.rv_init['data'])
-
-        for i in range(total_orderlet):
-            map_key = self.get_map_key(self.od_names[i])
-            self.output_level2.header[self.ccf_ext][self.orderlet_key_map[self.ins][map_key]['ccf']['name']] = \
-                self.od_names[i]
-
+            for ext in ccf_exts:
+                if ccf_key not in self.output_level2.header[ext]:
+                    self.output_level2.header[ext][ccf_key] = \
+                        RadialVelocityAlg.get_orderlet_masktype(self.ins, self.od_names[i], self.rv_init['data'])
         return True
 
     def make_rv_table(self, output_df):
@@ -517,6 +578,7 @@ class RadialVelocity(KPF1_Primitive):
         for o_name, o_df in output_df.items():
             if o_df is not None:
                 total_segment = np.shape(o_df.values)[0] - self.alg.ROWS_FOR_ANALYSIS
+                total_vel = np.shape(o_df.values)[1]
                 break
 
         segment_table = self.alg.get_segment_info()
@@ -537,9 +599,6 @@ class RadialVelocity(KPF1_Primitive):
         orderlet_rvs = {}
         orderlet_ervs = {}
 
-        # summation of rv and erv across science orderlet
-        sum_rv_segs = np.zeros(total_segment)
-        sum_erv_segs = list()
 
         # cal rv per segment
         cal_rvs = np.zeros(total_segment)
@@ -565,8 +624,11 @@ class RadialVelocity(KPF1_Primitive):
             else:
                 continue   # this should not happen unless the specified orderlet name is wrong
 
-        sum_total = 0
         sci_ccf_ratio = None
+        ccf_summ_h_rw = np.zeros((total_segment, total_vel))
+        ccf_summ_h_rw_nonnorm = np.zeros((total_segment, total_vel))
+        ccf_summ_v_rw = np.zeros(total_vel)        # sum CCF across orderlet per segment
+        ccf_summ_v_rw_nonnorm = np.zeros(total_vel)                  # sum CCF summation across orders
         for idx, od_name in enumerate(self.od_names):
             b_sci = od_name in self.sci_names
             if output_df[od_name] is None :             # skip no ccf and no cal correction if some sci ccf is none
@@ -583,37 +645,51 @@ class RadialVelocity(KPF1_Primitive):
             if starrv is None:
                 starrv = output_df[od_name].attrs['STARRV']
 
-
             if sci_mask is None and b_sci:
                 sci_mask = RadialVelocityAlg.get_orderlet_masktype(ins, od_name, self.rv_init['data'])
                 sci_ccf_ratio = self.get_ratio_ccf(od_name)
 
-            # set rv for each orderlet
+            # set rv column and rv error column for each orderlet
             if orderlet_cols[od_name]:
                 rv_table[orderlet_cols[od_name]][self.start_seg:self.end_seg+1] = \
                     output_df[od_name].attrs['RV_SEGMS'][self.start_seg:self.end_seg+1]
-            if erv_cols[od_name]:
+            if erv_cols[od_name]:   # no erv column for sci orderlet
                 rv_table[erv_cols[od_name]][self.start_seg:self.end_seg + 1] = \
                     output_df[od_name].attrs['ERV_SEGMS'][self.start_seg:self.end_seg + 1]
 
-            orderlet_rvs[od_name] = output_df[od_name].attrs['RV_MEAN']      # rv and erv for each orderlet
-            orderlet_ervs[od_name] = output_df[od_name].attrs['ERV_MEAN']
+            # rv and erv for each orderlet
+            # method 1: get rv and rv error per orderlet by CCF summation
+            orderlet_rvs[od_name] = output_df[od_name].attrs['CCF-RVC'][0]  # method2: output_df[od_name].attrs['RV_MEAN']
+            orderlet_ervs[od_name] = output_df[od_name].attrs['CCF-ERV']    # method2: output_df[od_name].attrs['ERV_MEAN']
 
+            # ccf summation across orderlet
+            # for rv, using un-reweighted or reweighted ccf
+            # for rv error, using un-reweighted or non-normalized reweighted ccf
             if b_sci or (self.is_sky(od_name) and self.is_solar_data):
-                sum_rv_segs[self.start_seg:self.end_seg+1] += rv_table[orderlet_cols[od_name]][self.start_seg:self.end_seg+1]
-                sum_erv_segs.append(output_df[od_name].attrs['ERV_SEGMS'])
-                sum_total += 1
+                ccf_summ_h_rw[self.start_seg:self.end_seg+1, :] += output_df[od_name].values[self.start_seg:self.end_seg+1, :]
+                ccf_summ_h_rw_nonnorm[self.start_seg:self.end_seg+1, :] += \
+                    output_df[od_name].attrs['CCF_NONNORM'][self.start_seg:self.end_seg+1, :]
+                ccf_summ_v_rw += output_df[od_name].values[-1, :]
+                ccf_summ_v_rw_nonnorm += output_df[od_name].attrs['CCF_NONNORM'][-1, :]
             elif self.is_cal(od_name):
                 cal_rvs = rv_table[orderlet_cols[od_name]]
-                cal_rv = output_df[od_name].attrs['RV_MEAN']
+                cal_rv =  output_df[od_name].attrs['CCF-RVC'][0]  # record rv per segments and final rv for cal orderlet
 
-        # for rv and rv error column
-        if sum_total > 0:
-            col_rv = sum_rv_segs/sum_total
-            for r in range(self.start_seg, self.end_seg+1):
-                rv_err_ary = np.array([sum_erv_segs[i][r] for i in range(sum_total)])
-                col_rv_err[r] = RadialVelocityAlg.weighted_rv_error(rv_err_ary, sum_total, None)
-
+        # method 1: for rv and rv error column, based on summation of ccf across orderlet
+        for r in range(self.start_seg, self.end_seg+1):
+            _, col_rv[r], _, _, col_rv_err[r] = RadialVelocityAlg.fit_ccf(ccf_summ_h_rw[r, :], self.alg.get_rv_guess(),
+                                                self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_LOOP],
+                                                sci_mask,
+                                                # self.input.header[od_name]['MASK'],
+                                                rv_guess_on_ccf=(self.ins.lower() == 'kpf'),
+                                                vel_span_pixel=self.alg.get_vel_span_pixel() if sci_ccf_ratio is None else None)
+            if sci_ccf_ratio is not None:
+                _, _, _, _, col_rv_err[r] = RadialVelocityAlg.fit_ccf(ccf_summ_h_rw_nonnorm[r, :], self.alg.get_rv_guess(),
+                                                self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_LOOP],
+                                                sci_mask,
+                                                # self.input.header[od_name]['MASK'],
+                                                rv_guess_on_ccf=(self.ins.lower() == 'kpf'),
+                                                vel_span_pixel=self.alg.get_vel_span_pixel())
         rv_table[self.RV_COL_RV] = col_rv
         rv_table[self.RV_COL_RV_ERR] = col_rv_err
 
@@ -634,33 +710,33 @@ class RadialVelocity(KPF1_Primitive):
 
         results = pd.DataFrame(rv_table)
 
-        # add keys to rv table ccd1rv[1-3], ccd1erv[1-3],  ccd2rv[1-3], ccd2erv[1-3] (for rv ext header)
-        rv_unit = 'Bary-corrected RV (km/s)'
-        rvc_unit = 'Cal fiber RV (km/s)'
-        rvs_unit = 'Sky fiber RV (km/s)'
-
         for od_name in self.od_names:
             map_key = self.get_map_key(od_name)
             if map_key:
                 od_rv = orderlet_rvs[od_name] - cal_rv if do_corr and self.is_sci(od_name) else orderlet_rvs[od_name]
-                if self.is_cal(od_name):
-                    unit = rvc_unit
-                elif self.is_sky(od_name):
-                    unit = rvs_unit
-                else:
-                    unit = rv_unit
+                unit = self.get_rv_unit(od_name)
                 results.attrs['ccd_'+self.orderlet_key_map[self.ins][map_key]['rv']['rv']] = (f_decimal(od_rv), unit)
                 results.attrs['ccd_'+self.orderlet_key_map[self.ins][map_key]['rv']['erv']] = f_decimal(orderlet_ervs[od_name])
 
         final_rv = final_rv_err = 0.0
 
+        # compute rv & rv error for the chip
         if sci_mask is not None:
-            final_rv = RadialVelocityAlg.weighted_rv(rv_table[self.RV_COL_RV], total_segment, None)
-            final_rv_err = RadialVelocityAlg.weighted_rv_error(rv_table[self.RV_COL_RV_ERR], total_segment, sci_ccf_ratio)
+            _, final_rv, _, _, final_rv_err = RadialVelocityAlg.fit_ccf(ccf_summ_v_rw, self.alg.get_rv_guess(),
+                     self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_LOOP],
+                     sci_mask,
+                     rv_guess_on_ccf=(self.ins.lower() == 'kpf'),
+                     vel_span_pixel=self.alg.get_vel_span_pixel() if sci_ccf_ratio is None else None)
 
-        sky_note = ', including SKY RV ' if self.is_solar_data else ''
-        results.attrs['ccd_rv'] = (f_decimal(final_rv - cal_rv), rv_unit) \
-            if do_corr and final_rv != 0.0 else (f_decimal(final_rv), rv_unit + sky_note)
+            if sci_ccf_ratio is not None:
+                _, _, _, _, final_rv_err =  RadialVelocityAlg.fit_ccf(ccf_summ_v_rw_nonnorm, self.alg.get_rv_guess(),
+                      self.rv_init['data'][RadialVelocityAlgInit.VELOCITY_LOOP],
+                      sci_mask,
+                      rv_guess_on_ccf=(self.ins.lower() == 'kpf'), vel_span_pixel=self.alg.get_vel_span_pixel())
+
+        unit = self.get_rv_unit(self.sci_names[0], is_final=True)
+        results.attrs['ccd_rv'] = (f_decimal(final_rv - cal_rv), unit) \
+            if do_corr and final_rv != 0.0 else (f_decimal(final_rv), unit)
         results.attrs['ccd_erv'] = f_decimal(final_rv_err)
         results.attrs['ccd_jd'] = jd[0]
         results.attrs['star_rv'] = starrv

--- a/modules/radial_velocity/src/radial_velocity_reweighting.py
+++ b/modules/radial_velocity/src/radial_velocity_reweighting.py
@@ -75,6 +75,7 @@ from keckdrpframework.models.processing_context import ProcessingContext
 
 from modules.radial_velocity.src.alg import RadialVelocityAlg
 from modules.radial_velocity.src.alg_rv_init import RadialVelocityAlgInit
+from modules.radial_velocity.src.radial_velocity import RadialVelocity as RV
 
 DEFAULT_CFG_PATH = 'modules/optimal_extraction/configs/default.cfg'
 
@@ -84,49 +85,30 @@ class RadialVelocityReweighting(KPF2_Primitive):
     default_agrs_val = {
         'order_name': 'SCI'
     }
-    RV_COL_ORDERLET = 'orderlet'
-    RV_COL_START_W = 's_wavelength'
-    RV_COL_END_W = 'e_wavelength'
-    RV_COL_SEG_NO = 'segment no.'
-    RV_COL_ORD_NO = 'order no.'
-    RV_COL_RV = 'RV'
-    RV_COL_RV_ERR = 'RV error'
-    RV_COL_CAL_ERR = 'CAL error'
-    RV_COL_SKY_ERR = 'SKY error'
-    RV_COL_CCFJD = 'CCFJD'
-    RV_COL_BARY = 'Bary_RVC'
-    RV_COL_SOURCE = 'source'
-    RV_COL_CAL = 'CAL RV'
-    RV_COL_CAL_SOURCE = 'source CAL'
-    RV_COL_SKY = 'SKY RV'
-    RV_COL_SKY_SOURCE ='source SKY'
-    RV_WEIGHTS = 'CCF Weights'
-    rv_col_names = [RV_COL_ORDERLET, RV_COL_START_W, RV_COL_END_W, RV_COL_SEG_NO, RV_COL_ORD_NO,
-                    RV_COL_RV, RV_COL_RV_ERR, RV_COL_CAL, RV_COL_CAL_ERR, RV_COL_SKY, RV_COL_SKY_ERR,
-                    RV_COL_CCFJD, RV_COL_BARY, RV_COL_SOURCE, RV_COL_CAL_SOURCE, RV_COL_SKY_SOURCE, RV_WEIGHTS]
-    rv_col_on_orderlet = [RV_COL_ORDERLET, RV_COL_SOURCE]
 
-    orderlet_key_map = {'kpf':{
-        'sci_flux1': {'ccf': {'mask': 'sci_mask', 'name': 'ccf1'}, 'rv': {'rv':'rv1', 'erv':'erv1'}},
-        'sci_flux2': {'ccf': {'mask': 'sci_mask', 'name': 'ccf2'}, 'rv': {'rv': 'rv2', 'erv': 'erv2'}},
-        'sci_flux3': {'ccf': {'mask': 'sci_mask', 'name': 'ccf3'}, 'rv': {'rv': 'rv3', 'erv': 'erv3'}},
-        'sky_flux': {'ccf': {'mask': 'sky_mask', 'name': 'ccf5'}, 'rv': {'rv': 'rvs', 'erv': 'ervs'}},
-        'cal_flux': {'ccf': {'mask': 'cal_mask', 'name': 'ccf4'}, 'rv': {'rv': 'rvc', 'erv': 'ervc'}}},
-        'neid':{
-            'sci': {'ccf': {'mask': 'sci_mask', 'name': 'ccf1'}, 'rv': {'rv':'rv1', 'erv':'erv1'}}
-        }
-    }
+    RV_COL_ORDERLET = RV.RV_COL_ORDERLET
+    RV_COL_START_W = RV.RV_COL_START_W
+    RV_COL_END_W = RV.RV_COL_END_W
+    RV_COL_SEG_NO = RV.RV_COL_SEG_NO
+    RV_COL_ORD_NO = RV.RV_COL_ORD_NO
+    RV_COL_RV = RV.RV_COL_RV
+    RV_COL_RV_ERR = RV.RV_COL_RV_ERR
+    RV_COL_CAL_ERR = RV.RV_COL_CAL_ERR
+    RV_COL_SKY_ERR = RV.RV_COL_SKY_ERR
+    RV_COL_CCFJD = RV.RV_COL_CCFJD
+    RV_COL_BARY = RV.RV_COL_BARY
+    RV_COL_SOURCE = RV.RV_COL_SOURCE
+    RV_COL_CAL = RV.RV_COL_CAL
+    RV_COL_CAL_SOURCE = RV.RV_COL_CAL_SOURCE
+    RV_COL_SKY = RV.RV_COL_SKY
+    RV_COL_SKY_SOURCE = RV.RV_COL_SKY_SOURCE
+    RV_WEIGHTS = RV.RV_WEIGHTS
+    rv_col_names = RV.rv_col_names
 
-    orderlet_rv_col_map = {'kpf':{
-        'sci_flux1': {'orderlet':'orderlet1', 'source':'source1', 'erv': ''},
-        'sci_flux2': {'orderlet':'orderlet2', 'source':'source2', 'erv': ''},
-        'sci_flux3': {'orderlet': 'orderlet3', 'source': 'source3', 'erv': ''},
-        'sky_flux': {'orderlet': RV_COL_SKY,  'source': RV_COL_SKY_SOURCE, 'erv': RV_COL_SKY_ERR},
-        'cal_flux': {'orderlet': RV_COL_CAL, 'source': RV_COL_CAL_SOURCE, 'erv': RV_COL_CAL_ERR}},
-        'neid':{
-            'sci': {'orderlet':'orderlet1', 'source':'source1', 'erv': ''}
-        }
-    }
+    rv_col_on_orderlet = RV.rv_col_on_orderlet
+
+    orderlet_key_map = RV.orderlet_key_map
+    orderlet_rv_col_map = RV.orderlet_rv_col_map
 
     def __init__(self,
                  action: Action,
@@ -139,6 +121,7 @@ class RadialVelocityReweighting(KPF2_Primitive):
         self.ccf_start_index = action.args['ccf_start_index'] if 'ccf_start_index' in args_keys else 0
         self.rv_ext = action.args['rv_ext'] if 'rv_ext' in args_keys else 'RV'
         self.rv_ext_idx = action.args['rv_ext_idx'] if 'rv_ext_idx' in args_keys else 0
+
         lev2_obj = None
 
         if isinstance(action.args[0], str):
@@ -156,6 +139,16 @@ class RadialVelocityReweighting(KPF2_Primitive):
         else:
             self.instrument = None
 
+        # for the use of 'ccf_static'
+        self.reweighting_masks = None
+        if 'reweighting_masks' in args_keys:
+            self.reweighting_masks = action.args['reweighting_masks']
+        if self.reweighting_masks is None or not self.reweighting_masks:
+            if self.instrument.lower() == 'kpf':
+                self.reweighting_masks = ['espresso', 'lfc', 'thar', 'etalon']
+            else:
+                self.reweighting_masks = None
+
         self.is_solar_data = p_header is not None and self.instrument == 'kpf' and \
                              'OBJECT' in p_header and p_header['OBJECT'].lower() == 'sun' and \
                              (RadialVelocityAlgInit.KEY_SCI_OBJ in p_header and
@@ -163,7 +156,7 @@ class RadialVelocityReweighting(KPF2_Primitive):
                              (RadialVelocityAlgInit.KEY_SKY_OBJ in p_header and
                               p_header[RadialVelocityAlgInit.KEY_SKY_OBJ].lower() == 'target')
 
-        self.ccf_data = {}
+        self.ccf_data = {}              # original ccf in terms of orderlet name
         self.ccf_ext_header = None
 
         self.ccf_dim = 2
@@ -175,19 +168,26 @@ class RadialVelocityReweighting(KPF2_Primitive):
         self.cal_orderlets = list()
         self.sky_orderlets = list()
         self.od_names = list()
+        self.orderlet_ccf = {}
+        self.rw_ccf_exts = None         # 2D or 3D containing reweighted ccf
+        self.is_solor_data = False
 
         if self.ccf_ext and hasattr(lev2_obj, self.ccf_ext):
             self.ccf_ext_header = lev2_obj.header[self.ccf_ext]
             ccf_ext_data = lev2_obj[self.ccf_ext]
+            self.original_ccf_exts = np.copy(ccf_ext_data)
+            self.rw_ccf_exts = np.copy(ccf_ext_data)
             if ccf_ext_data.any():
                 self.ccf_dim = self.ccf_ext_header['NAXIS']
                 if self.ccf_dim == 2:
                     self.totals, self.totalv = np.shape(ccf_ext_data)
                     self.ccf_data[self.ccf_ext_header['CCF1']] = ccf_ext_data
+                    self.orderlet_ccf[self.ccf_ext_header['CCF1']] = 0
                 elif self.ccf_dim == 3:
                     self.total_orderlet, self.totals, self.totalv = np.shape(ccf_ext_data)
                     for i in range(self.total_orderlet):
                         od_name = self.ccf_ext_header['CCF'+str(i+1)]
+                        self.orderlet_ccf[od_name] = i
                         self.ccf_data[od_name] = ccf_ext_data[i, :, :]
                         self.od_names.append(od_name)
                         if self.is_sci(od_name):
@@ -235,7 +235,6 @@ class RadialVelocityReweighting(KPF2_Primitive):
             self.logger = self.context.logger
         self.logger.info('Loading config from: {}'.format(self.config_path))
 
-
     def _pre_condition(self) -> bool:
         """
         Check for some necessary pre conditions
@@ -270,7 +269,6 @@ class RadialVelocityReweighting(KPF2_Primitive):
             return Arguments(self.lev2_obj)
 
         is_rv_ext = hasattr(self.lev2_obj, self.rv_ext) and not self.lev2_obj[self.rv_ext].empty
-        rv_ext_header = self.lev2_obj.header[self.rv_ext] if is_rv_ext else None
 
         do_corr = False
         if is_rv_ext:
@@ -284,7 +282,9 @@ class RadialVelocityReweighting(KPF2_Primitive):
         velocities = np.array([start_v + i * v_intv for i in range(ccf_w)])
 
         # do cal rv col first
-        ccf_ref_list = {}
+        ccf_ref_list = {}       # ccf ref per orderlet
+
+        rw_ccf_ext = self.ccf_ext + '_RW'
 
         for o in range(self.total_orderlet-1, -1, -1):
             if self.logger:
@@ -294,78 +294,51 @@ class RadialVelocityReweighting(KPF2_Primitive):
             result_ccf_data = self.ccf_data[od_name]
             ccf_ref = None
             if self.reweighting_method.lower() == 'ccf_static':
-                for idx, r_col in enumerate(self.ccf_ref.columns):
-                    if self.mask_type[od_name] is not None and r_col.lower() == self.mask_type[od_name].lower():
-                        col_idx = np.array([0, idx], dtype=int)
-                        ccf_ref = self.ccf_ref.values[:, col_idx]
-                        break
+                mtype = self.mask_type[od_name]
+                is_mask_enable = mtype is not None and \
+                                 (self.reweighting_masks is None or
+                                  any([m.lower() in mtype.lower() for m in self.reweighting_masks]))
+                if is_mask_enable:
+                    for idx, r_col in enumerate(self.ccf_ref.columns):
+                        if mtype is not None and r_col.lower() == mtype.lower():
+                            col_idx = np.array([0, idx], dtype=int)
+                            ccf_ref = self.ccf_ref.values[:, col_idx]
+                            break
             else:
                 ccf_ref = self.ccf_ref.values if isinstance(self.ccf_ref, pd.DataFrame) else self.ccf_ref
 
+            ccf_ref_list[od_name] = ccf_ref
             if ccf_ref is None:
                 if self.logger:
-                    self.logger.info("RadialVelocityReweighting: No reweighting ratio for " + self.ccf_ext + " found")
-                return Arguments(self.lev2_obj)
+                    self.logger.info("RadialVelocityReweighting: No reweighting for " + od_name)
+                continue
 
-            ccf_ref_list[od_name] = ccf_ref
             rw_ccf, new_total_seg = RadialVelocityAlg.reweight_ccf(result_ccf_data, self.total_segment, ccf_ref,
                                                                    self.reweighting_method, s_seg=self.ccf_start_index,
                                                                    do_analysis=True, velocities=velocities)
-            (self.ccf_data[od_name])[0:new_total_seg, :] = rw_ccf[0:new_total_seg, :]     # update ccf value for each orderlet
-            self.lev2_obj[self.ccf_ext][o, 0:new_total_seg, :] = rw_ccf[0:new_total_seg, :]
+            (self.ccf_data[od_name])[0:new_total_seg, :] = rw_ccf[0:new_total_seg, :]
+            if self.instrument.lower() == 'kpf':
+                self.rw_ccf_exts[self.orderlet_ccf[od_name], 0:new_total_seg, :] = rw_ccf[0:new_total_seg, :]
+            else:
+                self.lev2_obj[self.ccf_ext][o, 0:new_total_seg, :] = rw_ccf[0:new_total_seg, :]
 
-            # if existing ccf table with summary row
+            # if existing ccf table with summation row
             if np.shape(self.ccf_data[od_name])[1] >= new_total_seg + RadialVelocityAlg.ROWS_FOR_ANALYSIS and not is_rv_ext:
                 self.ccf_data[od_name][-1, :] = rw_ccf[-1]
+
+        if self.instrument.lower() == 'kpf':
+            self.create_rw_ccf(rw_ccf_ext)
 
         # update rv table
         if is_rv_ext:
             if self.logger:
                 self.logger.info("RadialVelocityReweighting: start updating rv for each segment")
-            self.update_rv_table(self.total_orderlet, velocities, do_corr, ccf_ref_list)
+            new_rv_table = self.update_rv_table(velocities, do_corr, ccf_ref_list)
+            self.lev2_obj[self.rv_ext] = new_rv_table
+            for att in new_rv_table.attrs:
+                if att in self.lev2_obj.header[self.rv_ext]:
+                    self.lev2_obj.header[self.rv_ext][att] = new_rv_table.attrs[att]
 
-        # update rv keyword, ccd[1-2]rv[1-3], ccd[1-2]rv, ccd[1-2]rvc
-        cal_rv = 0.0
-        ods_rv = list()
-        for o in range(self.total_orderlet):
-            map_key = self.get_map_key(self.od_names[o])
-            rv_colname = self.orderlet_rv_col_map[self.instrument][map_key]['orderlet']
-            ccd_rv = self.reweight_rv(rv_colname, ccf_ref_list[self.od_names[o]])
-            ods_rv.append(ccd_rv)
-
-            if self.od_names[o] in self.cal_orderlets:
-                cal_rv = ccd_rv
-
-        if is_rv_ext:
-            done_sci = False
-            for o in range(self.total_orderlet):
-                map_key = self.get_map_key(self.od_names[o])
-                rv_key = 'ccd' + str(self.rv_ext_idx + 1) + self.orderlet_key_map[self.instrument][map_key]['rv']['rv']
-                if self.is_sci(self.od_names[o]) and do_corr:
-                    self.lev2_obj.header[self.rv_ext][rv_key] = ods_rv[o] - cal_rv    # ccd[1-2]rv[1-3]
-                else:
-                    self.lev2_obj.header[self.rv_ext][rv_key] = ods_rv[o]             # ccd[1-2]rv[1-3], ccd[1-2][rvc, rvs]
-
-                if done_sci and self.is_sci(self.od_names[o]):
-                    continue
-
-                if self.is_sci(self.od_names[o]):
-                    rv_col = self.RV_COL_RV
-                    rv_key = 'ccd'+str(self.rv_ext_idx + 1)+'rv'
-                    ccd_rv = self.reweight_rv(rv_col, ccf_ref_list[self.od_names[o]])
-                    rv_ext_header[rv_key] = self.f_decimal(ccd_rv - cal_rv) if do_corr else self.f_decimal(ccd_rv)
-                    done_sci = True
-
-                    erv_col = self.RV_COL_RV_ERR
-                    erv_key = 'ccd' + str(self.rv_ext_idx + 1) + 'erv'
-                else:
-                    erv_col = self.orderlet_rv_col_map[self.instrument][map_key]['erv']
-                    erv_key = 'ccd' + str(self.rv_ext_idx + 1) + self.orderlet_key_map[self.instrument][map_key]['rv']['erv']
-
-                ccd_erv = self.reweight_rv(erv_col, ccf_ref_list[self.od_names[o]], is_sigma=True)
-                rv_ext_header[erv_key] = self.f_decimal(ccd_erv)
-
-        rv_ext_header['rwccfrv'] = 'T'
 
         self.lev2_obj.receipt_add_entry('RadialVelocityReweighting on '+ self.ccf_ext,
                                     self.__module__, f'config_path={self.config_path}', 'PASS')
@@ -376,21 +349,14 @@ class RadialVelocityReweighting(KPF2_Primitive):
 
         return Arguments(self.lev2_obj)
 
-    @staticmethod
-    def f_decimal(num):
-        return float("{:.10f}".format(num))
+    def is_sci(self, sci_name):
+        return RV.is_sci(self, sci_name)
 
-    @staticmethod
-    def is_sci(sci_name):
-        return 'sci' in sci_name.lower()
+    def is_cal(self, sci_name):
+        return RV.is_cal(self, sci_name)
 
-    @staticmethod
-    def is_cal(sci_name):
-        return 'cal' in sci_name.lower()
-
-    @staticmethod
-    def is_sky(sci_name):
-        return 'sky' in sci_name.lower()
+    def is_sky(self, sci_name):
+        return RV.is_sky(self, sci_name)
 
     def get_map_key(self, od_name):
         for k in self.orderlet_key_map[self.instrument].keys():
@@ -398,7 +364,17 @@ class RadialVelocityReweighting(KPF2_Primitive):
                 return k
         return ''
 
-    def update_rv_table(self, total_orderlet, velocities, do_corr, ccf_ref_list):
+    def get_rv_unit(self, od_name, is_final=False):
+        return RV.get_rv_unit(self, od_name, is_final=is_final)
+
+    def create_rw_ccf(self, rw_ext):
+        if not self.lev2_obj[rw_ext]:
+            self.lev2_obj[rw_ext] = self.rw_ccf_exts
+        for key in self.ccf_ext_header.keys():
+            if key not in ['XTENSION', 'BITPIX', 'NAXIS', 'NAXIS1', 'NAXIS2', 'NAXIS3', 'PCOUNT', 'GCOUNT', 'EXTNAME']:
+                self.lev2_obj.header[rw_ext][key] = self.ccf_ext_header[key]
+
+    def update_rv_table(self, velocities, do_corr, ccf_ref_list):
         rv_ext_values = self.lev2_obj[self.rv_ext].values
         rv_ext_columns = self.lev2_obj[self.rv_ext].columns
         rv_ext_header = self.lev2_obj.header[self.rv_ext]
@@ -407,6 +383,9 @@ class RadialVelocityReweighting(KPF2_Primitive):
         # for only one ccd or old L2 file with no such key defined
         rv_start_idx = (ccdrow in rv_ext_header and rv_ext_header[ccdrow]) or \
                        (self.processed_row is not None and self.processed_row) or 0
+
+        def f_decimal(num):
+            return float("{:.10f}".format(num))
 
         def col_idx_rv_table(colname):
             if colname in rv_ext_columns:
@@ -417,10 +396,11 @@ class RadialVelocityReweighting(KPF2_Primitive):
         seg_size = self.totals
         cal_idx = col_idx_rv_table(RadialVelocityReweighting.RV_COL_CAL)
         rv_idx = col_idx_rv_table(self.RV_COL_RV)
+        rv_err_idx = col_idx_rv_table(self.RV_COL_RV_ERR)
 
-        ods_idx = {}
-        scis_idx = []
-        sci_ccf_ref = None
+        ods_idx = {}        # column index for each orderlet
+        scis_idx = []       # column index list for sci orderlet
+        sci_ccf_ref = None  # ccf ref for sci orderlet
         for od_name in self.od_names:
             map_key = self.get_map_key(od_name)
             if map_key:
@@ -430,48 +410,100 @@ class RadialVelocityReweighting(KPF2_Primitive):
                     if sci_ccf_ref is None:
                         sci_ccf_ref = ccf_ref_list[od_name]
 
-        for s in range(seg_size):
-            sum_rv = list()
+        total_vel = np.shape(self.original_ccf_exts)[2]
+        ccf_summ_h_rw = np.zeros((seg_size, total_vel))
+        ccf_summ_h_rw_nonnorm = np.zeros((seg_size, total_vel))
+        ccf_summ_v_rw = np.zeros(total_vel)
+        ccf_summ_v_rw_nonnorm = np.zeros(total_vel)
+        new_rv = {}                     # new rv per orderlet
+        new_rv_err = {}                 # new rv error per orderlet
+        new_ccd_rv = None
+        new_ccd_rv_err = None
+        new_cal_rv = None
+        new_cal_rvs = np.zeros(seg_size)
 
-            for od_name in self.od_names:
-                ccf_orderlet = self.ccf_data[od_name][s, :]
-                _, od_rv, _, _, _ = RadialVelocityAlg.fit_ccf(ccf_orderlet,
-                                                                RadialVelocityAlg.get_rv_estimation(rv_ext_header),
-                                                                velocities, self.mask_type[od_name],
-                                                                rv_guess_on_ccf=(self.instrument == 'kpf'))
+        def get_new_rv(ccfs, orderlet_name, is_rv_err=False):
+            if is_rv_err:
+                vel_pix = RadialVelocityAlg.comp_velocity_span_pixel(None, self.config, self.instrument)
+                _, _, _, _, new_rv_err = RadialVelocityAlg.fit_ccf(ccfs,
+                                        RadialVelocityAlg.get_rv_estimation(rv_ext_header),
+                                        velocities, self.mask_type[orderlet_name],
+                                        rv_guess_on_ccf=(self.instrument == 'kpf'),
+                                        vel_span_pixel=vel_pix)
+                return new_rv_err
+            else:
+                _, new_rv, _, _, _ = RadialVelocityAlg.fit_ccf(ccfs,
+                                        RadialVelocityAlg.get_rv_estimation(rv_ext_header),
+                                        velocities, self.mask_type[orderlet_name],
+                                        rv_guess_on_ccf=(self.instrument == 'kpf'))
+                return new_rv
 
-                rv_ext_values[s + rv_start_idx, ods_idx[od_name]] = od_rv
+        for od_name in self.od_names:
+            if ccf_ref_list[od_name] is None:
+                continue
+
+            rw_ccf_nonnorm, _ = RadialVelocityAlg.reweight_ccf(
+                                self.original_ccf_exts[self.orderlet_ccf[od_name], 0:seg_size, :],
+                                seg_size,
+                                ccf_ref_list[od_name],
+                                self.reweighting_method,
+                                do_analysis=False,
+                                velocities=velocities,
+                                normalized=False)
+            for s in range(seg_size):
+                rv_ext_values[s+rv_start_idx, ods_idx[od_name]] = \
+                    get_new_rv(self.rw_ccf_exts[self.orderlet_ccf[od_name], s, :], od_name)
+
+                # update rv error for non sci orderlet
+                if not self.is_sci(od_name):
+                    od_rv_err = get_new_rv(rw_ccf_nonnorm[s, :], od_name, is_rv_err=True)
+                    map_key = self.get_map_key(od_name)
+                    rv_err_nonsci_idx = col_idx_rv_table(self.orderlet_rv_col_map[self.instrument][map_key]['erv'])
+                    rv_ext_values[s+rv_start_idx, rv_err_nonsci_idx] = od_rv_err
+
+                # summ ccf across sci orderlet
                 if self.is_sci(od_name) or (self.is_sky(od_name) and self.is_solar_data):
-                    sum_rv.append(od_rv)
-            rv_ext_values[s + rv_start_idx, rv_idx] = sum(sum_rv)/len(sum_rv) if len(sum_rv) > 0 else 0.0
+                    ccf_summ_h_rw[s, :] += self.ccf_data[od_name][s, :]
+                    ccf_summ_h_rw_nonnorm[s, :] += rw_ccf_nonnorm[s, :]
 
+            # summ ccf across segments => final ccf per orderlet
+            ccf_summ = np.sum(self.ccf_data[od_name][0:seg_size, :], axis=0)
+            ccf_summ_nonnorm = np.sum(rw_ccf_nonnorm[0:seg_size, :], axis=0)
+
+            # rv and rv error for each orderlet
+            new_rv[od_name] = get_new_rv(ccf_summ, od_name)
+            new_rv_err[od_name] = get_new_rv(ccf_summ_nonnorm, od_name, is_rv_err=True)
+            if self.is_cal(od_name):
+                new_cal_rv = new_rv[od_name]
+                new_cal_rvs = rv_ext_values[rv_start_idx:rv_start_idx+seg_size, cal_idx]
+
+            # summ final ccf across orderlet
+            if self.is_sci(od_name) or (self.is_sky(od_name) and self.is_solar_data):
+                ccf_summ_v_rw += ccf_summ
+                ccf_summ_v_rw_nonnorm += ccf_summ_nonnorm
+
+        # rv and rv error per ccd
+        if np.any(ccf_summ_v_rw):
+            new_ccd_rv = get_new_rv(ccf_summ_v_rw, self.sci_orderlets[0])
+            new_ccd_rv_err = get_new_rv(ccf_summ_v_rw_nonnorm, self.sci_orderlets[0], is_rv_err=True)
+
+        # update rv and rv error column based on summation across sci orderlets per segment
+        for s in range(seg_size):
+            rv_ext_values[s+rv_start_idx, rv_idx] = get_new_rv(ccf_summ_h_rw[s, :], self.sci_orderlets[0])
+            rv_ext_values[s+rv_start_idx, rv_err_idx] = get_new_rv(ccf_summ_h_rw_nonnorm[s, :],
+                                                                       self.sci_orderlets[0],
+                                                                       is_rv_err=True)
+        # weight column
         ccf_weight = sci_ccf_ref if len(np.shape(sci_ccf_ref)) >= 2 else sci_ccf_ref.reshape(sci_ccf_ref.size, 1)
         ccf_ref_idx = col_idx_rv_table(self.RV_WEIGHTS)
         if ccf_ref_idx >= 0:
             rv_ext_values[rv_start_idx:rv_start_idx+seg_size, ccf_ref_idx] = ccf_weight[0:seg_size, -1]
-        # error columns
-        sci_done = False
-        for od_name in self.od_names:
-            if self.is_sci(od_name) and not sci_done:
-                err_col = self.RV_COL_RV_ERR
-                sci_done = True
-            elif not self.is_sci(od_name):
-                err_col = self.orderlet_rv_col_map[self.instrument][self.get_map_key(od_name)]['erv']
-            else:
-                continue
-
-            od_ref = ccf_ref_list[od_name]
-            od_weight = od_ref if len(np.shape(od_ref)) >= 2 else od_ref.reshape(od_ref.size, 1)
-            e_idx = col_idx_rv_table(err_col)
-            rv_ext_values[rv_start_idx:rv_start_idx+seg_size, e_idx] *= od_weight[0:seg_size, -1]
 
         # do correction on orderletx columns
         if do_corr:
             for s_idx in scis_idx:
-                rv_ext_values[rv_start_idx:rv_start_idx+seg_size, s_idx] -= \
-                    rv_ext_values[rv_start_idx:rv_start_idx+seg_size, cal_idx]
-                rv_ext_values[rv_start_idx:rv_start_idx+seg_size, rv_idx] -= \
-                    rv_ext_values[rv_start_idx:rv_start_idx+seg_size, cal_idx]
+                rv_ext_values[rv_start_idx:rv_start_idx+seg_size, s_idx] -= new_cal_rvs
+            rv_ext_values[rv_start_idx:rv_start_idx+seg_size, rv_idx] -= new_cal_rvs
 
         # create a new rv table to take rv_ext_values with rv update
         new_rv_table = {}
@@ -489,8 +521,38 @@ class RadialVelocityReweighting(KPF2_Primitive):
                 if idx >= 0:
                     new_rv_table[c_name] = rv_ext_values[:, idx].tolist()
 
-        self.lev2_obj[self.rv_ext] = pd.DataFrame(new_rv_table)      # update rv table
-        return True
+        results = pd.DataFrame(new_rv_table)      # update rv table
+        cal_rv_key = 'ccd'+str(self.rv_ext_idx + 1) + 'rvc'
+        if cal_rv_key in rv_ext_header:
+            cal_rv = rv_ext_header[cal_rv_key] if new_cal_rv is None else new_cal_rv
+        else:
+            cal_rv = 0.0
+
+        ccd_p = 'ccd'+str(self.rv_ext_idx+1)
+
+        if new_ccd_rv is not None:
+            unit = self.get_rv_unit(self.sci_orderlets[0], is_final=True)
+            results.attrs[ccd_p+'rv'] = (f_decimal(new_ccd_rv - cal_rv), unit) \
+                if do_corr else (f_decimal(new_ccd_rv), unit)
+        if new_ccd_rv_err is not None:
+            results.attrs[ccd_p+'erv'] = f_decimal(new_ccd_rv_err)
+
+        for od_name in new_rv.keys():
+            map_key = self.get_map_key(od_name)
+            if map_key:
+                od_rv = new_rv[od_name] - cal_rv if do_corr and self.is_sci(od_name) else new_rv[od_name]
+                unit = self.get_rv_unit(od_name)
+
+                results.attrs[ccd_p+self.orderlet_key_map[self.instrument][map_key]['rv']['rv']] = \
+                    (f_decimal(od_rv), unit)
+                results.attrs[ccd_p+self.orderlet_key_map[self.instrument][map_key]['rv']['erv']] = \
+                    f_decimal(new_rv_err[od_name])
+
+                ccf_key = self.orderlet_key_map[self.instrument][map_key]['rv']['ccf']
+                rwkey = 'rw'+ccf_key
+                rwkey = rwkey[0:8] if len(rwkey) > 8 else rwkey
+                results.attrs[rwkey] = 'T' if ccf_ref_list[od_name] is not None else 'F'
+        return results
 
     def reweight_rv(self, rv_colname,  weighting_ratio, is_sigma=False):
         rv_table = self.lev2_obj[self.rv_ext]

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -257,6 +257,7 @@ bc_path = output_dir + config.ARGUMENT.output_barycorr
 lev2_pattern = output_rv + '*' + lev2_stem_suffix + fits_ext
 
 reweighting_method = config.ARGUMENT.reweighting_method
+reweighting_masks = config.ARGUMENT.reweighting_enable_masks
 data_ext_rv = config.ARGUMENT.orderlet_names_rv
 ccf_ext_names = config.ARGUMENT.ccf_ext
 rv_ext = config.ARGUMENT.rv_ext
@@ -572,7 +573,6 @@ if do_spectral_extraction or do_hk or do_bc:
 #    RadialVelocityInit: do rv init on each L1 input.
 #    RadialVelocity: do radial velocity per ccd per L1 data.
 #
-rv_test = do_rv or do_rv_reweighting
 if do_rv or do_rv_reweighting:
 	rv_star_dir = masters_data_dir
 
@@ -616,15 +616,17 @@ if do_rv or do_rv_reweighting:
 			if rv_init != None:
 				for idx in ccd_idx:
 					ratio_ref = None
+					rw_mask = None
 					# rewighting if the reweighted L2 at the same directory as unweighted L2.
-					if ratio_refs and output_rv == output_rv_rw:
+					if ratio_refs and output_rv == output_rv_rw and do_rv_reweighting:
 						ratio_ref = ratio_refs[idx]
-
+						rw_mask = reweighting_masks[idx]
 					rv_data = RadialVelocity(lev1_data, rv_init, rv_data,
 						data_ext_rv[idx], ccf_ext=ccf_ext_names[idx], rv_ext=rv_ext,
 						area_def=area_def[idx], start_seg=area_def[idx][0], end_seg=area_def[idx][1],
 						rv_set=idx, ccf_engine='c', start_bary_index=s_bary_idx[idx], rv_correction_by_cal=is_rv_cal,
-						reweighting_method=reweighting_method, input_ref=ratio_ref)
+						reweighting_method=reweighting_method,
+						input_ref=ratio_ref, reweighting_masks=rw_mask )
 				if rv_data != None:
 					result = to_fits(rv_data, output_lev2_file)
 
@@ -647,14 +649,17 @@ if do_rv or do_rv_reweighting:
 				reweighted_output = output_rv_rw + short_lev2
 				for idx in ccd_idx:
 					ratio_ref = None
+					rw_mask = None
 					if ratio_refs:
 						ratio_ref = ratio_refs[idx]
+						rw_mask = reweighting_masks[idx]
 
 					if ratio_ref is not None:
 						t_segment = area_def[idx][1] -  area_def[idx][0] + 1
 						lev2_rv = RadialVelocityReweighting(lev2_rv, reweighting_method, ratio_ref,
 								t_segment, ccf_ext=ccf_ext_names[idx],
-								rv_ext=rv_ext,  rv_ext_idx=idx, ccf_start_index=area_def[idx][0])
+								rv_ext=rv_ext,  rv_ext_idx=idx, ccf_start_index=area_def[idx][0],
+								reweighting_masks=rw_mask)
 				if lev2_rv is not None:
 					result = to_fits(lev2_rv, reweighted_output)
 


### PR DESCRIPTION
This PR include the development for 
- Add extension to record original CCF before reweighting. 
   extensions GREEN_CCF, RED_CCF have the data of original CCF (before reweighting) for each orderlet. 
   extensions GREEN_CCF_RW, RED_CCF_RW have the data of the reweighted CCF or the original CCF if no reweighting is applied to some orderlet. 
- https://github.com/Keck-DataReductionPipelines/KPF-Pipeline/issues/571
  Add configuation argument to set the mask for doing the reweighting. Current setting: reweighting is applied to any espress masks, not mask 'lfc', 'thar' and 'etalon'. 
- https://github.com/Keck-DataReductionPipelines/KPF-Pipeline/issues/573: 
   RV error is computed based on original CCF. RV is cmputed based on summation of CCF across the orderlet and the segments.  
- If SCI1, SC2, and SC3 use any espresso mask, then use G2_espresso for the SKY fiber. 
- Enlarge RV window used for CCF computation as needed to cover the RV window for  non-espresso type mask.
