### PR TITLE
Fix the TOC in readthedocs

### DIFF
--- a/docs/source/data_exploration/tutorial_2D_ion_pump.rst
+++ b/docs/source/data_exploration/tutorial_2D_ion_pump.rst
@@ -1,5 +1,5 @@
-Manipulating 2D images to diagnose problem with ion pumps
-=========================================================
+Manipulating 2D images to diagnose a problem with the ion pumps
+===============================================================
 
 .. toctree::
    :maxdepth: 0

--- a/docs/source/data_exploration/tutorial_L2.rst
+++ b/docs/source/data_exploration/tutorial_L2.rst
@@ -1,3 +1,6 @@
+Reading L1 files and examining the data products
+================================================
+
 .. toctree::
    :maxdepth: 0
 


### PR DESCRIPTION
Very minor change to fix a nagging problem with the table of contents in readthedocs that lists the contributed Jupyter Notebooks.