### PR TITLE
masters L1/L2 recipe and config update

### DIFF
--- a/configs/kpf_masters_l1.cfg
+++ b/configs/kpf_masters_l1.cfg
@@ -72,7 +72,7 @@ ccd_idx = [0, 1]
 #        ex: start_order = [-1, -1] means the traces of sky fiber of first order for both green and red are missing in the order trace result.
 #    - note: order_per_ccd, start_order, orderlet_names should have size as that of ccd_list.
 orders_per_ccd=[35,32]
-start_order = [-1, -1]
+start_order = [-1, 0]
 orderlet_names = [['GREEN_SKY_FLUX', 'GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3', 'GREEN_CAL_FLUX'], ['RED_SKY_FLUX', 'RED_SCI_FLUX1', 'RED_SCI_FLUX2', 'RED_SCI_FLUX3', 'RED_CAL_FLUX']]
 orderlet_widths_ccds = [[-1, -1, -1, 1, -1],[-1, -1, -1, -1, -1]]
 

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -466,9 +466,16 @@ if do_spectral_extraction or do_hk or do_bc:
 			if lev0_stem_suffix in lev1_stem:
 				lev1_stem = str_replace(lev1_stem, lev0_stem_suffix, "")
 		output_lev1_file = output_extraction + lev1_stem + lev1_stem_suffix + fits_ext
+		is_raw = 1
+		if rect_method in input_lev0_file:
+			is_raw = 0
+		if lev1_stem_suffix in input_lev0_file:
+			is_raw = 0
+		if lev2_stem_suffix in input_lev0_file:
+			is_raw = 0
 
 		# produce level 1 by spectral extraction if overwrite or L1 file doesn't exist
-		if overwrite or not exists(output_lev1_file):
+		if (is_raw == 1) and (overwrite or not exists(output_lev1_file)):
 			b_level1_sp = False
 
 			# do spectral extraction if do_spectral_extraction, rectified flat data existing and all trace results exist.


### PR DESCRIPTION
This PR includes the updates to 
- fix config for masters generation,  kpf_masters_l1.cfg, to use order trace result on 20230411
- fix master recipe, kpf_drp.recipe, to skip the fits which is not with 2D raw data for the spectral extraction. 