### PR TITLE
EXPTIME->ELAPSED for accurate exposure times

### DIFF
--- a/modules/Utils/analyze_2d.py
+++ b/modules/Utils/analyze_2d.py
@@ -52,7 +52,7 @@ class Analyze2D:
         self.header = primary_header.header
         self.name = primary_header.get_name()
         self.ObsID = primary_header.get_obsid()
-        self.exptime = self.header['EXPTIME']
+        self.exptime = self.header['ELAPSED']
         self.green_dark_current_regions = None # Green CCD regions where dark current is measured, defined below
         self.red_dark_current_regions   = None # Red CCD regions where dark current is measured, defined below
         self.green_coll_pressure_torr = 0

--- a/modules/Utils/frame_subtract.py
+++ b/modules/Utils/frame_subtract.py
@@ -25,7 +25,7 @@ class FrameSubtract(KPF0_Primitive):
                 assert self.correcting_file.header['PRIMARY']['OBSTYPE'] == 'Bias', "Correcting file is not a master bias. Check failed."
             if self.sub_type == 'dark':
                 assert self.correcting_file.header['PRIMARY']['OBSTYPE'] == 'Dark', "Correcting file is not a dark frame file. Check failed."
-                assert self.principal_file.header['PRIMARY']['EXPTIME'] == self.correcting_file.header['PRIMARY']['EXPTIME'], "Frames' exposure times don't match. Check failed."
+                assert self.principal_file.header['PRIMARY']['ELAPSED'] == self.correcting_file.header['PRIMARY']['ELAPSED'], "Frames' exposure times don't match. Check failed."
             subtracted = self.principal_file[ffi] - self.correcting_file[ffi]
                 
     def _perform(self):

--- a/modules/Utils/kpf_fits.py
+++ b/modules/Utils/kpf_fits.py
@@ -171,7 +171,7 @@ class FitsHeaders:
                 val1 = fits.getval(fits_file, 'SCI-OBJ')
                 val2 = fits.getval(fits_file, 'CAL-OBJ')
                 val3 = fits.getval(fits_file, 'SKY-OBJ')
-                val4 = fits.getval(fits_file, 'EXPTIME')        # Require EXPTIME <= 2.0 seconds to avoid saturation.
+                val4 = fits.getval(fits_file, 'ELAPSED')        # Require EXPTIME <= 2.0 seconds to avoid saturation.
 
                 if ((val1 == val2) and (val2 == val3) and (val1 != '') and (val1.lower() != 'none') and (val4 <= 2.0)):
                     flag = 'keep'
@@ -225,7 +225,7 @@ class FitsHeaders:
 
             try:
 
-                val4 = float(fits.getval(fits_file, 'EXPTIME'))
+                val4 = float(fits.getval(fits_file, 'ELAPSED'))
 
                 if (val4 >= exptime_minimum):
                     flag = 'keep'
@@ -341,7 +341,7 @@ class FitsHeaders:
 
             try:
 
-                val4 = float(fits.getval(fits_file, 'EXPTIME'))
+                val4 = float(fits.getval(fits_file, 'ELAPSED'))
 
                 if (val4 <= exptime_maximum):
                     flag = 'keep'

--- a/modules/Utils/kpf_parse.py
+++ b/modules/Utils/kpf_parse.py
@@ -73,8 +73,8 @@ class HeaderParse:
         """
         try: 
             if 'IMTYPE' in self.header:
-                if (('EXPTIME' in self.header) and 
-                    ((self.header['IMTYPE'] == 'Bias') or (self.header['EXPTIME'] == 0))):
+                if (('ELAPSED' in self.header) and 
+                    ((self.header['IMTYPE'] == 'Bias') or (self.header['ELAPSED'] == 0))):
                         self.name = 'Bias'
                 elif self.header['IMTYPE'] == 'Dark':
                     self.name = 'Dark' 

--- a/modules/image_processing/src/alg.py
+++ b/modules/image_processing/src/alg.py
@@ -122,7 +122,7 @@ class ImageProcessingAlg():
             return
 
         for ffi in self.ffi_exts:
-            image_exptime = float(self.rawimage.header['PRIMARY']['EXPTIME'])
+            image_exptime = float(self.rawimage.header['PRIMARY']['ELAPSED'])
             dark_exptime = 1.0   # master darks are already normalized
             try:
                 self.rawimage[ffi] = self.rawimage[ffi] - dark_frame[ffi]*(image_exptime/dark_exptime)

--- a/modules/master_arclamp/src/master_arclamp_framework.py
+++ b/modules/master_arclamp/src/master_arclamp_framework.py
@@ -167,7 +167,7 @@ class MasterArclampFramework(KPF0_Primitive):
             arclamp_file = KPF0.from_fits(arclamp_file_path,self.data_type)
             mjd_obs = float(arclamp_file.header['PRIMARY']['MJD-OBS'])
             mjd_obs_list.append(mjd_obs)
-            exp_time = float(arclamp_file.header['PRIMARY']['EXPTIME'])
+            exp_time = float(arclamp_file.header['PRIMARY']['ELAPSED'])
             exp_time_list.append(exp_time)
             header_object = arclamp_file.header['PRIMARY']['OBJECT']
             arclamp_object_list.append(header_object)

--- a/modules/master_dark/src/master_dark_framework.py
+++ b/modules/master_dark/src/master_dark_framework.py
@@ -166,7 +166,7 @@ class MasterDarkFramework(KPF0_Primitive):
             dark_file = KPF0.from_fits(dark_file_path,self.data_type)
             mjd_obs = float(dark_file.header['PRIMARY']['MJD-OBS'])
             mjd_obs_list.append(mjd_obs)
-            exp_time = float(dark_file.header['PRIMARY']['EXPTIME'])
+            exp_time = float(dark_file.header['PRIMARY']['ELAPSED'])
             exp_time_list.append(exp_time)
             self.logger.debug('dark_file_path,exp_time = {},{}'.format(dark_file_path,exp_time))
             header_object = dark_file.header['PRIMARY']['OBJECT']

--- a/modules/master_lfc/src/master_lfc_framework.py
+++ b/modules/master_lfc/src/master_lfc_framework.py
@@ -104,7 +104,7 @@ class MasterLFCFramework(KPF0_Primitive):
             frames_data=[]
             for path in all_lfc_files:
                 obj = KPF0.from_fits(path)
-                exp = obj.header['PRIMARY']['EXPTIME']
+                exp = obj.header['PRIMARY']['ELAPSED']
                 frames_data.append(obj[ffi] / exp)
             frames_data = np.array(frames_data)
 

--- a/modules/master_superflat/src/master_superflat_framework.py
+++ b/modules/master_superflat/src/master_superflat_framework.py
@@ -191,7 +191,7 @@ class MasterSuperFlatFramework(KPF0_Primitive):
             flat_file = KPF0.from_fits(flat_file_path,self.data_type)
             mjd_obs = float(flat_file.header['PRIMARY']['MJD-OBS'])
             mjd_obs_list.append(mjd_obs)
-            exp_time = float(flat_file.header['PRIMARY']['EXPTIME'])
+            exp_time = float(flat_file.header['PRIMARY']['ELAPSED'])
             exp_time_list.append(exp_time)
             self.logger.debug('flat_file_path,exp_time = {},{}'.format(flat_file_path,exp_time))
 

--- a/modules/quality_control_exposure/src/quality_control_exposure_framework.py
+++ b/modules/quality_control_exposure/src/quality_control_exposure_framework.py
@@ -340,7 +340,7 @@ class QualityControlExposureFramework(KPF0_Primitive):
             mjd_obs = "NotFound"
 
         try:
-            exptime_str = float(l0_file.header['PRIMARY']['EXPTIME'])
+            exptime_str = float(l0_file.header['PRIMARY']['ELAPSED'])
 
             try:
                 exptime = float(exptime_str)

--- a/modules/quicklook/src/alg_nightly.py
+++ b/modules/quicklook/src/alg_nightly.py
@@ -71,7 +71,7 @@ class Nightly_summaryAlg:
             hdulist = fits.open(L0_data)
             hdr = hdulist[0].header
 
-            exptime = hdr['EXPTIME']
+            exptime = hdr['ELAPSED']
             print(hdulist.info())
 
             #get ccd names
@@ -99,8 +99,8 @@ class Nightly_summaryAlg:
                     counts = np.array(hdulist[ccd_color[i_color]+'_STACK'].data,'d')
                     if master_master_file != 'None': master_counts = np.array(hdulist1[ccd_color[i_color]+'_STACK'].data,'d')
                 if master_list[i].find('dark')!=-1:#scale up dark exposures
-                    counts*=hdulist[0].header['EXPTIME']
-                    if master_master_file != 'None':master_counts*=hdulist1[0].header['EXPTIME']
+                    counts*=hdulist[0].header['ELAPSED']
+                    if master_master_file != 'None':master_counts*=hdulist1[0].header['ELAPSED']
 
                 flatten_counts = np.ravel(counts)
                 if master_master_file != 'None': master_flatten_counts = np.ravel(master_counts)

--- a/modules/quicklook/src/alg_old.py
+++ b/modules/quicklook/src/alg_old.py
@@ -169,7 +169,7 @@
                 master_counts = np.array(hdulist1[ccd_color[i_color]].data,'d')
                 master_flatten_counts = np.ravel(master_counts)
                 if version == 'Dark':#scale up dark exposures
-                    master_flatten_counts*=hdr['EXPTIME']
+                    master_flatten_counts*=hdr['ELAPSED']
             #print(version,hdr,hdr['EXPTIME'],type(hdr['EXPTIME']),hdulist1[0].header['EXPTIME'],Cal_Source,master_file,os.path.exists(master_file))
             #print(master_counts)
             #input("Press Enter to continue...")

--- a/modules/radial_velocity/src/alg.py
+++ b/modules/radial_velocity/src/alg.py
@@ -392,7 +392,7 @@ class RadialVelocityAlg(RadialVelocityBase):
         if seg >= 0 and self.bary_corr_table is not None and not self.bary_corr_table.empty and \
                 np.shape(self.bary_corr_table.values)[0] > ord_idx:
             obs_time = np.array(self.bary_corr_table['PHOTON_BJD'])[ord_idx+self.start_bary_index]
-        elif 'MJD-OBS' in self.header and 'EXPTIME' in self.header:
+        elif 'MJD-OBS' in self.header and 'ELAPSED' in self.header:
             obs_time = self.header['MJD-OBS'] + 2400000.5
         else:
             obs_time = default

--- a/modules/radial_velocity/src/radial_velocity.py
+++ b/modules/radial_velocity/src/radial_velocity.py
@@ -317,7 +317,7 @@ class RadialVelocity(KPF1_Primitive):
                         exptime_v = 1.0
                 d_obs = 'DATE-MID'
                 if d_obs in p_header: # get from primary header if the key exists
-                    exptime_k = 'EXPTIME' if 'EXPTIME' in p_header else None
+                    exptime_k = 'ELAPSED' if 'ELAPSED' in p_header else None
                     exptime_v = p_header[exptime_k] if exptime_k else 1.0
                     m_obs = Time(p_header[d_obs]).jd - 2400000.5
 

--- a/modules/spectral_extraction/src/alg.py
+++ b/modules/spectral_extraction/src/alg.py
@@ -1505,7 +1505,7 @@ class SpectralExtractionAlg(ModuleAlgBase):
         elif 'OBS MJD' in header_keys:
             mjd = flux_header['OBS MJD']
 
-        expt = 'EXPTIME'
+        expt = 'ELAPSED'
         if expt in header_keys:
             exptime = flux_header[expt]
         else:
@@ -1518,7 +1518,7 @@ class SpectralExtractionAlg(ModuleAlgBase):
         if mjd != 0.0:
             df_result.attrs['MJD-OBS'] = mjd
             df_result.attrs['OBSJD'] = mjd + 2400000.5
-        df_result.attrs['EXPTIME'] = exptime
+        df_result.attrs['ELAPSED'] = exptime
         df_result.attrs['TOTALORD'] = total_order
         df_result.attrs['FIRSTORD'] = self.start_row_index() if first_row is None else first_row
         df_result.attrs['FROMIMGX'] = self.origin[self.X]

--- a/modules/spectral_extraction/src/alg_bary_corr.py
+++ b/modules/spectral_extraction/src/alg_bary_corr.py
@@ -47,7 +47,7 @@ class BaryCorrTableAlg(ModuleAlgBase):
     
     DATE_MID = 'DATE-MID'
     DATE_BEG = 'DATE-BEG'
-    EXPTIME = 'EXPTIME'
+    EXPTIME = 'ELAPSED'
     IMTYPE = 'IMTYPE'
     TARGFRAM = 'TARGFRAM'
     year_days = 365.25

--- a/tests/regression/test_FitsHeaders.py
+++ b/tests/regression/test_FitsHeaders.py
@@ -9,7 +9,7 @@ def test_match_headers_float_le():
     Find all fits files with matching EXPTIME less than or equal zero.
     """
 
-    fh = FitsHeaders(files_in_dir, 'EXPTIME', '0.0')
+    fh = FitsHeaders(files_in_dir, 'ELAPSED', '0.0')
     input_files = fh.match_headers_float_le()
 
     print('Output from match_headers_float_le...')


### PR DESCRIPTION
It appears that the keyword we should pull from for exposure times is ELAPSED instead of the usual EXPTIME.