### PR TITLE
change the use of order trace result files to 20230730

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -42,9 +42,9 @@ ccd_list = ['GREEN_CCD', 'RED_CCD']
 #    flat_file: flat file for order trace process. updated upon new flat file.
 #    ccd_idx: index in ccd_list for the ccd to be processed in DRP recipe
 #flat_file = KP.20221107.04689.77
-flat_file = /data/reference_fits/kpf_20230411_master_flat.fits
-order_trace_flat = /data/reference_fits/kpf_20230411_master_flat.fits
-order_trace_files = [ '/data/reference_fits/kpf_20230411_master_flat_GREEN_CCD.csv', '/data/reference_fits/kpf_20230411_master_flat_RED_CCD.csv']
+flat_file = /data/reference_fits/kpf_20230730_master_flat.fits
+order_trace_flat = /data/reference_fits/kpf_20230730_master_flat.fits
+order_trace_files = [ '/data/reference_fits/kpf_20230730_master_flat_GREEN_CCD.csv', '/data/reference_fits/kpf_20230730_master_flat_RED_CCD.csv']
 fitting_poly_degree = 3
 ccd_idx = [0, 1]
 
@@ -60,7 +60,7 @@ ccd_idx = [0, 1]
 #    - note: order_per_ccd, start_order, orderlet_names should (the outer list), orderlet_widths_ccds (the outer list) have size as that of ccd_list.
 #            the inner lists of orderlet_names and orderlet_widths_ccds are with the same size.
 orders_per_ccd=[35,32]
-start_order = [-1, 0]
+start_order = [-1, -1]
 orderlet_names = [['GREEN_SKY_FLUX', 'GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREEN_SCI_FLUX3', 'GREEN_CAL_FLUX'], ['RED_SKY_FLUX', 'RED_SCI_FLUX1', 'RED_SCI_FLUX2', 'RED_SCI_FLUX3', 'RED_CAL_FLUX']]
 #orderlet_widths_ccds = [[],[]]
 orderlet_widths_ccds = [[-1, -1, -1, 1, -1],[-1, -1, -1, -1, -1]]


### PR DESCRIPTION
This PR update the config file kpf_drp.cfg to use the order trace result from 20230730. 
