### PR TITLE
Make order rectification on stack extension in master flat

### DIFF
--- a/modules/spectral_extraction/src/spectral_extraction.py
+++ b/modules/spectral_extraction/src/spectral_extraction.py
@@ -40,7 +40,8 @@
                       Clip file is used to store the polygon clip data for the rectification method
                       which is not NoRECT.
                     - `action.args['total_order_per_ccd']: (int, optional)`: total order per ccd. Defaults to False.
-                    - `action.args['data_extension']: (str, optional)`: the name of the extension containing data.
+                    - `action.args['data_extension']: (str, optional)`: the name of the extension in spectrum containing data.
+                    - `action.args['flat_extension']: (str, optional)`: the name of the extension in flat containing data.
                     - `action.args['trace_extension']: (str, optional)`: the name of the extension containing order
                       trace results.
                     - `action.args['trace_file']: (str, optional)`: the name file containing order trace results.
@@ -142,6 +143,7 @@ class SpectralExtraction(KPF0_Primitive):
                     'to_set_wavelength_cal': False,
                     'clip_file': None,
                     'data_extension': 'DATA',
+                    'flat_extension': 'DATA',
                     'poly_degree': 3,
                     'origin': [0, 0],
                     'trace_extension': None,
@@ -184,6 +186,7 @@ class SpectralExtraction(KPF0_Primitive):
         self.total_order_per_ccd = self.get_args_value('total_order_per_ccd', action.args, args_keys)
 
         data_ext = self.get_args_value('data_extension', action.args, args_keys)
+        flat_ext = self.get_args_value('flat_extension', action.args, args_keys)
         self.data_ext = data_ext
         order_trace_ext = self.get_args_value('trace_extension', action.args, args_keys)
         order_trace_file = self.get_args_value('trace_file', action.args, args_keys)
@@ -237,8 +240,8 @@ class SpectralExtraction(KPF0_Primitive):
             if self.outlier_lev0 is not None and hasattr(self.outlier_lev0, data_ext) else None
 
         try:
-            self.alg = SpectralExtractionAlg(self.input_flat[data_ext] if hasattr(self.input_flat, data_ext) else None,
-                                        self.input_flat.header[data_ext] if hasattr(self.input_flat, data_ext) else None,
+            self.alg = SpectralExtractionAlg(self.input_flat[flat_ext] if hasattr(self.input_flat, flat_ext) else None,
+                                        self.input_flat.header[flat_ext] if hasattr(self.input_flat, flat_ext) else None,
                                         self.spec_flux,
                                         self.spec_header,
                                         self.order_trace_data,
@@ -342,7 +345,7 @@ class SpectralExtraction(KPF0_Primitive):
                                      SpectralExtractionAlg.extracting_method[self.extraction_method] +
                                      " extraction on " + order_name + " of " + str(o_set.size) + " orders")
 
-                opt_ext_result = self.alg.extract_spectrum(order_set=o_set, first_index=first_index)
+                opt_ext_result = self.alg.extract_spectrum(order_set=o_set, first_index=first_index, order_name = order_name)
 
                 assert('spectral_extraction_result' in opt_ext_result and
                        isinstance(opt_ext_result['spectral_extraction_result'], pd.DataFrame))

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -327,6 +327,7 @@ flat_stem, flat_ext = splitext(short_flat_file)
 trace_list = []
 b_all_traces = False
 lev0_flat_rect = None
+ccd_stack = '_STACK'
 
 if do_order_trace:
 	trace_list = []
@@ -346,7 +347,7 @@ if do_order_trace:
 			output_lev0_trace_csv = str_replace(input_flat_file, fits_ext, '_' + ccd + csv_ext);
 			trace_list = trace_list + [output_lev0_trace_csv]
 			if not exists(output_lev0_trace_csv):
-				order_result_data = OrderTrace(flat_data, data_extension=ccd + '_STACK',
+				order_result_data = OrderTrace(flat_data, data_extension=ccd+ccd_stack,
 					result_path=output_lev0_trace_csv, is_output_file=True,
 					data_col_range=data_col_range, data_row_range=data_row_range,
 					fitting_poly_degree=poly_degree)
@@ -375,6 +376,7 @@ if do_order_trace:
 					lev0_flat_rect = OrderRectification(None, lev0_flat_rect,
 							orderlet_names=orderlet_names[idx],
 							trace_file=trace_file, data_extension=ccd,
+							flat_extension = ccd+ccd_stack,
 							rectification_method=rect_method,
 							clip_file=clip_file,
 							origin=origin, poly_degree=poly_degree)
@@ -529,6 +531,7 @@ if do_spectral_extraction or do_hk or do_bc:
 								ccd_index = idx,
 								rectification_method=rect_method, extraction_method=extract_method,
 								clip_file=clip_file, data_extension=ccd, trace_file=trace_file,
+								flat_extension=ccd+ccd_stack,
 								do_outlier_rejection=do_outlier, outlier_file=outlier_rejection_file)
 
 


### PR DESCRIPTION
This PR includes the development to add
add argument option, flat_extension, to OrderRectification and SpectralExtractio  to indicate the 2D data extension in master flat fits for 2D flat data extraction per order trace geometric information. 