### PR TITLE
Order trace result update

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -48,7 +48,7 @@ order_trace_files = [ '/data/reference_fits/kpf_20230920_master_flat_GREEN_CCD.c
 fitting_poly_degree = 3
 ccd_idx = [0, 1]
 # number of pixels to ignore between orderlets during extraction
-orderlet_gap_pixels = 1.5
+orderlet_gap_pixels = 1
 
 # for spectral extraction:
 #    - update orders_per_ccd, start_order, orderlet_names per new order trace result

--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -47,6 +47,8 @@ order_trace_flat = /data/reference_fits/kpf_20230920_master_flat.fits
 order_trace_files = [ '/data/reference_fits/kpf_20230920_master_flat_GREEN_CCD.csv', '/data/reference_fits/kpf_20230920_master_flat_RED_CCD.csv']
 fitting_poly_degree = 3
 ccd_idx = [0, 1]
+# number of pixels to ignore between orderlets during extraction
+orderlet_gap_pixels = 1.5
 
 # for spectral extraction:
 #    - update orders_per_ccd, start_order, orderlet_names per new order trace result
@@ -98,6 +100,10 @@ reweighting_enable_masks = [['espresso'], ['espresso']]
 ccf_ext = ['GREEN_CCF', 'RED_CCF']
 rv_ext = RV
 static_ccf_ratio = ['/code/KPF-Pipeline/static/static_green_ccf_ratio_2.csv', '/code/KPF-Pipeline/static/static_red_ccf_ratio_2.csv']
+# starting and ending location for CCF calculation, >= 0, position relative to left end of the image,
+#                                                   < 0,  position relative to the right end of the image
+rv_start_x = 500
+rv_end_x = -500
 
 # for ca_hk:
 #    hk_fiber_list: [<CA-HK spectrometer fibers>]

--- a/configs/kpf_masters_l1.cfg
+++ b/configs/kpf_masters_l1.cfg
@@ -64,7 +64,7 @@ order_trace_files = [ '/data/reference_fits/kpf_20230920_master_flat_GREEN_CCD.c
 fitting_poly_degree = 3
 ccd_idx = [0, 1]
 # number of pixels to ignore between orderlets during extraction
-orderlet_gap_pixels = 1.5
+orderlet_gap_pixels = 1
 
 # for spectral extraction:
 #    - update orders_per_ccd, start_order, orderlet_names per new order trace result

--- a/configs/kpf_masters_l1.cfg
+++ b/configs/kpf_masters_l1.cfg
@@ -63,6 +63,8 @@ order_trace_flat = /data/reference_fits/kpf_20230920_master_flat.fits
 order_trace_files = [ '/data/reference_fits/kpf_20230920_master_flat_GREEN_CCD.csv', '/data/reference_fits/kpf_20230920_master_flat_RED_CCD.csv']
 fitting_poly_degree = 3
 ccd_idx = [0, 1]
+# number of pixels to ignore between orderlets during extraction
+orderlet_gap_pixels = 1.5
 
 # for spectral extraction:
 #    - update orders_per_ccd, start_order, orderlet_names per new order trace result
@@ -110,6 +112,10 @@ reweighting_enable_masks = [['espresso'], ['espresso']]
 ccf_ext = ['GREEN_CCF', 'RED_CCF']
 rv_ext = RV
 static_ccf_ratio = ['/code/KPF-Pipeline/static/static_green_ccf_ratio_2.csv', '/code/KPF-Pipeline/static/static_red_ccf_ratio_2.csv']
+# starting and ending location for CCF calculation, >= 0, position relative to left end of the image,
+#                                                   < 0,  position relative to the right end of the image
+rv_start_x = 500
+rv_end_x = -500
 
 # for ca_hk:
 #    hk_fiber_list: [<CA-HK spectrometer fibers>]

--- a/modules/order_trace/src/alg.py
+++ b/modules/order_trace/src/alg.py
@@ -3119,7 +3119,7 @@ class OrderTraceAlg(ModuleAlgBase):
         self.time_check(t_start, "*** find widths: ")
         post_coeffs, post_widths = self.convert_for_post_process(cluster_coeffs, all_widths)
 
-        post_coeffs, all_widths = self.post_process(post_coeffs, post_widths)
+        _, all_widths = self.post_process(post_coeffs, post_widths)
         self.d_print("OrderTraceAlg: write result to Pandas Dataframe", info=True)
         df = self.write_cluster_info_to_dataframe(all_widths, cluster_coeffs)
         return {'order_trace_result': df, 'cluster_index': new_index, 'cluster_x': new_x, 'cluster_y': new_y}

--- a/modules/order_trace/src/order_trace.py
+++ b/modules/order_trace/src/order_trace.py
@@ -28,6 +28,10 @@
                       if it is defined.
                     - `action.args['is_output_file'] (boolean, optional)`: if the result is output to a file or data
                       model extension. Defaults to True meaning output to a file.
+                    - `action.args['orders_ccd'] (boolean, optional)`: total orders of the ccd. Defaults to -1.
+                    - `action.args['do_post'] (boolean, optional)`: do post process only on existing order trace file.
+                    - `action.args['orderlet_pixel_gaps'] (number, options)`: orderlet gap pixels between consecutive
+                      orderlets, i.e. number of pixels to ignore between orderlets during extraction. Defaults to 2.
 
                 - `context (keckdrpframework.models.processing_context.ProcessingContext)`: `context.config_path`
                   contains the path of the config file defined for the module of order trace  in the master
@@ -50,6 +54,8 @@
                 - `alg (modules.order_trace.src.alg.OrderTraceAlg)`: Instance of `OrderTraceAlg` which has operation
                   codes for the computation of order trace.
                 - `poly_degree (int)`: Order of polynomial for order trace fitting.
+                - `do_post (bool)`: if doing post processing on existing order trace data.
+                - `orderlet_gap_pixels`: number of pixels to ignore between orderlets during extraction.
 
 
         * Method `__perform`:
@@ -120,6 +126,9 @@ class OrderTrace(KPF0_Primitive):
         self.result_path = None
         self.poly_degree = None
         self.expected_traces = None
+        self.do_post = False
+        self.orderlet_gap_pixels = 2
+        self.orders_ccd = -1
 
         if 'data_row_range' in args_keys and action.args['data_row_range'] is not None:
             self.row_range = self.find_range(action.args['data_row_range'], row)
@@ -144,6 +153,16 @@ class OrderTrace(KPF0_Primitive):
         if 'expected_traces' in args_keys and action.args['expected_traces'] is not None:
             self.expected_traces = action.args['expected_traces']
 
+        if 'orders_ccd' in args_keys and action.args['orders_ccd'] is not None:
+            self.orders_ccd = action.args['orders_ccd']
+
+        if 'do_post' in args_keys and action.args['do_post'] is not None:
+            self.do_post = action.args['do_post']
+
+        if 'orderlet_gap_pixels' in args_keys and action.args['orderlet_gap_pixels'] is not None:
+            self.orderlet_gap_pixels = action.args['orderlet_gap_pixels']
+
+
         # input configuration
         self.config = configparser.ConfigParser()
         try:
@@ -162,7 +181,8 @@ class OrderTrace(KPF0_Primitive):
 
         # Order trace algorithm setup
         self.alg = OrderTraceAlg(self.flat_data, poly_degree=self.poly_degree,
-                                 expected_traces=self.expected_traces, config=self.config, logger=self.logger)
+                                 expected_traces=self.expected_traces, config=self.config, logger=self.logger,
+                                 orders_ccd=self.orders_ccd)
 
     def _pre_condition(self) -> bool:
         """
@@ -190,6 +210,19 @@ class OrderTrace(KPF0_Primitive):
         """
         self.alg.set_data_range([self.col_range[0], self.col_range[1],
                                 self.row_range[0], self.row_range[1]])
+
+        # if order trace result file exists and do_post is True, then process the result only
+        if self.result_path and os.path.isfile(self.result_path) and os.path.exists(self.result_path) and self.do_post:
+            df = self.alg.refine_order_trace(self.result_path, self.is_output_file, orderlet_gap = self.orderlet_gap_pixels)
+            self.input.receipt_add_entry('OrderTrace', self.__module__, f'config_path={self.config_path}', 'PASS')
+            if self.logger:
+                self.logger.info("OrderTrace: refine existing order trace result "+self.result_path)
+
+            if self.logger:
+                # self.logger.info("OrderTrace: Done!")
+                self.logger.warning("OrderTrace: Refinement is done!")
+            return Arguments(df)
+
         # 1) Locate cluster
         if self.logger:
             #self.logger.info("OrderTrace: locating cluster...")
@@ -220,8 +253,16 @@ class OrderTrace(KPF0_Primitive):
             self.logger.warning("OrderTrace: finding width...")
         all_widths, cluster_coeffs = self.alg.find_all_cluster_widths(c_index, c_x, c_y, power_for_width_estimation=3)
 
+        # 7) post processing
         if self.logger:
-            #self.logger.info("OrderTrace: writing cluster into dataframe...")
+            self.logger.warning('OrderTrace: post processing...')
+
+        post_coeffs, post_widths = self.alg.convert_for_post_process(cluster_coeffs, all_widths)
+
+        _, all_widths = self.alg.post_process(post_coeffs, post_widths, orderlet_gap=self.orderlet_gap_pixels)
+
+        # 8) convert result to dataframe
+        if self.logger:
             self.logger.warning("OrderTrace: writing cluster into dataframe...")
 
         df = self.alg.write_cluster_info_to_dataframe(all_widths, cluster_coeffs)

--- a/modules/spectral_extraction/src/alg.py
+++ b/modules/spectral_extraction/src/alg.py
@@ -488,7 +488,7 @@ class SpectralExtractionAlg(ModuleAlgBase):
     def data_extraction_for_optimal_extraction(self, data_group,
                             y_mid, y_output_mid,
                             input_widths, output_widths,
-                            input_x, x_output_step, mask_height, is_debug):
+                            input_x, x_output_step, mask_height, is_debug=False):
         """
 
         Args:
@@ -522,6 +522,7 @@ class SpectralExtractionAlg(ModuleAlgBase):
 
         s_data = np.zeros((p_height, p_width), dtype=float) if s_dt is not None else None
         f_data = np.zeros((p_height, p_width), dtype=float) if f_dt is not None else None
+
         for i_x, p_x in enumerate(input_x):
             y_input = np.floor(input_widths + y_mid[i_x]).astype(int)
             y_input_idx = np.where((y_input <= (input_y_dim - 1)) & (y_input >= 0))[0]
@@ -542,8 +543,8 @@ class SpectralExtractionAlg(ModuleAlgBase):
         return s_data, f_data, is_sdata_raw
 
     def outlier_rejection_for_optimal_extraction(self, s_data, f_data, input_x, x_output_step, is_sdata_raw,
-                                                  input_widths, output_widths,  y_mid, y_output_mid,
-                                                  do_column=True, is_debug=False):
+                                                 input_widths, output_widths,  y_mid, y_output_mid,
+                                                 do_column=True, is_debug=False):
         """
 
         Args:
@@ -556,8 +557,8 @@ class SpectralExtractionAlg(ModuleAlgBase):
             output_widths  (numpy.ndarray): from lower to upper width in output domain
             y_mid (numpy.ndarray): y location of the trace in input domain
             y_output_mid (int): y location of the trace in output domain
-            do_column (bool): do outlier rejection compuatation column by column.
-            is_debug (bool): output debug message
+            do_columm (bool, optional): do outlier rejection column by column.
+            is_debug (bool, optional): output debug message
 
         Returns:
             t_mask (numpy.ndarray):  a 2D mask denoting the rejected outlier with the same size as that of s_data.
@@ -807,8 +808,8 @@ class SpectralExtractionAlg(ModuleAlgBase):
         is_debug = False
         mask_height = np.shape(out_data)[1]
 
-        #if self.order_name == 'GREEN_SKY_FLUX':
-        #    if order_idx == 4:
+        #if self.order_name == 'GREEN_SCI_FLUX2':
+        #    if order_idx == 1:
         #        is_debug = True
         s_data, f_data, is_sdata_raw = self.data_extraction_for_optimal_extraction(data_group, y_mid, y_output_mid,
                                                                      input_widths, y_output_widths,

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -211,6 +211,7 @@ lev0_flat_pattern = config.ARGUMENT.flat_file
 # use the full path of ourder trace files defind in config
 order_trace_flat = config.ARGUMENT.order_trace_flat
 output_order_trace = config.ARGUMENT.order_trace_files
+orderlet_gap_pixels = config.ARGUMENT.orderlet_gap_pixels
 
 ## for spectral extraction: input and output
 #    lev0_science_pattern: if watch mode => a single 2D file, /data/2D/<date_dir>/<a single watched 2D fits>
@@ -265,6 +266,8 @@ if 'static' in reweighting_method:
 	static_ccf_ratio = config.ARGUMENT.static_ccf_ratio
 else:
 	static_ccf_ratio = None
+rv_start_x = config.ARGUMENT.rv_start_x
+rv_end_x = config.ARGUMENT.rv_end_x
 
 ## for ca_hk input 2D  and output L1, ca_hk trace and wavelength solution tables
 #    input_hk_pattern: for watch mode =>  a single 2D file,
@@ -339,7 +342,8 @@ if do_order_trace:
 				order_result_data = OrderTrace(flat_data, data_extension=ccd+ccd_stack,
 					result_path=output_lev0_trace_csv, is_output_file=True,
 					data_col_range=data_col_range, data_row_range=data_row_range,
-					fitting_poly_degree=poly_degree)
+					fitting_poly_degree=poly_degree, orders_ccd=orders_per_ccd[idx],
+					orderlet_gap_pixels=orderlet_gap_pixels)
 
 			b_all_traces = b_all_traces and exists(output_lev0_trace_csv)
 
@@ -618,7 +622,7 @@ if do_rv or do_rv_reweighting:
 	rv_star_dir = masters_data_dir
 
 	# L1 area to be processed
-	area_def = [[0, orders_per_ccd[0]-1, 500, -500], [0, orders_per_ccd[1]-1, 500, -500]]
+	area_def = [[0, orders_per_ccd[0]-1, rv_start_x, rv_end_x], [0, orders_per_ccd[1]-1, rv_start_x, rv_end_x]]
 
 	if not lev1_list:
 		lev1_list = find_files(input_lev1_pattern)

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -320,7 +320,7 @@ trace_list = []
 b_all_traces = False
 lev0_flat_rect = None
 ccd_stack = '_STACK'
-
+do_order_trace=True
 if do_order_trace:
 	trace_list = []
 	flat_data = None
@@ -338,12 +338,12 @@ if do_order_trace:
 			# output_lev0_trace_csv = output_order_trace[idx] 
 			output_lev0_trace_csv = str_replace(input_flat_file, fits_ext, '_' + ccd + csv_ext);
 			trace_list = trace_list + [output_lev0_trace_csv]
-			if not exists(output_lev0_trace_csv):
+			if overwrite or not exists(output_lev0_trace_csv):
 				order_result_data = OrderTrace(flat_data, data_extension=ccd+ccd_stack,
 					result_path=output_lev0_trace_csv, is_output_file=True,
 					data_col_range=data_col_range, data_row_range=data_row_range,
 					fitting_poly_degree=poly_degree, orders_ccd=orders_per_ccd[idx],
-					orderlet_gap_pixels=orderlet_gap_pixels)
+					do_post=True, orderlet_gap_pixels=orderlet_gap_pixels, overwrite=overwrite)
 
 			b_all_traces = b_all_traces and exists(output_lev0_trace_csv)
 
@@ -352,7 +352,7 @@ if do_order_trace:
 
 	# generate rectification result to flat level0 to avoid repeating the same process in spectral extraction
 
-	if not exists(output_lev0_flat_rect):
+	if overwrite or not exists(output_lev0_flat_rect):
 		# do rectification on the flat data in case the order trace result files for all ccds exist.
 		# b_lev0_rect: a boolean to determine if continuing to do OrderRectification and produce output_lev0_flat_rect
 

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -320,7 +320,7 @@ trace_list = []
 b_all_traces = False
 lev0_flat_rect = None
 ccd_stack = '_STACK'
-do_order_trace=True
+
 if do_order_trace:
 	trace_list = []
 	flat_data = None


### PR DESCRIPTION
This PR includes the development to 
- based on the existing calculations,  a new post process function in the Order Trace module is introduced to refine the current results of order trace (upper and lower edges along each trace). This function works column by column to identify the valley location (i.e., the point with the minimum flux along the vertical direction) between the consecutive orderlets. Once the valley is located, the funciton will adjust the upper and lower edges of each trace (orderlet) around the valley.
- add a parameter 'orderlet_gap_pixels' in the config file.  This parameter will serve as a computation hint, indicating  the number of pixels to be excluded between orderlets during the extraction process. The post-process funciton adjusts the upper and lower edges around the valley between the consecutive orderlets (traces) based on the value set for this parameter. 
- extra parameters added to the config file, 'rv_start_x' and 'rv_end_x' to denote the starting and ending x location for CCF computation. 
