### PR TITLE
Fix Memory Leak

### DIFF
--- a/modules/Utils/overscan_subtract.py
+++ b/modules/Utils/overscan_subtract.py
@@ -517,7 +517,7 @@ class OverscanSubtraction(KPF0_Primitive):
                 frames_data = np.array(frames_data)
 
                 if self.mode == 'clippedmean':
-                    global overscan_clipped_mean
+                    # global overscan_clipped_mean
                     overscan_clipped_mean = {}
 
                 for frame in range(len(self.ffi_exts)):


### PR DESCRIPTION
- removed global definition of the `overscan_clipped_mean` variable in `overscan_subtract.py`