### PR TITLE
readthedocs pipeline info

### DIFF
--- a/docs/source/data_exploration/start.rst
+++ b/docs/source/data_exploration/start.rst
@@ -1,3 +1,5 @@
+.. _label-tutorials:
+
 Opening, Examining, and Manipulating KPF Files
 ==============================================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,3 @@
-.. KPFPipeline documentation master file, created by
-   sphinx-quickstart on Thu Jan 23 21:59:39 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 KPF Data Reduction Pipeline Documentation
 =========================================
 Welcome! This is the documentation for the KPF Data Reduction Pipeline.
@@ -11,8 +6,8 @@ Welcome! This is the documentation for the KPF Data Reduction Pipeline.
    :maxdepth: 2
 
    info/info.rst
-   intro/start.rst
    data_exploration/start.rst
+   intro/start.rst
    develop/start.rst
    api/api.rst
    primitives/primitives.rst

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -1,7 +1,14 @@
-KPF Calibrations:
-=================
+KPF Calibrations and Master Files:
+==================================
+
+Calibrations
+------------
 
 Add a list of the standard calibrations taken at WMKO on a daily basis and any on a less regular basis.  
 These should include the more obvious bias, darks, flats, LFC, etalon, and ThAr for the main spectrometer 
 as well as calibrations for the Ca H&K spectrometer, exposure meter (and anything else?)
 
+Master Files
+------------
+
+Add a list of the master files that are created from standard calibrations

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -4,11 +4,38 @@ KPF Calibrations and Master Files
 Calibrations
 ------------
 
-Add a list of the standard calibrations taken at WMKO on a daily basis and any on a less regular basis.  
-These should include the more obvious bias, darks, flats, LFC, etalon, and ThAr for the main spectrometer 
-as well as calibrations for the Ca H&K spectrometer, exposure meter (and anything else?)
+With rare exceptions, calibration spectra are taken on a daily basis with KPF to characterize the instrument.  While the set of calibrations has evolved with time, it is mostly fixed, as shown in the table below (current as of October 2023).  This set of calibrations is designed to be sufficient for regular DRP processing without 'manual' calibrations taken by KPF observers.
+
+======  ===========================  ==============  =======  ==================
+Type    Object name                  Ex. time (sec)  Num/day  Comment
+======  ===========================  ==============  =======  ==================
+Dark    autocal-dark                 1200            5          
+Bias    autocal-bias                 0               22
+Flat    autocal-flat-all             30              100
+LFC     autocal-lfc-all-morn         60              5        morning sequence
+
+        autocal-lfc-all-eve          60              5        evening sequence
+ThAr    autocal-thar-all-morn        10              9        morning sequence
+
+        autocal-thar-all-eve         10              10       evening sequence
+Etalon  autocal-etalon-all-morn      60              10       morning sequence
+
+        autocal-etalon-all-eve       60              10       evening sequence
+
+        autocal-etalon-all-night     60              varies   30x per quarter night while off-sky
+
+        slewcal                      60              varies   approx. once per hour while on-sky
+UNe     autocal-une-all-morn         5               5        not used
+
+        autocal-une-all-eve          5               5        not used 
+======  ===========================  ==============  =======  ==================
+
+
+<Add note about Ca H&K spectrometer calibrations>
+
+<Add note about exposure meter calibrations>
 
 Master Files
 ------------
 
-Add a list of the master files that are created from standard calibrations
+<Add a list of the master files that are created from standard calibrations.>

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -42,4 +42,4 @@ Master Files
 
 .. |date| date::
 
-* Last Updated on |date| *
+Last Updated on |date|

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -1,5 +1,5 @@
-KPF Calibrations and Master Files:
-==================================
+KPF Calibrations and Master Files
+=================================
 
 Calibrations
 ------------

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -42,4 +42,4 @@ Master Files
 
 .. |date| date::
 
-*Last Updated on |date|*
+Last Updated on |date|

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -46,7 +46,7 @@ Processing data from KPF's Exposure Meter (EM) is handled in real-time with a se
 ======  ===========================  ===============  =======  ==================
 Type    Object name                  Exp. time (sec)  Num/day  Comment
 ======  ===========================  ===============  =======  ==================
-TBD
+Bias    bias                         0.12             50       taken daily, then stacked, and used by ExpMeter DRP that night.
 ======  ===========================  ===============  =======  ==================
 
 

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -42,4 +42,4 @@ Master Files
 
 .. |date| date::
 
-Last Updated on |date|
+* Last Updated on |date| *

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -1,0 +1,7 @@
+KPF Calibrations:
+=================
+
+Add a list of the standard calibrations taken at WMKO on a daily basis and any on a less regular basis.  
+These should include the more obvious bias, darks, flats, LFC, etalon, and ThAr for the main spectrometer 
+as well as calibrations for the Ca H&K spectrometer, exposure meter (and anything else?)
+

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -64,6 +64,3 @@ Master Files
 
 For the main spectrometer, master files for bias, dark, flat, and the wavelength calibration sources listed above are created each day from the calibrations during the UT date.  The co-addition process involves iterative outlier rejection per pixel.  
 
-.. |date| date::
-
-Last Updated on |date|

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -41,5 +41,4 @@ Master Files
 <Add a list of the master files that are created from standard calibrations.>
 
 .. |date| date::
-
-Last Updated on |date|
+*Last Updated on |date|*

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -39,3 +39,7 @@ Master Files
 ------------
 
 <Add a list of the master files that are created from standard calibrations.>
+
+.. |date| date::
+
+Last Updated on |date|

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -41,4 +41,5 @@ Master Files
 <Add a list of the master files that are created from standard calibrations.>
 
 .. |date| date::
+
 *Last Updated on |date|*

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -4,7 +4,7 @@ KPF Calibrations and Master Files
 Calibrations
 ------------
 
-With rare exceptions, calibration spectra are taken on a daily basis with KPF to characterize the instrument.  While the set of calibrations has evolved with time, it is mostly fixed, as shown in the table below (current as of October 2023).  This set of calibrations is designed to be sufficient for regular DRP processing without 'manual' calibrations taken by KPF observers.
+With rare exceptions, calibration spectra are taken on a daily basis with KPF to characterize the instrument.  While the calibration set has evolved with time, but is now mostly fixed (the table below is current as of October 2023).  This set of calibrations is designed to be sufficient for regular DRP processing without 'manual' calibrations taken by KPF observers.
 
 ======  ===========================  ===============  =======  ==================
 Type    Object name                  Exp. time (sec)  Num/day  Comment
@@ -30,15 +30,30 @@ UNe     autocal-une-all-morn         5                5        not used
         autocal-une-all-eve          5                5        not used 
 ======  ===========================  ===============  =======  ==================
 
+The Ca H&K spectrometer shares several calibration exposures with the main spectrometer.  The full set is listed below.  
 
-<Add note about Ca H&K spectrometer calibrations>
+======  ===========================  ===============  =======  ==================
+Type    Object name                  Exp. time (sec)  Num/day  Comment
+======  ===========================  ===============  =======  ==================
+Dark    autocal-dark                 1200             5        the same exposures as for the main spectrometer (above)
+Bias    autocal-bias                 0                22       the same exposures as for the main spectrometer (above)
+ThAr    autocal-thar-hk              60               3        light detected in two bluest orders only
+======  ===========================  ===============  =======  ==================
 
-<Add note about exposure meter calibrations>
+
+Processing data from KPF's Exposure Meter (EM) is handled in real-time with a separate pipeline.  For documentation proposes, the table below lists the EM calibrations.  Note that because of coatings on optics in the Fiber Injection Unit that are specific to the light path for calibrations, most calibrations of that type do not deliver measurable flux to the Ca H&K Spectrometer.
+
+======  ===========================  ===============  =======  ==================
+Type    Object name                  Exp. time (sec)  Num/day  Comment
+======  ===========================  ===============  =======  ==================
+TBD
+======  ===========================  ===============  =======  ==================
+
 
 Master Files
 ------------
 
-<Add a list of the master files that are created from standard calibrations.>
+Master files for bias, dark, flat, and the wavelength calibration sources listed above are created each day from the calibrations during the UT date.  The co-addition process involves iterative outlier rejection per pixel.  
 
 .. |date| date::
 

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -4,6 +4,9 @@ KPF Calibrations and Master Files
 Calibrations
 ------------
 
+Main Spectrometer
+^^^^^^^^^^^^^^^^^
+
 With rare exceptions, calibration spectra are taken on a daily basis with KPF to characterize the instrument.  While the calibration set has evolved with time, but is now mostly fixed (the table below is current as of October 2023).  This set of calibrations is designed to be sufficient for regular DRP processing without 'manual' calibrations taken by KPF observers.
 
 ======  ===========================  ===============  =======  ==================
@@ -30,7 +33,11 @@ UNe     autocal-une-all-morn         5                5        not used
         autocal-une-all-eve          5                5        not used 
 ======  ===========================  ===============  =======  ==================
 
-The Ca H&K spectrometer shares several calibration exposures with the main spectrometer.  The full set is listed below.  
+
+Ca H & K Spectrometer
+^^^^^^^^^^^^^^^^^^^^^
+
+The Ca H & K spectrometer shares several calibration exposures with the main spectrometer.  The full set is listed below.  
 
 ======  ===========================  ===============  =======  ==================
 Type    Object name                  Exp. time (sec)  Num/day  Comment
@@ -40,6 +47,8 @@ Bias    autocal-bias                 0                22       the same exposure
 ThAr    autocal-thar-hk              60               3        light detected in two bluest orders only
 ======  ===========================  ===============  =======  ==================
 
+Exposure Meter
+^^^^^^^^^^^^^^
 
 Processing data from KPF's Exposure Meter (EM) is handled in real-time with a separate pipeline.  For documentation proposes, the table below lists the EM calibrations.  Note that because of coatings on optics in the Fiber Injection Unit that are specific to the light path for calibrations, most calibrations of that type do not deliver measurable flux to the Ca H&K Spectrometer.
 
@@ -53,7 +62,7 @@ Bias    bias                         0.12             50       taken daily, then
 Master Files
 ------------
 
-Master files for bias, dark, flat, and the wavelength calibration sources listed above are created each day from the calibrations during the UT date.  The co-addition process involves iterative outlier rejection per pixel.  
+For the main spectrometer, master files for bias, dark, flat, and the wavelength calibration sources listed above are created each day from the calibrations during the UT date.  The co-addition process involves iterative outlier rejection per pixel.  
 
 .. |date| date::
 

--- a/docs/source/info/calibrations.rst
+++ b/docs/source/info/calibrations.rst
@@ -6,29 +6,29 @@ Calibrations
 
 With rare exceptions, calibration spectra are taken on a daily basis with KPF to characterize the instrument.  While the set of calibrations has evolved with time, it is mostly fixed, as shown in the table below (current as of October 2023).  This set of calibrations is designed to be sufficient for regular DRP processing without 'manual' calibrations taken by KPF observers.
 
-======  ===========================  ==============  =======  ==================
-Type    Object name                  Ex. time (sec)  Num/day  Comment
-======  ===========================  ==============  =======  ==================
-Dark    autocal-dark                 1200            5          
-Bias    autocal-bias                 0               22
-Flat    autocal-flat-all             30              100
-LFC     autocal-lfc-all-morn         60              5        morning sequence
+======  ===========================  ===============  =======  ==================
+Type    Object name                  Exp. time (sec)  Num/day  Comment
+======  ===========================  ===============  =======  ==================
+Dark    autocal-dark                 1200             5          
+Bias    autocal-bias                 0                22
+Flat    autocal-flat-all             30               100
+LFC     autocal-lfc-all-morn         60               5        morning sequence
 
-        autocal-lfc-all-eve          60              5        evening sequence
-ThAr    autocal-thar-all-morn        10              9        morning sequence
+        autocal-lfc-all-eve          60               5        evening sequence
+ThAr    autocal-thar-all-morn        10               9        morning sequence
 
-        autocal-thar-all-eve         10              10       evening sequence
-Etalon  autocal-etalon-all-morn      60              10       morning sequence
+        autocal-thar-all-eve         10               10       evening sequence
+Etalon  autocal-etalon-all-morn      60               10       morning sequence
 
-        autocal-etalon-all-eve       60              10       evening sequence
+        autocal-etalon-all-eve       60               10       evening sequence
 
-        autocal-etalon-all-night     60              varies   30x per quarter night while off-sky
+        autocal-etalon-all-night     60               varies   30x per qtr. night when off-sky
 
-        slewcal                      60              varies   approx. once per hour while on-sky
-UNe     autocal-une-all-morn         5               5        not used
+        slewcal                      60               varies   ~once per hour when on-sky
+UNe     autocal-une-all-morn         5                5        not used
 
-        autocal-une-all-eve          5               5        not used 
-======  ===========================  ==============  =======  ==================
+        autocal-une-all-eve          5                5        not used 
+======  ===========================  ===============  =======  ==================
 
 
 <Add note about Ca H&K spectrometer calibrations>

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -26,4 +26,5 @@ Are KPF wavelengths in vacuum or air?
 The KPF DRP produces L1 and L2 data with vacuum wavelengths.
 
 .. |date| date::
-*Last Updated on |date|*
+
+Last Updated on |date|

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -7,7 +7,7 @@ How do I download my data?
 
 How do I cite the KPF DRP in scientific publications?
 -----------------------------------------------------
-<add answer here>
+See the `Readme file <https://github.com/Keck-DataReductionPipelines/KPF-Pipeline/blob/docs-pipeline-info/README.md>`_ for the DRP.
 
 Is there a quick-start guide to plot and interpret KPF spectra and RVs?
 -----------------------------------------------------------------------

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -1,19 +1,22 @@
 KPF Data Frequently Asked Questions (FAQ)
 =========================================
 
-How do I download my data
--------------------------
-<add answer here>
-
-Which RVs from the header should I use?
----------------------------------------
+How do I download my data?
+--------------------------
 <add answer here>
 
 Is there a quick-start guide to plot and interpret KPF spectra and RVs?
 -----------------------------------------------------------------------
 <add link to tutorials>
 
+Which RVs from the header should I use?
+---------------------------------------
+<add answer here>
+
+What is the difference between the SCI1, SCI2, and SCI3 spectra?
+----------------------------------------------------------------
+<add answer here>
+
 Are KPF wavelengths in vacuum or air?
 -------------------------------------
 The KPF DRP produces L1 and L2 data with vacuum wavelengths.
-

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -24,3 +24,7 @@ What is the difference between the SCI1, SCI2, and SCI3 spectra?
 Are KPF wavelengths in vacuum or air?
 -------------------------------------
 The KPF DRP produces L1 and L2 data with vacuum wavelengths.
+
+.. |date| date::
+
+Last Updated on |date|

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -1,0 +1,10 @@
+KPF Data Frequently Asked Questions (FAQ)
+=========================================
+
+Question 1
+----------
+Answer 1
+
+Question 2
+----------
+Answer 2

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -5,6 +5,10 @@ How do I download my data?
 --------------------------
 <add answer here>
 
+How do I cite the KPF DRP in scientific publicaitons?
+-----------------------------------------------------
+<add answer here>
+
 Is there a quick-start guide to plot and interpret KPF spectra and RVs?
 -----------------------------------------------------------------------
 <add link to tutorials>

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -3,28 +3,29 @@ KPF Data Frequently Asked Questions (FAQ)
 
 How do I download my data?
 --------------------------
-<add answer here>
+The primary portal for KPF data access is the Keck Observatory Archive, which hosts Level 0, Level 1, and Level 2 data products.  Members of the California Planet Search (CPS) can also access KPF data products on the Jump portal or on the computer called shrek.
+
 
 How do I cite the KPF DRP in scientific publications?
 -----------------------------------------------------
 See the `Readme file <https://github.com/Keck-DataReductionPipelines/KPF-Pipeline/blob/docs-pipeline-info/README.md>`_ for the DRP.
 
+
 Is there a quick-start guide to plot and interpret KPF spectra and RVs?
 -----------------------------------------------------------------------
-<add link to tutorials>
+See the section titled :ref:`label-tutorials` for tutorials on the various KPF data files.
+
 
 Which RVs from the header should I use?
 ---------------------------------------
 <add answer here>
 
+
 What is the difference between the SCI1, SCI2, and SCI3 spectra?
 ----------------------------------------------------------------
-<add answer here>
+KPF has a single object fiber called 'SCI', a fiber offset by 10 arcsec called 'SKY', and another fiber offset by 10 arcsec in the opposite direction called 'EM-SKY'.  The latter two fibers record the sky spectrum for the main spectrometer and the Exposure Meter, respectively.  The SCI fiber has a diameter of 1.14 arcsec and captures light from the target (usually a star).  Light injected into SCI is optically sliced inside KPF by a device called the Reformatter into three different 'slices' called SCI1, SCI2, and SCI3.  Images of the SCI2 slice have a nealry rectangular shape (as seen in the L0 and 2D spectra of laser frequency comb spectra).  The shapes of the SCI1 and SCI3 slices are the outer sections of an octagon.  SCI1, SCI2, and SCI3 have the same spectrum, but with slightly different line shapes and wavelength solutions (the maximum difference between SCI1 and SCI3 is ~0.2 pixel, which is about 200 m/s in Doppler units).  SCI1, SCI2, and SCI3 should be separately analyzed for precision measurements like radial velocity determination.  For stellar characterization, they can be added to form a composite spectrum.
 
 Are KPF wavelengths in vacuum or air?
 -------------------------------------
 The KPF DRP produces L1 and L2 data with vacuum wavelengths.
 
-.. |date| date::
-
-Last Updated on |date|

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -1,10 +1,19 @@
 KPF Data Frequently Asked Questions (FAQ)
 =========================================
 
-Question 1
-----------
-Answer 1
+How do I download my data
+-------------------------
+<add answer here>
 
-Question 2
-----------
-Answer 2
+Which RVs from the header should I use?
+---------------------------------------
+<add answer here>
+
+Is there a quick-start guide to plot and interpret KPF spectra and RVs?
+-----------------------------------------------------------------------
+<add link to tutorials>
+
+Are KPF wavelengths in vacuum or air?
+-------------------------------------
+The KPF DRP produces L1 and L2 data with vacuum wavelengths.
+

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -26,5 +26,4 @@ Are KPF wavelengths in vacuum or air?
 The KPF DRP produces L1 and L2 data with vacuum wavelengths.
 
 .. |date| date::
-
-Last Updated on |date|
+*Last Updated on |date|*

--- a/docs/source/info/data_faq.rst
+++ b/docs/source/info/data_faq.rst
@@ -5,7 +5,7 @@ How do I download my data?
 --------------------------
 <add answer here>
 
-How do I cite the KPF DRP in scientific publicaitons?
+How do I cite the KPF DRP in scientific publications?
 -----------------------------------------------------
 <add answer here>
 

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -13,7 +13,7 @@ KPF data products are defined for these data levels:
 
 Each of these data levels is a standardized, multi-extension FITS format, and can be read using standard fits tools (e.g., `astropy.fits.io <https://docs.astropy.org/en/stable/io/fits/>`_) and the `KPF-Pipeline <https://github.com/Keck-DataReductionPipelines/KPF-Pipeline>`_.
 
-KPF L0 files follow the naming convention: KP.YYYYMMDD.SSSSS.ss.fits, where YYYYMMDD is a date and SSSSS.ss is the number of decimal seconds after UT midnight corresponding to XXXX (when the file was read out?).  2D/L1/L2 files have similar file names, but with '_2D', '_L1', or '_L2' before '.fits'.  For example, KP.YYYYMMDD.SSSSS.ss_2D.fits is a 2D file name.
+KPF L0 files follow the naming convention: KP.YYYYMMDD.SSSSS.ss.fits, where YYYYMMDD is a date and SSSSS.ss is the number of decimal seconds after UT midnight corresponding to the start of the exposure.  2D/L1/L2 files have similar file names, but with '_2D', '_L1', or '_L2' before '.fits'.  For example, KP.YYYYMMDD.SSSSS.ss_2D.fits is a 2D file name.
 
 Level 0 Data Format
 -------------------

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -1,2 +1,37 @@
 KPF Data Format
 ===============
+
+Overview
+--------
+
+KPF data products are defined for these data levels:
+
+* **Level 0 (L0)**: Raw data products produced by KPF at the W. M. Keck Observatory
+* **2D**: Assembled CCD images with minimal processing.  This data product is produced by the DRP during processing from L0 to L1, but is not fundamental and is frequently not archived.
+* **Level 1 (L1)**: Extracted, wavelength-calibrated spectra
+* **Level 2 (L2)**: Derived data products including cross-correlation functions, radial velocities, and activity indicators
+
+Each of these data levels is a standardized, multi-extension FITS format, and can be read using standard fits tools (e.g., `astropy.fits.io <https://docs.astropy.org/en/stable/io/fits/>`_) and the `KPF-Pipeline <https://github.com/Keck-DataReductionPipelines/KPF-Pipeline>`_.
+
+KPF L0 files follow the naming convention: KP.YYYYMMDD.SSSSS.ss.fits, where YYYYMMDD is a date and SSSSS.ss is the number of decimal seconds after UT midnight corresponding to XXXX (when the file was read out?).  2D/L1/L2 files have similar file names, but with '_2D', '_L1', or '_L2' before '.fits'.  For example, KP.YYYYMMDD.SSSSS.ss_2D.fits is a 2D file name.
+
+Level 0 Data Format
+-------------------
+
+Add a table of the HDUs and their contents.  Add a list of important Level 0 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+
+'2D' Data Format
+-------------------
+
+Add a table of the HDUs and their contents.  Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+
+Level 1 Data Format
+-------------------
+
+Add a table of the HDUs and their contents.  Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+
+Level 2 Data Format
+-------------------
+
+Add a table of the HDUs and their contents.  Add a list of important Level 2 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -44,17 +44,105 @@ GUIDER_CUBE_ORIGINS  table      variable        Table of time-series guide camer
 '2D' Data Format
 -------------------
 
-Add a table of the HDUs and their contents.  Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+*Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.*
+
+2D File FITS Extensions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+RECEIPT              table      variable        Receipt of DRP processing
+CONFIG               table      variable        Configuration parameters
+GREEN_CCD            image      4080 x 4080     Assembled Green CCD image with bias/dark correction   
+RED_CCD              image      4080 x 4080     Assembled Red CCD image with bias/dark correction   
+CA_HK                image      255 x 1024      Same as in L0 file    
+EXPMETER_SCI         table      variable        Same as in L0 file 
+EXPMETER_SKY         table      variable        Same as in L0 file 
+TELEMETRY            table      variable        Same as in L0 file 
+SOLAR_IRRADIANCE     table      variable        Same as in L0 file 
+GUIDER_AVG           image      512 x 640       Same as in L0 file 
+GUIDER_CUBE_ORIGINS  table      variable        Same as in L0 file          
+===================  =========  ==============  =======
+
 
 Level 1 Data Format
 -------------------
 
-Add a table of the HDUs and their contents.  Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+*Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.*
+
+Level 1 FITS Extensions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+RECEIPT              table      variable        Receipt of DRP processing
+CONFIG               table      variable        Configuration parameters
+TELEMETRY            table      variable        Table of telemetry measurements
+GREEN_SCI_FLUX1      image      35 x 4080       1D spectra for 35 GREEN CCD orders of SCI1 orderlet
+GREEN_SCI_FLUX2      image      35 x 4080       1D spectra for 35 GREEN CCD orders of SCI2 orderlet
+GREEN_SCI_FLUX3      image      35 x 4080       1D spectra for 35 GREEN CCD orders of SCI3 orderlet
+GREEN_SKY_FLUX       image      35 x 4080       1D spectra for 35 GREEN CCD orders of SKY orderlet
+GREEN_CAL_FLUX       image      35 x 4080       1D spectra for 35 GREEN CCD orders of CAL orderlet
+GREEN_SCI_VAR1       image      35 x 4080       Variance vs. pixel for GREEN_SCI_FLUX1
+GREEN_SCI_VAR2       image      35 x 4080       Variance vs. pixel for GREEN_SCI_FLUX2
+GREEN_SCI_VAR3       image      35 x 4080       Variance vs. pixel for GREEN_SCI_FLUX3
+GREEN_SKY_VAR        image      35 x 4080       Variance vs. pixel for GREEN_SKY_FLUX
+GREEN_CAL_VAR        image      35 x 4080       Variance vs. pixel for GREEN_CAL_FLUX
+GREEN_SCI_WAV1       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX1
+GREEN_SCI_WAV2       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX2
+GREEN_SCI_WAV3       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX3
+GREEN_SKY_WAV        image      35 x 4080       Wavelength vs. pixel for GREEN_SKY_FLUX
+GREEN_CAL_WAV        image      35 x 4080       Wavelength vs. pixel for GREEN_CAL_FLUX
+GREEN_TELLURIC       table      n/a             Not used yet (will include telluric spectrum)
+GREEN_SKY            table      n/a             Not used yet (will include modeled sky spectrum)
+RED_SCI_FLUX1        image      32 x 4080       1D spectra for 32 RED CCD orders of SCI1 orderlet
+RED_SCI_FLUX2        image      32 x 4080       1D spectra for 32 RED CCD orders of SCI2 orderlet
+RED_SCI_FLUX3        image      32 x 4080       1D spectra for 32 RED CCD orders of SCI3 orderlet
+RED_SKY_FLUX         image      32 x 4080       1D spectra for 32 RED CCD orders of SKY orderlet
+RED_CAL_FLUX         image      32 x 4080       1D spectra for 32 RED CCD orders of CAL orderlet
+RED_SCI_VAR1         image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX1
+RED_SCI_VAR2         image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX2
+RED_SCI_VAR3         image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX3
+RED_SKY_VAR          image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX
+RED_CAL_VAR          image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX
+RED_SCI_WAV1         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX1
+RED_SCI_WAV2         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX2
+RED_SCI_WAV3         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX3
+RED_SKY_WAV          image      32 x 4080       Wavelength vs. pixel for RED_SKY_FLUX
+RED_CAL_WAV          image      32 x 4080       Wavelength vs. pixel for RED_CAL_FLUX
+RED_TELLURIC         table      n/a             Not used yet (will include telluric spectrum)
+RED_SKY              table      n/a             Not used yet (will include modeled sky spectrum)
+CA_HK_SCI            image      6 x 1024        1D spectra (6 orders) of SCI in Ca H&K spectrometer
+CA_HK_SKY            image      6 x 1024        1D spectra (6 orders) of SKY in Ca H&K spectrometer
+CA_HK_SCI_WAVE       image      6 x 1024        Wavelength vs. pixel for CA_HK_SCI
+CA_HK_SKY_WAVE       image      6 x 1024        Wavelength vs. pixel for CA_HK_SKY
+BARY_CORR            table      67              Table of barycentric corrections by spectral order
+===================  =========  ==============  =======
+
 
 Level 2 Data Format
 -------------------
 
-Add a table of the HDUs and their contents.  Add a list of important Level 2 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+*Add a list of important Level 2 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.  Add a link or explanation here about how to interpret the RVs by order.* 
+
+Level 2 FITS Extensions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+RECEIPT              table      variable        Receipt of DRP processing
+CONFIG               table      variable        Configuration parameters
+TELEMETRY            table      variable        Table of telemetry measurements
+GREEN_CCF            image      5 x 52 x 804    CCFs (orderlet x order x RV step) for GREEN
+RED_CCF              image      5 x 52 x 804    CCFs (orderlet x order x RV step) for RED
+GREEN_CCF            image      5 x 52 x 804    Reweighted CCFs (orderlet x order x RV step) for GREEN
+RED_CCF              image      5 x 52 x 804    Reweighted CCFs (orderlet x order x RV step) for RED
+RV                   table      67              Table of RVs by spectral order
+ACTIVITY             table      n/a             Not used yet (will include activity measurements)
+===================  =========  ==============  =======
 
 .. |date| date::
 

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -36,5 +36,4 @@ Level 2 Data Format
 Add a table of the HDUs and their contents.  Add a list of important Level 2 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
 
 .. |date| date::
-
-Last Updated on |date|
+*Last Updated on |date|*

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -35,3 +35,6 @@ Level 2 Data Format
 
 Add a table of the HDUs and their contents.  Add a list of important Level 2 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
 
+.. |date| date::
+
+Last Updated on |date|

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -18,7 +18,28 @@ KPF L0 files follow the naming convention: KP.YYYYMMDD.SSSSS.ss.fits, where YYYY
 Level 0 Data Format
 -------------------
 
-Add a table of the HDUs and their contents.  Add a list of important Level 0 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
+*Add a list of important Level 0 primary keywords.  Add a link to the tutorial showing how to open and examine L0 files.*
+
+Level 0 FITS Extensions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+GREEN_AMP1           image      4110 x 2094     CCD image from Green amplifier 1   
+GREEN_AMP2           image      4110 x 2094     CCD image from Green amplifier 2 [a]       
+RED_AMP1             image      4110 x 2094     CCD image from Red amplifier 1   
+RED_AMP2             image      4110 x 2094     CCD image from Red amplifier 2    
+CA_HK                image      255 x 1024      CCD image from Ca H&K Spectrometer    
+EXPMETER_SCI         table      variable        Table of Exposure Meter measurements for SCI channel
+EXPMETER_SKY         table      variable        Table of Exposure Meter measurements for SKY channel
+TELEMETRY            table      variable        Table of telemetry measurements
+SOLAR_IRRADIANCE     table      variable        Table of pyrheliometer measurements (for SoCal spectra)
+GUIDER_AVG           image      512 x 640       Average image from the guide camera
+GUIDER_CUBE_ORIGINS  table      variable        Table of time-series guide camera measurements            
+===================  =========  ==============  =======
+
+[a] - the example shown above is for two-amplifier mode.  When KPF is operated in fast' read mode, four amplifiers per CCD will be used and there will be a corresponding number of AMP extensions.
 
 '2D' Data Format
 -------------------

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -176,8 +176,4 @@ SCI-OBJ   Target                          Science fiber source
 AGITSTA   Running                         Agitator status
 ========  ==============================  =========
 
-*Add a list of important Level 1 and Level 2 primary keywords.*
-
-.. |date| date::
-
-Last Updated on |date|
+*To-do: add a list of important Level 1 and Level 2 primary keywords.*

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -36,4 +36,5 @@ Level 2 Data Format
 Add a table of the HDUs and their contents.  Add a list of important Level 2 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.
 
 .. |date| date::
-*Last Updated on |date|*
+
+Last Updated on |date|

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -15,10 +15,8 @@ Each of these data levels is a standardized, multi-extension FITS format, and ca
 
 KPF L0 files follow the naming convention: KP.YYYYMMDD.SSSSS.ss.fits, where YYYYMMDD is a date and SSSSS.ss is the number of decimal seconds after UT midnight corresponding to the start of the exposure.  2D/L1/L2 files have similar file names, but with '_2D', '_L1', or '_L2' before '.fits'.  For example, KP.YYYYMMDD.SSSSS.ss_2D.fits is a 2D file name.
 
-Level 0 Data Format
--------------------
-
-*Add a list of important Level 0 primary keywords.  Add a link to the tutorial showing how to open and examine L0 files.*
+Data Format of KPF Files
+------------------------
 
 Level 0 FITS Extensions
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -41,8 +39,6 @@ GUIDER_CUBE_ORIGINS  table      variable        Table of time-series guide camer
 
 [a] - the example shown above is for two-amplifier mode.  When KPF is operated in fast' read mode, four amplifiers per CCD will be used and there will be a corresponding number of AMP extensions.
 
-'2D' Data Format
--------------------
 
 *Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.*
 
@@ -65,11 +61,6 @@ GUIDER_AVG           image      512 x 640       Same as in L0 file
 GUIDER_CUBE_ORIGINS  table      variable        Same as in L0 file          
 ===================  =========  ==============  =======
 
-
-Level 1 Data Format
--------------------
-
-*Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.*
 
 Level 1 FITS Extensions
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -122,11 +113,6 @@ BARY_CORR            table      67              Table of barycentric corrections
 ===================  =========  ==============  =======
 
 
-Level 2 Data Format
--------------------
-
-*Add a list of important Level 2 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.  Add a link or explanation here about how to interpret the RVs by order.* 
-
 Level 2 FITS Extensions
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -143,6 +129,53 @@ RED_CCF              image      5 x 52 x 804    Reweighted CCFs (orderlet x orde
 RV                   table      67              Table of RVs by spectral order
 ACTIVITY             table      n/a             Not used yet (will include activity measurements)
 ===================  =========  ==============  =======
+
+Important FITS Header Keywords
+------------------------------
+
+Level 0 Primary Extension Header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Most of the important keywords are stored in the primary extension of the Level 0 file, which is written immediately after each KPF exposure.
+
+========  ==============================  =========
+Keyword   Value (example)                 Comment
+========  ==============================  =========
+DATE-BEG  2023-10-22T15:30:01.056733      Start of exposure from kpfexpose
+DATE-MID  2023-10-22T15:32:31.065         Halfway point of the exposure (unweighted)
+DATE-END  2023-10-22T15:35:01.072797      End of exposure
+EXPTIME   300.0                           Requested exposure time
+ELAPSED   300.0                           Actual exposure time
+PROGNAME  N226                            Program name from kpfexpose
+OBJECT    42813                           Object name
+TARGRA    06:12:13.80                     Right ascension [hr] from DCS
+TARGDEC   -14:38:56.0                     Declination [deg] from DCS
+TARGEPOC  2000.0                          Target epoch from DCS
+TARGEQUI  2000.0                          Target equinox from DCS
+TARGPLAX  14.7                            Target parallax [arcsec] from DCS
+TARGPMDC  0.0                             Target proper motion [arcsec/yr] in declination from DCS
+TARGPMRA  0.0                             Target proper motion [s/yr] in right ascension from DCS
+TARGRADV  81.87                           Target radial velocity [km/s]
+AIRMASS   1.26                            Airmass from DCS
+PARANTEL  23.58                           Parallactic angle of the telescope from DCS
+HA        +01:01:37.22                    Hour angle
+EL        52.46                           Elevation [deg]
+AZ        204.46                          Azimuth [deg]
+LST       07:13:51.02                     Local sidereal time
+GAIAID    DR3 2993561629444856960         GAIA Target name
+2MASSID   J06121397-1439002               2MASS Target name
+GAIAMAG   9.28                            GAIA G band magnitude
+2MASSMAG  8.06                            2MASS J band magnitude
+TARGTEFF  5398.0                          Target effective temperature (K)
+OCTAGON   EtalonFiber                     Selected octagon calibration source (not necessarily powered on)
+TRIGTARG  Green,Red,Ca_HK,ExpMeter,Guide  Cameras that were sent triggers
+IMTYPE    Object                          Image Type
+CAL-OBJ   None                            Calibration fiber source
+SKY-OBJ   Sky                             Sky fiber source
+SCI-OBJ   Target                          Science fiber source
+AGITSTA   Running                         Agitator status
+========  ==============================  =========
+
 
 .. |date| date::
 

--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -15,6 +15,8 @@ Each of these data levels is a standardized, multi-extension FITS format, and ca
 
 KPF L0 files follow the naming convention: KP.YYYYMMDD.SSSSS.ss.fits, where YYYYMMDD is a date and SSSSS.ss is the number of decimal seconds after UT midnight corresponding to the start of the exposure.  2D/L1/L2 files have similar file names, but with '_2D', '_L1', or '_L2' before '.fits'.  For example, KP.YYYYMMDD.SSSSS.ss_2D.fits is a 2D file name.
 
+See the section titled :ref:`label-tutorials` for a set of tutorials on the various KPF data files.
+
 Data Format of KPF Files
 ------------------------
 
@@ -39,8 +41,6 @@ GUIDER_CUBE_ORIGINS  table      variable        Table of time-series guide camer
 
 [a] - the example shown above is for two-amplifier mode.  When KPF is operated in fast' read mode, four amplifiers per CCD will be used and there will be a corresponding number of AMP extensions.
 
-
-*Add a list of important Level 1 primary keywords.  Add a link to the Tutorial showing how to open and examine L0 files.*
 
 2D File FITS Extensions
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -176,6 +176,7 @@ SCI-OBJ   Target                          Science fiber source
 AGITSTA   Running                         Agitator status
 ========  ==============================  =========
 
+*Add a list of important Level 1 and Level 2 primary keywords.*
 
 .. |date| date::
 

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -13,7 +13,7 @@ The description of each algorithm should include:
 
 
 Current Limitations and Development Plans
------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 <Add a list of current limitations and plans to address them>
 

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -1,2 +1,58 @@
 KPF DRP Algorithms (including development status)
 =================================================
+
+Overview
+--------
+The target audience here is astronomers who will use the data.  
+The description of each algorithm should include:
+
+* a brief description of how the algorithm works
+* performance estimates, if appropriate
+* any caveats, if needed
+* development status (if partially implemented or not yet implemented)
+
+
+CCD Image Processing
+--------------------
+
+Master Files Creation
+---------------------
+
+Include a description of how master stacks are made for bias, dark, flats, LFC, etalon, and ThAr.
+
+Scattered light correction
+--------------------------
+
+Spectral Extraction
+-------------------
+
+Sky Correction (not yet implemented)
+------------------------------------
+
+Wavelength Calibration
+----------------------
+
+Barycentric Correction
+----------------------
+
+Telluric Model (not yet implemented)
+------------------------------------
+
+Cross-Correlation based RVs
+---------------------------
+
+Include a note about RV header information
+
+Stellar Activity Information (not yet implemented)
+--------------------------------------------------
+
+Ca H&K Spectrometer Data Processing
+-----------------------------------
+
+Exposure Meter Data Processing
+------------------------------
+
+Quality Control
+---------------
+Explain how the QC framework operates and describe the current status.
+

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -15,7 +15,15 @@ The description of each algorithm should include:
 Current Limitations and Development Plans
 -----------------------------------------
 
-<TBD to add content here>
+<Add a list of current limitations and plans to address them>
+
+Include:
+
+* Doppler stability on timescales longer than 1 day
+* Consistency of wavelength solutions
+* outlier rejection in spectral extraction
+* sky subtraction
+* telluric corrections
 
 
 CCD Image Processing

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -104,3 +104,6 @@ Explain how the QC framework operates and describe the current status.
 Guider Data Processing
 ----------------------
 The DRP does not further process the data from the KPF Guider that are stored in FITS extensions in the L0 files.  These data include a guider image summed over the spectrometer integration and a table of guiding corrections, flux measurements, and other diagnostics taken from real-time Source Extractor analysis of the guider frames (typically at 100 Hz speed).
+
+.. |date| date::
+*Last Updated on |date|*

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -15,44 +15,71 @@ The description of each algorithm should include:
 CCD Image Processing
 --------------------
 
+<TBD to add content here>
+
+
 Master Files Creation
 ---------------------
+
+<TBD to add content here>
 
 Include a description of how master stacks are made for bias, dark, flats, LFC, etalon, and ThAr.
 
 Scattered light correction
 --------------------------
 
+<TBD to add content here>
+
 Spectral Extraction
 -------------------
+
+<TBD to add content here>
 
 Sky Correction (not yet implemented)
 ------------------------------------
 
+<TBD to add content here>
+
 Wavelength Calibration
 ----------------------
+
+<TBD to add content here>
 
 Barycentric Correction
 ----------------------
 
+<TBD to add content here>
+
 Telluric Model (not yet implemented)
 ------------------------------------
 
+<TBD to add content here>
+
 Cross-Correlation based RVs
 ---------------------------
+
+<TBD to add content here>
 
 Include a note about RV header information
 
 Stellar Activity Information (not yet implemented)
 --------------------------------------------------
 
+<TBD to add content here>
+
 Ca H&K Spectrometer Data Processing
 -----------------------------------
+
+<TBD to add content here>
 
 Exposure Meter Data Processing
 ------------------------------
 
+<TBD to add content here>
+
 Quality Control
 ---------------
-Explain how the QC framework operates and describe the current status.
 
+<TBD to add content here>
+
+Explain how the QC framework operates and describe the current status.

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -105,6 +105,3 @@ Guider Data Processing
 ----------------------
 The DRP does not further process the data from the KPF Guider that are stored in FITS extensions in the L0 files.  These data include a guider image summed over the spectrometer integration and a table of guiding corrections, flux measurements, and other diagnostics taken from real-time Source Extractor analysis of the guider frames (typically at 100 Hz speed).
 
-.. |date| date::
-
-Last Updated on |date|

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -106,4 +106,5 @@ Guider Data Processing
 The DRP does not further process the data from the KPF Guider that are stored in FITS extensions in the L0 files.  These data include a guider image summed over the spectrometer integration and a table of guiding corrections, flux measurements, and other diagnostics taken from real-time Source Extractor analysis of the guider frames (typically at 100 Hz speed).
 
 .. |date| date::
-*Last Updated on |date|*
+
+Last Updated on |date|

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -1,5 +1,5 @@
-KPF DRP Algorithms (including development status)
-=================================================
+KPF DRP Algorithms
+==================
 
 Overview
 --------
@@ -10,6 +10,12 @@ The description of each algorithm should include:
 * performance estimates, if appropriate
 * any caveats, if needed
 * development status (if partially implemented or not yet implemented)
+
+
+Current Limitations and Development Plans
+-----------------------------------------
+
+<TBD to add content here>
 
 
 CCD Image Processing

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -20,7 +20,8 @@ Current Limitations and Development Plans
 Include:
 
 * Doppler stability on timescales longer than 1 day
-* Consistency of wavelength solutions
+* consistency of wavelength solutions
+* scattered light correction
 * outlier rejection in spectral extraction
 * sky subtraction
 * telluric corrections

--- a/docs/source/info/drp_algorithms.rst
+++ b/docs/source/info/drp_algorithms.rst
@@ -21,10 +21,12 @@ Include:
 
 * Doppler stability on timescales longer than 1 day
 * consistency of wavelength solutions
+* intranight drift corrections for wavelength solutions
 * scattered light correction
 * outlier rejection in spectral extraction
 * sky subtraction
 * telluric corrections
+* Stellar activity indicators (see below)
 
 
 CCD Image Processing
@@ -77,10 +79,10 @@ Cross-Correlation based RVs
 
 Include a note about RV header information
 
-Stellar Activity Information (not yet implemented)
---------------------------------------------------
+Stellar Activity Information
+----------------------------
+KPF does not yet have stellar activity indicators produced as a standard data product from the DRP.  The Ca H & K spectrometer covers the Ca H & K lines and we expect the DRP to produce S-values on the Mt. Wilson scale.  Future DRP developments are also expected to include code to generate other activity indicators (Ca IR triplet, Hα, etc.)
 
-<TBD to add content here>
 
 Ca H&K Spectrometer Data Processing
 -----------------------------------
@@ -98,3 +100,7 @@ Quality Control
 <TBD to add content here>
 
 Explain how the QC framework operates and describe the current status.
+
+Guider Data Processing
+----------------------
+The DRP does not further process the data from the KPF Guider that are stored in FITS extensions in the L0 files.  These data include a guider image summed over the spectrometer integration and a table of guiding corrections, flux measurements, and other diagnostics taken from real-time Source Extractor analysis of the guider frames (typically at 100 Hz speed).

--- a/docs/source/info/drp_overview
+++ b/docs/source/info/drp_overview
@@ -1,2 +1,0 @@
-KPF DRP Overview
-================

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -49,14 +49,36 @@ Level 1 to Level 2
 * <more ?>
 
 
-Wavelength Solution Construction
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Wavelength Solution Recipes
+---------------------------
+
+ThAr
+^^^^
 
 #. Step 1
 #. Step 2
 #. Step 3
 #. ...
 
+LFC
+^^^^
+
+#. Step 1
+#. Step 2
+#. Step 3
+#. ...
+
+Etalon
+^^^^
+
+#. Step 1
+#. Step 2
+#. Step 3
+#. ...
+
+
+Master Construction Recipes
+---------------------------
 
 The DRP also creates 'master' files that are stacks of particular observations of a particular type (e.g., darks, bias, flats).  The DRP also has a set of 'quick-look' recipes to produce diagnostic plots and measurements.
 

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -8,4 +8,5 @@ Provide a high-level overview of:
 * planned algorithms and other capabilities for the DRP
 
 .. |date| date::
-*Last Updated on |date|*
+
+Last Updated on |date|

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -9,10 +9,12 @@ Main Recipe
 Level 0 to 2D
 ^^^^^^^^^^^^^
 
-* Step 1
-* Step 2
-* Step 3
-* ...
+* Subtract overscan
+* Subtract maser bias
+* Subtract scaled master dark
+* Apply master flat
+* Apply bad-pixel mask
+
 
 2D to Level 1
 ^^^^^^^^^^^^^
@@ -23,7 +25,6 @@ Level 0 to 2D
 * ...
 
 
-
 Level 1 to Level 2
 ^^^^^^^^^^^^^^^^^^
 
@@ -31,6 +32,7 @@ Level 1 to Level 2
 * Step 2
 * Step 3
 * ...
+
 
 The DRP also creates 'master' files that are stacks of particular observations of a particular type (e.g., darks, bias, flats).  The DRP also has a set of 'quick-look' recipes to produce diagnostic plots and measurements.
 

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -1,0 +1,8 @@
+KPF DRP Overview
+================
+
+Provide a high-level overview of:
+
+* how data flows through the DRP
+* how the DRP operates -- this description should basically follow the recipe and should include an enumeration of the algorithms (with status and links to pages with additional details)
+* planned algorithms and other capabilities for the DRP

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -9,29 +9,53 @@ Main Recipe
 Level 0 to 2D
 ^^^^^^^^^^^^^
 
-* Subtract overscan
-* Subtract maser bias
-* Subtract scaled master dark
-* Apply master flat
-* Apply bad-pixel mask
+#. Subtract overscan
+#. Subtract maser bias
+#. Subtract scaled master dark
+#. Apply master flat
+#. Apply bad-pixel mask
 
 
 2D to Level 1
 ^^^^^^^^^^^^^
 
-* Step 1
-* Step 2
-* Step 3
-* ...
+#. Spectral Extraction
+
+   #. <part 1>
+
+   #. <part 2>
+
+   #. <part 3>
+
+#. ... <more>
+
+#. Ca H&K Spectrometer Spectra
+
+   #. Subtract master bias
+
+   #. Subtract scaled master dark
+
+   #. Spectral Extraction
+
+   #. Apply default wavelength solution to extracted spectra
 
 
 Level 1 to Level 2
 ^^^^^^^^^^^^^^^^^^
 
-* Step 1
-* Step 2
-* Step 3
-* ...
+* Compute Cross-correlation functions (CCFs) with binary masks
+* Compute RVs per order and per orderlet from fitting CCF peaks
+* Compute reweighted RVs based on information content per order
+* <more ?>
+
+
+Wavelength Solution Construction
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+#. Step 1
+#. Step 2
+#. Step 3
+#. ...
 
 
 The DRP also creates 'master' files that are stacks of particular observations of a particular type (e.g., darks, bias, flats).  The DRP also has a set of 'quick-look' recipes to produce diagnostic plots and measurements.

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -9,11 +9,12 @@ Main Recipe
 Level 0 to 2D
 ^^^^^^^^^^^^^
 
-#. Subtract overscan
-#. Subtract maser bias
-#. Subtract scaled master dark
-#. Apply master flat
-#. Apply bad-pixel mask
+#. Remove the overscan region from each amplifier region
+#. Stitch amplifier regions into a single image (per CCD)
+#. Subtract master bias (per CCD)
+#. Subtract scaled master dark (per CCD)
+#. Apply master flat (per CCD)
+#. Apply bad-pixel mask (per CCD)
 
 
 2D to Level 1
@@ -43,10 +44,10 @@ Level 0 to 2D
 Level 1 to Level 2
 ^^^^^^^^^^^^^^^^^^
 
-* Compute Cross-correlation functions (CCFs) with binary masks
-* Compute RVs per order and per orderlet from fitting CCF peaks
-* Compute reweighted RVs based on information content per order
-* <more ?>
+#. Compute Cross-correlation functions (CCFs) with binary masks
+#. Compute RVs per order and per orderlet from fitting CCF peaks
+#. Compute reweighted RVs based on information content per order
+#. <more ?>
 
 
 Wavelength Solution Recipes

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -83,6 +83,3 @@ Master Construction Recipes
 
 The DRP also creates 'master' files that are stacks of particular observations of a particular type (e.g., darks, bias, flats).  The DRP also has a set of 'quick-look' recipes to produce diagnostic plots and measurements.
 
-.. |date| date::
-
-Last Updated on |date|

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -6,3 +6,6 @@ Provide a high-level overview of:
 * how data flows through the DRP
 * how the DRP operates -- this description should basically follow the recipe and should include an enumeration of the algorithms (with status and links to pages with additional details)
 * planned algorithms and other capabilities for the DRP
+
+.. |date| date::
+*Last Updated on |date|*

--- a/docs/source/info/drp_overview.rst
+++ b/docs/source/info/drp_overview.rst
@@ -1,11 +1,38 @@
 KPF DRP Overview
 ================
 
-Provide a high-level overview of:
+The KPF DRP processes raw KPF spectra and associated data products stored in the Level 0 (L0) files into reduced spectra (L1) and radial velocities and other final data products associated with individual observations (L2).  The KPF DRP operates within the `WMKO DRP Framework <https://github.com/Keck-DataReductionPipelines/KeckDRPFramework>`_ using recipes to specify the algorithms applied and config files to specify parameters associated with the processing.  A summary of the main recipe used to process KPF data products is below.   
 
-* how data flows through the DRP
-* how the DRP operates -- this description should basically follow the recipe and should include an enumeration of the algorithms (with status and links to pages with additional details)
-* planned algorithms and other capabilities for the DRP
+Main Recipe
+-----------
+
+Level 0 to 2D
+^^^^^^^^^^^^^
+
+* Step 1
+* Step 2
+* Step 3
+* ...
+
+2D to Level 1
+^^^^^^^^^^^^^
+
+* Step 1
+* Step 2
+* Step 3
+* ...
+
+
+
+Level 1 to Level 2
+^^^^^^^^^^^^^^^^^^
+
+* Step 1
+* Step 2
+* Step 3
+* ...
+
+The DRP also creates 'master' files that are stacks of particular observations of a particular type (e.g., darks, bias, flats).  The DRP also has a set of 'quick-look' recipes to produce diagnostic plots and measurements.
 
 .. |date| date::
 

--- a/docs/source/info/info.rst
+++ b/docs/source/info/info.rst
@@ -4,8 +4,8 @@ Overview of KPF Data and the DRP
 .. toctree::
    :maxdepth: 1
 
-   data_format.rst
    drp_overview.rst
    drp_algorithms.rst
+   data_format.rst
    calibrations.rst
    data_faq.rst

--- a/docs/source/info/info.rst
+++ b/docs/source/info/info.rst
@@ -1,6 +1,8 @@
 Overview of KPF Data and the DRP
 ================================
 
+The sections below describe the data products and data reduction pipeline (DRP) for KPF.  The intended audience is astronomers who are consumers of the data.  Detailed information about the DRP code is available in other sections of this readthedocs documentation.
+
 .. toctree::
    :maxdepth: 1
 

--- a/docs/source/info/info.rst
+++ b/docs/source/info/info.rst
@@ -1,5 +1,5 @@
-KPF Data, DRP Overview & Algorithms, Master Files, and FAQ
-==========================================================
+Overview of KPF Data and the DRP
+================================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/info/info.rst
+++ b/docs/source/info/info.rst
@@ -2,10 +2,11 @@ KPF Data, DRP Overview & Algorithms, Master Files, and FAQ
 ==========================================================
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
 
    data_format.rst
    drp_overview.rst
    drp_algorithms.rst
    master_files.rst
+   calibrations.rst
    data_faq.rst

--- a/docs/source/info/info.rst
+++ b/docs/source/info/info.rst
@@ -7,6 +7,5 @@ KPF Data, DRP Overview & Algorithms, Master Files, and FAQ
    data_format.rst
    drp_overview.rst
    drp_algorithms.rst
-   master_files.rst
    calibrations.rst
    data_faq.rst

--- a/docs/source/info/master_files.rst
+++ b/docs/source/info/master_files.rst
@@ -1,2 +1,0 @@
-KPF Master Files
-================


### PR DESCRIPTION
I added a section called Overview of KPF Data and the DRP to our readthedocs page.  The overview section and the algorithms section need some work.  I'm hoping to use the DRP management meeting tomorrow to discuss assignments for writing these (brief) sections.

One reason for merging this now is that also includes an updated .readthedocs.yml file so that readthedocs compiles again.