### PR TITLE
Implementation of flat relative optimal extraction method for spectral extraction 

### DIFF
--- a/configs/kpf_drp.cfg
+++ b/configs/kpf_drp.cfg
@@ -68,9 +68,10 @@ orderlet_names = [['GREEN_SKY_FLUX', 'GREEN_SCI_FLUX1', 'GREEN_SCI_FLUX2', 'GREE
 orderlet_widths_ccds = [[-1, -1, -1, 1, -1],[-1, -1, -1, -1, -1]]
 
 #    rectification_method: norect|vertical|normal, method to rectify the trace.
-#    extraction_method:    summ|optimal, method to do spectral extraction.
+#    extraction_method:    summ|optimal|fox, method to do spectral extraction.
 rectification_method = norect
 extraction_method = optimal
+#extraction_method = fox
 
 #   - fits with wavelength calibration data
 #	  wls_fits: [ <wavelength solution file for each ccd>].

--- a/modules/spectral_extraction/src/spectral_extraction.py
+++ b/modules/spectral_extraction/src/spectral_extraction.py
@@ -55,7 +55,8 @@
                       data. Defaults to False.
                     - `action.args['outlier_file']: (str, optional)`: L0 file with outlier rejection results. Defaults
                       to None.
-
+                    - `action.args['spec_no_bk']: (str, optional)`: L0 file before background subtraction. Defaults
+                      to None.
 
                 - `context (keckdrpframework.models.processing_context.ProcessingContext)`: `context.config_path`
                   contains the path of the config file defined for the module of spectral extraction in the master
@@ -144,6 +145,7 @@ class SpectralExtraction(KPF0_Primitive):
                     'clip_file': None,
                     'data_extension': 'DATA',
                     'flat_extension': 'DATA',
+                    'var_extension': 'VAR',
                     'poly_degree': 3,
                     'origin': [0, 0],
                     'trace_extension': None,
@@ -153,7 +155,8 @@ class SpectralExtraction(KPF0_Primitive):
                     'total_order_per_ccd': None,
                     'orderlets_on_image': None,
                     'do_outlier_rejection': False,
-                    'outlier_file': ''
+                    'outlier_file': '',
+                    'spec_no_bk': None
                 }
 
     NORMAL = 0
@@ -186,6 +189,7 @@ class SpectralExtraction(KPF0_Primitive):
         self.total_order_per_ccd = self.get_args_value('total_order_per_ccd', action.args, args_keys)
 
         data_ext = self.get_args_value('data_extension', action.args, args_keys)
+        var_ext = self.get_args_value('var_extension', action.args, args_keys)
         flat_ext = self.get_args_value('flat_extension', action.args, args_keys)
         self.data_ext = data_ext
         order_trace_ext = self.get_args_value('trace_extension', action.args, args_keys)
@@ -194,7 +198,7 @@ class SpectralExtraction(KPF0_Primitive):
         self.outlier_rejection = self.get_args_value('do_outlier_rejection', action.args, args_keys)
         self.outlier_file = self.get_args_value("outlier_file", action.args, args_keys) if self.outlier_rejection \
             else ''
-
+        spec_no_bk = self.get_args_value('spec_no_bk', action.args, args_keys)
         # input configuration
         self.config = configparser.ConfigParser()
         try:
@@ -239,6 +243,11 @@ class SpectralExtraction(KPF0_Primitive):
         outlier_flux = self.outlier_lev0[self.data_ext] \
             if self.outlier_lev0 is not None and hasattr(self.outlier_lev0, data_ext) else None
 
+        if spec_no_bk is not None and hasattr(spec_no_bk, var_ext):
+            var_data = spec_no_bk[var_ext]
+        else:
+            var_data = None
+
         try:
             self.alg = SpectralExtractionAlg(self.input_flat[flat_ext] if hasattr(self.input_flat, flat_ext) else None,
                                         self.input_flat.header[flat_ext] if hasattr(self.input_flat, flat_ext) else None,
@@ -254,7 +263,8 @@ class SpectralExtraction(KPF0_Primitive):
                                         total_order_per_ccd=self.total_order_per_ccd,
                                         clip_file=self.clip_file,
                                         do_outlier_rejection = self.outlier_rejection,
-                                        outlier_flux=outlier_flux)
+                                        outlier_flux=outlier_flux,
+                                        var_data=var_data)
         except Exception as e:
             self.alg = None
 
@@ -539,6 +549,8 @@ class SpectralExtraction(KPF0_Primitive):
             if v is not None and isinstance(v, str):
                 if 'summ' in v.lower():
                     method = SpectralExtractionAlg.SUM
+                elif 'fox' in v.lower():
+                    method = SpectralExtractionAlg.FOX
                 else:
                     method = SpectralExtractionAlg.OPTIMAL
             else:

--- a/modules/spectral_extraction/src/spectral_extraction.py
+++ b/modules/spectral_extraction/src/spectral_extraction.py
@@ -243,7 +243,7 @@ class SpectralExtraction(KPF0_Primitive):
         outlier_flux = self.outlier_lev0[self.data_ext] \
             if self.outlier_lev0 is not None and hasattr(self.outlier_lev0, data_ext) else None
 
-        if spec_no_bk is not None and hasattr(spec_no_bk, var_ext):
+        if spec_no_bk is not None and hasattr(spec_no_bk, var_ext) and spec_no_bk[var_ext].size > 0:
             var_data = spec_no_bk[var_ext]
         else:
             var_data = None

--- a/recipes/kpf_drp.recipe
+++ b/recipes/kpf_drp.recipe
@@ -160,7 +160,6 @@ wave_fits = []
 for wls in wls_list:
 	wave_fits = wave_fits + [output_dir + wls]
 
-
 ## do L0->2D conversion for watch mode
 if do_l0_to_2d:
     invoke_subrecipe("./recipes/watchfor_kpf_l0.recipe")
@@ -419,6 +418,7 @@ if do_order_trace:
 
 lev1_list = []
 outlier_mask_path = config.ARGUMENT.outlier_mask_path
+
 if do_spectral_extraction or do_hk or do_bc:
 	lev0_flat_rect = None
 	trace_list = []
@@ -458,6 +458,9 @@ if do_spectral_extraction or do_hk or do_bc:
 	for input_lev0_file in lev0_files:
 		# lev0_data is KPF0 instance for input_lev0_file
 		lev0_data = kpf0_from_fits(input_lev0_file, data_type=data_type)
+		# this used to denote the level 0 data before background subtraction
+		lev0_data_no_bk = kpf0_from_fits(input_lev0_file, data_type=data_type)
+
 		_, short_lev0_file = split(input_lev0_file)
 		lev1_stem, lev1_ext = splitext(short_lev0_file)
 
@@ -500,7 +503,8 @@ if do_spectral_extraction or do_hk or do_bc:
 					# update L0 by background subtraction
 					if order_mask != None:
 						lev0_data = ImageProcessing(lev0_data, order_mask, ccd_list, data_type, None)
-
+						#output_lev0_bk = input_2d_dir + '/bk/' + lev1_stem + fits_ext
+						#to_fits(lev0_data, output_lev0_bk)
 				op_data = None
 				if outlier_mask_path == None:
 					outlier_mask_file = ''
@@ -511,7 +515,7 @@ if do_spectral_extraction or do_hk or do_bc:
 					ccd = ccd_list[idx]
 					order_names = orderlet_names[idx]
 					trace_file = trace_list[idx]
-
+					var_ccd = str_replace(ccd, '_CCD', '_VAR')
 					clip_file = None
 
 					op_data = SpectralExtraction(lev0_data, lev0_flat_rect, op_data,
@@ -523,7 +527,9 @@ if do_spectral_extraction or do_hk or do_bc:
 								rectification_method=rect_method, extraction_method=extract_method,
 								clip_file=clip_file, data_extension=ccd, trace_file=trace_file,
 								flat_extension=ccd+ccd_stack,
-								do_outlier_rejection=do_outlier, outlier_file=outlier_mask_file)
+								do_outlier_rejection=do_outlier, outlier_file=outlier_mask_file,
+								var_extension=var_ccd,
+								spec_no_bk = lev0_data_no_bk)
 
 				if op_data != None:
 				


### PR DESCRIPTION
This PR has the implementation of flat relative optimal extraction method.
- the implementation is included in modules/spectral_extraction/src/alg.py (flat_relative_optimal_extraction) and spectral_extraction (for the primitive by setting extraction_method to be 'fox' in the recipe)
- the implementation is mainly based on "Flat-relative optimal extraction A quick and efficient algorithm for stabilised spectrographs" by M. Zechmeister etc. 
