### PR TITLE
Simplify Linelist Format

### DIFF
--- a/configs/wls_auto.cfg
+++ b/configs/wls_auto.cfg
@@ -27,13 +27,13 @@ quicklook = 0
 f0_key = 'LFCCEOFR'
 frep_key = 'LFCFRREF'
 
-red_linelist = /data/reference_fits/kpfMaster_ThArLines20221005_red.npy
+thar_linelist = static/stellarmasks/Thorium_mask_031921.mas
+
 red_cal_orderlet_name = ['RED_CAL_FLUX', 'RED_SCI_FLUX1','RED_SCI_FLUX2','RED_SCI_FLUX3', 'RED_SKY_FLUX']
 red_output_ext = ['RED_CAL_WAVE', 'RED_SCI_WAVE1','RED_SCI_WAVE2','RED_SCI_WAVE3', 'RED_SKY_WAVE']
 red_min_order = 0
 red_max_order = 31
 
-green_linelist = /data/reference_fits/kpfMaster_ThArLines20230221_green.npy
 green_cal_orderlet_name = ['GREEN_CAL_FLUX', 'GREEN_SCI_FLUX1','GREEN_SCI_FLUX2','GREEN_SCI_FLUX3', 'GREEN_SKY_FLUX']
 green_output_ext = ['GREEN_CAL_WAVE', 'GREEN_SCI_WAVE1','GREEN_SCI_WAVE2','GREEN_SCI_WAVE3', 'GREEN_SKY_WAVE']
 green_min_order = 0

--- a/modules/wavelength_cal/src/alg.py
+++ b/modules/wavelength_cal/src/alg.py
@@ -383,11 +383,14 @@ class WaveCalibration:
                     good_peak_idx = np.arange(len(detected_peak_pixels))
 
                 if self.cal_type == 'LFC':
-                    wls, _, good_peak_idx = self.mode_match(
-                        order_flux, fitted_peak_pixels, good_peak_idx, 
-                        rough_wls_order, comb_lines_angstrom, 
-                        print_update=print_update, plot_path=order_plt_path
-                    )
+                    try:
+                        wls, _, good_peak_idx = self.mode_match(
+                            order_flux, fitted_peak_pixels, good_peak_idx, 
+                            rough_wls_order, comb_lines_angstrom, 
+                            print_update=print_update, plot_path=order_plt_path
+                        )
+                    except:
+                        import pdb; pdb.set_trace()
                 elif self.cal_type == 'Etalon':
 
                     assert comb_lines_angstrom is None, '`comb_lines_angstrom` \
@@ -418,11 +421,19 @@ class WaveCalibration:
                 else:
                     plot_toggle = False
 
-                line_wavelengths = expected_peak_locs[order_num]['known_wavelengths_vac']
-                line_pixels_expected = expected_peak_locs[order_num]['line_positions']
+                min_order_wave = np.min(rough_wls_order)
+                max_order_wave = np.max(rough_wls_order)
+                line_wavelengths = expected_peak_locs.query(f'{min_order_wave} < wave < {max_order_wave}')['wave'].values
+                
+                pixels_order = np.arange(0, len(rough_wls_order))
+                wave_to_pix = interp1d(rough_wls_order, pixels_order,
+                                       assume_sorted=False)
+                line_pixels_expected = wave_to_pix(line_wavelengths)
 
                 sorted_indices = np.argsort(line_pixels_expected)
                 line_wavelengths = line_wavelengths[sorted_indices]
+
+
                 line_pixels_expected = line_pixels_expected[sorted_indices]
 
                 line_wavelengths = np.array([

--- a/modules/wavelength_cal/src/wavelength_cal.py
+++ b/modules/wavelength_cal/src/wavelength_cal.py
@@ -175,6 +175,7 @@ class WaveCalibrate(KPF1_Primitive):
                                                            header=None,
                                                            names=['wave', 'weight'],
                                                            delim_whitespace=True)
+                        peak_wavelengths_ang = peak_wavelengths_ang.query('weight == 1')
                     else:
                         raise ValueError('ThAr run requires linelist_path')
 

--- a/modules/wavelength_cal/src/wavelength_cal.py
+++ b/modules/wavelength_cal/src/wavelength_cal.py
@@ -1,6 +1,7 @@
 # standard dependencies
 import configparser
 import numpy as np
+import pandas as pd
 import os
 from astropy import constants as cst, units as u
 import datetime
@@ -170,7 +171,10 @@ class WaveCalibrate(KPF1_Primitive):
                         # raise ValueError('Not a ThAr file!')
                     
                     if self.linelist_path is not None:
-                        peak_wavelengths_ang = np.load(self.linelist_path, allow_pickle=True).tolist()
+                        peak_wavelengths_ang = pd.read_csv(self.linelist_path,
+                                                           header=None,
+                                                           names=['wave', 'weight'],
+                                                           delim_whitespace=True)
                     else:
                         raise ValueError('ThAr run requires linelist_path')
 

--- a/modules/wavelength_cal/src/wavelength_cal.py
+++ b/modules/wavelength_cal/src/wavelength_cal.py
@@ -306,6 +306,8 @@ class WaveCalibrate(KPF1_Primitive):
             file_name = wlpixelwavedir + self.cal_type + 'lines_' + \
                 self.file_name + "_" + '{}.npy'.format(output_ext)
             self.alg.save_wl_pixel_info(file_name,wls_and_pixels)
+        else:
+            file_name = None
             
         if output_ext != None:
             self.l1_obj[output_ext] = wl_soln

--- a/recipes/wls_auto.recipe
+++ b/recipes/wls_auto.recipe
@@ -5,6 +5,7 @@ masters_dir = config.ARGUMENT.masters_dir
 output_dir = config.ARGUMENT.output_dir + '/'
 master_wls_file = config.ARGUMENT.master_wls_file
 save_diagnostics_dir = config.ARGUMENT.diagnostic_dir
+linelist = config.ARGUMENT.thar_linelist
 quicklook = config.ARGUMENT.quicklook
 f0 = config.ARGUMENT.f0_key
 fr = config.ARGUMENT.frep_key
@@ -42,7 +43,6 @@ for cal_type in ['ThAr', 'LFC', 'Etalon']:
                 master_wls = full_master_wls[ext]
 
                 if ext == 'RED_CAL_WAVE':
-                    linelist = config.ARGUMENT.red_linelist
                     output_exts = config.ARGUMENT.red_output_ext
                     orderlet_names = config.ARGUMENT.red_cal_orderlet_name
                     min_order = config.ARGUMENT.red_min_order
@@ -53,7 +53,6 @@ for cal_type in ['ThAr', 'LFC', 'Etalon']:
                         output_exts = ['RED_SCI_WAVE2']
                     
                 if ext == 'GREEN_CAL_WAVE':
-                    linelist = config.ARGUMENT.green_linelist
                     output_exts = config.ARGUMENT.green_output_ext
                     orderlet_names = config.ARGUMENT.green_cal_orderlet_name
                     min_order = config.ARGUMENT.green_min_order
@@ -69,8 +68,9 @@ for cal_type in ['ThAr', 'LFC', 'Etalon']:
                 else:
                     plot_dir = None
 
+                save_wlpixelfiles = False
                 l1_obj = WaveCalibrate(
-                    l1_obj, cal_type, orderlet_names, True, quicklook, min_order, max_order,
+                    l1_obj, cal_type, orderlet_names, save_wlpixelfiles, quicklook, min_order, max_order,
                     'KPF', output_exts,
                     rough_wls = master_wls, 
                     f0_key=f0, frep_key=fr,


### PR DESCRIPTION
- now using `static/stellarmasks/Thorium_mask_031921.mas` as the ThAr line list in that format
- turn off saving wlpixelfiles since Andrew's json files contain all of that information and much more

If this is a good line list to use (especially if we want the line list to be the same as our CCF mask) then we can stick with this format: 2 columns, wavelength, and weight. Only lines with weight == 1 are included in the fits. Let me know if you want a different format.