### PR TITLE
Set up Classes for Wavelength Interpolation

### DIFF
--- a/docs/source/info/data_format.rst
+++ b/docs/source/info/data_format.rst
@@ -83,11 +83,11 @@ GREEN_SCI_VAR2       image      35 x 4080       Variance vs. pixel for GREEN_SCI
 GREEN_SCI_VAR3       image      35 x 4080       Variance vs. pixel for GREEN_SCI_FLUX3
 GREEN_SKY_VAR        image      35 x 4080       Variance vs. pixel for GREEN_SKY_FLUX
 GREEN_CAL_VAR        image      35 x 4080       Variance vs. pixel for GREEN_CAL_FLUX
-GREEN_SCI_WAV1       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX1
-GREEN_SCI_WAV2       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX2
-GREEN_SCI_WAV3       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX3
-GREEN_SKY_WAV        image      35 x 4080       Wavelength vs. pixel for GREEN_SKY_FLUX
-GREEN_CAL_WAV        image      35 x 4080       Wavelength vs. pixel for GREEN_CAL_FLUX
+GREEN_SCI_WAVE1       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX1
+GREEN_SCI_WAVE2       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX2
+GREEN_SCI_WAVE3       image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX3
+GREEN_SKY_WAVE        image      35 x 4080       Wavelength vs. pixel for GREEN_SKY_FLUX
+GREEN_CAL_WAVE        image      35 x 4080       Wavelength vs. pixel for GREEN_CAL_FLUX
 GREEN_TELLURIC       table      n/a             Not used yet (will include telluric spectrum)
 GREEN_SKY            table      n/a             Not used yet (will include modeled sky spectrum)
 RED_SCI_FLUX1        image      32 x 4080       1D spectra for 32 RED CCD orders of SCI1 orderlet
@@ -100,11 +100,11 @@ RED_SCI_VAR2         image      32 x 4080       Variance vs. pixel for RED_SCI_F
 RED_SCI_VAR3         image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX3
 RED_SKY_VAR          image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX
 RED_CAL_VAR          image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX
-RED_SCI_WAV1         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX1
-RED_SCI_WAV2         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX2
-RED_SCI_WAV3         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX3
-RED_SKY_WAV          image      32 x 4080       Wavelength vs. pixel for RED_SKY_FLUX
-RED_CAL_WAV          image      32 x 4080       Wavelength vs. pixel for RED_CAL_FLUX
+RED_SCI_WAVE1         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX1
+RED_SCI_WAVE2         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX2
+RED_SCI_WAVE3         image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX3
+RED_SKY_WAVE          image      32 x 4080       Wavelength vs. pixel for RED_SKY_FLUX
+RED_CAL_WAVE          image      32 x 4080       Wavelength vs. pixel for RED_CAL_FLUX
 RED_TELLURIC         table      n/a             Not used yet (will include telluric spectrum)
 RED_SKY              table      n/a             Not used yet (will include modeled sky spectrum)
 CA_HK_SCI            image      6 x 1024        1D spectra (6 orders) of SCI in Ca H&K spectrometer

--- a/modules/wavelength_cal/src/alg.py
+++ b/modules/wavelength_cal/src/alg.py
@@ -1846,3 +1846,48 @@ def plot_drift(wlpixelfile1,wlpixelfile2, figsave_name):
     plt.ylabel('Drift [cm s$^{-1}$]')
     plt.savefig(figsave_name, dpi=250)
     plt.close()
+
+class WaveInterpolate:
+    """
+    This module defines 'WaveInterpolation' and methods to perform the 
+    wavelength interpolation.
+    
+    Wavelength interpolation computation. Algorithm is called under _perform() 
+    in wavelength_cal.py. Algorithm itself iterates over orders.
+    """
+    
+    def __init__(
+        self, l1_timestamp, wls_timestamps, wls1_arrays, wls2_arrays, config=None, logger=None
+    ):
+        """Initializes WaveCalibration class.
+        Args:
+            l1_timestamp (float): Datetime of the input L1 file. WLS will be interpolated to this point in time         
+            wls_timestamps (list): List of timestamps for each of the input WLS arrays
+            wls1_arrays (dict): Dictionary of the input WLS arrays for the first WLS. Keys should match the extension names in the L1 obj
+            wls2_arrays (dict): Dictionary of the input WLS arrays for the second WLS. Keys should match the extension names in the L1 obj
+            config (configparser.ConfigParser, optional): Config context. 
+                Defaults to None.
+            logger (logging.Logger, optional): Instance of logging.Logger. 
+                Defaults to None.        
+
+        """
+        self.l1_timestamp = l1_timestamp
+        self.wls_timestamps = wls_timestamps
+        self.wls1_arrays = wls1_arrays
+        self.wls2_arrays = wls2_arrays
+        self.config = config
+        self.logger = logger
+
+    def wave_interpolation(self):
+        msg = "Performing wavelength interpolation."
+        if self.logger:
+            self.logger.info(msg)
+        else:
+            print(msg)
+
+        # dummy to return WLS arrays from first WLS at the moment
+        new_wls_arrays = {}
+        for ext, arr in self.wls1_arrays.items():
+            new_wls_arrays[ext] = arr
+
+        return new_wls_arrays

--- a/modules/wavelength_cal/src/alg.py
+++ b/modules/wavelength_cal/src/alg.py
@@ -1847,7 +1847,7 @@ def plot_drift(wlpixelfile1,wlpixelfile2, figsave_name):
     plt.savefig(figsave_name, dpi=250)
     plt.close()
 
-class WaveInterpolate:
+class WaveInterpolation:
     """
     This module defines 'WaveInterpolation' and methods to perform the 
     wavelength interpolation.

--- a/modules/wavelength_cal/src/wavelength_cal.py
+++ b/modules/wavelength_cal/src/wavelength_cal.py
@@ -10,6 +10,7 @@ from modules.quicklook.src.analyze_wls import write_wls_json
 # pipeline dependencies
 from kpfpipe.primitives.level1 import KPF1_Primitive
 from kpfpipe.logger import start_logger
+from kpfpipe.models.level1 import KPF1
 
 # external dependencies
 from keckdrpframework.models.action import Action
@@ -17,7 +18,7 @@ from keckdrpframework.models.arguments import Arguments
 from keckdrpframework.models.processing_context import ProcessingContext
 
 # local dependencies
-from modules.wavelength_cal.src.alg import WaveCalibration, calcdrift_polysolution
+from modules.wavelength_cal.src.alg import WaveCalibration, WaveInterpolation, calcdrift_polysolution
 
 # global read-only variables
 DEFAULT_CFG_PATH = 'modules/wavelength_cal/configs/default.cfg'
@@ -334,4 +335,77 @@ class WaveCalibrate(KPF1_Primitive):
 
         self.l1_obj[output_ext] = wl_soln
 
+
+class WaveInterpolate(KPF1_Primitive):
+    """
+    This module defines class `WaveInterpolate,` which inherits from `KPF1_Primitive` and provides methods 
+    to interpolate a wavelength solution between two bracketing calibrations in the recipe.
     
+    Args:
+        KPF1_Primitive: Parent class
+        action (keckdrpframework.models.action.Action): Contains positional arguments and keyword arguments passed by the `WaveInterpolate` event issued in recipe.
+        context (keckdrpframework.models.processing_context.ProcessingContext): Contains path of config file defined for `wavelength_cal` module in master config file associated with recipe.
+    
+    Attributes:
+        l1_obj (kpfpipe.models.level1.KPF1): Instance of `KPF1`. Interpolated WLS will be injected into this object  assigned by `actions.args[0]`
+        wls1_filename (string): Input WLS prior to the observation, assigned by `actions.args[1]`
+        wls2_filename (string): Input WLS after the observation, assigned by `actions.args[2]`
+        wls_extensions (list): List of the WLS extensions, assigned by `actions.args[3]`
+        config (configparser.ConfigParser): Config context.
+        logger (logging.Logger): Instance of logging.Logger
+        alg (modules.wavelength_cal.src.alg.WaveInterpolate): Instance of `WaveInterpolate,` which has operation codes for wavelength interpolation.
+    """
+    def __init__(self, action:Action, context:ProcessingContext) -> None:
+        """
+        WaveInterpolate constructor.
+        """ 
+        KPF1_Primitive.__init__(self, action, context)
+        
+        self.l1_obj = self.action.args[0]
+        self.wls1_filename = self.action.args[1]
+        self.wls2_filename = self.action.args[2]
+        self.wls_extensions = self.action.args[3]
+        self.config=configparser.ConfigParser()
+
+        try:
+            config_path=context.config_path['wavelength_interpolate']
+        except:
+            config_path = DEFAULT_CFG_PATH
+        self.config.read(config_path)
+
+        #Start logger
+        self.logger=start_logger(self.__class__.__name__,config_path)
+        if not self.logger:
+            self.logger=self.context.logger
+        self.logger.info('Loading config from: {}'.format(config_path))
+
+        l1_timestamp = self.l1_obj.header['PRIMARY']['DATE-BEG']
+        wls1_l1 = KPF1.from_fits(self.wls1_filename)
+        wls1_timestamp = wls1_l1.header['PRIMARY']['DATE-BEG']
+        wls2_l1 = KPF1.from_fits(self.wls2_filename)
+        wls2_timestamp = wls2_l1.header['PRIMARY']['DATE-BEG']
+        wls_timestamps = [wls1_timestamp, wls2_timestamp]
+
+        wls1_arrays = {}
+        wls2_arrays = {}
+        for ext in self.wls_extensions:
+            wls1_arrays[ext] = wls1_l1[ext]
+            wls2_arrays[ext] = wls2_l1[ext]
+
+        self.alg = WaveInterpolation(l1_timestamp, wls_timestamps, wls1_arrays, wls2_arrays)
+
+    def _perform(self) -> None: 
+        """
+        Primitive action - perform wavelength interpolation by calling method `wavelength_interpolate` from WaveInterpolate.
+        This method will update the input L1 object with the interpolated wavelength solition
+        
+        Returns:
+            Level 1 Data Object
+        """
+
+        new_wls_arrays = self.alg
+        for ext, wls in new_wls_arrays.items():
+            self.l1_obj[ext] = new_wls_arrays[ext]
+                            
+        return Arguments(self.l1_obj)
+            


### PR DESCRIPTION
- Added `modules.wavelength_cal.src.wavelength_cal.WaveInterpolate` primitive to be called from a recipe
- Added `modules.wavelength_cal.src.alg.WaveInterpolation` class to perform the wavelength interpolation. This is a dummy class for now. Code to perform the wavelength interpolation should go into the wave_interpolation method.
- Fixed bug in data format docs