### PR TITLE
Add --only_recent option to launch_QLP.sh

### DIFF
--- a/recipes/quicklook_watch_only_recent.recipe
+++ b/recipes/quicklook_watch_only_recent.recipe
@@ -1,0 +1,46 @@
+# This recipe on quicklook_watch.recipe, which 
+# is used to watch a [L0/2D/L1/L2/masters] directory for modified 
+# files and then to run the appropriate section of the QLP 
+# (L0/2D/L1/L2/masters) to generate standard data products.  It must be run 
+# in watch mode.  Separate instances should to be run for L0, 2D, L1, L2, 
+# and masters data directories.  In this version of the recipe, only 
+# files from recent observations (within the past day) are processed 
+# to compute QLP data products.  The observation date is determined by the 
+# date encoded into the filename.
+#
+# Examples:
+#    > kpf --ncpus=2 --watch /data/ -c configs/quicklook_watch.cfg -r recipes/quicklook_watch_only_recent.recipe
+#    > kpf --ncpus=2 --watch /data/L1/20240118/ -c configs/quicklook_watch.cfg -r recipes/quicklook_watch_only_recent.recipe
+
+from modules.Utils.string_proc import level_from_kpffile
+from modules.Utils.string_proc import date_from_kpffile
+from modules.Utils.string_proc import date_from_path
+from modules.Utils.string_proc import days_since_observation
+from modules.quicklook.src.quick_prim import Quicklook
+
+
+file_path = context.file_path # from context in watch mode, e.g.  
+                              # /data/2D/20230711/KP.20230711.00415.52_2D.fits
+datecode = date_from_path(file_path)
+days_since = days_since_observation(file_path)
+
+if days_since < 1 and days_since != 0:
+    abc = 'abc'
+
+if days_since < 1 and days_since != 0:
+    if 'masters' in file_path: # Masters
+        output_dir= '/data/QLP/' + datecode + '/Masters/'
+        Quicklook(file_path, output_dir, 'master')
+    else: # L0/2D/L1/L2
+        level = level_from_kpffile(file_path)  # 'L0', '2D', 'L1', 'L2', None
+        output_dir= '/data/QLP/' + datecode + '/'
+        if level != None:
+            if level == 'L0':
+                open_file = kpf0_from_fits(file_path, data_type='KPF')
+            if level == '2D':
+                open_file = kpf0_from_fits(file_path, data_type='KPF')
+            if level == 'L1':
+                open_file = kpf1_from_fits(file_path, data_type='KPF')
+            if level == 'L2':
+                open_file = kpf2_from_fits(file_path, data_type='KPF')
+            Quicklook(open_file, output_dir, level)

--- a/scripts/launch_QLP.sh
+++ b/scripts/launch_QLP.sh
@@ -29,6 +29,7 @@ done
 
 for lvl in "${data_levels[@]}"; do
     ncpus=15
-    cmd="kpf --ncpus=${ncpus} --watch ${KPFPIPE_DATA}/${lvl}/ -r ${recipe_file} -c {config_file}"
+    cmd="kpf --ncpus=${ncpus} --watch ${KPFPIPE_DATA}/${lvl}/ -r ${recipe_file} -c ${config_file}"
+    echo $cmd
     eval $cmd &
 done

--- a/scripts/launch_QLP.sh
+++ b/scripts/launch_QLP.sh
@@ -1,12 +1,34 @@
 #!/bin/bash
 
-# This script is designed to launch the 5 QLP instances with a single command
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo
+    echo "This script launches 15 QLP instances for L0/2D/L1/L2/masters"
+    echo
+    echo "Options:"
+    echo "  --only_recent  Only process QLP for observations in the day."
+    echo "  -h, --help     Display this help message and exit."
+    echo
+}
 
+recipe_file="recipes/quicklook_watch.recipe"
+config_file="configs/quicklook_watch.cfg"
 data_levels=("L0" "2D" "L1" "L2" "masters")
 
+for arg in "$@"; do
+    case "$arg" in
+        --only_recent)
+            recipe_file="recipes/quicklook_watch_only_recent.recipe"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+    esac
+done
+
 for lvl in "${data_levels[@]}"; do
-    ncpus=10
-    cmd="kpf --ncpus=${ncpus} --watch ${KPFPIPE_DATA}/${lvl}/ -r recipes/quicklook_watch.recipe -c configs/quicklook_watch.cfg"
-    fi
+    ncpus=15
+    cmd="kpf --ncpus=${ncpus} --watch ${KPFPIPE_DATA}/${lvl}/ -r ${recipe_file} -c {config_file}"
     eval $cmd &
 done


### PR DESCRIPTION
When the command line option `--only_recent` is invoked for launch_QLP.sh, QLP plots are only generated for observations from the past day.

This is helpful during reprocessing so that QLP plots are produced for recent observations.  Otherwise, the QLP pipelines get backed up.

This branch can be deleted after merging.