### PR TITLE
QC Test for LFC Flux (test before merging)

### DIFF
--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -191,12 +191,12 @@ class QCDefinitions:
 
         name8 = 'lfc_flux_check'
         self.names.append(name8)
-        self.kpf_data_levels[name8] = ['L0']
-        self.descriptions[name8] = 'Check if an LFC frame that goes into a masters has enough flux'
+        self.kpf_data_levels[name8] = ['2D']
+        self.descriptions[name8] = 'Check if an LFC frame that goes into a master has sufficient flux'
         self.data_types[name8] = 'int'
-        self.spectrum_types[name8] = ['all', ]
+        self.spectrum_types[name8] = ['LFC', ]
         self.fits_keywords[name8] = 'LFC2DFOK'
-        self.fits_comments[name8] = 'QC: LFC Flux not below threshold'
+        self.fits_comments[name8] = 'QC: LFC flux meets threshold of 4000 counts'
         self.db_columns[name8] = None
         
         # Integrity checks

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -189,6 +189,16 @@ class QCDefinitions:
         self.fits_comments[name7] = 'QC: EM not negative flux'
         self.db_columns[name7] = None
 
+        name8 = 'lfc_flux_check'
+        self.names.append(name8)
+        self.kpf_data_levels[name8] = ['L0']
+        self.descriptions[name8] = 'Check if an LFC frame that goes into a masters has enough flux'
+        self.data_types[name8] = 'int'
+        self.spectrum_types[name7] = ['all', ]
+        self.fits_keywords[name8] = 'LFC2DFOK'
+        self.fits_comments[name8] = 'QC: LFC Flux not below threshold'
+        self.db_columns[name8] = None
+        
         # Integrity checks
         if len(self.names) != len(self.kpf_data_levels):
             raise ValueError("Length of kpf_data_levels list does not equal number of entries in descriptions dictionary.")

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -189,7 +189,7 @@ class QCDefinitions:
         self.fits_comments[name7] = 'QC: EM not negative flux'
         self.db_columns[name7] = None
 
-        name8 = 'lfc_flux_check'
+        name8 = 'D2_lfc_flux_check'
         self.names.append(name8)
         self.kpf_data_levels[name8] = ['2D']
         self.descriptions[name8] = 'Check if an LFC frame that goes into a master has sufficient flux'
@@ -772,7 +772,7 @@ class QC2D(QC):
     def __init__(self,kpf_object):
         super().__init__(kpf_object)
 
-    def lfc_flux_check(self, debug = False):
+    def D2_lfc_flux_check(self, threshold=4000, debug=False):
         """
         This Quality Control function checks if the flux values in the green and red chips of the
         given 2D file are above a defined threshold at the 98th percentile.
@@ -786,14 +786,16 @@ class QC2D(QC):
         """
         
         Two_D = self.kpf_object
-        threshold = 4000
         green_counts = Two_D['GREEN_CCD'].data
         red_counts = Two_D['RED_CCD'].data
         
         QC_Test = True
+        if debug:
+            print("******Green - 98th percentile counts: " + str(np.percentile(green_counts, 98)))
+            print("******Red - 98th percentile counts: " + str(np.percentile(red_counts, 98)))
         if np.percentile(green_counts, 98) < threshold or np.percentile(red_counts, 98) < threshold:
             QC_Test = False
-            
+           
         return QC_Test
 
 

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -789,8 +789,7 @@ class QC2D(QC):
         threshold (4000) to determine if the quality control check passes.
         """
         
-        from astropy.io import fits
-        Two_D = fits.open(file)
+        Two_D = self.kpf_object
         threshold = 4000
         green_counts = Two_D['GREEN_CCD'].data
         red_counts = Two_D['RED_CCD'].data

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -194,7 +194,7 @@ class QCDefinitions:
         self.kpf_data_levels[name8] = ['L0']
         self.descriptions[name8] = 'Check if an LFC frame that goes into a masters has enough flux'
         self.data_types[name8] = 'int'
-        self.spectrum_types[name7] = ['all', ]
+        self.spectrum_types[name8] = ['all', ]
         self.fits_keywords[name8] = 'LFC2DFOK'
         self.fits_comments[name8] = 'QC: LFC Flux not below threshold'
         self.db_columns[name8] = None

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -772,6 +772,35 @@ class QC2D(QC):
     def __init__(self,kpf_object):
         super().__init__(kpf_object)
 
+    def lfc_flux_check(file, debug = False):
+        """
+        This Quality Control function checks if the flux values in the green and red chips of the
+        given FITS file are above a defined threshold at the 98th percentile.
+        
+        Args:
+            debug
+        
+        Returns:
+            QC_Test (bool): True if both green and red channels have 98th percentile values above the
+                            threshold, False otherwise.
+        
+        The function opens the FITS file, extracts data for 'GREEN_CCD' and 'RED_CCD' extensions, and
+        computes the 98th percentile of their values. It compares these values against a preset 
+        threshold (4000) to determine if the quality control check passes.
+        """
+        
+        from astropy.io import fits
+        Two_D = fits.open(file)
+        threshold = 4000
+        green_counts = Two_D['GREEN_CCD'].data
+        red_counts = Two_D['RED_CCD'].data
+        
+        QC_Test = True
+        if np.percentile(green_counts, 98) < threshold or np.percentile(red_counts, 98) < threshold:
+            QC_Test = False
+            
+        return QC_Test
+
 
 #####################################################################
 

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -772,10 +772,10 @@ class QC2D(QC):
     def __init__(self,kpf_object):
         super().__init__(kpf_object)
 
-    def lfc_flux_check(file, debug = False):
+    def lfc_flux_check(self, debug = False):
         """
         This Quality Control function checks if the flux values in the green and red chips of the
-        given FITS file are above a defined threshold at the 98th percentile.
+        given 2D file are above a defined threshold at the 98th percentile.
         
         Args:
             debug
@@ -783,10 +783,6 @@ class QC2D(QC):
         Returns:
             QC_Test (bool): True if both green and red channels have 98th percentile values above the
                             threshold, False otherwise.
-        
-        The function opens the FITS file, extracts data for 'GREEN_CCD' and 'RED_CCD' extensions, and
-        computes the 98th percentile of their values. It compares these values against a preset 
-        threshold (4000) to determine if the quality control check passes.
         """
         
         Two_D = self.kpf_object


### PR DESCRIPTION
Adds a quality check for LFC frames that go into LFC Masters. Flux threshold was set to 4000 counts based on combing through jump (the good 2D LFC frames I saw all have > 6000 counts). We can lower this if need be.  @RussLaher this should add a keyword ('LFC2DFOK') that can be used to rule out bad frames for masters creation. 

I benchmarked this with a known good file (D2_good) and a known bad file (D2_bad), and it seems to work. @awhoward when you have a second, if you can test this and make sure I'm not messing anything up, that would be helpful reassurance. I'll play around with it a bit more tomorrow as well. Also, lmk if I should add something for `debug` 
```
>>> D2_good = 'KP.20240122.11102.15_2D.fits' 
>>> Two_D = KPF0.from_fits(D2_good)
>>> qc2d = QC2D(Two_D)
>>> qc2d.lfc_flux_check(Two_D)
True
>>> D2_bad = 'KP.20240122.11319.38_2D.fits'
>>> Two_D = KPF0.from_fits(D2_bad)
>>> qc2d = QC2D(Two_D)
>>> qc2d.lfc_flux_check(Two_D)
False
```