### PR TITLE
Adding keyword for path to mask.

### DIFF
--- a/modules/radial_velocity/src/alg_rv_init.py
+++ b/modules/radial_velocity/src/alg_rv_init.py
@@ -114,6 +114,7 @@ class RadialVelocityAlgInit(RadialVelocityBase):
     MASK_TYPE = 'mask_type'
     VEL_SPAN_PIXEL = 'vel_span_pixel'
     MASK_ORDERLET = 'mask_orderlet'
+    MASK_PATH = 'mask_path'
 
     # primary key
     KEY_SCI_OBJ = 'SCI-OBJ'

--- a/modules/radial_velocity/src/radial_velocity.py
+++ b/modules/radial_velocity/src/radial_velocity.py
@@ -338,6 +338,8 @@ class RadialVelocity(KPF1_Primitive):
                     self.rv_init['data'][mod][RadialVelocityAlg.get_fiber_object_in_header(self.ins, sci)][mtype]
 
         self.total_orderlet = len(self.spectrum_data_set)
+        mpath = RadialVelocityAlgInit.MASK_PATH
+        self.input.header['MASKPATH'] = mpath # input the etalon file path into the header.
 
         do_rv_corr = False
         self.is_solar_data = False

--- a/modules/radial_velocity/src/radial_velocity.py
+++ b/modules/radial_velocity/src/radial_velocity.py
@@ -328,7 +328,8 @@ class RadialVelocity(KPF1_Primitive):
             for hkey in ['IMTYPE', 'SCI-OBJ', 'SKY-OBJ', 'CAL-OBJ', 'STAR_RV', 'QRV', 'TARGRADV', 'OBJECT']:
                 if hkey in p_header:
                     self.input.header[sci][hkey] = p_header[hkey]
-
+            mpath = RadialVelocityAlgInit.MASK_PATH
+            self.input.header[sci]['MASKPATH'] = mpath # input the etalon file path into the header.
             mod, mtype = RadialVelocityAlgInit.MASK_ORDERLET, RadialVelocityAlgInit.MASK_TYPE
             self.input.header[sci]['MASK'] = None
             if not self.rv_init['data'][mod]:
@@ -338,8 +339,6 @@ class RadialVelocity(KPF1_Primitive):
                     self.rv_init['data'][mod][RadialVelocityAlg.get_fiber_object_in_header(self.ins, sci)][mtype]
 
         self.total_orderlet = len(self.spectrum_data_set)
-        mpath = RadialVelocityAlgInit.MASK_PATH
-        self.input.header['MASKPATH'] = mpath # input the etalon file path into the header.
 
         do_rv_corr = False
         self.is_solar_data = False


### PR DESCRIPTION
@bjfultn I found the location to add the path to the etalon mask. When I ran this L1->L2 file, I confirmed the etalon file being used was correct, but the header keyword that I tried to add did not get saved. I checked L2 extensions and did not find it. 

I will continue to check into the offset for the etalon, but wasn't able to add to the header keyword.