### PR TITLE
Adding QC test for high SNR LFC frames.

### DIFF
--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -1708,6 +1708,38 @@ class QCL1(QC):
         
         return QC_pass
 
+    def L1_check_snr_flc(L1, data_products=['auto']):
+        """
+        This Quality Control function checks checks the SNR of
+        LFC frames, marking satured frames as failing the test.
+        
+        Args:
+            L1 - an L1 object
+            data_products - L1 data_products to check (list)
+            
+            This file should pass: KP.20240711.11549.10_L1.fits
+            This file should fail: KP.20240506.33962.36_L1.fits
+        Returns:
+            QC_pass - a boolean signifying that the QC passed for failed
+        """
+
+        # Check L1 header
+        # SNR_452 = L1.header['PRIMARY']['SNRSC452'] # Not used for LFC
+        SNR_548 = L1.header['PRIMARY']['SNRSC548'] # 
+        # SNR_652 = L1.header['PRIMARY']['SNRSC652'] # # Not used for LFC
+        SNR_747 = L1.header['PRIMARY']['SNRSC747'] # 
+        object  = L1.header['PRIMARY']['OBJECT']
+
+        if object like 'autocal-lfc' 
+            SNR_limit = 2800 # Optimistic limit. Could be lower.
+            if (SNR_548 >= SNR_limit) | (SNR_747 >= SNR_limit):
+                QC_pass = False
+            else:
+                QC_pass = True
+        else:
+            QC_pass = True
+            
+        return QC_pass
 
 #####################################################################
 

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -571,6 +571,19 @@ class QCDefinitions:
         self.db_columns[name17] = None
         self.fits_keyword_fail_value[name17] = -1
 
+        name19 = 'L1_check_snr_lfc'
+        self.names.append(name19)
+        self.kpf_data_levels[name19] = ['L1']#, '2D', 'L1', 'L2']
+        self.descriptions[name19] = 'QC test for identifying saturated LFC frames.'
+        self.data_types[name19] = 'float'
+        self.spectrum_types[name19] = ['all', ]
+        self.master_types[name19] = ['lfc', ]
+        self.required_data_products[name19] = ['L1',] # no required data products
+        self.fits_keywords[name19] = 'LFCSAT'
+        self.fits_comments[name19] = 'LFC is saturated'
+        self.db_columns[name19] = None
+        self.fits_keyword_fail_value[name19] = 0
+
         # Integrity checks
         if len(self.names) != len(self.kpf_data_levels):
             raise ValueError("Length of kpf_data_levels list does not equal number of entries in descriptions dictionary.")
@@ -1708,7 +1721,7 @@ class QCL1(QC):
         
         return QC_pass
 
-    def L1_check_snr_flc(L1, data_products=['auto']):
+    def L1_check_snr_lfc(L1, data_products=['auto']):
         """
         This Quality Control function checks checks the SNR of
         LFC frames, marking satured frames as failing the test.
@@ -1720,7 +1733,7 @@ class QCL1(QC):
             This file should pass: KP.20240711.11549.10_L1.fits
             This file should fail: KP.20240506.33962.36_L1.fits
         Returns:
-            QC_pass - a boolean signifying that the QC passed for failed
+            QC_pass - a boolean signifying that the QC passed or failed
         """
 
         # Check L1 header
@@ -1728,11 +1741,11 @@ class QCL1(QC):
         SNR_548 = L1.header['PRIMARY']['SNRSC548'] # 
         # SNR_652 = L1.header['PRIMARY']['SNRSC652'] # # Not used for LFC
         SNR_747 = L1.header['PRIMARY']['SNRSC747'] # 
-        object  = L1.header['PRIMARY']['OBJECT']
+        object_name  = L1.header['PRIMARY']['OBJECT']
 
-        if object like 'autocal-lfc' 
+        if object_name in 'autocal-lfc':
             SNR_limit = 2800 # Optimistic limit. Could be lower.
-            if (SNR_548 >= SNR_limit) | (SNR_747 >= SNR_limit):
+            if (SNR_548 >= SNR_limit) or (SNR_747 >= SNR_limit):
                 QC_pass = False
             else:
                 QC_pass = True

--- a/tests/notebooks/qc_test_check_snr_of_lfc.ipynb
+++ b/tests/notebooks/qc_test_check_snr_of_lfc.ipynb
@@ -1,0 +1,167 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Develop a notebook that identifies SNR levels that exceed a specified limit.\n",
+    "### Start with LFC frames."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from modules.Utils.kpf_parse import get_datecode\n",
+    "from kpfpipe.models.level1 import KPF1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def L1_check_snr_flc(L1, data_products=['auto']):\n",
+    "    \"\"\"\n",
+    "    This Quality Control function checks checks the SNR of\n",
+    "    LFC frames, marking satured frames as failing the test.\n",
+    "    \n",
+    "    Args:\n",
+    "         L1 - an L1 object\n",
+    "         data_products - L1 data_products to check (list)\n",
+    "         \n",
+    "         This file should pass: KP.20240711.11549.10_L1.fits\n",
+    "         This file should fail: KP.20240506.33962.36_L1.fits\n",
+    "     Returns:\n",
+    "         QC_pass - a boolean signifying that the QC passed for failed\n",
+    "    \"\"\"\n",
+    "\n",
+    "    # Check L1 header\n",
+    "    # SNR_452 = L1.header['PRIMARY']['SNRSC452'] # Not used for LFC\n",
+    "    SNR_548 = L1.header['PRIMARY']['SNRSC548'] # \n",
+    "    # SNR_652 = L1.header['PRIMARY']['SNRSC652'] # # Not used for LFC\n",
+    "    SNR_747 = L1.header['PRIMARY']['SNRSC747'] # \n",
+    "\n",
+    "    object = L1.header['PRIMARY']['OBJECT']\n",
+    "    if object like 'autocal-lfc' \n",
+    "        SNR_limit = 2800 # Optimistic limit. Could be lower.\n",
+    "        if (SNR_548 >= SNR_limit) | (SNR_747 >= SNR_limit):\n",
+    "            QC_pass = False\n",
+    "        else:\n",
+    "            QC_pass = True\n",
+    "    else:\n",
+    "        QC_pass = True\n",
+    "        \n",
+    "    return QC_pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/data/L1/20241023/KP.20241023.50299.76_L1.fits\n",
+      "SNR at 452nm:  199.1\n",
+      "SNR at 548nm:  442.8\n",
+      "SNR at 652nm:  507.4\n",
+      "SNR at 747nm:  525.4\n",
+      "KP.20241023.50299.76 True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ObsID = \"KP.20240711.11549.10\" # should pass.\n",
+    "ObsID = \"KP.20240506.33962.36\" # Saturated file. should fail\n",
+    "ObsID = \"KP.20241023.50299.76\" # Not an lfc, should not be checked.\n",
+    "L1_filename = '/data/L1/' + get_datecode(ObsID) + '/' + ObsID + '_L1.fits'\n",
+    "L1a = KPF1.from_fits(L1_filename)\n",
+    "print(L1_filename)\n",
+    "\n",
+    "\n",
+    "SNR_452 = L1a.header['PRIMARY']['SNRSC452'] # \n",
+    "SNR_548 = L1a.header['PRIMARY']['SNRSC548'] # \n",
+    "SNR_652 = L1a.header['PRIMARY']['SNRSC652'] # \n",
+    "SNR_747 = L1a.header['PRIMARY']['SNRSC747'] # \n",
+    "\n",
+    "print('SNR at 452nm: ',SNR_452)\n",
+    "print('SNR at 548nm: ',SNR_548)\n",
+    "print('SNR at 652nm: ',SNR_652)\n",
+    "print('SNR at 747nm: ',SNR_747)\n",
+    "\n",
+    "SNR_limit = 2800\n",
+    "object = L1a.header['PRIMARY']['OBJECT']\n",
+    "if object in ('autocal-lfc'):\n",
+    "    SNR_limit = 2800 # Optimistic limit. Could be lower.\n",
+    "    if (SNR_548 >= SNR_limit) | (SNR_747 >= SNR_limit):\n",
+    "        QC_pass = False\n",
+    "    else:\n",
+    "        QC_pass = True\n",
+    "else:\n",
+    "    QC_pass = True\n",
+    "print(ObsID, QC_pass)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "L1_check_snr_flc(L1a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This QC test on L1 LFC files, will fail an LFC frame if the SNR is above a critical threshold. I set the threshold at 2800 by examining spectra. Saturation can be identified by eye in the L0 or L1 files. Here are some examples.
![saturated_lfc_example3](https://github.com/user-attachments/assets/3123ce5b-6f30-42ba-9aae-4065e9483540)
![saturated_lfc_example2](https://github.com/user-attachments/assets/fc3f8c41-d650-4ad3-a15c-e9973e5634e4)
![saturated_lfc_example](https://github.com/user-attachments/assets/bb891788-edb5-46f8-bf00-a76603d29d86)

I looked for L2 metrics that would help define the proper threshold, including green RV and green RV error, but they were inconclusive. 

![snrsc548_vs_ccd1rv_err](https://github.com/user-attachments/assets/1c87b0e4-3b0c-44c8-8644-1fb0d613ddbd)
![snrsc548_vs_ccd1rv](https://github.com/user-attachments/assets/d38da70d-5506-40d0-a18b-8afa7ed90372)

In addition to this QC test, I junked any LFC frames from 2024 March 1-Oct 28 that were above this threshold. The masters should be improved upon the next return, with these saturated frames excluded. Once specific example is UT 20240503, which had one saturated spectrum that could be the reason for the outlying RVs of standard star HD 55575 on the same day.