### PR TITLE
Bug fix: Added new runPerlScriptsUnderCrontab.sh

### DIFF
--- a/cronjobs/runPerlScriptsUnderCrontab.sh
+++ b/cronjobs/runPerlScriptsUnderCrontab.sh
@@ -1,0 +1,13 @@
+#! /bin/bash -l
+
+printenv >& $KPFCRONJOB_LOGS/jobs/runPerlScriptsUnderCrontab.env
+
+procdate=$(date +\%Y\%m\%d)
+
+echo "Processing date: $procdate"
+
+$KPFCRONJOB_CODE/cronjobs/updateSoftwareAndReferenceFits.pl >& $KPFCRONJOB_LOGS/jobs/updateSoftwareAndReferenceFits_$procdate.out
+echo Return value from updateSoftwareAndReferenceFits.pl = $?
+
+$KPFCRONJOB_CODE/cronjobs/cleanOldFilesFromDisk.pl >& $KPFCRONJOB_LOGS/jobs/cleanOldFilesFromDisk_$procdate.out
+echo Return value from cleanOldFilesFromDisk.pl = $?


### PR DESCRIPTION
On Decemeber 13, 2024, when I replaced the hard-coded paths with environment variables in:

```
updateSoftwareAndReferenceFits.pl
cleanOldFilesFromDisk.pl
```
I failed to notice that Perl scripts running under crontab do not inherit the environment.  Here is the error:

```
[rlaher@shrek KPF-Pipeline]$ more cleanOldFilesFromDisk_20241213.out
*** Env. var. KPFCRONJOB_SBX not set; quitting...

```
Therefore, the master files computed under my crontab for 20241213 through 20250202 (except for 20250128 through 20250130 which I am running this morning)  did not necessarily point to the latest Junk_Observations_for_KPF.csv.

I will modify my crontab to run the Perl scripts via the following shell script that has -l switch to explicitly inherit the login environment:

```
runPerlScriptsUnderCrontab.sh
```

I have already installed it in my crontab run-time environment.
