### PR TITLE
Bias/dark-subtracted QLP images

### DIFF
--- a/configs/quicklook_match.cfg
+++ b/configs/quicklook_match.cfg
@@ -12,7 +12,7 @@ outdir= '/data/QLP/'
 # see quicklook_match.recipe for a description of how to set fullpath
 #fullpath = '/data/L1/202?????/KP.20240116.?????.??*.fits'
 #fullpath = '/data/masters/20230429/*.fits'
-fullpath = '/data/2D/20240305/KP.20240305.01936.10_2D.fits'
+fullpath = '/data/2D/20240402/KP.20240402.08087.31_2D.fits'
 
 [MODULE_CONFIGS]
 quicklook = modules/quicklook/configs/default.cfg

--- a/configs/quicklook_match.cfg
+++ b/configs/quicklook_match.cfg
@@ -12,7 +12,7 @@ outdir= '/data/QLP/'
 # see quicklook_match.recipe for a description of how to set fullpath
 #fullpath = '/data/L1/202?????/KP.20240116.?????.??*.fits'
 #fullpath = '/data/masters/20230429/*.fits'
-fullpath = '/data/L2/20250110/KP.20250110.45546.07_L2.fits'
+fullpath = '/data/2D/20240305/KP.20240305.01936.10_2D.fits'
 
 [MODULE_CONFIGS]
 quicklook = modules/quicklook/configs/default.cfg

--- a/modules/Utils/kpf_parse.py
+++ b/modules/Utils/kpf_parse.py
@@ -360,7 +360,7 @@ def get_data_products_expected(kpf_object, data_level):
     """
     primary_header = HeaderParse(kpf_object, 'PRIMARY')
     header = primary_header.header
-    name = primary_header.get_name() # 'Star','Sun','LFC', etc.
+    name = primary_header.get_name(use_star_names=False) # 'Star','Sun','LFC', etc.
     data_products = ['Telemetry']
     if data_level in ['2D', 'L1', 'L2']:
         data_products.append('Config')

--- a/modules/quicklook/src/alg.py
+++ b/modules/quicklook/src/alg.py
@@ -276,7 +276,6 @@ class QuicklookAlg:
                 self.logger.error(f"Failure in CaHK quicklook pipeline: {e}\n{traceback.format_exc()}")
 
         # Make 2D images
-        # to-do: process bias and dark differently
         if chips != []:    
             try:
                 savedir = D2_QLP_file_base +'2D/'
@@ -295,6 +294,40 @@ class QuicklookAlg:
                                             fig_path=filename, show_plot=False)
                     except Exception as e:
                         self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
+
+            except Exception as e:
+                self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
+
+        # Make Bias-subtracted Bias - 2D images
+        if chips != []:    
+            try:
+                my_2D = Analyze2D(kpf2d, logger=self.logger)
+                if my_2D.name == 'Bias': 
+                    for chip in chips:
+                        try:
+                            filename = savedir + self.ObsID + '_2D_image_bias_subtracted_' + chip + '_zoomable.png'
+                            self.logger.info('Generating QLP image ' + filename)
+                            my_2D.plot_2D_image(chip=chip, subtract_master_bias=True, 
+                                                fig_path=filename, show_plot=False)
+                        except Exception as e:
+                            self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
+
+            except Exception as e:
+                self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
+
+        # Make Dark-subtracted Darks - 2D images
+        if chips != []:    
+            try:
+                my_2D = Analyze2D(kpf2d, logger=self.logger)
+                if my_2D.name == 'Dark': 
+                    for chip in chips:
+                        try:
+                            filename = savedir + self.ObsID + '_2D_image_dark_subtracted_' + chip + '_zoomable.png'
+                            self.logger.info('Generating QLP image ' + filename)
+                            my_2D.plot_2D_image(chip=chip, subtract_master_dark=True, 
+                                                fig_path=filename, show_plot=False)
+                        except Exception as e:
+                            self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
 
             except Exception as e:
                 self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
@@ -363,7 +396,7 @@ class QuicklookAlg:
 
             except Exception as e:
                 self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
-        
+       
         
     #######################
     ##### QLP Level 1 #####

--- a/modules/quicklook/src/alg.py
+++ b/modules/quicklook/src/alg.py
@@ -324,8 +324,11 @@ class QuicklookAlg:
                         try:
                             filename = savedir + self.ObsID + '_2D_image_dark_subtracted_' + chip + '_zoomable.png'
                             self.logger.info('Generating QLP image ' + filename)
+                            my_2D.measure_2D_dark_current(chip=chip)
                             my_2D.plot_2D_image(chip=chip, subtract_master_dark=True, 
+                                                overplot_dark_current=True, 
                                                 fig_path=filename, show_plot=False)
+
                         except Exception as e:
                             self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
 
@@ -340,7 +343,7 @@ class QuicklookAlg:
                 my_2D = Analyze2D(kpf2d, logger=self.logger)
                 for chip in chips:
                     try:
-                        filename = savedir + self.ObsID + '_2D_image_3x3zoom_' + chip + '_zoomable.png'
+                        filename = savedir + self.ObsID + '_2D_image_zoom3x3_' + chip + '_zoomable.png'
                         self.logger.info('Generating QLP image ' + filename)
                         my_2D.plot_2D_image_zoom_3x3(chip=chip, fig_path=filename, show_plot=False)
                     except Exception as e:
@@ -371,11 +374,13 @@ class QuicklookAlg:
         if chips != []:    
             try:
                 my_2D = Analyze2D(kpf2d, logger=self.logger)
+                is_bias = my_2D.name == 'Bias'
+                is_dark = my_2D.name == 'Dark'
                 for chip in chips:
                     try:
                         filename = savedir + self.ObsID + '_2D_histogram_' + chip + '_zoomable.png'
                         self.logger.info('Generating QLP image ' + filename)
-                        my_2D.plot_2D_image_histogram(chip=chip, fig_path=filename, show_plot=False)
+                        my_2D.plot_2D_image_histogram(chip=chip, subtract_master_bias=is_bias, subtract_master_dark=is_dark, fig_path=filename, show_plot=False)
                     except Exception as e:
                         self.logger.error(f"Failure in 2D quicklook pipeline: {e}\n{traceback.format_exc()}")
 

--- a/modules/quicklook/src/analyze_2d.py
+++ b/modules/quicklook/src/analyze_2d.py
@@ -1,4 +1,5 @@
 import time
+import copy
 import traceback
 import numpy as np
 import pandas as pd
@@ -15,6 +16,7 @@ from astropy.time import Time
 from astropy.table import Table
 from datetime import datetime, timedelta
 from scipy.optimize import curve_fit
+from kpfpipe.models.level0 import KPF0
 #import emcee
 #import corner
 
@@ -56,7 +58,7 @@ class Analyze2D:
 
     def __init__(self, D2, logger=None):
         self.logger = logger if logger is not None else DummyLogger()
-        self.D2 = D2 # use D2 instead of 2D because variable names can't start with a number
+        self.D2 = copy.deepcopy(D2) # use D2 instead of 2D because variable names can't start with a number
         self.df_telemetry = self.D2['TELEMETRY']  # read as Table for astropy.io version of FITS
         primary_header = HeaderParse(D2, 'PRIMARY')
         self.header = primary_header.header
@@ -282,6 +284,7 @@ class Analyze2D:
     def plot_2D_image(self, chip=None, variance=False, data_over_sqrt_variance=False,
                             overplot_dark_current=False, blur_size=None, 
                             subtract_master_bias=False,
+                            subtract_master_dark=False,
                             fig_path=None, show_plot=False):
         """
         Generate a plot of the a 2D image.  Overlay measurements of 
@@ -292,11 +295,12 @@ class Analyze2D:
             variance - plot variance (VAR extensions) instead of signal (CCD extensions)
             data_over_sqrt_variance - plot data divided by sqrt(variance), an approximate SNR image
             overlay_dark_current - if True, dark current measurements are over-plotted
-            subtract_master_bias - if not False, a master bias will be subtracted'
-                                   if 'auto', then the path to the master bias is 
+            subtract_master_bias - if not False, a master bias will be subtracted
+                                   if True, then the path to the master bias is 
                                    the value from the BIASFILE keyword
                                    if his parameter is set to a path, that file 
                                    will be used 
+            subtract_master_dark - same as subtract_master_bias
             fig_path (string) - set to the path for the file to be generated.
             show_plot (boolean) - show the plot in the current environment.
 
@@ -305,6 +309,61 @@ class Analyze2D:
             (e.g., in a Jupyter Notebook).
 
         """
+    
+        # Subtract master bias frame
+        bias_read = False
+        dark_read = False
+        if subtract_master_bias == False:
+            pass
+        else:
+            if subtract_master_bias == True:
+                if ('BIASDIR' in self.header) and ('BIASFILE' in self.header):
+                    if self.header['BIASDIR'].startswith("/masters"):
+                        pre = '/data'
+                    else:
+                        pre = ''
+                    bias_filename = pre + self.header['BIASDIR'] + '/' + self.header['BIASFILE']
+            else:
+            	bias_filename = subtract_master_bias
+            
+            try:
+                D2_master_bias = KPF0.from_fits(bias_filename)
+                bias_read = True
+            except Exception as e:
+                self.logger.error(f"Problem reading {bias_filename}: {e}\n{traceback.format_exc()}")
+            if bias_read:
+                for extension in ['GREEN_CCD', 'RED_CCD']:
+                    if extension in D2_master_bias.extensions:
+                        self.D2[extension] -= D2_master_bias[extension]
+            else:
+                subtract_master_bias = False
+        
+        # Subtract scaled master dark frame
+        if subtract_master_dark == False:
+            pass
+        else:
+            if subtract_master_dark == True:
+                if ('DARKDIR' in self.header) and ('DARKFILE' in self.header):
+                    if self.header['DARKDIR'].startswith("/masters"):
+                        pre = '/data'
+                    else:
+                        pre = ''
+                    dark_filename = pre + self.header['DARKDIR'] + '/' + self.header['DARKFILE']
+            else:
+            	dark_filename = subtract_master_dark
+            
+            try:
+                D2_master_dark = KPF0.from_fits(dark_filename)
+                dark_read = True
+            except Exception as e:
+                self.logger.error(f"Problem reading {dark_filename}: {e}\n{traceback.format_exc()}")
+            if dark_read:
+                for extension in ['GREEN_CCD', 'RED_CCD']:
+                    if extension in D2_master_dark.extensions:
+                        self.D2[extension] -= D2_master_dark[extension] * float(self.exptime)
+            else:
+                subtract_master_dark = False
+        
         chip = chip.lower()
 
         # Set parameters based on the chip selected
@@ -359,7 +418,11 @@ class Analyze2D:
             title_txt = title_txt + ' (Variance)'
         elif data_over_sqrt_variance:
             title_txt = title_txt + ' (SNR)'
-        plt.title(title_txt, fontsize=18)
+        if bias_read:
+            title_txt = title_txt + ' (Bias subtracted)'
+        if dark_read:
+            title_txt = title_txt + ' (Dark subtracted)'
+        plt.title(title_txt, fontsize=14)
         plt.xlabel('Column (pixel number)', fontsize=18)
         plt.ylabel('Row (pixel number)', fontsize=18)
         plt.xticks(fontsize=14)
@@ -430,7 +493,17 @@ class Analyze2D:
         plt.annotate(timestamp_label, xy=(1, 0), xycoords='axes fraction', 
                     fontsize=8, color="darkgray", ha="right", va="bottom",
                     xytext=(0, -35), textcoords='offset points')
-        plt.subplots_adjust(bottom=0.1)     
+        if bias_read:
+            bias_label = 'Bias: ' + bias_filename
+            plt.annotate(bias_label, xy=(-0.1, 0), xycoords='axes fraction', 
+                        fontsize=8, color="darkgray", ha="left", va="bottom",
+                        xytext=(0, -52), textcoords='offset points')
+        if dark_read:
+            dark_label = 'Dark: ' + dark_filename
+            plt.annotate(dark_label, xy=(-0.1, 0), xycoords='axes fraction', 
+                        fontsize=8, color="darkgray", ha="left", va="bottom",
+                        xytext=(0, -52), textcoords='offset points')
+            plt.subplots_adjust(bottom=0.1)     
 
         # Display the plot
         if fig_path != None:

--- a/modules/quicklook/src/analyze_em.py
+++ b/modules/quicklook/src/analyze_em.py
@@ -1,4 +1,5 @@
 import time
+import copy
 import math
 import numpy as np
 import pandas as pd
@@ -57,8 +58,8 @@ class AnalyzeEM:
             self.logger.debug('Initializing AnalyzeEM object.')
         else:
             self.logger = None
-        self.L0 = L0 
-        primary_header = HeaderParse(L0, 'PRIMARY')
+        self.L0 = copy.deepcopy(L0)
+        primary_header = HeaderParse(self.L0, 'PRIMARY')
         self.header = primary_header.header
         self.name = primary_header.get_name()
         self.ObsID = primary_header.get_obsid()
@@ -72,8 +73,8 @@ class AnalyzeEM:
         self.wav4 = 870      # "
 
         # Read data tables
-        self.dat_SCI = L0['EXPMETER_SCI']
-        self.dat_SKY = L0['EXPMETER_SKY']
+        self.dat_SCI = self.L0['EXPMETER_SCI']
+        self.dat_SKY = self.L0['EXPMETER_SKY']
         self.df_SCI_EM = self.dat_SCI
         self.df_SKY_EM = self.dat_SKY
         i = 0

--- a/modules/quicklook/src/analyze_guider.py
+++ b/modules/quicklook/src/analyze_guider.py
@@ -1,4 +1,5 @@
 import time
+import copy
 import numpy as np
 from datetime import datetime
 import matplotlib.pyplot as plt
@@ -47,7 +48,7 @@ class AnalyzeGuider:
     def __init__(self, L0, logger=None):
         self.logger = logger if logger is not None else DummyLogger()
         self.logger.info('Starting AnalyzeGuider')
-        self.L0 = L0
+        self.L0 = copy.deepcopy(L0)
         self.pixel_scale = 0.056 # arcsec per pixel for the CRED-2 imager on the KPF FIU
 
         header_primary_obj = HeaderParse(L0, 'PRIMARY')

--- a/modules/quicklook/src/analyze_l0.py
+++ b/modules/quicklook/src/analyze_l0.py
@@ -1,4 +1,5 @@
 import re
+import copy
 import time
 import numpy as np
 import matplotlib.pyplot as plt
@@ -30,7 +31,7 @@ class AnalyzeL0:
 
     def __init__(self, L0, logger=None):
         self.logger = logger if logger is not None else DummyLogger()
-        self.L0 = L0
+        self.L0 = copy.deepcopy(L0)
         self.data_products = get_data_products_L0(L0)
         primary_header = HeaderParse(L0, 'PRIMARY')
         self.header = primary_header.header

--- a/modules/quicklook/src/analyze_l1.py
+++ b/modules/quicklook/src/analyze_l1.py
@@ -1,4 +1,5 @@
 import time
+import copy
 import traceback
 import numpy as np
 import matplotlib.pyplot as plt
@@ -117,7 +118,7 @@ class AnalyzeL1:
 
     def __init__(self, L1, logger=None):
         self.logger = logger if logger is not None else DummyLogger()
-        self.L1 = L1
+        self.L1 = copy.deepcopy(L1)
         primary_header = HeaderParse(L1, 'PRIMARY')
         self.header = primary_header.header
         self.name = primary_header.get_name()

--- a/modules/quicklook/src/analyze_l2.py
+++ b/modules/quicklook/src/analyze_l2.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 from datetime import datetime
 import matplotlib.pyplot as plt
@@ -34,7 +35,7 @@ class AnalyzeL2:
             self.logger.debug('Initializing AnalyzeL2 object')
         else:
             self.logger = None
-        self.L2 = L2
+        self.L2 = copy.deepcopy(L2)
         self.df_RV = self.L2['RV']
         self.n_green_orders = 35
         self.n_red_orders   = 32

--- a/modules/quicklook/src/analyze_time_series.py
+++ b/modules/quicklook/src/analyze_time_series.py
@@ -1558,11 +1558,11 @@ class AnalyzeTimeSeries:
                         colors = [state_to_color[state] if state in state_to_color else 'black' for state in states]
                         color_map = {state: state_to_color[state] for state in unique_states if state in state_to_color}
                     else:
+                        unique_states = sorted(list(set(unique_states)))
                         state_to_num = {state: i for i, state in enumerate(unique_states)}
                         mapped_states = [state_to_num[state] for state in states]
                         colors = plt.cm.jet(np.linspace(0, 1, len(unique_states)))
                         color_map = {state: colors[i] for i, state in enumerate(unique_states)}
-                    unique_states = sorted(list(set(unique_states)))
                     try:
                         # check for a set of conditions that took forever to figure out
                         if (hasattr(t, 'tolist') and callable(getattr(t, 'tolist'))):

--- a/modules/quicklook/src/analyze_time_series.py
+++ b/modules/quicklook/src/analyze_time_series.py
@@ -78,7 +78,6 @@ class AnalyzeTimeSeries:
     To-do:
         * Add temperature derivatives as columns; they will need to be computed.
         * Add the option of using a Postgres database
-        * For time series plots of states, put the states in alphabetical order (e.g. for KPF ERA values or DRP Version Numbers)
         * Make standard correlation plots.
         * Make standard phased plots (by day)
         * Make plot of correlation between per-order RVs and RVs per-chip and overall RVs.
@@ -1563,6 +1562,7 @@ class AnalyzeTimeSeries:
                         mapped_states = [state_to_num[state] for state in states]
                         colors = plt.cm.jet(np.linspace(0, 1, len(unique_states)))
                         color_map = {state: colors[i] for i, state in enumerate(unique_states)}
+                    unique_states = sorted(list(set(unique_states)))
                     try:
                         # check for a set of conditions that took forever to figure out
                         if (hasattr(t, 'tolist') and callable(getattr(t, 'tolist'))):

--- a/modules/quicklook/src/analyze_time_series.py
+++ b/modules/quicklook/src/analyze_time_series.py
@@ -78,6 +78,7 @@ class AnalyzeTimeSeries:
     To-do:
         * Add temperature derivatives as columns; they will need to be computed.
         * Add the option of using a Postgres database
+        * For time series plots of states, put the states in alphabetical order (e.g. for KPF ERA values or DRP Version Numbers)
         * Make standard correlation plots.
         * Make standard phased plots (by day)
         * Make plot of correlation between per-order RVs and RVs per-chip and overall RVs.


### PR DESCRIPTION
This PR mostly addresses Issue https://github.com/Keck-DataReductionPipelines/KPF-Pipeline/issues/831.  I did not get to the task of a Fourier assessment of read noise and defer that to another day.

The usual Quicklook plots of Bias and Dark frames are not bias-subtracted or dark-subtracted because those files are in that state.  The added code now generates plots of individual Bias and Dark frames that are bias-subtracted and dark-subtracted.  This histogram Quicklook plots of those files also show before and after subtraction.