### PR TITLE
L2 Primary Header BCV Percent Changes

### DIFF
--- a/modules/quicklook/src/analyze_l2.py
+++ b/modules/quicklook/src/analyze_l2.py
@@ -92,6 +92,15 @@ class AnalyzeL2:
         var_pop = np.sum(w * (x - wmean)**2) / np.sum(w) # weighted variance
         self.Delta_Bary_RVC_weighted_std = np.sqrt(var_pop) * 1000 # m/s
         self.Delta_Bary_RVC_weighted_range = (x[nonzero_mask].max() - x[nonzero_mask].min()) * 1000 # m/s
+        # compute per-order percent change difference from weighted Barycentric RV correction
+        if self.CCFBCV != 0:
+            self.df_RV['Perc_Delta_Bary_RVC'] = (self.df_RV['Delta_Bary_RVC'].copy() / self.CCFBCV) * 100 # percent
+        else:
+            self.df_RV['Perc_Delta_Bary_RVC'] = self.df_RV['Delta_Bary_RVC'].copy() * 0 # just set to zero
+        # compute maximum and minimum percent change difference (for only orders with nonzero weights)
+        x = self.df_RV['Perc_Delta_Bary_RV']
+        self.Max_Perc_Delta_Bary_RV = x[nonzero_mask].max()
+        self.Min_Perc_Delta_Bary_RV = x[nonzero_mask].min()
 
 
     def plot_CCF_grid(self, chip=None, annotate=False, 

--- a/modules/quicklook/src/diagnostics.py
+++ b/modules/quicklook/src/diagnostics.py
@@ -1154,6 +1154,12 @@ def add_headers_L2_barycentric(L2, logger=None):
                  orders excluded (sec)
         BJDSTD - Standard deviation of BJD values for the spectral orders, 
                  weighted by the CCF Weights (sec)
+        MAXPCBCV - The maximum of the spectral orders' percent change 
+                 differences from an observation's CCFBCV, with zero-weight 
+                 orders excluded (%)
+        MINPCBCV - The minimum of the spectral orders' percent change
+                 differences from an observation's CCFBCV, with zero-weight
+                 orders excluded (%)
 
     Args:
         L2 - a KPF L2 object 
@@ -1186,7 +1192,7 @@ def add_headers_L2_barycentric(L2, logger=None):
         if hasattr(myL2, 'CCFBJD'):
             L2.header['PRIMARY']['CCFBJD']  = (myL2.CCFBJD, 'Weighted avg of BJD values (days)')
     
-        # Add range and standard deviation stats
+        # Add range, standard deviation, and percent difference stats
         if hasattr(myL2, 'Delta_CCFBJD_weighted_std'):
             L2.header['PRIMARY']['BJDSTD'] = (myL2.Delta_CCFBJD_weighted_std, 'Weighted stddev of BJD for orders (sec)')
         if hasattr(myL2, 'Delta_CCFBJD_weighted_range'):
@@ -1195,6 +1201,10 @@ def add_headers_L2_barycentric(L2, logger=None):
             L2.header['PRIMARY']['BCVSTD'] = (myL2.Delta_Bary_RVC_weighted_std, 'Weighted stddev of BCV for orders (m/s)')
         if hasattr(myL2, 'Delta_Bary_RVC_weighted_range'):
             L2.header['PRIMARY']['BCVRNG'] = (myL2.Delta_Bary_RVC_weighted_range, 'Range(BCV) for non-zero-weight orders (m/s)')
+        if hasattr(myL2, 'Max_Perc_Delta_Bary_RV'):
+            L2.header['PRIMARY']['MAXPCBCV'] = (myL2.Max_Perc_Delta_Bary_RV, 'Maximum percent change from CCFBCV for non-zero-weight orders (%)')
+        if hasattr(myL2, 'Min_Perc_Delta_Bary_RV'):
+            L2.header['PRIMARY']['MINPCBCV'] = (myL2.Min_Perc_Delta_Bary_RV, 'Minimum percent change from CCFBCV for non-zero-weight orders (%)')
 
     except Exception as e:
         logger.error(f"Problem with L2 BJD/BCV measurements: {e}\n{traceback.format_exc()}")


### PR DESCRIPTION
Under Howard's guidance, I'm adding two headers to the L2 Primary Headers: MAXPCBCV and MINPCBCV. These track the maximum and minimum percent changes of the spectral orders' percent change differences from an observation's CCFBCV, with zero-weight orders excluded.

In order to add these headers, I added the necessary functionality to the function compute_statistics() within analyze.py, and the headers themselves to the function add_headers_L2_barycentric() within diagnostics.py.