### PR TITLE
'not_recent' quicklook recipe

### DIFF
--- a/docs/source/intro/production.rst
+++ b/docs/source/intro/production.rst
@@ -15,10 +15,13 @@ Launch QLP instances for all data levels with the default recipe::
 
     ./scripts/launch_qlp.sh
 
-Alternatively, launch QLP instances for only recent observations::
+Alternatively, launch QLP instances for only recent observations (within the last day)::
 
     ./scripts/launch_qlp.sh --only_recent
 
+And one for not recent observations (more than a day ago)::
+
+    ./scripts/launch_qlp.sh --not_recent
   
 **Time Series Database Ingestion:**
   

--- a/recipes/quicklook_watch_not_recent.recipe
+++ b/recipes/quicklook_watch_not_recent.recipe
@@ -1,0 +1,46 @@
+# This recipe on quicklook_watch.recipe, which 
+# is used to watch a [L0/2D/L1/L2/masters] directory for modified 
+# files and then to run the appropriate section of the QLP 
+# (L0/2D/L1/L2/masters) to generate standard data products.  It must be run 
+# in watch mode.  Separate instances should to be run for L0, 2D, L1, L2, 
+# and masters data directories.  In this version of the recipe, only 
+# files not from recent observations (more than one day ago) are processed 
+# to compute QLP data products.  The observation date is determined by the 
+# date encoded into the filename.
+#
+# Examples:
+#    > kpf --ncpus=2 --watch /data/ -c configs/quicklook_watch.cfg -r recipes/quicklook_watch_only_recent.recipe
+#    > kpf --ncpus=2 --watch /data/L1/20240118/ -c configs/quicklook_watch.cfg -r recipes/quicklook_watch_only_recent.recipe
+
+from modules.Utils.string_proc import level_from_kpffile
+from modules.Utils.string_proc import date_from_kpffile
+from modules.Utils.string_proc import date_from_path
+from modules.Utils.string_proc import days_since_observation
+from modules.quicklook.src.quick_prim import Quicklook
+
+
+file_path = context.file_path # from context in watch mode, e.g.  
+                              # /data/2D/20230711/KP.20230711.00415.52_2D.fits
+datecode = date_from_path(file_path)
+days_since = days_since_observation(file_path)
+
+if days_since > 0.95 and days_since != 0:
+    abc = 'abc'
+
+if days_since > 0.95 and days_since != 0:
+    if 'masters' in file_path: # Masters
+        output_dir= '/data/QLP/' + datecode + '/Masters/'
+        Quicklook(file_path, output_dir, 'master')
+    else: # L0/2D/L1/L2
+        level = level_from_kpffile(file_path)  # 'L0', '2D', 'L1', 'L2', None
+        output_dir= '/data/QLP/' + datecode + '/'
+        if level != None:
+            if level == 'L0':
+                open_file = kpf0_from_fits(file_path, data_type='KPF')
+            if level == '2D':
+                open_file = kpf0_from_fits(file_path, data_type='KPF')
+            if level == 'L1':
+                open_file = kpf1_from_fits(file_path, data_type='KPF')
+            if level == 'L2':
+                open_file = kpf2_from_fits(file_path, data_type='KPF')
+            Quicklook(open_file, output_dir, level)

--- a/scripts/launch_qlp.sh
+++ b/scripts/launch_qlp.sh
@@ -12,6 +12,8 @@ optionally process only recent observations from the current day.
 Command-line options (all are optional):
   --only_recent       Use a specialized recipe to process only observations
                       from the current day.
+  --not_recent        Use a specialized recipe to process only observations
+                      from more than one day ago.
   -h, --help          Display this help message and exit.
 
 Examples:
@@ -21,7 +23,10 @@ Examples:
 2. Launch QLP instances for only recent observations:
    ./launch_qlp.sh --only_recent
 
-3. Display the help message:
+2. Launch QLP instances for observations from more than a day ago:
+   ./launch_qlp.sh --not_recent
+
+4. Display the help message:
    ./launch_qlp.sh -h
 EOF
 
@@ -35,6 +40,9 @@ for arg in "$@"; do
     case "$arg" in
         --only_recent)
             recipe_file="recipes/quicklook_watch_only_recent.recipe"
+            ;;
+        --not_recent)
+            recipe_file="recipes/quicklook_watch_not_recent.recipe"
             ;;
         -h|--help)
             echo "$SCRIPT_DOC"


### PR DESCRIPTION
Our current mode of operating the quicklook pipeline is to run `scripts/launch_qlp.sh` twice.  The first instances processes all observations and the second one ("only_recent") processes observations from the last 24 hours.  The idea is that the first instance may get bogged down in reprocessing and the second instance can keep up with recent observations, especially during nighttime observing.

The change with this PR is that there's a new recipe `recipes/quicklook_watch_not_recent.recipe` which only processes observations from more than one day ago.  `scripts/launch_qlp.sh` was modified so that there's a command line option to invoke this recipe.  When this version is run as the first QLP processing instance, there's no duplicate processing and the system is more efficient.