### PR TITLE
QLP Guider bugfix

### DIFF
--- a/configs/quicklook_match.cfg
+++ b/configs/quicklook_match.cfg
@@ -12,7 +12,7 @@ outdir= '/data/QLP/'
 # see quicklook_match.recipe for a description of how to set fullpath
 #fullpath = '/data/L1/202?????/KP.20240116.?????.??*.fits'
 #fullpath = '/data/masters/20230429/*.fits'
-fullpath = '/data/2D/20250409/KP.20250409.08314.70_2D.fits'
+fullpath = '/data/L0/20250429/KP.20250429.2????.??.fits'
 
 [MODULE_CONFIGS]
 quicklook = modules/quicklook/configs/default.cfg

--- a/modules/quicklook/src/analyze_guider.py
+++ b/modules/quicklook/src/analyze_guider.py
@@ -1,6 +1,7 @@
 import time
 import copy
 import numpy as np
+import seaborn as sns
 from datetime import datetime
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
@@ -426,7 +427,7 @@ class AnalyzeGuider:
         
         # Create the figure and subplots
         fig, axes = plt.subplots(1, 2, figsize=(16, 4), gridspec_kw={'width_ratios': [2, 1]}, tight_layout=True)
-        plt.style.use('seaborn-whitegrid')
+        sns.set_theme(style='whitegrid')
 
         # Plot the data
         if self.nframes_uniq_mas > 10:
@@ -488,7 +489,7 @@ class AnalyzeGuider:
         
         # Create the figure and subplots
         fig, axes = plt.subplots(4, 2, figsize=(16, 15), gridspec_kw={'width_ratios': [2, 1]}, tight_layout=True)
-        plt.style.use('seaborn-whitegrid')
+        sns.set_theme(style='whitegrid')
 
         # Count number of stars
         #nstars = []
@@ -698,7 +699,7 @@ class AnalyzeGuider:
         """
 
         # Construct plots
-        plt.style.use('seaborn-whitegrid')
+        sns.set_theme(style='whitegrid')
         plt.figure(figsize=(8, 4), tight_layout=True)
         if self.nframes > 0:
             plt.plot(self.t-min(self.t), self.df_GUIDER.object1_flux/np.nanpercentile(self.df_GUIDER.object1_flux, 95), color='royalblue')
@@ -743,7 +744,7 @@ class AnalyzeGuider:
         fwhm = (self.df_GUIDER.object1_a**2 + self.df_GUIDER.object1_b**2)**0.5 / self.pixel_scale * (2*(2*np.log(2))**0.5)
 
         # Construct plots
-        plt.style.use('seaborn-whitegrid')
+        sns.set_theme(style='whitegrid')
         plt.figure(figsize=(8, 4), tight_layout=True)
         if self.nframes > 0:
             plt.plot(self.t-min(self.t), fwhm, color='royalblue')

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ psycopg2-binary
 tqdm
 dataclasses
 pyyaml
+seaborn
 # The following is required by polly.
 pyfonts
 


### PR DESCRIPTION
This addresses Issue https://github.com/Keck-DataReductionPipelines/KPF-Pipeline/issues/1095 that @howardisaacson posted.

The latest version of matplotlib that we're using doesn't include 'seaborn' for plot formatting as part of that package.  One must import the package.  Doing so required adding it to the dependencies.  @bjfultn, if you think this is an unwise dependency, let me know and I'll find another solution.

@bjfultn -- I suggest merging this soon after it passes CI.  It will be very helpful for observing tomorrow night.