### PR TITLE
Overhaul Jenkins

### DIFF
--- a/Jenkinsfile.development
+++ b/Jenkinsfile.development
@@ -55,6 +55,7 @@ pipeline {
             -e CI_PULL_REQUEST=\$ghprbPullId \
             -v \"\${PWD}:/code/KPF-Pipeline\" \
             -v \"${CI_DATA_DIR}:/data" \
+            -v \"${CI_DATA_DIR}/masters:/masters" \
             -v \"${KPFPIPE_TEST_DATA}:/testdata" \
             kpf-drp:latest \
             make init regression_tests

--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ docker:
 			   -v ${PWD}:/code/KPF-Pipeline -v ${KPFPIPE_TEST_DATA}:/testdata -v ${KPFPIPE_DATA}:/data -v ${KPFPIPE_DATA}/masters:/masters kpf-drp:latest bash
 
 regression_tests:
-	pytest -x --cov=kpfpipe --cov=modules --pyargs tests.regression
+	pytest -x --cov=kpfpipe --cov=modules --pyargs tests.regression.test_kpf_masters_drp_recipe
 	coveralls
 
 performance_tests:


### PR DESCRIPTION
- Use Jenkins file for finer control over when the CI runs
- Now it should only run when PRs are submitted, not on every push
- Each executor has its own environment where test files are copied into in order to allow for more parallelization and less collisions