### PR TITLE
QC report in yaml files

### DIFF
--- a/configs/quicklook_match.cfg
+++ b/configs/quicklook_match.cfg
@@ -12,7 +12,7 @@ outdir= '/data/QLP/'
 # see quicklook_match.recipe for a description of how to set fullpath
 #fullpath = '/data/L1/202?????/KP.20240116.?????.??*.fits'
 #fullpath = '/data/masters/20230429/*.fits'
-fullpath = '/data/L1/20241026/KP.20241026.43702.96_L1.fits'
+fullpath = '/data/2D/20250515/KP.20250515.74655.02*.fits'
 
 [MODULE_CONFIGS]
 quicklook = modules/quicklook/configs/default.cfg

--- a/modules/quality_control/src/quality_control.py
+++ b/modules/quality_control/src/quality_control.py
@@ -317,6 +317,7 @@ def QC_report(kpf_object, return_keywords=True, print_output=False, yaml_outfile
     this_spectrum_type = primary_header.get_name(use_star_names=False)
 
     ObsID = kpf_object.header['PRIMARY'].get('OFNAME', 'ObsID not available')
+    ObsID = ObsID.removesuffix('.fits')
 
     data_levels_map = {'L0': ['L0'], '2D': ['L0', '2D'], 'L1': ['L0', '2D', 'L1'], 'L2': ['L0', '2D', 'L1', 'L2']}
     data_levels = data_levels_map.get(this_data_level, [])

--- a/modules/quicklook/src/alg.py
+++ b/modules/quicklook/src/alg.py
@@ -23,6 +23,7 @@ from modules.quicklook.src.analyze_2d import Analyze2D
 from modules.quicklook.src.analyze_l1 import AnalyzeL1
 from modules.quicklook.src.analyze_wls import AnalyzeWLS
 from modules.quicklook.src.analyze_l2 import AnalyzeL2
+from modules.quality_control.src.quality_control import QC_report
 from modules.Utils.kpf_parse import HeaderParse
 #import kpfpipe.pipelines.fits_primitives as fits_primitives
 from modules.Utils.kpf_parse import get_data_products_L0
@@ -239,6 +240,14 @@ class QuicklookAlg:
         except Exception as e:
             self.logger.error(f"Failure creating base output diretory in Exposure Meter quicklook pipeline: {e}\n{traceback.format_exc()}")
 
+        # Generate Quality Control report
+        try:    
+            savedir = D2_QLP_file_base +'QC/'    
+            os.makedirs(savedir, exist_ok=True) # make directories if needed
+            
+            yaml_filename = savedir + self.ObsID + '_2D_QC_report.yaml' 
+            QC_report(kpf2d, yaml_outfile=yaml_filename)
+
         # Make CaHK plots
         if 'HK' in self.data_products:    
             try:    
@@ -440,6 +449,14 @@ class QuicklookAlg:
         except Exception as e:
             self.logger.error(f"Failure creating base output diretory in Exposure Meter quicklook pipeline: {e}\n{traceback.format_exc()}")
 
+        # Generate Quality Control report
+        try:    
+            savedir = L1_QLP_file_base +'QC/'    
+            os.makedirs(savedir, exist_ok=True) # make directories if needed
+            
+            yaml_filename = savedir + self.ObsID + '_L1_QC_report.yaml' 
+            QC_report(kpf1, yaml_outfile=yaml_filename)
+
         # Make WLS plots
         try:
             savedir = L1_QLP_file_base +'WLS/'
@@ -599,6 +616,14 @@ class QuicklookAlg:
 
         except Exception as e:
             self.logger.error(f"Failure creating base output diretory in Exposure Meter quicklook pipeline: {e}\n{traceback.format_exc()}")
+
+        # Generate Quality Control report
+        try:    
+            savedir = L2_QLP_file_base +'QC/'    
+            os.makedirs(savedir, exist_ok=True) # make directories if needed
+            
+            yaml_filename = savedir + self.ObsID + '_L2_QC_report.yaml' 
+            QC_report(kpf2, yaml_outfile=yaml_filename)
 
         # Make CCF grid plots
         if chips != []:    

--- a/modules/quicklook/src/alg.py
+++ b/modules/quicklook/src/alg.py
@@ -248,6 +248,9 @@ class QuicklookAlg:
             yaml_filename = savedir + self.ObsID + '_2D_QC_report.yaml' 
             QC_report(kpf2d, yaml_outfile=yaml_filename)
 
+        except Exception as e:    
+            self.logger.error(f"Problem generating QC report: {e}\n{traceback.format_exc()}")
+
         # Make CaHK plots
         if 'HK' in self.data_products:    
             try:    
@@ -457,6 +460,9 @@ class QuicklookAlg:
             yaml_filename = savedir + self.ObsID + '_L1_QC_report.yaml' 
             QC_report(kpf1, yaml_outfile=yaml_filename)
 
+        except Exception as e:    
+            self.logger.error(f"Problem generating QC report: {e}\n{traceback.format_exc()}")
+
         # Make WLS plots
         try:
             savedir = L1_QLP_file_base +'WLS/'
@@ -624,6 +630,9 @@ class QuicklookAlg:
             
             yaml_filename = savedir + self.ObsID + '_L2_QC_report.yaml' 
             QC_report(kpf2, yaml_outfile=yaml_filename)
+
+        except Exception as e:    
+            self.logger.error(f"Problem generating QC report: {e}\n{traceback.format_exc()}")
 
         # Make CCF grid plots
         if chips != []:    


### PR DESCRIPTION
We've recently had the ability to produce Quality Control reports like the one shown below in ASCII format.  This PR adds the ability for these reports to be exported in YAML format and automates their production in the Quicklook recipe.  The next step will be parsing and displaying them using Jump

<img width="717" alt="Screenshot 2025-05-28 at 5 41 42 PM" src="https://github.com/user-attachments/assets/a96eb248-99f0-4fd0-980a-57340855e3d1" />
