### PR TITLE
reprocess_obs.sh working again

### DIFF
--- a/docs/source/processing/reprocessing.rst
+++ b/docs/source/processing/reprocessing.rst
@@ -14,8 +14,8 @@ In production processing by the DRP development team, this command is in the xte
 
 Here's the docstring showing all of the options.::
 
-    usage: reprocess_obs.py [-h] [--ncpu NCPU] [--overwrite] [--logfile LOGFILE] [--forward] [--not-nice]
-                            [--no-delete] [--dry-run] [--stdout] [--local-tz LOCAL_TZ]
+    usage: reprocess_obs.py [-h] [--ncpu NCPU] [--overwrite] [--logfile LOGFILE] [--forward] [--force]
+                            [--not-nice] [--delete] [--dry-run] [--local-tz LOCAL_TZ]
                             startdate enddate
     
     Reprocess KPF data over a date range.
@@ -27,13 +27,12 @@ Here's the docstring showing all of the options.::
     options:
       -h, --help           show this help message and exit
       --ncpu NCPU          Number of CPUs to use
-      --overwrite          Overwrite previous successful processing results with current version in logfile
+      --delete             Delete existing 2D/L1/L2/QLP files before reprocessing
+      --force              Process even if datecode/version are listed in the logfile
       --logfile LOGFILE    Log file path
       --forward            Process datecodes in chronological order (reverse is default)
       --not-nice           Do not apply standard nice (=15) deprioritization
-      --no-delete          Do not delete existing 2D/L1/L2/QLP files before reprocessing
       --dry-run            Print commands without executing them
-      --stdout             Display stdout from kpf command
       --local-tz LOCAL_TZ  Local timezone (default: America/Los_Angeles)
 
 One can also reprocess KPF data using the `kpf` command and a recipe.  

--- a/kpfpipe/cli.py
+++ b/kpfpipe/cli.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-
 import sys
 import os
 import gc
@@ -26,6 +25,7 @@ from keckdrpframework.config.framework_config import ConfigClass
 
 from kpfpipe.pipelines.kpfpipeline import KPFPipeline
 from kpfpipe.logger import start_logger
+from kpfpipe.tools.git_tools import get_git_tag, get_git_branch
 
 # This is the default framework configuration file path
 framework_config = 'configs/framework.cfg'
@@ -36,12 +36,13 @@ pipeline_logcfg = 'configs/logger.cfg'
 update_lock = threading.Lock()
 
 def _parseArguments(in_args: list) -> argparse.Namespace:
-    from kpfpipe import __version__  # Delayed import to avoid circularity
     
-    description = f"KPF Pipeline CLI (version {__version__})"
+    git_tag = get_git_tag()
+    git_branch = get_git_branch()
+    description = f"KPF Pipeline CLI ({git_tag}, branch: {git_branch})"
 
     parser = argparse.ArgumentParser(description=description, prog='kpf')
-    parser.add_argument('--version', action='version', version=f'%(prog)s {__version__}',
+    parser.add_argument('--version', action='version', version=f'%(prog)s {git_tag}',
                         help="Show version number and exit")
     parser.add_argument('--watch', dest='watch', type=str, default=None,
                         help="Watch for new data arriving in a directory and run the recipe and config on each file.")

--- a/scripts/reprocess_obs.py
+++ b/scripts/reprocess_obs.py
@@ -63,7 +63,7 @@ def main():
 
     if not log_exists:
         with open(args.logfile, 'w') as f:
-            f.write(f"{'Datecode':<10}  {'Start Time':<19}  {'End Time':<19}  {'Run Time':<15}  {'Version':<10}\n")
+            f.write(f"{'Datecode':<10}  {'Start Time':<19}  {'End Time':<19}  {'Run Time':<11}  {'Version':<10}\n")
         os.chmod(args.logfile, 0o666)
 
     start_date = datetime.datetime.strptime(args.startdate, '%Y%m%d')


### PR DESCRIPTION
I think I fixed the script `reprocess_obs.sh`.  I'm currently testing it on the two-day date range 20240629-20240630.  The script passed through 20240630 (this previously failed) and 20240629 is running now.  I'm submitting this PR now so that the CI tests can start running.  I'll remove the "don't merge" tag when the second day successfully completes running.

The problem had to do with the subprocess module hanging depending on how stdout and stderr are captured.