### PR TITLE
Reprocess Flag

### DIFF
--- a/kpfpipe/cli.py
+++ b/kpfpipe/cli.py
@@ -36,48 +36,69 @@ pipeline_logcfg = 'configs/logger.cfg'
 update_lock = threading.Lock()
 
 def _parseArguments(in_args: list) -> argparse.Namespace:
-    
+    """
+    Parse command-line arguments for the KPF Pipeline CLI.
+
+    This function sets up the argument parser, including mutually exclusive --watch and --reprocess modes,
+    and returns the parsed arguments namespace. Required and optional arguments are documented in the CLI help.
+
+    Args:
+        in_args (list): List of command-line arguments (typically sys.argv).
+
+    Returns:
+        argparse.Namespace: Parsed arguments.
+    """
     git_tag = get_git_tag()
     git_branch = get_git_branch()
-    description = f"KPF Pipeline CLI ({git_tag}, branch: {git_branch})"
+    description = (
+        f"KPF Pipeline CLI ({git_tag}, branch: {git_branch})\n"
+        "A command-line interface for running the KPF data reduction pipeline in batch or watch mode.\n\n"
+        "Examples:\n"
+        "  kpf --watch /data/kpf/ -r my_recipe.txt -c my_config.cfg\n"
+        "  kpf --reprocess /data/kpf/20240806/ -r my_recipe.txt -c my_config.cfg\n"
+        "  kpf --reprocess /data/kpf/filelist.txt -r my_recipe.txt -c my_config.cfg\n"
+        "  kpf --reprocess /data/kpf/singlefile.fits -r my_recipe.txt -c my_config.cfg\n"
+    )
 
-    parser = argparse.ArgumentParser(description=description, prog='kpf')
+    parser = argparse.ArgumentParser(description=description, prog='kpf', formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument('--version', action='version', version=f'%(prog)s {git_tag}',
-                        help="Show version number and exit")
-    parser.add_argument('--watch', dest='watch', type=str, default=None,
-                        help="Watch for new data arriving in a directory and run the recipe and config on each file.")
-    parser.add_argument('--reprocess', dest='reprocess', action='store_true',
-                        help="For use in watch mode. Process any existing files found in the watch mode path.")
+                        help="Show version number and exit.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--watch', dest='watch', type=str, default=None,
+                        help="Watch a directory for new FITS files and process them as they arrive. The pipeline will continue running until stopped. Default: None.")
+    group.add_argument('--reprocess', dest='reprocess', type=str, default=None,
+                        help="Process existing files and exit. Accepts a directory (processes all .fits files in reverse order), a single .fits file, or a text file containing a list of .fits files (processed in listed order). Mutually exclusive with --watch. Default: None.")
     parser.add_argument('--masters', dest='masters', action='store_true',
-                        help="For use in watch mode. Process any existing files found in the watch mode path. Use if processing a directory of masters files. Will only look for files without 'WLS', 'L1', or 'L2' in the filename")
-    parser.add_argument('-r', '--recipe', required=True, dest='recipe', type=str, help="Recipe file with list of actions to take.")
-    parser.add_argument('-c', '--config', required=True, dest="config_file", type=str, help="Configuration file")
-    parser.add_argument('--date', dest='date', type=str, default=None, help="Date for the data to be processed.")
-    parser.add_argument('-n', '--ncpus', dest='ncpus', type=int, default=1, help="Number of CPU cores to utilize.")
+                        help="When used with --watch or --reprocess, only process files that do not contain 'WLS', 'L1', or 'L2' in the filename (useful for master calibration files). Default: False.")
+    parser.add_argument('--date', dest='date', type=str, default=None, 
+                        help="Date string for the data to be processed (used in non-watch mode). Default: None.")
+    parser.add_argument('-n', '--ncpus', dest='ncpus', type=int, default=1, 
+                        help="Number of CPU cores to use for parallel processing. Default: 1.")
+    parser.add_argument('-r', '--recipe', required=True, dest='recipe', type=str, 
+                        help="Path to the recipe file specifying the pipeline actions to perform. (Required)")
+    parser.add_argument('-c', '--config', required=True, dest="config_file", type=str, 
+                        help="Path to the pipeline configuration file. (Required)")
 
     args = parser.parse_args(in_args[1:])
 
+    # If both are set, argparse will error due to mutually exclusive group
     return args
 
 
 def worker(worker_num, pipeline_config, framework_logcfg_file, framework_config_file):
-    """The worker framework instances that will execute items from the queue
-
-    Parameters
-    ----------
-    worker_num : int
-        Number of this worker (just nice for printing out)
-    pipeline_config : ConfigClass
-        Pipeline config
-    framework_logcfg_file : str
-        Logger config file
-    framework_config_file : str
-        Framework config file
     """
-    # Initialize the framework however you normally do
+    Worker process for running a pipeline instance.
+
+    Each worker initializes a Framework instance and starts the pipeline, typically used for parallel processing.
+
+    Args:
+        worker_num (int): Worker index (for logging and identification).
+        pipeline_config (ConfigClass): Pipeline configuration object.
+        framework_logcfg_file (str): Path to the logger configuration file.
+        framework_config_file (str): Path to the framework configuration file.
+    """
     try:
         framework = Framework(KPFPipeline, framework_config_file)
-        # logging.config.fileConfig(framework_logcfg_file)
         framework.config.instrument = pipeline_config
     except Exception as e:
         print("Failed to initialize framework, exiting ...", e)
@@ -90,14 +111,28 @@ def worker(worker_num, pipeline_config, framework_logcfg_file, framework_config_
 
     # Start the framework. We set wait_for_event and continous to true, which
     # tells this instance to wait for something to happen, forever
-    # qm_only=False, ingest_data_only=False,
     framework.pipeline.start(pipeline_config)
-    # framework.start(wait_for_event=True, continuous=True)
     framework.start()
 
 
 class FileAlarm(PatternMatchingEventHandler):
+    """
+    Event handler for file system events in watch mode.
+
+    This class is used with watchdog to monitor a directory for new or modified FITS files.
+    When a relevant file event is detected, it triggers the pipeline to process the file.
+    Duplicate or temporary file events are filtered to avoid redundant processing.
+    """
     def __init__(self, framework, arg, patterns=["*"], cooldown=1):
+        """
+        Initialize the FileAlarm event handler.
+
+        Args:
+            framework: The pipeline framework instance.
+            arg: Arguments object for the pipeline event.
+            patterns (list): List of file patterns to watch.
+            cooldown (float): Minimum time (seconds) between processing the same file.
+        """
         PatternMatchingEventHandler.__init__(self, patterns=patterns,
                                              ignore_patterns=['*/.*', '*/*~'])
 
@@ -106,24 +141,27 @@ class FileAlarm(PatternMatchingEventHandler):
         self.arg.watch = True
         self.logging = framework.pipeline.logger
         self.cooldown = 0.5
-
         self.file_cache = {}
 
     def check_redundant(self, event):
-        # ignore multiple triggers that happen within 1 second of each other
-        seconds = int(time.time())
-        # key = (seconds, event.src_path)
+        """
+        Check if a file event is redundant (e.g., multiple triggers in quick succession).
+        Returns True if the event should be processed, False if it should be ignored.
+        """
         key = event.src_path
         if key in self.file_cache:
             last_update = self.file_cache[key]
             if time.time() - last_update < 2 * self.cooldown:
                 self.logging.info("Ignoring duplicate file event: {}".format(event.src_path))
                 return False
-
         self.file_cache[key] = time.time()
         return True
 
     def process(self, event):
+        """
+        Process a file event, triggering the pipeline if appropriate.
+        Handles temporary/partial files and ensures only complete files are processed.
+        """
         if os.path.basename(event.src_path).startswith('.'):
             final_file = os.path.dirname(event.src_path) + "/" + \
                 '.'.join(os.path.basename(event.src_path).split('.')[1:-1])
@@ -140,28 +178,48 @@ class FileAlarm(PatternMatchingEventHandler):
             self.framework.append_event('next_file', self.arg)
 
     def on_modified(self, event):
+        """Handle file modification events."""
         self.logging.info("File modification event: {}".format(event.src_path))
         self.process(event)
 
     def on_moved(self, event):
+        """Handle file move events."""
         self.logging.info("File move event: {}".format(event.src_path))
         self.process(event)
 
     def on_created(self, event):
+        """Handle file creation events."""
         self.logging.info("File creation event: {}".format(event.src_path))
         self.process(event)
 
     def on_deleted(self, event):
+        """Handle file deletion events."""
         self.logging.info("File removal event: {}".format(event.src_path))
 
     def stop(self):
+        """Stop the event handler and exit the process."""
         os._exit(0)
 
 
 def main():
-    '''
-    This is executed when 'kpfpipe' is called from commandline
-    '''
+    """
+    Entry point for the KPF Pipeline CLI.
+
+    Supports two main modes:
+      --watch: Watches a directory for new FITS files and processes them as they arrive. The pipeline continues running until stopped.
+      --reprocess: Processes a specified set of files and exits. Accepts a directory (all .fits files in reverse order), a single .fits file, or a file containing a list of .fits files (processed in listed order).
+
+    Use --masters to restrict processing to master calibration files (excludes files with 'WLS', 'L1', or 'L2' in the filename).
+
+    Defaults:
+      --watch: None
+      --reprocess: None
+      --masters: False
+      --date: None
+      --ncpus: 1
+
+    See --help for more details and usage examples.
+    """
     args = _parseArguments(sys.argv)
     # Set the pipeline and read the config file.
     # Using configparser for any configuration reading on the pipeline's
@@ -183,6 +241,8 @@ def main():
         frame_config.set('DEFAULT', 'event_timeout', '10')
         frame_config.set('DEFAULT', 'no_event_event', 'exit')
         frame_config.set('DEFAULT', 'no_event_wait_time', '5')
+        # For downstream logic, treat as watch mode
+        args.watch = True
     elif args.watch:
         frame_config.set('DEFAULT', 'event_timeout', '1200')
         frame_config.set('DEFAULT', 'no_event_event', 'Event("wait", None)')
@@ -196,7 +256,6 @@ def main():
     # Using the multiprocessing library, create the specified number of instances
     if args.watch:
         for i in range(args.ncpus):
-            # This could be done with a careful use of subprocess.Popen, if that's more your style
             p = Process(target=worker, args=(i, pipe_config, framework_logcfg, frame_config))
             p.start()
     else:
@@ -216,28 +275,57 @@ def main():
     # watch mode
 
 
-    if args.watch != None:
-        framework.pipeline.logger.info("Waiting for files to appear in {}".format(args.watch))
+    if args.watch is not None:
+        framework.pipeline.logger.info("Waiting for files to appear in {}".format(args.watch if not args.reprocess else args.reprocess))
         framework.pipeline.logger.info("Getting existing file list.")
-        infiles = sorted(glob(args.watch + "*.fits"), reverse=True) + \
-                sorted(glob(args.watch + "20*/*.fits"), reverse=True)
 
-        if args.masters:
-            infiles_all_fits = sorted(glob(args.watch + "*.fits"), reverse=True)
+        # Determine infiles based on reprocess or watch
+        infiles = []
+        if args.reprocess:
+            reproc_path = args.reprocess
+            if os.path.isdir(reproc_path):
+                # Directory: all .fits files, reverse order
+                infiles = sorted(glob(os.path.join(reproc_path, "*.fits")), reverse=True)
+            elif os.path.isfile(reproc_path):
+                if reproc_path.lower().endswith('.fits'):
+                    # Single fits file
+                    infiles = [reproc_path]
+                else:
+                    # Assume file list
+                    with open(reproc_path, 'r') as f:
+                        listed_files = [line.strip() for line in f if line.strip()]
+                    for fpath in listed_files:
+                        if os.path.isfile(fpath):
+                            infiles.append(fpath)
+                        else:
+                            framework.pipeline.logger.warning(f"File listed in {reproc_path} not found: {fpath}")
+            else:
+                framework.pipeline.logger.error(f"--reprocess argument '{reproc_path}' is not a valid file or directory.")
+                sys.exit(1)
+            # If masters, filter out L1/L2
+            if args.masters:
+                infiles = [f for f in infiles if 'L1' not in f and 'L2' not in f]
+        else:
+            # Watch mode: gather files in directory
+            infiles = sorted(glob(args.watch + "*.fits"), reverse=True) + \
+                    sorted(glob(args.watch + "20*/*.fits"), reverse=True)
+            if args.masters:
+                infiles_all_fits = sorted(glob(args.watch + "*.fits"), reverse=True)
+                infiles = []
+                for f in infiles_all_fits:
+                    if "L1" in f:
+                        continue
+                    if "L2" in f:
+                        continue
+                    infiles.append(f)
 
-            infiles = []
-            for f in infiles_all_fits:
-                if "L1" in f:
-                    continue
-                if "L2" in f:
-                    continue
-                infiles.append(f)
-
-        observer = PollingObserver(framework.config.monitor_interval)
-        al = FileAlarm(framework, arg, patterns=[args.watch+"*.fits*",
-                                                 args.watch+"20*/*.fits"])
-        observer.schedule(al, path=args.watch, recursive=True)
-        observer.start()
+        # Only start observer in watch mode (not reprocess)
+        if not args.reprocess:
+            observer = PollingObserver(framework.config.monitor_interval)
+            al = FileAlarm(framework, arg, patterns=[args.watch+"*.fits*",
+                                                     args.watch+"20*/*.fits"])
+            observer.schedule(al, path=args.watch, recursive=True)
+            observer.start()
 
         if args.reprocess:
             framework.pipeline.logger.info("Found {:d} files to process.".format(len(infiles)))
@@ -251,7 +339,8 @@ def main():
                 arg.watch = True
                 framework.append_event('next_file', arg)
                 time.sleep(0.1)
-
+            # After processing, exit
+            return
         else:
             framework.start(qm_only=True)
     else:

--- a/scripts/reprocess_obs.py
+++ b/scripts/reprocess_obs.py
@@ -100,7 +100,7 @@ def main():
         ]
 
         cmd_kpf = [
-            'kpf', '--ncpu', str(args.ncpu), '--watch', f'/data/L0/{datecode}/', '--reprocess',
+            'kpf', '--ncpu', str(args.ncpu), '--reprocess', f'/data/L0/{datecode}/',
             '-c', 'configs/kpf_drp.cfg', '-r', 'recipes/kpf_drp.recipe'
         ]
 


### PR DESCRIPTION
- `--reprocess` can now take a directory (processes all .fits files in reverse order), a single .fits file, or a text file with a list of .fits files.
- The CLI now makes sure you can’t use --watch and --reprocess at the same time.
- Updated help text and examples to show the right way to use these flags.
- Cleaned up the code and docstrings for clarity.
- All scripts and docs now use the new flag logic—no more old patterns with both flags together.
