### PR TITLE
Optimize masters by reducing l0 reads

### DIFF
--- a/modules/Utils/kpf_fits.py
+++ b/modules/Utils/kpf_fits.py
@@ -79,8 +79,6 @@ class FitsHeaders:
         matched_fits_files = []
         for fits_file in self.input_fits_files:
 
-            hdul = fits.open(fits_file)
-
             match_count = 0
             for i in range(self.n_header_keywords):
 
@@ -88,7 +86,7 @@ class FitsHeaders:
 
                 try:
 
-                    val = hdul[0].header[self.header_keywords[i]]
+                    val = fits.getval(fits_file, self.header_keywords[i])
                     fits_value = (val).lower()
                     if (fits_value == input_value):
                         match_count += 1
@@ -109,8 +107,6 @@ class FitsHeaders:
 
             if match_count == self.n_header_keywords:
                 matched_fits_files.append(fits_file)
-
-            hdul.close()
 
         if self.logger:
              self.logger.info('FitsHeaders.match_headers_string_lower(): matched_fits_files = {}'.\
@@ -240,8 +236,6 @@ class FitsHeaders:
         all_dark_objects = []
         for fits_file in matched_fits_files:
 
-            hdul = fits.open(fits_file)
-
             flag = 'remove'
 
             try:
@@ -251,7 +245,7 @@ class FitsHeaders:
                 if (val4 >= exptime_minimum):
                     flag = 'keep'
                     filtered_matched_fits_files.append(fits_file)
-                    obj = hdul[0].header['OBJECT']
+                    obj = fits.getval(fits_file, 'OBJECT')
                     if obj not in all_dark_objects:
                         all_dark_objects.append(obj)
 
@@ -268,8 +262,6 @@ class FitsHeaders:
                     self.logger.info('Exception caught: {} for FITS file {}; skipping...'.format(err,fits_file))
                 else:
                     print('---->Exception caught: {} for FITS file {}; skipping...'.format(err,fits_file))
-
-            hdul.close()
 
         if self.logger:
              self.logger.info('FitsHeaders.get_good_darks(): filtered_matched_fits_files = {}'.\
@@ -290,7 +282,6 @@ class FitsHeaders:
         all_arclamp_objects = []
         for fits_file in self.input_fits_files:
 
-            hdul = fits.open(fits_file)
             match_count = 0
             for i in range(self.n_header_keywords):
 
@@ -298,7 +289,7 @@ class FitsHeaders:
 
                 try:
 
-                    val = hdul[0].header[self.header_keywords[i]]
+                    val = fits.getval(fits_file, self.header_keywords[i])
                     fits_value = (val).lower()
                     if (fits_value == input_value):
                         match_count += 1
@@ -321,7 +312,7 @@ class FitsHeaders:
 
                 try:
 
-                    obj = hdul[0].header['OBJECT']
+                    obj = fits.getval(fits_file, 'OBJECT')
                     matched_fits_files.append(fits_file)
                     if obj not in all_arclamp_objects:
                         all_arclamp_objects.append(obj)
@@ -332,9 +323,6 @@ class FitsHeaders:
                         self.logger.info('KeyError: {} ({}); skipping...'.format(err,fits_file))
                     else:
                         print('---->KeyError: {} ({}); skipping...'.format(err,fits_file))
-
-
-            hdul.close()
 
         if self.logger:
              self.logger.info('FitsHeaders.get_good_arclamps(): matched_fits_files = {}'.\
@@ -360,8 +348,6 @@ class FitsHeaders:
         all_bias_objects = []
         for fits_file in matched_fits_files:
 
-            hdul = fits.open(fits_file)
-
             flag = 'remove'
 
             try:
@@ -373,13 +359,13 @@ class FitsHeaders:
                 # SCRAMSHT= 'closed ' / Scrambler shutter at exp. midpoint
                 # SIMCALSH= 'closed ' / Simult Cal shutter at exp. midpoint
 
-                SCISEL = hdul[0].header['SCISEL']
-                SKYSEL = hdul[0].header['SKYSEL']
-                FFSHTR = hdul[0].header['FFSHTR']
-                SCRAMSHT = hdul[0].header['SCRAMSHT']
-                SIMCALSH = hdul[0].header['SIMCALSH']
+                SCISEL = fits.getval(fits_file, 'SCISEL')
+                SKYSEL = fits.getval(fits_file, 'SKYSEL')
+                FFSHTR = fits.getval(fits_file, 'FFSHTR')
+                SCRAMSHT = fits.getval(fits_file, 'SCRAMSHT')
+                SIMCALSH = fits.getval(fits_file, 'SIMCALSH')
 
-                ELAPSED = hdul[0].header['ELAPSED']
+                ELAPSED = fits.getval(fits_file, 'ELAPSED')
 
                 if 'closed' in SCISEL and \
                    'closed' in SKYSEL and \
@@ -390,7 +376,7 @@ class FitsHeaders:
                     if (ELAPSED <= exptime_maximum):
                         flag = 'keep'
                         filtered_matched_fits_files.append(fits_file)
-                        obj = hdul[0].header['OBJECT']
+                        obj = fits.getval(fits_file, 'OBJECT')
                         if obj not in all_bias_objects:
                             all_bias_objects.append(obj)
 
@@ -407,8 +393,6 @@ class FitsHeaders:
                     self.logger.info('Exception caught: {} for FITS file {}; skipping...'.format(err,fits_file))
                 else:
                     print('---->Exception caught: {} for FITS file {}; skipping...'.format(err,fits_file))
-
-            hdul.close()
 
         if self.logger:
              self.logger.info('FitsHeaders.get_good_biases(): filtered_matched_fits_files = {}'.\

--- a/modules/Utils/overscan_subtract.py
+++ b/modules/Utils/overscan_subtract.py
@@ -97,17 +97,22 @@ class OverscanSubtraction(KPF0_Primitive):
         elif self.ffi_exts[0] == 'GREEN_CCD':
             self.module_config_path = DEFAULT_CFG_PATH_GREEN
 
-        print("{} class: self.module_config_path = {}".format(self.__class__.__name__,self.module_config_path))
-
-        print("Starting logger...")
-        self.logger = start_logger(self.__class__.__name__, self.module_config_path)
-
-        if self.logger is not None:
-            print("--->self.logger is not None...")
+        # Only start logger if it doesn't already exist for this class
+        logger_name = self.__class__.__name__
+        existing_logger = logging.getLogger(logger_name)
+        
+        if not existing_logger.handlers or not hasattr(self.__class__, '_class_logger'):
+            # Logger doesn't exist or has no handlers, create it
+            print("Starting logger for {}...".format(logger_name))
+            self.logger = start_logger(logger_name, self.module_config_path)
+            # Cache the logger at class level to reuse
+            self.__class__._class_logger = self.logger
+            print("Logger started for {}.".format(logger_name))
         else:
-            print("--->self.logger is None...")
+            # Reuse existing logger
+            self.logger = getattr(self.__class__, '_class_logger', existing_logger)
 
-        self.logger.info('Started {}'.format(self.__class__.__name__))
+        self.logger.info('Started {} instance'.format(self.__class__.__name__))
         self.logger.debug('module_config_path = {}'.format(self.module_config_path))
 
         if self.mode == 'clippedmean':

--- a/modules/master_arclamp/src/master_arclamp_framework.py
+++ b/modules/master_arclamp/src/master_arclamp_framework.py
@@ -288,6 +288,11 @@ class MasterArclampFramework(KPF0_Primitive):
         except Exception as e:
             self.logger.warning('Error closing database connection: {}'.format(str(e)))
             # Continue execution even if close fails
+        finally:
+            # Ensure we always move past this point
+            dbh = None
+            
+        self.logger.debug('Starting to load master calibration files...')
 
         master_bias_data = KPF0.from_fits(self.masterbias_path,self.data_type)
         master_dark_data = KPF0.from_fits(self.masterdark_path,self.data_type)
@@ -299,12 +304,12 @@ class MasterArclampFramework(KPF0_Primitive):
         exp_time_list = []
         arclamp_object_list = []
         for arclamp_file_path in (all_arclamp_files):
-            arclamp_file = KPF0.from_fits(arclamp_file_path,self.data_type)
-            mjd_obs = float(arclamp_file.header['PRIMARY']['MJD-OBS'])
+            # Optimized: Read only header instead of full file for MJD-OBS, ELAPSED, and OBJECT
+            mjd_obs = float(fits.getval(arclamp_file_path, 'MJD-OBS'))
             mjd_obs_list.append(mjd_obs)
-            exp_time = float(arclamp_file.header['PRIMARY']['ELAPSED'])
+            exp_time = float(fits.getval(arclamp_file_path, 'ELAPSED'))
             exp_time_list.append(exp_time)
-            header_object = arclamp_file.header['PRIMARY']['OBJECT']
+            header_object = fits.getval(arclamp_file_path, 'OBJECT')
             arclamp_object_list.append(header_object)
             #self.logger.debug('arclamp_file_path,exp_time,header_object = {},{},{}'.format(arclamp_file_path,exp_time,header_object))
 
@@ -312,32 +317,36 @@ class MasterArclampFramework(KPF0_Primitive):
         # Ensure prototype FITS header for product file has matching OBJECT and contains both
         # GRNAMPS and REDAMPS keywords (indicating that the data exist).
 
+        tester = None
         for arclamp_file_path in (all_arclamp_files):
 
-            tester = KPF0.from_fits(arclamp_file_path)
-            tester_object = tester.header['PRIMARY']['OBJECT']
+            # Optimized: Use header-only reads to check conditions before loading full file
+            try:
+                tester_object = fits.getval(arclamp_file_path, 'OBJECT')
+                
+                if tester_object == self.arclamp_object:
+                    # Check for required keywords using header-only access
+                    try:
+                        tester_grnamps = fits.getval(arclamp_file_path, 'GRNAMPS')
+                    except KeyError as err:
+                        continue
 
-            if tester_object == self.arclamp_object:
+                    try:
+                        tester_redamps = fits.getval(arclamp_file_path, 'REDAMPS')
+                    except KeyError as err:
+                        continue
 
-                try:
-                    tester_grnamps = tester.header['PRIMARY']['GRNAMPS']
-                except KeyError as err:
-                    continue
-
-                try:
-                    tester_redamps = tester.header['PRIMARY']['REDAMPS']
-                except KeyError as err:
-                    continue
-
-                self.logger.info('Prototype FITS header from {}'.format(arclamp_file_path))
-
-                date_obs = tester.header['PRIMARY']['DATE-OBS']
-
-                break
-
-            else:
-
-                tester = None
+                    # All conditions met - now load the full file for use as prototype
+                    tester = KPF0.from_fits(arclamp_file_path)
+                    date_obs = tester.header['PRIMARY']['DATE-OBS']
+                    
+                    self.logger.info('Prototype FITS header from {}'.format(arclamp_file_path))
+                    break
+                    
+            except Exception as e:
+                # Skip files that can't be read
+                self.logger.debug('Could not read header from {}: {}'.format(arclamp_file_path, str(e)))
+                continue
 
         if tester is None:
             master_arclamp_exit_code = 6
@@ -351,62 +360,89 @@ class MasterArclampFramework(KPF0_Primitive):
                 del_ext_list.append(i)
         master_holder = tester
 
+        # Initialize data structures for each extension
         filenames_kept = {}
         n_frames_kept = {}
         mjd_obs_min = {}
         mjd_obs_max = {}
+        frames_data_by_ffi = {}
+        frames_data_exptimes_by_ffi = {}
+        frames_data_mjdobs_by_ffi = {}
+        frames_data_path_by_ffi = {}
+        keep_ffi_flags = {}
+        
         for ffi in self.lev0_ffi_exts:
+            filenames_kept[ffi] = []
+            frames_data_by_ffi[ffi] = []
+            frames_data_exptimes_by_ffi[ffi] = []
+            frames_data_mjdobs_by_ffi[ffi] = []
+            frames_data_path_by_ffi[ffi] = []
+            keep_ffi_flags[ffi] = 0
 
-            self.logger.debug('Loading arclamp data, ffi = {}'.format(ffi))
-            keep_ffi = 0
+        # File-first processing: load each file once and process for both chips
+        files_processed = 0
+        for i in range(0, n_all_arclamp_files):
+            exp_time = exp_time_list[i]
+            mjd_obs = mjd_obs_list[i]
+            header_object = arclamp_object_list[i]
 
-            filenames_kept_list = []
-            frames_data = []
-            frames_data_exptimes = []
-            frames_data_mjdobs = []
-            frames_data_path = []
-            n = 0
-            for i in range(0, n_all_arclamp_files):
-                exp_time = exp_time_list[i]
-                mjd_obs = mjd_obs_list[i]
-                header_object = arclamp_object_list[i]
+            # Skip files that don't match the target object
+            if header_object != self.arclamp_object:
+                continue
 
-                #self.logger.debug('i,fitsfile,ffi,exp_time,arclamp_object_list[i] = {},{},{},{},{}'.format(i,all_arclamp_files[i],ffi,exp_time,arclamp_object_list[i]))
+            # Check if we've reached the maximum number of frames
+            if files_processed >= self.max_num_frames_to_stack:
+                continue
 
+            path = all_arclamp_files[i]
+            
+            # Load the file once for both chips
+            obj = KPF0.from_fits(path)
+
+            # Check QC keywords once per file (applies to both chips)
+            skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
+            self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
+            if skip:
+                continue
+
+            # Process both chips for this file
+            file_valid_for_any_chip = False
+            for ffi in self.lev0_ffi_exts:
                 if not (ffi == 'GREEN_CCD' or ffi == 'RED_CCD'):
                     raise NameError('FITS extension {} not supported; check recipe config file.'.format(ffi))
 
-                if header_object != self.arclamp_object:
-                    #self.logger.debug('---->ffi,header_object,self.arclamp_object = {},{},{}'.format(ffi,header_object,self.arclamp_object))
+                # Check if this extension has valid 2D data
+                try:
+                    np_obj_ffi = np.array(obj[ffi])
+                    np_obj_ffi_shape = np.shape(np_obj_ffi)
+                    n_dims = len(np_obj_ffi_shape)
+                    
+                    if n_dims == 2:       # Valid data extension
+                        keep_ffi_flags[ffi] = 1
+                        filenames_kept[ffi].append(all_arclamp_files[i])
+                        frames_data_by_ffi[ffi].append(obj[ffi])
+                        frames_data_exptimes_by_ffi[ffi].append(exp_time)
+                        frames_data_mjdobs_by_ffi[ffi].append(mjd_obs)
+                        frames_data_path_by_ffi[ffi].append(path)
+                        file_valid_for_any_chip = True
+                        #self.logger.debug('Keeping arclamp image: i,fitsfile,ffi,mjd_obs,exp_time = {},{},{},{},{}'.format(i,all_arclamp_files[i],ffi,mjd_obs,exp_time))
+                except Exception as e:
+                    self.logger.debug('Could not process extension {} for file {}: {}'.format(ffi, path, str(e)))
                     continue
 
-                path = all_arclamp_files[i]
-                obj = KPF0.from_fits(path)
+            # Only increment counter if file was valid for at least one chip
+            if file_valid_for_any_chip:
+                files_processed += 1
 
-
-                # Check QC keywords and skip image if it does not pass QC checking.
-
-                skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
-                self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
-                if skip:
-                    continue
-
-
-                np_obj_ffi = np.array(obj[ffi])
-                np_obj_ffi_shape = np.shape(np_obj_ffi)
-                n_dims = len(np_obj_ffi_shape)
-                #self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
-                if n_dims == 2:       # Check if valid data extension
-                    keep_ffi = 1
-                    filenames_kept_list.append(all_arclamp_files[i])
-                    frames_data.append(obj[ffi])
-                    frames_data_exptimes.append(exp_time)
-                    frames_data_mjdobs.append(mjd_obs)
-                    frames_data_path.append(path)
-                    #self.logger.debug('Keeping arclamp image: i,fitsfile,ffi,mjd_obs,exp_time = {},{},{},{},{}'.format(i,all_arclamp_files[i],ffi,mjd_obs,exp_time))
-                    if n >= self.max_num_frames_to_stack:
-                        continue
-                    n += 1
+        # Process each extension's collected data
+        for ffi in self.lev0_ffi_exts:
+            self.logger.debug('Processing collected arclamp data, ffi = {}'.format(ffi))
+            
+            frames_data = frames_data_by_ffi[ffi]
+            frames_data_exptimes = frames_data_exptimes_by_ffi[ffi]
+            frames_data_mjdobs = frames_data_mjdobs_by_ffi[ffi]
+            frames_data_path = frames_data_path_by_ffi[ffi]
+            keep_ffi = keep_ffi_flags[ffi]
 
             n_frames = (np.shape(frames_data))[0]
             self.logger.debug('Number of frames in stack = {}'.format(n_frames))
@@ -431,7 +467,7 @@ class MasterArclampFramework(KPF0_Primitive):
 
             normalized_frames_data = []
 
-            filenames_kept[ffi] = filenames_kept_list
+            # filenames_kept[ffi] already populated above
             n_frames_kept[ffi] = n_frames
             mjd_obs_min[ffi] = min(frames_data_mjdobs)
             mjd_obs_max[ffi] = max(frames_data_mjdobs)
@@ -623,7 +659,8 @@ class MasterArclampFramework(KPF0_Primitive):
         # Add informational to FITS header.  This is the only way I know of to keep the keyword comment.
 
         master_holder.header['PRIMARY']['IMTYPE'] = ('Arclamp','Master arclamp')
-
+        # log the file writing
+        self.logger.info('Writing master arclamp to {}'.format(self.masterarclamp_path))
         master_holder.to_fits(self.masterarclamp_path)
 
 

--- a/modules/master_arclamp/src/master_arclamp_framework.py
+++ b/modules/master_arclamp/src/master_arclamp_framework.py
@@ -196,11 +196,19 @@ class MasterArclampFramework(KPF0_Primitive):
                     self.masterbias_path = dbh.filename
                 else:
                      self.logger.info('Master bias file cannot be queried from database; returning...')
+                     try:
+                         dbh.close()
+                     except:
+                         pass
                      master_arclamp_exit_code = 5
                      exit_list = [master_arclamp_exit_code,master_arclamp_infobits]
                      return Arguments(exit_list)
             else:
                 self.logger.info('Observation date not available so master bias file cannot be queried from database; returning...')
+                try:
+                    dbh.close()
+                except:
+                    pass
                 master_arclamp_exit_code = 10
                 exit_list = [master_arclamp_exit_code,master_arclamp_infobits]
                 return Arguments(exit_list)
@@ -220,11 +228,19 @@ class MasterArclampFramework(KPF0_Primitive):
                      self.masterdark_path = dbh.filename
                 else:
                      self.logger.info('Master dark file cannot be queried from database; returning...')
+                     try:
+                         dbh.close()
+                     except:
+                         pass
                      master_arclamp_exit_code = 5
                      exit_list = [master_arclamp_exit_code,master_arclamp_infobits]
                      return Arguments(exit_list)
             else:
                 self.logger.info('Observation date not available so master dark file cannot be queried from database; returning...')
+                try:
+                    dbh.close()
+                except:
+                    pass
                 master_arclamp_exit_code = 10
                 exit_list = [master_arclamp_exit_code,master_arclamp_infobits]
                 return Arguments(exit_list)
@@ -245,18 +261,33 @@ class MasterArclampFramework(KPF0_Primitive):
                         self.masterflat_path = dbh.filename
                     else:
                         self.logger.info('Master flat file cannot be queried from database; returning...')
+                        try:
+                            dbh.close()
+                        except:
+                            pass
                         master_arclamp_exit_code = 5
                         exit_list = [master_arclamp_exit_code,master_arclamp_infobits]
                         return Arguments(exit_list)
                 else:
                     self.logger.info('Observation date not available so master flat file cannot be queried from database; returning...')
+                    try:
+                        dbh.close()
+                    except:
+                        pass
                     master_arclamp_exit_code = 10
                     exit_list = [master_arclamp_exit_code,master_arclamp_infobits]
                     return Arguments(exit_list)
 
             self.logger.info('self.masterflat_path = {}'.format(self.masterflat_path))
 
-        dbh.close()      # Close database connection.
+        # Close database connection with error handling
+        try:
+            self.logger.debug('Closing database connection...')
+            dbh.close()
+            self.logger.debug('Database connection closed successfully.')
+        except Exception as e:
+            self.logger.warning('Error closing database connection: {}'.format(str(e)))
+            # Continue execution even if close fails
 
         master_bias_data = KPF0.from_fits(self.masterbias_path,self.data_type)
         master_dark_data = KPF0.from_fits(self.masterdark_path,self.data_type)

--- a/modules/master_arclamp/src/master_arclamp_framework.py
+++ b/modules/master_arclamp/src/master_arclamp_framework.py
@@ -23,6 +23,9 @@ DEFAULT_CFG_PATH = 'modules/master_arclamp/configs/default.cfg'
 
 class MasterArclampFramework(KPF0_Primitive):
 
+    # Class-level logger cache to avoid creating multiple loggers
+    _logger_cache = {}
+
     """
     Description:
         This class works within the Keck pipeline framework to compute the master arclamp,
@@ -95,14 +98,21 @@ class MasterArclampFramework(KPF0_Primitive):
 
         try:
             self.module_config_path = context.config_path['master_arclamp']
-            print("--->MasterFlatFramework class: self.module_config_path =",self.module_config_path)
+            print("--->MasterArclampFramework class: self.module_config_path =",self.module_config_path)
         except:
             self.module_config_path = DEFAULT_CFG_PATH
 
         print("{} class: self.module_config_path = {}".format(self.__class__.__name__,self.module_config_path))
 
-        print("Starting logger...")
-        self.logger = start_logger(self.__class__.__name__, self.module_config_path)
+        # Use cached logger to avoid creating multiple loggers for different arc lamp types
+        logger_key = (self.__class__.__name__, self.module_config_path)
+        if logger_key in MasterArclampFramework._logger_cache:
+            self.logger = MasterArclampFramework._logger_cache[logger_key]
+            print("Reusing cached logger...")
+        else:
+            print("Starting new logger...")
+            self.logger = start_logger(self.__class__.__name__, self.module_config_path)
+            MasterArclampFramework._logger_cache[logger_key] = self.logger
 
         if self.logger is not None:
             print("--->self.logger is not None...")

--- a/modules/master_bias/src/master_bias_framework.py
+++ b/modules/master_bias/src/master_bias_framework.py
@@ -107,43 +107,42 @@ class MasterBiasFramework(KPF0_Primitive):
         mjd_obs_list = []
         bias_object_list = []
         for bias_file_path in (all_bias_files):
-            bias_file = KPF0.from_fits(bias_file_path,self.data_type)
-            mjd_obs = float(bias_file.header['PRIMARY']['MJD-OBS'])
+            # Optimized: Read only header instead of full file for MJD-OBS and OBJECT
+            mjd_obs = float(fits.getval(bias_file_path, 'MJD-OBS'))
             mjd_obs_list.append(mjd_obs)
-            header_object = bias_file.header['PRIMARY']['OBJECT']
+            header_object = fits.getval(bias_file_path, 'OBJECT')
             bias_object_list.append(header_object)
-            #self.logger.debug('bias_file_path,exp_time,header_object = {},{},{}'.format(bias_file_path,exp_time,header_object))
+            #self.logger.debug('bias_file_path,header_object = {},{}'.format(bias_file_path,header_object))
 
 
         # Ensure prototype FITS header for product file has matching OBJECT and contains both
         # GRNAMPS and REDAMPS keywords (indicating that the data exist).
 
+        tester = None
+        date_obs = None
         for bias_file_path in (all_bias_files):
-
-            tester = KPF0.from_fits(bias_file_path)
-            tester_object = tester.header['PRIMARY']['OBJECT']
+            
+            tester_object = fits.getval(bias_file_path, 'OBJECT')
 
             if tester_object == self.bias_object:
 
                 try:
-                    tester_grnamps = tester.header['PRIMARY']['GRNAMPS']
+                    tester_grnamps = fits.getval(bias_file_path, 'GRNAMPS')
                 except KeyError as err:
                     continue
 
                 try:
-                    tester_redamps = tester.header['PRIMARY']['REDAMPS']
+                    tester_redamps = fits.getval(bias_file_path, 'REDAMPS')
                 except KeyError as err:
                     continue
 
                 self.logger.info('Prototype FITS header from {}'.format(bias_file_path))
 
-                date_obs = tester.header['PRIMARY']['DATE-OBS']
+                date_obs = fits.getval(bias_file_path, 'DATE-OBS')
+                # Load the full file only ONE TIME for the selected prototype
+                tester = KPF0.from_fits(bias_file_path)
 
                 break
-
-            else:
-
-                tester = None
 
         if tester is None:
             master_bias_exit_code = 6
@@ -157,52 +156,78 @@ class MasterBiasFramework(KPF0_Primitive):
                 del_ext_list.append(i)
         master_holder = tester
 
+        # Restructured to process files first, then extensions to eliminate redundant KPF0.from_fits calls
         filenames_kept = {}
         n_frames_kept = {}
         mjd_obs_min = {}
         mjd_obs_max = {}
+        
+        # Initialize data storage dictionaries for each extension
+        extension_data = {}
         for ffi in self.lev0_ffi_exts:
-            keep_ffi = 0
-
-            filenames_kept_list = []
-            frames_data = []
-            frames_data_mjdobs = []
-            frames_data_path = []
-            n_all_bias_files = len(all_bias_files)
-            for i in range(0, n_all_bias_files):
-
-                mjd_obs = mjd_obs_list[i]
-                header_object = bias_object_list[i]
-
-                if header_object != self.bias_object:
-                    #self.logger.debug('---->ffi,header_object,self.bias_object = {},{},{}'.format(ffi,header_object,self.bias_object))
+            extension_data[ffi] = {
+                'filenames_kept_list': [],
+                'frames_data': [],
+                'frames_data_mjdobs': [],
+                'frames_data_path': [],
+                'keep_ffi': 0
+            }
+        
+        n_all_bias_files = len(all_bias_files)
+        for i in range(0, n_all_bias_files):
+            mjd_obs = mjd_obs_list[i]
+            header_object = bias_object_list[i]
+            path = all_bias_files[i]
+            
+            self.logger.debug('Processing file: i,bias_file,header_object = {},{},{}'.format(i,path,header_object))
+            
+            # Conservative approach: skip entire file if OBJECT doesn't match
+            if header_object != self.bias_object:
+                self.logger.debug('---->Skipping file: header_object,self.bias_object = {},{}'.format(header_object,self.bias_object))
+                continue
+            
+            # Load file only once for all extensions
+            obj = KPF0.from_fits(path)
+            
+            # Check QC keywords once per file
+            skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
+            self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
+            if skip:
+                continue
+            
+            # Process each extension for this file
+            for ffi in self.lev0_ffi_exts:
+                self.logger.debug('Processing extension: i,bias_file,ffi = {},{},{}'.format(i,path,ffi))
+                
+                try:
+                    np_obj_ffi = np.array(obj[ffi])
+                    np_obj_ffi_shape = np.shape(np_obj_ffi)
+                    n_dims = len(np_obj_ffi_shape)
+                    self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
+                    
+                    if n_dims == 2:       # Check if valid data extension
+                        extension_data[ffi]['keep_ffi'] = 1
+                        extension_data[ffi]['filenames_kept_list'].append(all_bias_files[i])
+                        extension_data[ffi]['frames_data'].append(obj[ffi])
+                        extension_data[ffi]['frames_data_mjdobs'].append(mjd_obs)
+                        extension_data[ffi]['frames_data_path'].append(path)
+                        
+                except Exception as e:
+                    self.logger.debug('Extension {} not found or invalid in file {}: {}'.format(ffi, path, str(e)))
                     continue
+        
+        # Now process each extension's collected data
+        for ffi in self.lev0_ffi_exts:
+            self.logger.debug('Processing collected data for ffi = {}'.format(ffi))
+            
+            keep_ffi = extension_data[ffi]['keep_ffi']
+            filenames_kept_list = extension_data[ffi]['filenames_kept_list']
+            frames_data = extension_data[ffi]['frames_data']
+            frames_data_mjdobs = extension_data[ffi]['frames_data_mjdobs']
+            frames_data_path = extension_data[ffi]['frames_data_path']
 
-                path = all_bias_files[i]
-                obj = KPF0.from_fits(path)
-
-
-                # Check QC keywords and skip image if it does not pass QC checking.
-
-                skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
-                self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
-                if skip:
-                    continue
-
-
-                np_obj_ffi = np.array(obj[ffi])
-                np_obj_ffi_shape = np.shape(np_obj_ffi)
-                n_dims = len(np_obj_ffi_shape)
-                self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
-                if n_dims == 2:       # Check if valid data extension
-                    keep_ffi = 1
-                    filenames_kept_list.append(all_bias_files[i])
-                    frames_data.append(obj[ffi])
-                    frames_data_mjdobs.append(mjd_obs)
-                    frames_data_path.append(path)
-
-            if keep_ffi == 0:
-                self.logger.debug('ffi,keep_ffi = {},{}'.format(ffi,keep_ffi))
+            if keep_ffi == 0 or len(frames_data) == 0:
+                self.logger.debug('No valid data for ffi = {}, skipping'.format(ffi))
                 del_ext_list.append(ffi)
                 continue
 

--- a/modules/master_dark/src/master_dark_framework.py
+++ b/modules/master_dark/src/master_dark_framework.py
@@ -217,13 +217,13 @@ class MasterDarkFramework(KPF0_Primitive):
         exp_time_list = []
         dark_object_list = []
         for dark_file_path in (all_dark_files):
-            dark_file = KPF0.from_fits(dark_file_path,self.data_type)
-            mjd_obs = float(dark_file.header['PRIMARY']['MJD-OBS'])
+            # Optimized: Read only header instead of full file for MJD-OBS, ELAPSED, and OBJECT
+            mjd_obs = float(fits.getval(dark_file_path, 'MJD-OBS'))
             mjd_obs_list.append(mjd_obs)
-            exp_time = float(dark_file.header['PRIMARY']['ELAPSED'])
+            exp_time = float(fits.getval(dark_file_path, 'ELAPSED'))
             exp_time_list.append(exp_time)
             self.logger.debug('dark_file_path,exp_time = {},{}'.format(dark_file_path,exp_time))
-            header_object = dark_file.header['PRIMARY']['OBJECT']
+            header_object = fits.getval(dark_file_path, 'OBJECT')
             dark_object_list.append(header_object)
             #self.logger.debug('dark_file_path,exp_time,header_object = {},{},{}'.format(dark_file_path,exp_time,header_object))
 
@@ -231,32 +231,31 @@ class MasterDarkFramework(KPF0_Primitive):
         # Ensure prototype FITS header for product file has matching OBJECT and contains both
         # GRNAMPS and REDAMPS keywords (indicating that the data exist).
 
+        tester = None
+        date_obs = None
         for dark_file_path in (all_dark_files):
 
-            tester = KPF0.from_fits(dark_file_path)
-            tester_object = tester.header['PRIMARY']['OBJECT']
+            tester_object = fits.getval(dark_file_path, 'OBJECT')
 
             if tester_object == self.dark_object:
 
                 try:
-                    tester_grnamps = tester.header['PRIMARY']['GRNAMPS']
+                    tester_grnamps = fits.getval(dark_file_path, 'GRNAMPS')
                 except KeyError as err:
                     continue
 
                 try:
-                    tester_redamps = tester.header['PRIMARY']['REDAMPS']
+                    tester_redamps = fits.getval(dark_file_path, 'REDAMPS')
                 except KeyError as err:
                     continue
 
                 self.logger.info('Prototype FITS header from {}'.format(dark_file_path))
 
-                date_obs = tester.header['PRIMARY']['DATE-OBS']
+                date_obs = fits.getval(dark_file_path, 'DATE-OBS')
+                # Load the full file only ONE TIME for the selected prototype
+                tester = KPF0.from_fits(dark_file_path)
 
                 break
-
-            else:
-
-                tester = None
 
         if tester is None:
             master_dark_exit_code = 6
@@ -270,57 +269,85 @@ class MasterDarkFramework(KPF0_Primitive):
                 del_ext_list.append(i)
         master_holder = tester
 
+        # Restructured to process files first, then extensions to eliminate redundant KPF0.from_fits calls
         filenames_kept = {}
         n_frames_kept = {}
         mjd_obs_min = {}
         mjd_obs_max = {}
+        
+        # Initialize data storage dictionaries for each extension
+        extension_data = {}
         for ffi in self.lev0_ffi_exts:
-
-            self.logger.debug('Loading dark data, ffi = {}'.format(ffi))
-            keep_ffi = 0
-
-            filenames_kept_list = []
-            frames_data = []
-            frames_data_exptimes = []
-            frames_data_mjdobs = []
-            frames_data_path = []
-            n_all_dark_files = len(all_dark_files)
-            for i in range(0, n_all_dark_files):
-
-                exp_time = exp_time_list[i]
-                mjd_obs = mjd_obs_list[i]
-                header_object = dark_object_list[i]
-
-                #self.logger.debug('i,fitsfile,ffi,exp_time,dark_object_list[i] = {},{},{},{},{}'.format(i,all_dark_files[i],ffi,exp_time,dark_object_list[i]))
-
-                if header_object != self.dark_object:
-                    #self.logger.debug('---->ffi,header_object,self.dark_object = {},{},{}'.format(ffi,header_object,self.dark_object))
+            extension_data[ffi] = {
+                'filenames_kept_list': [],
+                'frames_data': [],
+                'frames_data_exptimes': [],
+                'frames_data_mjdobs': [],
+                'frames_data_path': [],
+                'keep_ffi': 0
+            }
+        
+        n_all_dark_files = len(all_dark_files)
+        for i in range(0, n_all_dark_files):
+            exp_time = exp_time_list[i]
+            mjd_obs = mjd_obs_list[i]
+            header_object = dark_object_list[i]
+            path = all_dark_files[i]
+            
+            self.logger.debug('Processing file: i,dark_file,header_object = {},{},{}'.format(i,path,header_object))
+            
+            # Conservative approach: skip entire file if OBJECT doesn't match
+            if header_object != self.dark_object:
+                self.logger.debug('---->Skipping file: header_object,self.dark_object = {},{}'.format(header_object,self.dark_object))
+                continue
+            
+            # Load file only once for all extensions
+            obj = KPF0.from_fits(path)
+            
+            # Check QC keywords once per file
+            skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
+            self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
+            if skip:
+                continue
+            
+            # Process each extension for this file
+            for ffi in self.lev0_ffi_exts:
+                self.logger.debug('Processing extension: i,dark_file,ffi = {},{},{}'.format(i,path,ffi))
+                
+                try:
+                    np_obj_ffi = np.array(obj[ffi])
+                    np_obj_ffi_shape = np.shape(np_obj_ffi)
+                    n_dims = len(np_obj_ffi_shape)
+                    self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
+                    
+                    if n_dims == 2:       # Check if valid data extension
+                        extension_data[ffi]['keep_ffi'] = 1
+                        extension_data[ffi]['filenames_kept_list'].append(all_dark_files[i])
+                        extension_data[ffi]['frames_data'].append(obj[ffi])
+                        extension_data[ffi]['frames_data_exptimes'].append(exp_time)
+                        extension_data[ffi]['frames_data_mjdobs'].append(mjd_obs)
+                        extension_data[ffi]['frames_data_path'].append(path)
+                        
+                except Exception as e:
+                    self.logger.debug('Extension {} not found or invalid in file {}: {}'.format(ffi, path, str(e)))
                     continue
+        
+        # Now process each extension's collected data
+        for ffi in self.lev0_ffi_exts:
+            self.logger.debug('Processing collected data for ffi = {}'.format(ffi))
+            
+            keep_ffi = extension_data[ffi]['keep_ffi']
+            filenames_kept_list = extension_data[ffi]['filenames_kept_list']
+            frames_data = extension_data[ffi]['frames_data']
+            frames_data_exptimes = extension_data[ffi]['frames_data_exptimes']
+            frames_data_mjdobs = extension_data[ffi]['frames_data_mjdobs']
+            frames_data_path = extension_data[ffi]['frames_data_path']
 
-                path = all_dark_files[i]
-                obj = KPF0.from_fits(path)
-
-
-                # Check QC keywords and skip image if it does not pass QC checking.
-
-                skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
-                self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
-                if skip:
-                    continue
-
-
-                np_obj_ffi = np.array(obj[ffi])
-                np_obj_ffi_shape = np.shape(np_obj_ffi)
-                n_dims = len(np_obj_ffi_shape)
-                self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
-                if n_dims == 2:       # Check if valid data extension
-                    keep_ffi = 1
-                    filenames_kept_list.append(all_dark_files[i])
-                    frames_data.append(obj[ffi])
-                    frames_data_exptimes.append(exp_time)
-                    frames_data_mjdobs.append(mjd_obs)
-                    frames_data_path.append(path)
-
+            if keep_ffi == 0 or len(frames_data) == 0:
+                self.logger.debug('No valid data for ffi = {}, skipping'.format(ffi))
+                del_ext_list.append(ffi)
+                continue
+                
             np_frames_data = np.array(frames_data)
             np_bias_data = np.array(master_bias_data[ffi])
 
@@ -497,7 +524,7 @@ class MasterDarkFramework(KPF0_Primitive):
         # Add informational to FITS header.  This is the only way I know of to keep the keyword comment.
 
         master_holder.header['PRIMARY']['IMTYPE'] = ('Dark','Master dark')
-
+        self.logger.info('Writing master dark to {}'.format(self.masterdark_path))
         master_holder.to_fits(self.masterdark_path)
 
 

--- a/modules/master_flat/src/master_flat_framework.py
+++ b/modules/master_flat/src/master_flat_framework.py
@@ -302,43 +302,41 @@ class MasterFlatFramework(KPF0_Primitive):
         mjd_obs_list = []
         exp_time_list = []
         for flat_file_path in (all_flat_files):
-            flat_file = KPF0.from_fits(flat_file_path,self.data_type)
-            mjd_obs = float(flat_file.header['PRIMARY']['MJD-OBS'])
+            # Optimized: Read only header instead of full file for MJD-OBS and EXPTIME           
+            mjd_obs = float(fits.getval(flat_file_path, 'MJD-OBS'))
             mjd_obs_list.append(mjd_obs)
-            exp_time = float(flat_file.header['PRIMARY']['EXPTIME'])
+            exp_time = float(fits.getval(flat_file_path, 'EXPTIME'))
             exp_time_list.append(exp_time)
             self.logger.debug('flat_file_path,exp_time = {},{}'.format(flat_file_path,exp_time))
-
 
         # Ensure prototype FITS header for product file has matching OBJECT and contains both
         # GRNAMPS and REDAMPS keywords (indicating that the data exist).
 
+        tester = None
+        date_obs = None
         for flat_file_path in (all_flat_files):
-
-            tester = KPF0.from_fits(flat_file_path)
-            tester_object = tester.header['PRIMARY']['OBJECT']
+            
+            tester_object = fits.getval(flat_file_path, 'OBJECT')
 
             if tester_object == self.flat_object:
 
                 try:
-                    tester_grnamps = tester.header['PRIMARY']['GRNAMPS']
+                    tester_grnamps = fits.getval(flat_file_path, 'GRNAMPS')
                 except KeyError as err:
                     continue
 
                 try:
-                    tester_redamps = tester.header['PRIMARY']['REDAMPS']
+                    tester_redamps = fits.getval(flat_file_path, 'REDAMPS')
                 except KeyError as err:
                     continue
 
                 self.logger.info('Prototype FITS header from {}'.format(flat_file_path))
 
-                date_obs = tester.header['PRIMARY']['DATE-OBS']
+                date_obs = fits.getval(flat_file_path, 'DATE-OBS')
+                # Load the full file only ONE TIME for the selected prototype
+                tester = KPF0.from_fits(flat_file_path)
 
                 break
-
-            else:
-
-                tester = None
 
         if tester is None:
             master_flat_exit_code = 6
@@ -352,64 +350,102 @@ class MasterFlatFramework(KPF0_Primitive):
                 del_ext_list.append(i)
         master_holder = tester
 
+        # Restructured to process files first, then extensions to eliminate redundant KPF0.from_fits calls
         filenames_kept = {}
         n_frames_kept = {}
         mjd_obs_min = {}
         mjd_obs_max = {}
+        
+        # Initialize data storage dictionaries for each extension
+        extension_data = {}
         for ffi in self.lev0_ffi_exts:
-
-            self.logger.debug('Loading flat data, ffi = {}'.format(ffi))
-            keep_ffi = 0
-
-            filenames_kept_list = []
-            frames_data = []
-            frames_data_exptimes = []
-            frames_data_mjdobs = []
-            frames_data_path = []
-            n_all_flat_files = len(all_flat_files)
-            for i in range(0, n_all_flat_files):
-
-                exp_time = exp_time_list[i]
-                mjd_obs = mjd_obs_list[i]
-                self.logger.debug('i,fitsfile,ffi,exp_time = {},{},{},{}'.format(i,all_flat_files[i],ffi,exp_time))
-
+            extension_data[ffi] = {
+                'filenames_kept_list': [],
+                'frames_data': [],
+                'frames_data_exptimes': [],
+                'frames_data_mjdobs': [],
+                'frames_data_path': [],
+                'keep_ffi': 0
+            }
+        
+        n_all_flat_files = len(all_flat_files)
+        for i in range(0, n_all_flat_files):
+            exp_time = exp_time_list[i]
+            mjd_obs = mjd_obs_list[i]
+            path = all_flat_files[i]
+            
+            self.logger.debug('Processing file: i,fitsfile,exp_time = {},{},{}'.format(i,path,exp_time))
+            
+            # Check exposure time limits for all extensions first - skip entire file if any fail
+            skip_file = False
+            for ffi in self.lev0_ffi_exts:
                 if not (ffi == 'GREEN_CCD' or ffi == 'RED_CCD' or ffi == 'CA_HK'):
                     raise NameError('FITS extension {} not supported; check recipe config file.'.format(ffi))
-
+                
                 if ffi == 'GREEN_CCD' and exp_time > self.green_ccd_flat_exptime_maximum:
-                    self.logger.debug('---->ffi,exp_time,self.green_ccd_flat_exptime_maximum = {},{},{}'.format(ffi,exp_time,self.green_ccd_flat_exptime_maximum))
-                    continue
+                    self.logger.debug('---->Skipping file for GREEN_CCD: ffi,exp_time,limit = {},{},{}'.format(ffi,exp_time,self.green_ccd_flat_exptime_maximum))
+                    skip_file = True
+                    break
                 if ffi == 'RED_CCD' and exp_time > self.red_ccd_flat_exptime_maximum:
-                    self.logger.debug('---->ffi,exp_time,self.red_ccd_flat_exptime_maximum = {},{},{}'.format(ffi,exp_time,self.red_ccd_flat_exptime_maximum))
-                    continue
+                    self.logger.debug('---->Skipping file for RED_CCD: ffi,exp_time,limit = {},{},{}'.format(ffi,exp_time,self.red_ccd_flat_exptime_maximum))
+                    skip_file = True
+                    break
                 if ffi == 'CA_HK' and exp_time > self.ca_hk_flat_exptime_maximum:
+                    self.logger.debug('---->Skipping file for CA_HK: ffi,exp_time,limit = {},{},{}'.format(ffi,exp_time,self.ca_hk_flat_exptime_maximum))
+                    skip_file = True
+                    break
+            
+            if skip_file:
+                continue
+            
+            # Load file only once for all extensions
+            obj = KPF0.from_fits(path)
+            
+            # Check QC keywords once per file
+            skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
+            self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
+            if skip:
+                continue
+            
+            # Process each extension for this file
+            for ffi in self.lev0_ffi_exts:
+                self.logger.debug('Processing extension: i,fitsfile,ffi,exp_time = {},{},{},{}'.format(i,path,ffi,exp_time))
+                
+                try:
+                    np_obj_ffi = np.array(obj[ffi])
+                    np_obj_ffi_shape = np.shape(np_obj_ffi)
+                    n_dims = len(np_obj_ffi_shape)
+                    self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
+                    
+                    if n_dims == 2:       # Check if valid data extension
+                        extension_data[ffi]['keep_ffi'] = 1
+                        extension_data[ffi]['filenames_kept_list'].append(all_flat_files[i])
+                        extension_data[ffi]['frames_data'].append(obj[ffi])
+                        extension_data[ffi]['frames_data_exptimes'].append(exp_time)
+                        extension_data[ffi]['frames_data_mjdobs'].append(mjd_obs)
+                        extension_data[ffi]['frames_data_path'].append(path)
+                        self.logger.debug('Keeping flat image: i,fitsfile,ffi,mjd_obs,exp_time = {},{},{},{},{}'.format(i,all_flat_files[i],ffi,mjd_obs,exp_time))
+                        
+                except Exception as e:
+                    self.logger.debug('Extension {} not found or invalid in file {}: {}'.format(ffi, path, str(e)))
                     continue
+        
+        # Now process each extension's collected data
+        for ffi in self.lev0_ffi_exts:
+            self.logger.debug('Processing collected data for ffi = {}'.format(ffi))
+            
+            keep_ffi = extension_data[ffi]['keep_ffi']
+            filenames_kept_list = extension_data[ffi]['filenames_kept_list']
+            frames_data = extension_data[ffi]['frames_data']
+            frames_data_exptimes = extension_data[ffi]['frames_data_exptimes']
+            frames_data_mjdobs = extension_data[ffi]['frames_data_mjdobs']
+            frames_data_path = extension_data[ffi]['frames_data_path']
 
-                path = all_flat_files[i]
-                obj = KPF0.from_fits(path)
-
-
-                # Check QC keywords and skip image if it does not pass QC checking.
-
-                skip = qc.check_all_qc_keywords(obj,path,input_master_type,self.logger)
-                self.logger.debug('After calling qc.check_all_qc_keywords: i,path,skip = {},{},{}'.format(i,path,skip))
-                if skip:
-                    continue
-
-
-                np_obj_ffi = np.array(obj[ffi])
-                np_obj_ffi_shape = np.shape(np_obj_ffi)
-                n_dims = len(np_obj_ffi_shape)
-                self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
-                if n_dims == 2:       # Check if valid data extension
-                     keep_ffi = 1
-                     filenames_kept_list.append(all_flat_files[i])
-                     frames_data.append(obj[ffi])
-                     frames_data_exptimes.append(exp_time)
-                     frames_data_mjdobs.append(mjd_obs)
-                     frames_data_path.append(path)
-                     self.logger.debug('Keeping flat image: i,fitsfile,ffi,mjd_obs,exp_time = {},{},{},{},{}'.format(i,all_flat_files[i],ffi,mjd_obs,exp_time))
-
+            if keep_ffi == 0 or len(frames_data) == 0:
+                self.logger.debug('No valid data for ffi = {}, skipping'.format(ffi))
+                del_ext_list.append(ffi)
+                continue
+                
             np_frames_data = np.array(frames_data)
             np_bias_data = np.array(master_bias_data[ffi])
 
@@ -728,6 +764,8 @@ class MasterFlatFramework(KPF0_Primitive):
 
         master_holder.header['PRIMARY']['IMTYPE'] = ('Flat','Master flat')
 
+        # log the file writing
+        self.logger.info('Writing master-flat FITS file: {}'.format(self.masterflat_path))
         master_holder.to_fits(self.masterflat_path)
 
 

--- a/modules/master_superflat/src/master_superflat_framework.py
+++ b/modules/master_superflat/src/master_superflat_framework.py
@@ -5,6 +5,7 @@ import configparser as cp
 from datetime import datetime, timezone
 from scipy.ndimage import gaussian_filter
 from scipy.stats import mode
+from astropy.io import fits
 
 from modules.Utils.kpf_fits import FitsHeaders
 from modules.Utils.frame_stacker import FrameStacker
@@ -188,69 +189,115 @@ class MasterSuperFlatFramework(KPF0_Primitive):
         mjd_obs_list = []
         exp_time_list = []
         for flat_file_path in (all_flat_files):
-            flat_file = KPF0.from_fits(flat_file_path,self.data_type)
-            mjd_obs = float(flat_file.header['PRIMARY']['MJD-OBS'])
+            # Optimized: Read only header instead of full file for MJD-OBS and ELAPSED
+            mjd_obs = float(fits.getval(flat_file_path, 'MJD-OBS'))
             mjd_obs_list.append(mjd_obs)
-            exp_time = float(flat_file.header['PRIMARY']['ELAPSED'])
+            exp_time = float(fits.getval(flat_file_path, 'ELAPSED'))
             exp_time_list.append(exp_time)
             self.logger.debug('flat_file_path,exp_time = {},{}'.format(flat_file_path,exp_time))
 
-        tester = KPF0.from_fits(all_flat_files[0])
+        # Optimized: Use header-only approach to find a good prototype
+        tester = None
+        for flat_file_path in all_flat_files:
+            try:
+                # Check if file has required extensions using header-only access
+                with fits.open(flat_file_path) as hdul:
+                    ext_names = [hdu.name for hdu in hdul]
+                    if any(ext in ext_names for ext in ['GREEN_CCD', 'RED_CCD', 'CA_HK']):
+                        # Load this file as prototype since it has needed extensions
+                        tester = KPF0.from_fits(flat_file_path)
+                        break
+            except:
+                continue
+        
+        if tester is None:
+            tester = KPF0.from_fits(all_flat_files[0])  # Fallback to first file
+        
         del_ext_list = []
         for i in tester.extensions.keys():
             if i != 'GREEN_CCD' and i != 'RED_CCD' and i != 'CA_HK' and i != 'PRIMARY' and i != 'RECEIPT' and i != 'CONFIG':
                 del_ext_list.append(i)
         master_holder = tester
 
+        # Optimized: Conservative approach - filter files first, then process extensions
+        # Pre-filter files based on exposure time constraints and extension validity
+        filtered_files_per_ext = {}
+        for ffi in self.lev0_ffi_exts:
+            if not (ffi == 'GREEN_CCD' or ffi == 'RED_CCD' or ffi == 'CA_HK'):
+                raise NameError('FITS extension {} not supported; check recipe config file.'.format(ffi))
+            filtered_files_per_ext[ffi] = []
+        
+        n_all_flat_files = len(all_flat_files)
+        for i in range(0, n_all_flat_files):
+            exp_time = exp_time_list[i]
+            mjd_obs = mjd_obs_list[i]
+            path = all_flat_files[i]
+            
+            # Check exposure time constraints for each extension
+            valid_for_extensions = []
+            for ffi in self.lev0_ffi_exts:
+                if ffi == 'GREEN_CCD' and exp_time <= self.green_ccd_flat_exptime_maximum:
+                    valid_for_extensions.append(ffi)
+                elif ffi == 'RED_CCD' and exp_time <= self.red_ccd_flat_exptime_maximum:
+                    valid_for_extensions.append(ffi)
+                elif ffi == 'CA_HK' and exp_time <= self.ca_hk_flat_exptime_maximum:
+                    valid_for_extensions.append(ffi)
+            
+            # Add file to valid extensions
+            for ffi in valid_for_extensions:
+                filtered_files_per_ext[ffi].append({
+                    'path': path,
+                    'exp_time': exp_time,
+                    'mjd_obs': mjd_obs,
+                    'index': i
+                })
+
+        # Now process each extension with file-first approach
         n_frames_kept = {}
         mjd_obs_min = {}
         mjd_obs_max = {}
+        
         for ffi in self.lev0_ffi_exts:
-
             self.logger.debug('Loading flat data, ffi = {}'.format(ffi))
-            keep_ffi = 0
-
+            
+            valid_files = filtered_files_per_ext[ffi]
+            if len(valid_files) == 0:
+                self.logger.debug('ffi,keep_ffi = {},{}'.format(ffi, 0))
+                del_ext_list.append(ffi)
+                continue
+            
+            # File-first processing - load each file only once
             frames_data = []
             frames_data_exptimes = []
             frames_data_mjdobs = []
             frames_data_path = []
-            n_all_flat_files = len(all_flat_files)
-            for i in range(0, n_all_flat_files):
-
-                exp_time = exp_time_list[i]
-                mjd_obs = mjd_obs_list[i]
-                self.logger.debug('i,fitsfile,ffi,exp_time = {},{},{},{}'.format(i,all_flat_files[i],ffi,exp_time))
-
-                if not (ffi == 'GREEN_CCD' or ffi == 'RED_CCD' or ffi == 'CA_HK'):
-                    raise NameError('FITS extension {} not supported; check recipe config file.'.format(ffi))
-
-                if ffi == 'GREEN_CCD' and exp_time > self.green_ccd_flat_exptime_maximum:
-                    self.logger.debug('---->ffi,exp_time,self.green_ccd_flat_exptime_maximum = {},{},{}'.format(ffi,exp_time,self.green_ccd_flat_exptime_maximum))
-                    continue
-                if ffi == 'RED_CCD' and exp_time > self.red_ccd_flat_exptime_maximum:
-                    self.logger.debug('---->ffi,exp_time,self.red_ccd_flat_exptime_maximum = {},{},{}'.format(ffi,exp_time,self.red_ccd_flat_exptime_maximum))
-                    continue
-                if ffi == 'CA_HK' and exp_time > self.ca_hk_flat_exptime_maximum:
-                    continue
-
-                path = all_flat_files[i]
+            
+            for file_info in valid_files:
+                path = file_info['path']
+                exp_time = file_info['exp_time']
+                mjd_obs = file_info['mjd_obs']
+                i = file_info['index']
+                
+                self.logger.debug('i,fitsfile,ffi,exp_time = {},{},{},{}'.format(i,path,ffi,exp_time))
+                
+                # Load file once and check extension validity
                 obj = KPF0.from_fits(path)
-                np_obj_ffi = np.array(obj[ffi])
-                np_obj_ffi_shape = np.shape(np_obj_ffi)
-                n_dims = len(np_obj_ffi_shape)
-                self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
-                if n_dims == 2:       # Check if valid data extension
-                     keep_ffi = 1
-                     frames_data.append(obj[ffi])
-                     frames_data_exptimes.append(exp_time)
-                     frames_data_mjdobs.append(mjd_obs)
-                     frames_data_path.append(path)
-                     self.logger.debug('Keeping flat image: i,fitsfile,ffi,mjd_obs,exp_time = {},{},{},{},{}'.format(i,all_flat_files[i],ffi,mjd_obs,exp_time))
-
-            if keep_ffi == 0:
-                self.logger.debug('ffi,keep_ffi = {},{}'.format(ffi,keep_ffi))
+                if ffi in obj.extensions:
+                    np_obj_ffi = np.array(obj[ffi])
+                    np_obj_ffi_shape = np.shape(np_obj_ffi)
+                    n_dims = len(np_obj_ffi_shape)
+                    self.logger.debug('path,ffi,n_dims = {},{},{}'.format(path,ffi,n_dims))
+                    if n_dims == 2:       # Check if valid data extension
+                        frames_data.append(obj[ffi])
+                        frames_data_exptimes.append(exp_time)
+                        frames_data_mjdobs.append(mjd_obs)
+                        frames_data_path.append(path)
+                        self.logger.debug('Keeping flat image: i,fitsfile,ffi,mjd_obs,exp_time = {},{},{},{},{}'.format(i,path,ffi,mjd_obs,exp_time))
+            
+            if len(frames_data) == 0:
+                self.logger.debug('ffi,keep_ffi = {},{}'.format(ffi, 0))
                 del_ext_list.append(ffi)
-                break
+                continue
 
             frames_data = np.array(frames_data) - np.array(master_bias_data[ffi])      # Subtract master bias.
 

--- a/modules/quality_control/src/quality_control_framework.py
+++ b/modules/quality_control/src/quality_control_framework.py
@@ -36,21 +36,25 @@ class QualityControlFramework(KPF0_Primitive):
 
         try:
             self.module_config_path = context.config_path['quality_control']
-            print("--->",self.__class__.__name__,": self.module_config_path =",self.module_config_path)
         except:
             self.module_config_path = DEFAULT_CFG_PATH
 
-        print("{} class: self.module_config_path = {}".format(self.__class__.__name__,self.module_config_path))
-
-        print("Starting logger...")
-        self.logger = start_logger(self.__class__.__name__, self.module_config_path)
-
-        if self.logger is not None:
-            print("--->self.logger is not None...")
+        # Only start logger if it doesn't already exist for this class
+        logger_name = self.__class__.__name__
+        existing_logger = logging.getLogger(logger_name)
+        
+        if not existing_logger.handlers or not hasattr(self.__class__, '_class_logger'):
+            # Logger doesn't exist or has no handlers, create it
+            print("Starting logger for {}...".format(logger_name))
+            self.logger = start_logger(logger_name, self.module_config_path)
+            # Cache the logger at class level to reuse
+            self.__class__._class_logger = self.logger
+            print("Logger started for {}.".format(logger_name))
         else:
-            print("--->self.logger is None...")
+            # Reuse existing logger
+            self.logger = getattr(self.__class__, '_class_logger', existing_logger)
 
-        self.logger.info('Started {}'.format(self.__class__.__name__))
+        self.logger.info('Started {} instance'.format(self.__class__.__name__))
         self.logger.debug('module_config_path = {}'.format(self.module_config_path))
 
         module_config_obj = cp.ConfigParser()

--- a/modules/quicklook/src/diagnostics_framework.py
+++ b/modules/quicklook/src/diagnostics_framework.py
@@ -51,11 +51,33 @@ class DiagnosticsFramework(KPF0_Primitive):
 
         self.config.read(self.config_path)
 
-        # Start logger
-        self.logger=None
-        if not self.logger:
-            self.logger=self.context.logger
-        self.logger.info('Started {}'.format(self.__class__.__name__))
+        # Start logger - check if already available
+        self.logger = None
+        
+        # First check if context has a valid logger
+        if hasattr(self.context, 'logger') and self.context.logger is not None:
+            try:
+                # Test if the logger is functional
+                self.context.logger.handlers
+                self.logger = self.context.logger
+            except (AttributeError, Exception):
+                # Context logger is not valid, will create new one below
+                pass
+        
+        # If no valid context logger, check for existing class logger or create new one
+        if self.logger is None:
+            logger_name = self.__class__.__name__
+            existing_logger = logging.getLogger(logger_name)
+            
+            if existing_logger.handlers and hasattr(self.__class__, '_class_logger'):
+                # Reuse existing class logger
+                self.logger = self.__class__._class_logger
+            else:
+                # Create new logger and cache it
+                self.logger = start_logger(logger_name, self.config_path)
+                self.__class__._class_logger = self.logger
+        
+        self.logger.info('Started {} instance'.format(self.__class__.__name__))
         self.logger.info('self.diagnostics_name = {}'.format(self.diagnostics_name))
 
 


### PR DESCRIPTION
While running some tests, I noticed some redundant l0/2D reads from the masters recipes.

I changed many instances of KPF0_from_fits() to calls reading only headers. This should improve our I/O problems.

I did not do any performance checks and only ran one recipe: kpf_masters_drp.cfg.

I am interested to know how much performance we gain from from this.