### PR TITLE
quick fix to include readnoise in 2D variance patch

### DIFF
--- a/modules/spectral_extraction/src/alg.py
+++ b/modules/spectral_extraction/src/alg.py
@@ -132,8 +132,9 @@ class SpectralExtractionAlg:
     def _check_for_variance_frame(self, chip, do_patch=True):
         var_ext_name = f'{chip}_VAR'
 
-        # hard-code 2D variance fix
-        self.target_2D[var_ext_name] = np.abs(self.target_2D[f'{chip}_CCD'])
+        # hard-code 2D variance fix w/ quick readnoise addition
+        readnoise = 0.5*(self.target_2D.header['PRIMARY'][f'RN{chip}1'] + self.target_2D.header['PRIMARY'][f'RN{chip}2'])
+        self.target_2D[var_ext_name] = np.abs(self.target_2D[f'{chip}_CCD']) + readnoise
 
         if var_ext_name not in self.target_2D.extensions:
             self.log.warning(f"Variance extension {var_ext_name} not found, setting variance equal to photon noise")
@@ -150,6 +151,8 @@ class SpectralExtractionAlg:
                 raise ValueError(f"Variance extension {var_ext_name} not found")
 
     
+
+
     def _fix_order_trace_indexing(self):
         datecode = self.target_2D.header['PRIMARY']['DATE-OBS'].replace('-', '')
         try:

--- a/recipes/kpf_l0_to_2d_science.recipe
+++ b/recipes/kpf_l0_to_2d_science.recipe
@@ -18,9 +18,9 @@ do_order_trace = config.ARGUMENT.do_order_trace
 
 # L1 level flags
 do_spectral_extraction = config.WATCHFOR_2D.do_spectral_extraction
-# if copy wavelength solution data to L1 from file samples with wls data.
+# if copy wavelength solution data to L1 from file samples with wls data
 do_sp_wavecopy = config.ARGUMENT.do_wavecopy_in_sp
-# Peroform wavelength interpolation
+# perform wavelength interpolation
 do_db_query_for_before_after_master_files = config.WLS_INTERPOLATION.do_db_query_for_before_after_master_files 
 
 # L2 level flags
@@ -124,7 +124,6 @@ if do_quality_control:
 
     if overwrite: 
         # read l0 file. Modify this object throughout the routine.
-
         kpf_object = kpf0_from_fits(l0_filename_science,data_type) # L0, not 2D file is input
         dt_string = GetHeaderValue(kpf_object, 'DATE-MID')
         cals = CalibrationLookup(dt_string)


### PR DESCRIPTION
The read noise estimate does not check if the expected extensions exist ('RNRED1', 'RNRED2' at same for GREEN). The code will crash if these don't exist or have unexpected values (e.g. NaN, inf). For testing this is probably the behavior we want.

The real fix will be adding read noise properly when the correct variance extension is created.