### PR TITLE
Repair new era

### DIFF
--- a/database/scripts/registerCalFilesForDate.py
+++ b/database/scripts/registerCalFilesForDate.py
@@ -542,12 +542,7 @@ def update_minmjd_maxmjd_etc_in_calfiles_table(datearg,cur):
         "where caltype = 'TEMPLATE_CALTYPE1' " +\
         "and level = TEMPLATE_LEVEL " +\
         "and startdate = 'TEMPLATE_STARTDATE' " +\
-        "and object in (" +\
-        "select regexp_replace(object,'_red|_green','') " +\
-        "from calfiles " +\
-        "where startdate='TEMPLATE_STARTDATE' " +\
-        "and caltype='TEMPLATE_CALTYPE2' " +\
-        "and object like 'autocal%');"
+        "and object like 'autocal-etalon-all-%';"
 
 
     # Define query.

--- a/modules/wavelength_cal/src/alg.py
+++ b/modules/wavelength_cal/src/alg.py
@@ -168,7 +168,7 @@ class WaveCalibration:
 
                     ax[0].set_title('Derived WLS - Approx WLS')
                     ax[0].set_xlabel('Pixel')
-                    ax[0].set_ylabel(r'[$\\rm \AA$]')
+                    ax[0].set_ylabel(r'[\$\\rm \AA$]')
                     ax[1].set_xlabel('Pixel')
                     ax[1].set_ylabel('[Pixel]')
                     plt.tight_layout()
@@ -483,7 +483,7 @@ class WaveCalibration:
                     fig, ax = plt.subplots(2, 1, figsize=(12,5))
                     ax[0].set_title('Precise WLS - Rough WLS')
                     ax[0].plot(np.arange(n_pixels), leg_out(np.arange(n_pixels)) - rough_wls_order, color='k')
-                    ax[0].set_ylabel(r'[$\\rm \AA$]')
+                    ax[0].set_ylabel(r'[\$\\rm \AA$]')
                     pixel_sizes = rough_wls_order[1:] - rough_wls_order[:-1]
                     ax[1].plot(np.arange(n_pixels - 1),   
                               (leg_out(np.arange(n_pixels - 1)) - rough_wls_order[:-1]) / pixel_sizes, color='k')
@@ -1254,7 +1254,7 @@ class WaveCalibration:
             plt.vlines(comb_lines_angstrom, ymin=0, ymax=5000, color='r', label='Comb Lines')
             plt.xlim(np.nanmin(rough_wls_order), np.nanmin(rough_wls_order) + 6)
             plt.yscale('symlog')
-            plt.xlabel(r'Wavelength [$\\rm \AA$]', fontsize=14)
+            plt.xlabel(r'Wavelength [\$\\rm \AA$]', fontsize=14)
             plt.ylabel('Flux', fontsize=14)
             plt.title('Rough Solution and LFC Lines', fontsize=18)
             plt.savefig('{}/rough_sol_and_lfc_lines.png'.format(plot_path), dpi=250)

--- a/recipes/wls_auto.recipe
+++ b/recipes/wls_auto.recipe
@@ -32,19 +32,19 @@ for cal_type in ['ThAr', 'LFC', 'Etalon']:
             l1_obj = kpf1_from_fits(L1_file, data_type='KPF')
             dt_string = GetHeaderValue(l1_obj, 'DATE-MID')
             cals = CalibrationLookup(dt_string)
-            master_wls_file = cals['rough_wls'] # TRY A NEW ROUGH WLS
-#            master_wls_file = '/data/masters/20241024/kpf_20241024_master_WLS_autocal-lfc-all-eve_L1.fits' # HTI HARD CODE.
+            # master_wls_file = cals['rough_wls'] # TRY A NEW ROUGH WLS
+            master_wls_file = '/data/reference_fits/kpf_20241010_master_WLS_autocal-lfc-all-eve_L1.fits' # HTI HARD CODE.
             full_master_wls = kpf1_from_fits(master_wls_file, data_type='KPF')
             base_path = masters_dir + date_dir
             obj_string = str_replace(L1_file, base_path + '/kpf_' + date_dir + '_master_arclamp_', '')
             obj_string_short = str_replace(obj_string, '_L1.fits', '')
             output_filename = output_dir + date_dir + '/kpf_' + date_dir + '_master_WLS_' + obj_string_short + '_L1.fits'
 
-            for ext in ['RED_CAL_WAVE', 'GREEN_CAL_WAVE']: # iterate over RED/GREEN CCDs
+            for ext in ['RED_SCI_WAVE2', 'GREEN_SCI_WAVE2']: # iterate over RED/GREEN CCDs
 
                 master_wls = full_master_wls[ext]
 
-                if ext == 'RED_CAL_WAVE':
+                if ext == 'RED_SCI_WAVE2':
                     output_exts = config.ARGUMENT.red_output_ext
                     orderlet_names = config.ARGUMENT.red_cal_orderlet_name
                     min_order = config.ARGUMENT.red_min_order
@@ -54,7 +54,7 @@ for cal_type in ['ThAr', 'LFC', 'Etalon']:
                         orderlet_names = ['RED_SCI_FLUX2']
                         output_exts = ['RED_SCI_WAVE2']
                     
-                if ext == 'GREEN_CAL_WAVE':
+                if ext == 'GREEN_SCI_WAVE2':
                     output_exts = config.ARGUMENT.green_output_ext
                     orderlet_names = config.ARGUMENT.green_cal_orderlet_name
                     min_order = config.ARGUMENT.green_min_order


### PR DESCRIPTION
Data taken since 20251025 (post servicing mission) has "SCI-OBJ = 'None ' / Science fiber source"

We have a check in the L2 creation that checks for this and does not produce CCFs if this is the case.

This pull request removes that check and adds some additional logging.  We may want a more careful handing of this condition. Currently, we just want to get L2 CCFs and view them on the QLP.