### PR TITLE
L2 files from masters 20251209 now running.

### DIFF
--- a/modules/spectral_extraction/src/alg.py
+++ b/modules/spectral_extraction/src/alg.py
@@ -112,8 +112,8 @@ class SpectralExtractionAlg:
         # GJG needs to be moved to calibrations lookup
         self.order_trace = self._fix_order_trace_indexing()
 
-        #for chip in ['GREEN', 'RED']:
-        #    self.bad_pixel_mask[f'{chip}_CCD'] &= self._make_bad_pixel_mask(chip)
+        for chip in ['GREEN', 'RED']:
+            self.bad_pixel_mask[f'{chip}_CCD'] &= self._make_bad_pixel_mask(chip)
 
         # initialize L1 object
         self.target_l1 = KPF1.from_l0(self.target_2D)
@@ -526,6 +526,11 @@ class SpectralExtractionAlg:
         # variance from non-photon sources
         V0 = V - np.abs(D)/Q
 
+        # Pre-check variance to avoid NaN residuals
+        if np.any(V0 <= 0) or np.any(np.isnan(V0)) or np.any(np.isinf(V0)):
+            self.log.info("Invalid variance values (V0 <= 0, NaN, or inf) detected in optimal_extraction. Patching V0 with photon noise to prevent NaN residuals.")
+            V0 = np.maximum(V0, np.abs(D)/Q)
+
         # optimal extraction loop
         loop = 0
         while loop < max_iter:
@@ -548,13 +553,26 @@ class SpectralExtractionAlg:
             
             # mask cosmic rays
             bad_pixel_count = np.nansum(M==0)
-            worst_pixel_row = np.nanargmax(R*M, axis=0)
+            
+            # Handle all-NaN columns gracefully
+            try:
+                worst_pixel_row = np.nanargmax(R*M, axis=0)
+            except ValueError:
+                # If all-NaN slice encountered, find worst pixel per column individually
+                self.log.warning("All-NaN columns detected in residuals during cosmic ray masking. Processing columns individually.")
+                worst_pixel_row = np.full(ncol, -1, dtype=int)
+                for col in range(ncol):
+                    col_residuals = R[:, col] * M[:, col]
+                    if not np.all(np.isnan(col_residuals)):
+                        worst_pixel_row[col] = np.nanargmax(col_residuals)
     
             if verbose:
-                print(f"loop {loop} | {bad_pixel_count - np.nansum(W==0)} pixels flagged")
+                self.log.info(f"loop {loop} | {bad_pixel_count - np.nansum(W==0)} pixels flagged")
         
             for col in range(ncol):
                 row = worst_pixel_row[col]
+                if row == -1:
+                    continue  # skip columns with all NaN residuals
             
                 if R[row,col] > extraction_sigma_clip**2:
                     M[row,col] = 0


### PR DESCRIPTION
I tried to run 20251209 and L2's were still failing. I made some changes to the spectral extraction.  @gjgilbert Can you please look at this and see the changes make sense to you. I tried to handle the cases where columns were all NaN in ThAr exposures. Let me know if these changes may cause unintended consequences.

AI summary of the changes:

1. Uncommenting bad pixel mask (lines 115-116)
Purpose: Masks NaN/inf pixels in data and variance arrays
Why needed: Without this, NaN/inf values propagate through calculations causing the downstream error
Impact if reverted: The root cause (invalid pixels) won't be filtered, making other fixes insufficient

2. Variance pre-check (lines 529-532) - 
Purpose: Ensures variance is always positive and finite before loop
Why needed: Negative/zero/NaN variance causes division by zero in [R = (D - f*P - S)**2/V]
Impact if reverted: All-NaN residuals will occur, triggering the error

3. Try-except wrapper for np.nanargmax (lines 556-566) 
Purpose: Handles edge case where all columns are NaN despite other protections
Why needed: Even with fixes #1 and #2, pathological data (e.g., all masked pixels in orderlet) can still cause all-NaN columns
Impact if reverted: Code will crash with "All-NaN slice encountered" error
4. Skip all-NaN columns (lines 572-574) 
Purpose: Prevents indexing errors when fallback identifies invalid columns
Why needed: Completes the error handling from change #3
Impact if reverted: Array indexing errors or incorrect masking
5. Logging change print → self.log.info (line 569) 
Purpose: Consistent logging infrastructure
Could revert: Yes, but it's good practice to use the logger

