### PR TITLE
Add QLP L0: quicklook plots for raw detector images

### DIFF
--- a/docs/superpowers/plans/2026-04-14-qlp-l0.md
+++ b/docs/superpowers/plans/2026-04-14-qlp-l0.md
@@ -1,0 +1,714 @@
+# QLP L0 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement PlotL0 — a quicklook plotting class that renders raw KPF L0 detector images, replicating the v2.12 `plot_L0_stitched_image` behavior.
+
+**Architecture:** PlotL0 takes a KPF0 object, stitches raw amplifier arrays for display, and renders a matplotlib figure matching the v2.12 format (viridis colormap, ADU units, percentile scaling, timestamp annotation). A standalone CLI script provides ad-hoc access. QLP does zero science computation — it is pure visualization.
+
+**Tech Stack:** Python 3.14, numpy, matplotlib, astropy (FITS I/O via KPF0 data model), pytest
+
+**Spec:** `docs/superpowers/specs/2026-04-14-qlp-l0-design.md`
+
+---
+
+### Task 1: Create qlp package and PlotL0 constructor
+
+**Files:**
+- Create: `kpfpipe/qlp/__init__.py`
+- Create: `kpfpipe/qlp/plot_l0.py`
+- Create: `tests/test_qlp_l0.py`
+
+- [ ] **Step 1: Write failing test — PlotL0 can be instantiated with a KPF0 object**
+
+Create `tests/test_qlp_l0.py`:
+
+```python
+"""Tests for L0 quicklook plots."""
+
+import os
+import numpy as np
+import pytest
+from astropy.io import fits
+
+import matplotlib
+matplotlib.use('Agg')
+
+from kpfpipe.data_models.level0 import KPF0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def synthetic_4amp_l0(tmp_path):
+    """Create a synthetic KPF0 with 4-amp green and red data."""
+    fn = str(tmp_path / "KP.20240405.00001.00.fits")
+    rng = np.random.default_rng(42)
+
+    nrow, ncol = 2070, 2094
+    bias_level = 1000.0
+
+    primary = fits.PrimaryHDU()
+    primary.header["INSTRUME"] = "KPF"
+    primary.header["OBJECT"] = "synthetic-4amp"
+    primary.header["IMTYPE"] = "Bias"
+    primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
+
+    hdus = [primary]
+    for chip in ["GREEN", "RED"]:
+        for amp in range(1, 5):
+            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+
+    hdul = fits.HDUList(hdus)
+    hdul.writeto(fn, overwrite=True)
+    hdul.close()
+    return KPF0.from_fits(fn)
+
+
+@pytest.fixture
+def synthetic_2amp_l0(tmp_path):
+    """Create a synthetic KPF0 with 2-amp green and red data."""
+    fn = str(tmp_path / "KP.20240405.00002.00.fits")
+    rng = np.random.default_rng(99)
+
+    nrow, ncol = 4080, 2094
+    bias_level = 1000.0
+
+    primary = fits.PrimaryHDU()
+    primary.header["INSTRUME"] = "KPF"
+    primary.header["OBJECT"] = "synthetic-2amp"
+    primary.header["IMTYPE"] = "Bias"
+    primary.header["DATE-OBS"] = "2024-04-05T01:00:38"
+
+    hdus = [primary]
+    for chip in ["GREEN", "RED"]:
+        for amp in range(1, 3):
+            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+
+    hdul = fits.HDUList(hdus)
+    hdul.writeto(fn, overwrite=True)
+    hdul.close()
+    return KPF0.from_fits(fn)
+
+
+# ---------------------------------------------------------------------------
+# Task 1: Constructor
+# ---------------------------------------------------------------------------
+
+class TestPlotL0Constructor:
+
+    def test_init_with_l0(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        assert qlp.l0 is synthetic_4amp_l0
+        assert qlp.obs_id == "KP.20240405.00001.00"
+        assert qlp.name == "synthetic-4amp"
+        assert qlp.output_dir is None
+
+    def test_init_with_output_dir(self, synthetic_4amp_l0, tmp_path):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0, output_dir=str(tmp_path))
+        assert qlp.output_dir == str(tmp_path)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py::TestPlotL0Constructor -v`
+Expected: `ModuleNotFoundError: No module named 'kpfpipe.qlp'`
+
+- [ ] **Step 3: Create the package and PlotL0 class**
+
+Create `kpfpipe/qlp/__init__.py`:
+
+```python
+from kpfpipe.qlp.plot_l0 import PlotL0
+
+__all__ = ['PlotL0']
+```
+
+Create `kpfpipe/qlp/plot_l0.py`:
+
+```python
+"""L0 quicklook plots for raw KPF detector images."""
+
+
+class PlotL0:
+    """
+    Quicklook plots for KPF L0 (raw CCD) data.
+
+    Takes a KPF0 object and generates plots of the raw detector images.
+    Pure visualization — no science computation.
+
+    Args:
+        l0_obj: KPF0 data object.
+        output_dir: Directory to save PNG files. None = return Figure only.
+    """
+
+    def __init__(self, l0_obj, output_dir=None):
+        self.l0 = l0_obj
+        self.output_dir = output_dir
+        self.obs_id = getattr(l0_obj, 'obs_id', None) or ''
+        self.name = ''
+        if 'PRIMARY' in l0_obj.headers:
+            self.name = l0_obj.headers['PRIMARY'].get('OBJECT', '')
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py::TestPlotL0Constructor -v`
+Expected: 2 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd KPF-Pipeline && git add kpfpipe/qlp/__init__.py kpfpipe/qlp/plot_l0.py tests/test_qlp_l0.py
+git commit -m "Add PlotL0 class and qlp package skeleton"
+```
+
+---
+
+### Task 2: Implement stitched_image for 4-amp mode
+
+**Files:**
+- Modify: `kpfpipe/qlp/plot_l0.py`
+- Modify: `tests/test_qlp_l0.py`
+
+- [ ] **Step 1: Write failing test — stitched_image returns a Figure with correct structure**
+
+Append to `tests/test_qlp_l0.py`:
+
+```python
+import matplotlib.pyplot as plt
+
+
+class TestStitchedImage4Amp:
+
+    def test_returns_figure(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_title_format(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        ax = fig.axes[0]
+        title = ax.get_title()
+        assert 'L0 - Green CCD' in title
+        assert 'KP.20240405.00001.00' in title
+        assert 'synthetic-4amp' in title
+        plt.close(fig)
+
+    def test_red_chip(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('red')
+        ax = fig.axes[0]
+        assert 'L0 - Red CCD' in ax.get_title()
+        plt.close(fig)
+
+    def test_colorbar_label_adu(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        # Figure should have 2 axes: image + colorbar
+        assert len(fig.axes) == 2
+        plt.close(fig)
+
+    def test_image_shape_4amp(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        ax = fig.axes[0]
+        images = ax.get_images()
+        assert len(images) == 1
+        # 4-amp: 2 amps stacked vertically (2070*2) x 2 amps side by side (2094*2)
+        assert images[0].get_array().shape == (2070 * 2, 2094 * 2)
+        plt.close(fig)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py::TestStitchedImage4Amp -v`
+Expected: `AttributeError: 'PlotL0' object has no attribute 'stitched_image'`
+
+- [ ] **Step 3: Implement stitched_image**
+
+Replace the full contents of `kpfpipe/qlp/plot_l0.py` with:
+
+```python
+"""L0 quicklook plots for raw KPF detector images."""
+
+import os
+from datetime import datetime, timezone
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+class PlotL0:
+    """
+    Quicklook plots for KPF L0 (raw CCD) data.
+
+    Takes a KPF0 object and generates plots of the raw detector images.
+    Pure visualization — no science computation.
+
+    Args:
+        l0_obj: KPF0 data object.
+        output_dir: Directory to save PNG files. None = return Figure only.
+    """
+
+    def __init__(self, l0_obj, output_dir=None):
+        self.l0 = l0_obj
+        self.output_dir = output_dir
+        self.obs_id = getattr(l0_obj, 'obs_id', None) or ''
+        self.name = ''
+        if 'PRIMARY' in l0_obj.headers:
+            self.name = l0_obj.headers['PRIMARY'].get('OBJECT', '')
+
+    def _count_amps(self, chip):
+        """Count amplifier extensions present for a chip."""
+        chip = chip.upper()
+        count = 0
+        for i in range(1, 5):
+            ext = f'{chip}_AMP{i}'
+            if ext in self.l0.data and self.l0.data[ext] is not None:
+                if np.size(self.l0.data[ext]) > 0:
+                    count += 1
+        return count
+
+    def _stitch(self, chip):
+        """Concatenate raw amplifier arrays into a single display image."""
+        chip = chip.upper()
+        namp = self._count_amps(chip)
+
+        if namp == 2:
+            image = np.concatenate(
+                (self.l0.data[f'{chip}_AMP1'], self.l0.data[f'{chip}_AMP2']),
+                axis=1,
+            )
+            if chip == 'GREEN':
+                image = np.flipud(image)
+        elif namp == 4:
+            bot = np.concatenate(
+                (self.l0.data[f'{chip}_AMP1'], self.l0.data[f'{chip}_AMP2']),
+                axis=1,
+            )
+            top = np.concatenate(
+                (self.l0.data[f'{chip}_AMP3'], self.l0.data[f'{chip}_AMP4']),
+                axis=1,
+            )
+            image = np.concatenate((bot, top), axis=0)
+        else:
+            raise ValueError(
+                f"Unsupported amplifier count ({namp}) for {chip} CCD. "
+                f"Expected 2 or 4."
+            )
+
+        return image
+
+    def stitched_image(self, chip):
+        """
+        Plot the stitched raw detector image for one CCD.
+
+        Replicates plot_L0_stitched_image from v2.12.
+
+        Args:
+            chip: 'green' or 'red'.
+
+        Returns:
+            matplotlib.Figure
+        """
+        chip_upper = chip.upper()
+
+        image = self._stitch(chip_upper)
+
+        # Legacy data format: values stored with extra 2^16 factor
+        twotosixteen = False
+        if np.nanmedian(image) > 200 * 2**16:
+            twotosixteen = True
+            image = image / 2**16
+
+        fig = plt.figure(figsize=(10, 8), tight_layout=True)
+        plt.imshow(
+            image, cmap='viridis', origin='lower',
+            vmin=np.percentile(image, 1),
+            vmax=np.percentile(image, 99.5),
+        )
+
+        plt.title(
+            f'L0 - {chip_upper.capitalize()} CCD: {self.obs_id} - {self.name}',
+            fontsize=14,
+        )
+        plt.xlabel('Column (pixel number)', fontsize=14)
+        plt.ylabel('Row (pixel number)', fontsize=14)
+
+        cbar_label = 'ADU'
+        if twotosixteen:
+            cbar_label += r' / $2^{16}$'
+        cbar = plt.colorbar(shrink=0.95, label=cbar_label)
+        cbar.ax.yaxis.label.set_size(14)
+        cbar.ax.tick_params(labelsize=12)
+        plt.grid(False)
+
+        # Timestamp annotation
+        current_time = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+        timestamp_label = f'KPF QLP: {current_time} UT'
+        plt.annotate(
+            timestamp_label, xy=(1, 0), xycoords='axes fraction',
+            fontsize=8, color='darkgray', ha='right', va='top',
+            xytext=(100, -21), textcoords='offset points',
+        )
+        plt.subplots_adjust(bottom=0.1)
+
+        if self.output_dir is not None:
+            fig_path = os.path.join(
+                self.output_dir,
+                f'{self.obs_id}_L0_stitched_image_{chip.lower()}_zoomable.png',
+            )
+            fig.savefig(fig_path, dpi=600, facecolor='w')
+
+        return fig
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py::TestStitchedImage4Amp -v`
+Expected: 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd KPF-Pipeline && git add kpfpipe/qlp/plot_l0.py tests/test_qlp_l0.py
+git commit -m "Implement PlotL0.stitched_image for 4-amp mode"
+```
+
+---
+
+### Task 3: Add 2-amp mode support and 2^16 scaling test
+
+**Files:**
+- Modify: `tests/test_qlp_l0.py`
+
+The 2-amp stitching logic is already in `_stitch()` from Task 2. This task adds tests to verify it works and to verify the 2^16 scaling path.
+
+- [ ] **Step 1: Write tests for 2-amp mode and 2^16 scaling**
+
+Append to `tests/test_qlp_l0.py`:
+
+```python
+class TestStitchedImage2Amp:
+
+    def test_returns_figure(self, synthetic_2amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_2amp_l0)
+        fig = qlp.stitched_image('green')
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_image_shape_2amp(self, synthetic_2amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_2amp_l0)
+        fig = qlp.stitched_image('red')
+        ax = fig.axes[0]
+        images = ax.get_images()
+        # 2-amp: full height (4080) x 2 amps side by side (2094*2)
+        assert images[0].get_array().shape == (4080, 2094 * 2)
+        plt.close(fig)
+
+    def test_title_2amp(self, synthetic_2amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_2amp_l0)
+        fig = qlp.stitched_image('green')
+        ax = fig.axes[0]
+        assert 'synthetic-2amp' in ax.get_title()
+        plt.close(fig)
+
+
+class TestStitchedImage2To16:
+
+    def test_scales_high_values(self, tmp_path):
+        """Data with median > 200 * 2^16 should be divided by 2^16."""
+        fn = str(tmp_path / "KP.20240405.00003.00.fits")
+        high_val = 300 * 2**16
+
+        primary = fits.PrimaryHDU()
+        primary.header["OBJECT"] = "high-value"
+        hdus = [primary]
+        for chip in ["GREEN", "RED"]:
+            for amp in range(1, 5):
+                data = np.full((100, 100), high_val, dtype=np.float64)
+                hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+
+        hdul = fits.HDUList(hdus)
+        hdul.writeto(fn, overwrite=True)
+        hdul.close()
+
+        l0 = KPF0.from_fits(fn)
+
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(l0)
+        fig = qlp.stitched_image('green')
+
+        # Image data should be scaled down to ~300
+        ax = fig.axes[0]
+        img_data = ax.get_images()[0].get_array()
+        assert np.nanmedian(img_data) == pytest.approx(300, abs=1)
+        plt.close(fig)
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py::TestStitchedImage2Amp tests/test_qlp_l0.py::TestStitchedImage2To16 -v`
+Expected: 4 passed (implementation already handles both cases)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd KPF-Pipeline && git add tests/test_qlp_l0.py
+git commit -m "Add tests for 2-amp mode and 2^16 scaling in PlotL0"
+```
+
+---
+
+### Task 4: Add file saving and all() method
+
+**Files:**
+- Modify: `kpfpipe/qlp/plot_l0.py`
+- Modify: `tests/test_qlp_l0.py`
+
+- [ ] **Step 1: Write failing tests for file output and all()**
+
+Append to `tests/test_qlp_l0.py`:
+
+```python
+class TestPlotL0FileSaving:
+
+    def test_saves_png_when_output_dir_set(self, synthetic_4amp_l0, tmp_path):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0, output_dir=str(tmp_path))
+        fig = qlp.stitched_image('green')
+        expected_path = tmp_path / "KP.20240405.00001.00_L0_stitched_image_green_zoomable.png"
+        assert expected_path.exists()
+        assert expected_path.stat().st_size > 0
+        plt.close(fig)
+
+    def test_no_file_when_output_dir_none(self, synthetic_4amp_l0, tmp_path):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        # No PNG should exist anywhere in tmp_path
+        pngs = list(tmp_path.glob("*.png"))
+        assert pngs == []
+        plt.close(fig)
+
+
+class TestPlotL0All:
+
+    def test_all_returns_dict_of_figures(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        figs = qlp.all()
+        assert isinstance(figs, dict)
+        assert 'L0_stitched_green' in figs
+        assert 'L0_stitched_red' in figs
+        assert all(isinstance(f, plt.Figure) for f in figs.values())
+        for f in figs.values():
+            plt.close(f)
+
+    def test_all_skips_missing_chip(self, tmp_path):
+        """L0 with only green amps should only produce green plot."""
+        fn = str(tmp_path / "KP.20240405.00004.00.fits")
+        rng = np.random.default_rng(7)
+
+        primary = fits.PrimaryHDU()
+        primary.header["OBJECT"] = "green-only"
+        hdus = [primary]
+        for amp in range(1, 5):
+            data = rng.normal(1000, 3, (100, 100)).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"GREEN_AMP{amp}"))
+
+        hdul = fits.HDUList(hdus)
+        hdul.writeto(fn, overwrite=True)
+        hdul.close()
+
+        l0 = KPF0.from_fits(fn)
+
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(l0)
+        figs = qlp.all()
+        assert 'L0_stitched_green' in figs
+        assert 'L0_stitched_red' not in figs
+        for f in figs.values():
+            plt.close(f)
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py::TestPlotL0FileSaving tests/test_qlp_l0.py::TestPlotL0All -v`
+Expected: File saving tests pass (already implemented in Task 2). `all()` tests fail with `AttributeError: 'PlotL0' object has no attribute 'all'`
+
+- [ ] **Step 3: Add all() method to PlotL0**
+
+Add to the end of the `PlotL0` class in `kpfpipe/qlp/plot_l0.py`:
+
+```python
+    def all(self):
+        """
+        Generate all L0 plots for chips present in the data.
+
+        Returns:
+            dict mapping plot name to matplotlib.Figure.
+        """
+        figures = {}
+        for chip in ['green', 'red']:
+            if self._count_amps(chip.upper()) > 0:
+                figures[f'L0_stitched_{chip}'] = self.stitched_image(chip)
+        return figures
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py::TestPlotL0FileSaving tests/test_qlp_l0.py::TestPlotL0All -v`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd KPF-Pipeline && git add kpfpipe/qlp/plot_l0.py tests/test_qlp_l0.py
+git commit -m "Add all() method and file saving tests for PlotL0"
+```
+
+---
+
+### Task 5: Create standalone CLI script
+
+**Files:**
+- Create: `scripts/qlp.py`
+
+- [ ] **Step 1: Create the script**
+
+Create `scripts/qlp.py`:
+
+```python
+#!/usr/bin/env python
+"""
+Standalone QLP (quicklook plot) generator.
+
+Usage:
+    python scripts/qlp.py --obs_id KP.20240405.03637.74 --level L0 --config configs/kpf_drp_science.toml
+
+    # Or specify paths directly:
+    python scripts/qlp.py --input /data/kpf/L0/20240405/KP.20240405.03637.74.fits --level L0 --output_dir ./qlp_output
+"""
+
+import argparse
+import os
+import sys
+
+from kpfpipe.data_models.level0 import KPF0
+from kpfpipe.qlp.plot_l0 import PlotL0
+from kpfpipe.utils.config import ConfigHandler
+from kpfpipe.utils.kpf import get_datecode
+from kpfpipe.utils.pipeline import build_filepath
+
+
+def main():
+    parser = argparse.ArgumentParser(description="KPF Quicklook Plot Generator")
+    parser.add_argument("--obs_id", type=str, help="Observation ID (e.g. KP.20240405.03637.74)")
+    parser.add_argument("--input", type=str, help="Direct path to input FITS file")
+    parser.add_argument("--level", type=str, required=True, choices=["L0"], help="Data level to plot")
+    parser.add_argument("--config", type=str, help="Path to TOML config file")
+    parser.add_argument("--output_dir", type=str, help="Output directory for plots")
+    args = parser.parse_args()
+
+    # Determine input file path
+    if args.input:
+        input_file = args.input
+    elif args.obs_id and args.config:
+        config = ConfigHandler(args.config)
+        params = config.get_params(["DATA_DIRS"])
+        data_root = params.get("KPF_DATA_INPUT", "/data/kpf/")
+        input_file = build_filepath(args.obs_id, "L0", data_root=data_root)
+    else:
+        parser.error("Provide either --input or both --obs_id and --config")
+
+    if not os.path.isfile(input_file):
+        print(f"Error: file not found: {input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Determine output directory
+    if args.output_dir:
+        output_dir = args.output_dir
+    elif args.config:
+        config = ConfigHandler(args.config)
+        params = config.get_params(["DATA_DIRS"])
+        data_root = params.get("KPF_DATA_OUTPUT", "/data/kpf-next/")
+        obs_id = args.obs_id or KPF0.from_fits(input_file).obs_id
+        datecode = get_datecode(obs_id)
+        output_dir = os.path.join(data_root, "QLP", datecode, obs_id, "L0")
+    else:
+        output_dir = "."
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Generate plots
+    if args.level == "L0":
+        l0 = KPF0.from_fits(input_file)
+        print(f"Generating L0 QLP for {l0.obs_id}")
+        qlp = PlotL0(l0, output_dir=output_dir)
+        figs = qlp.all()
+        for name, fig in figs.items():
+            fig.clear()
+        print(f"Plots saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Verify script parses arguments**
+
+Run: `cd KPF-Pipeline && python scripts/qlp.py --help`
+Expected: prints usage with `--obs_id`, `--input`, `--level`, `--config`, `--output_dir` flags
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd KPF-Pipeline && git add scripts/qlp.py
+git commit -m "Add standalone QLP CLI script"
+```
+
+---
+
+### Task 6: Run full test suite and final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run all QLP tests**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/test_qlp_l0.py -v`
+Expected: All tests pass (should be ~14 tests)
+
+- [ ] **Step 2: Run the full project test suite to check for regressions**
+
+Run: `cd KPF-Pipeline && python -m pytest tests/ -v`
+Expected: All existing tests still pass, plus the new QLP tests
+
+- [ ] **Step 3: Verify with a real L0 file (if available)**
+
+Run: `cd KPF-Pipeline && python scripts/qlp.py --input /path/to/real/L0.fits --level L0 --output_dir /tmp/qlp_test`
+
+Verify: Open the PNG files and confirm they match the v2.12 stitched image format (viridis colormap, ADU colorbar, title with obs_id, timestamp annotation).
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+cd KPF-Pipeline && git add -A && git commit -m "QLP L0: final cleanup"
+```

--- a/docs/superpowers/specs/2026-04-14-qlp-l0-design.md
+++ b/docs/superpowers/specs/2026-04-14-qlp-l0-design.md
@@ -1,0 +1,127 @@
+# QLP L0 Design Spec
+
+## Context
+
+KPF-Pipeline v3 (kpf-next) can process L0 through L2 but has no quicklook plotting (QLP), diagnostics, or quality control (QC) infrastructure. The v2.12 pipeline has a comprehensive QLP system; we are porting it to v3 starting with L0-level plots.
+
+This spec covers the first QLP module: L0 plots for development verification.
+
+## Architecture decisions
+
+**No Diagnostics module.** v2.12 had separate Diagnostics, QLP, and QC layers. In v3, Diagnostics is eliminated. Pipeline modules (ImageAssembly, etc.) compute and store all metrics in data products. QLP reads data products and makes plots. QC reads data products and makes pass/fail checks. No separate metric-computation layer.
+
+**QLP does not compute.** QLP is pure visualization. It reads from data product extensions and headers. If a metric isn't in the data product, QLP doesn't show it. This ensures a clean separation: science logic lives in pipeline modules, display logic lives in QLP.
+
+**Standalone first, recipe integration later.** QLP runs as a standalone script during development. Recipe integration is a future step.
+
+## Scope
+
+PlotL0 only. PlotL1, PlotL2, PlotL4, and QC are future work.
+
+## Module structure
+
+```
+kpfpipe/qlp/
+    __init__.py
+    plot_l0.py          # PlotL0 class
+
+scripts/
+    qlp.py              # standalone CLI entry point
+
+tests/
+    test_qlp_l0.py      # structural tests
+```
+
+Future files (`plot_l1.py`, `plot_l2.py`, `plot_l4.py`) will follow the same pattern.
+
+## PlotL0 class
+
+File: `kpfpipe/qlp/plot_l0.py`
+
+### Constructor
+
+```python
+class PlotL0:
+    def __init__(self, l0_obj, output_dir=None):
+        self.l0 = l0_obj
+        self.output_dir = output_dir  # None = return Figure only, don't save
+```
+
+Takes a KPF0 object (raw CCD data). If `output_dir` is set, plots are saved as PNG files in addition to being returned.
+
+### Method: `stitched_image(chip)`
+
+Replicates `plot_L0_stitched_image` from v2.12 `modules/quicklook/src/analyze_l0.py`.
+
+**Input:** `chip` — `'green'` or `'red'`
+
+**Behavior:**
+
+1. Determine how many amplifier extensions are present for the chip (2-amp or 4-amp mode).
+2. Concatenate raw amp arrays into a single display image:
+   - 2-amp green: `flipud(concat(AMP1, AMP2, axis=1))`
+   - 2-amp red: `concat(AMP1, AMP2, axis=1)`
+   - 4-amp: bottom=`concat(AMP1, AMP2, axis=1)`, top=`concat(AMP3, AMP4, axis=1)`, then `concat(bottom, top, axis=0)`
+3. Check if pixel values need division by 2^16 (v2 threshold: `median > 200 * 2^16`).
+4. Plot with matplotlib:
+   - `plt.imshow(image, cmap='viridis', origin='lower', vmin=percentile(1), vmax=percentile(99.5))`
+   - Title: `'L0 - {Chip} CCD: {ObsID} - {name}'` (fontsize=14)
+   - X-label: `'Column (pixel number)'` (fontsize=14)
+   - Y-label: `'Row (pixel number)'` (fontsize=14)
+   - Colorbar: `shrink=0.95`, label=`'ADU'` (or `'ADU / 2^16'` if scaled), fontsize=14, tick labelsize=12
+   - `plt.grid(False)`
+   - Timestamp annotation (bottom right, gray, fontsize=8): `'KPF QLP: {YYYY-MM-DD HH:MM:SS} UT'`
+   - Figure size: 10x8 inches, `tight_layout=True`
+   - Save at 600 DPI, `facecolor='w'`
+5. No read noise annotations. Those metrics are computed by ImageAssembly and stored in L1 headers; they belong on PlotL1.
+
+**Output:**
+- Returns a `matplotlib.Figure`
+- If `output_dir` is set, saves to `{output_dir}/{obs_id}_L0_stitched_image_{chip}_zoomable.png`
+
+### Method: `all()`
+
+Convenience method. Calls `stitched_image()` for each chip present in the L0 object. Returns a dict of `{name: Figure}`.
+
+## Standalone script
+
+File: `scripts/qlp.py`
+
+```
+python scripts/qlp.py --obs_id KP.20230724.48905.30 --level L0 --config configs/kpf_drp_science.toml
+```
+
+- Parses obs_id to determine datecode and locate the L0 FITS file.
+- Loads KPF0 from FITS.
+- Creates PlotL0, calls `all()`.
+- Output directory: `{output_dir}/{datecode}/{obs_id}/L0/`
+
+The `--level` flag supports future expansion to L1, L2, L4.
+
+## Testing
+
+File: `tests/test_qlp_l0.py`
+
+- Load a test L0 FITS file.
+- Create PlotL0, call `stitched_image('green')` and `stitched_image('red')`.
+- Assert: returns a matplotlib Figure.
+- Assert: figure has expected title format.
+- Assert: figure has a colorbar.
+- Assert: image data shape matches expected CCD dimensions.
+- No pixel-level assertions.
+
+## Output format
+
+- PNG, 600 DPI, white facecolor
+- Filename convention: `{obs_id}_L0_stitched_image_{chip}_zoomable.png`
+- Directory structure: `{output_dir}/{datecode}/{obs_id}/L0/`
+
+## What this spec does NOT cover
+
+- PlotL1 (v2 "2D" level plots, including read noise annotations)
+- PlotL2 (extracted spectra plots)
+- PlotL4 (RV/CCF plots)
+- QC framework
+- Exposure meter, guider, CaHK plots (these are L0-adjacent but separate)
+- Recipe integration
+- Time-series / nightly summary plots

--- a/kpfpipe/qlp/__init__.py
+++ b/kpfpipe/qlp/__init__.py
@@ -1,0 +1,3 @@
+from kpfpipe.qlp.plot_l0 import PlotL0
+
+__all__ = ['PlotL0']

--- a/kpfpipe/qlp/plot_l0.py
+++ b/kpfpipe/qlp/plot_l0.py
@@ -1,5 +1,11 @@
 """L0 quicklook plots for raw KPF detector images."""
 
+import os
+from datetime import datetime, timezone
+
+import numpy as np
+import matplotlib.pyplot as plt
+
 
 class PlotL0:
     """
@@ -20,3 +26,107 @@ class PlotL0:
         self.name = ''
         if 'PRIMARY' in l0_obj.headers:
             self.name = l0_obj.headers['PRIMARY'].get('OBJECT', '')
+
+    def _count_amps(self, chip):
+        """Count amplifier extensions present for a chip."""
+        chip = chip.upper()
+        count = 0
+        for i in range(1, 5):
+            ext = f'{chip}_AMP{i}'
+            if ext in self.l0.data and self.l0.data[ext] is not None:
+                if np.size(self.l0.data[ext]) > 0:
+                    count += 1
+        return count
+
+    def _stitch(self, chip):
+        """Concatenate raw amplifier arrays into a single display image."""
+        chip = chip.upper()
+        namp = self._count_amps(chip)
+
+        if namp == 2:
+            image = np.concatenate(
+                (self.l0.data[f'{chip}_AMP1'], self.l0.data[f'{chip}_AMP2']),
+                axis=1,
+            )
+            if chip == 'GREEN':
+                image = np.flipud(image)
+        elif namp == 4:
+            bot = np.concatenate(
+                (self.l0.data[f'{chip}_AMP1'], self.l0.data[f'{chip}_AMP2']),
+                axis=1,
+            )
+            top = np.concatenate(
+                (self.l0.data[f'{chip}_AMP3'], self.l0.data[f'{chip}_AMP4']),
+                axis=1,
+            )
+            image = np.concatenate((bot, top), axis=0)
+        else:
+            raise ValueError(
+                f"Unsupported amplifier count ({namp}) for {chip} CCD. "
+                f"Expected 2 or 4."
+            )
+
+        return image
+
+    def stitched_image(self, chip):
+        """
+        Plot the stitched raw detector image for one CCD.
+
+        Replicates plot_L0_stitched_image from v2.12.
+
+        Args:
+            chip: 'green' or 'red'.
+
+        Returns:
+            matplotlib.Figure
+        """
+        chip_upper = chip.upper()
+
+        image = self._stitch(chip_upper)
+
+        # Legacy data format: values stored with extra 2^16 factor
+        twotosixteen = False
+        if np.nanmedian(image) > 200 * 2**16:
+            twotosixteen = True
+            image = image / 2**16
+
+        fig = plt.figure(figsize=(10, 8), tight_layout=True)
+        plt.imshow(
+            image, cmap='viridis', origin='lower',
+            vmin=np.percentile(image, 1),
+            vmax=np.percentile(image, 99.5),
+        )
+
+        plt.title(
+            f'L0 - {chip_upper.capitalize()} CCD: {self.obs_id} - {self.name}',
+            fontsize=14,
+        )
+        plt.xlabel('Column (pixel number)', fontsize=14)
+        plt.ylabel('Row (pixel number)', fontsize=14)
+
+        cbar_label = 'ADU'
+        if twotosixteen:
+            cbar_label += r' / $2^{16}$'
+        cbar = plt.colorbar(shrink=0.95, label=cbar_label)
+        cbar.ax.yaxis.label.set_size(14)
+        cbar.ax.tick_params(labelsize=12)
+        plt.grid(False)
+
+        # Timestamp annotation
+        current_time = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+        timestamp_label = f'KPF QLP: {current_time} UT'
+        plt.annotate(
+            timestamp_label, xy=(1, 0), xycoords='axes fraction',
+            fontsize=8, color='darkgray', ha='right', va='top',
+            xytext=(100, -21), textcoords='offset points',
+        )
+        plt.subplots_adjust(bottom=0.1)
+
+        if self.output_dir is not None:
+            fig_path = os.path.join(
+                self.output_dir,
+                f'{self.obs_id}_L0_stitched_image_{chip.lower()}_zoomable.png',
+            )
+            fig.savefig(fig_path, dpi=600, facecolor='w')
+
+        return fig

--- a/kpfpipe/qlp/plot_l0.py
+++ b/kpfpipe/qlp/plot_l0.py
@@ -1,12 +1,13 @@
 """L0 quicklook plots for raw KPF detector images."""
 
 import os
+from copy import deepcopy
 from datetime import datetime, timezone
 
 import numpy as np
 import matplotlib.pyplot as plt
 
-from kpfpipe import DETECTOR
+from kpfpipe.modules.image_assembly import ImageAssembly
 
 
 class PlotL0:
@@ -14,7 +15,9 @@ class PlotL0:
     Quicklook plots for KPF L0 (raw CCD) data.
 
     Takes a KPF0 object and generates plots of the raw detector images.
-    Pure visualization — no science computation.
+    Pure visualization — no science computation. Amplifier counting and
+    orientation delegate to ImageAssembly so detector-geometry knowledge
+    has a single home.
 
     Args:
         l0_obj: KPF0 data object.
@@ -29,35 +32,28 @@ class PlotL0:
         if 'PRIMARY' in l0_obj.headers:
             self.name = l0_obj.headers['PRIMARY'].get('OBJECT', '')
 
-    def _count_amps(self, chip):
-        """Count amplifier extensions present for a chip."""
-        chip = chip.upper()
-        count = 0
+    def _has_chip(self, chip):
+        """Return True if any AMP extension for the chip holds data."""
         for i in range(1, 5):
-            ext = f'{chip}_AMP{i}'
-            if ext in self.l0.data and self.l0.data[ext] is not None:
-                if np.size(self.l0.data[ext]) > 0:
-                    count += 1
-        return count
-
-    @staticmethod
-    def _orient(data, flip):
-        """Apply orientation flip to an amplifier array for display."""
-        if flip == 'none':
-            return data
-        elif flip == 'cols':
-            return np.flip(data, axis=1)
-        elif flip == 'rows':
-            return np.flip(data, axis=0)
-        elif flip == 'both':
-            return np.flip(data, axis=(0, 1))
-        else:
-            raise ValueError(f"Unknown flip value: '{flip}'")
+            ext = f'{chip.upper()}_AMP{i}'
+            arr = self.l0.data.get(ext)
+            if arr is not None and np.size(arr) > 0:
+                return True
+        return False
 
     def _stitch(self, chip):
-        """Concatenate raw amplifier arrays into a single display image."""
+        """Concatenate raw amplifier arrays into a single display image.
+
+        Uses ImageAssembly to count amps and (for 4-amp mode) apply per-amp
+        orientation. Orientation is performed on a deepcopy of the L0 so
+        the caller's object is not mutated.
+        """
         chip = chip.upper()
-        namp = self._count_amps(chip)
+
+        # Count amplifiers via ImageAssembly (non-destructive).
+        ia = ImageAssembly(self.l0)
+        ia.count_amplifiers(chip)
+        namp = ia.namp[chip]
 
         if namp == 2:
             image = np.concatenate(
@@ -67,20 +63,19 @@ class PlotL0:
             if chip == 'GREEN':
                 image = np.flipud(image)
         elif namp == 4:
-            # In 4-amp mode, each amp has a different readout orientation.
-            # Orient each amp, strip prescan/overscan, then stitch into FFI.
-            amp_cfg = {a['ext_name']: a for a in DETECTOR['amplifiers'][chip]}
-            prescan = DETECTOR['ccd']['prescan']
-            nrow_img = DETECTOR['ccd']['nrow'] // 2
-            ncol_img = DETECTOR['ccd']['ncol'] // 2
+            # orient_channels mutates l0.data, so operate on a copy.
+            l0_copy = deepcopy(self.l0)
+            ia = ImageAssembly(l0_copy)
+            ia.count_amplifiers(chip)
+            ia.orient_channels(chip)
+
+            prescan = ia.prescan
+            nrow_img = ia.nrow // 2
+            ncol_img = ia.ncol // 2
 
             panels = {}
             for i in range(1, 5):
-                ext = f'{chip}_AMP{i}'
-                raw = self.l0.data[ext]
-                oriented = self._orient(raw, amp_cfg[ext]['flip'])
-                # Strip prescan (left) and overscan (right cols, bottom rows)
-                panels[i] = oriented[:nrow_img, prescan:prescan + ncol_img]
+                panels[i] = l0_copy.data[f'{chip}_AMP{i}'][:nrow_img, prescan:prescan + ncol_img]
 
             bot = np.concatenate((panels[1], panels[2]), axis=1)
             top = np.concatenate((panels[3], panels[4]), axis=1)
@@ -88,11 +83,6 @@ class PlotL0:
 
             if chip == 'GREEN':
                 image = np.flipud(image)
-        else:
-            raise ValueError(
-                f"Unsupported amplifier count ({namp}) for {chip} CCD. "
-                f"Expected 2 or 4."
-            )
 
         return image
 
@@ -168,6 +158,6 @@ class PlotL0:
         """
         figures = {}
         for chip in ['green', 'red']:
-            if self._count_amps(chip.upper()) > 0:
+            if self._has_chip(chip):
                 figures[f'L0_stitched_{chip}'] = self.stitched_image(chip)
         return figures

--- a/kpfpipe/qlp/plot_l0.py
+++ b/kpfpipe/qlp/plot_l0.py
@@ -1,0 +1,22 @@
+"""L0 quicklook plots for raw KPF detector images."""
+
+
+class PlotL0:
+    """
+    Quicklook plots for KPF L0 (raw CCD) data.
+
+    Takes a KPF0 object and generates plots of the raw detector images.
+    Pure visualization — no science computation.
+
+    Args:
+        l0_obj: KPF0 data object.
+        output_dir: Directory to save PNG files. None = return Figure only.
+    """
+
+    def __init__(self, l0_obj, output_dir=None):
+        self.l0 = l0_obj
+        self.output_dir = output_dir
+        self.obs_id = getattr(l0_obj, 'obs_id', None) or ''
+        self.name = ''
+        if 'PRIMARY' in l0_obj.headers:
+            self.name = l0_obj.headers['PRIMARY'].get('OBJECT', '')

--- a/kpfpipe/qlp/plot_l0.py
+++ b/kpfpipe/qlp/plot_l0.py
@@ -130,3 +130,16 @@ class PlotL0:
             fig.savefig(fig_path, dpi=600, facecolor='w')
 
         return fig
+
+    def all(self):
+        """
+        Generate all L0 plots for chips present in the data.
+
+        Returns:
+            dict mapping plot name to matplotlib.Figure.
+        """
+        figures = {}
+        for chip in ['green', 'red']:
+            if self._count_amps(chip.upper()) > 0:
+                figures[f'L0_stitched_{chip}'] = self.stitched_image(chip)
+        return figures

--- a/kpfpipe/qlp/plot_l0.py
+++ b/kpfpipe/qlp/plot_l0.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 import numpy as np
 import matplotlib.pyplot as plt
 
+from kpfpipe import DETECTOR
+
 
 class PlotL0:
     """
@@ -38,6 +40,20 @@ class PlotL0:
                     count += 1
         return count
 
+    @staticmethod
+    def _orient(data, flip):
+        """Apply orientation flip to an amplifier array for display."""
+        if flip == 'none':
+            return data
+        elif flip == 'cols':
+            return np.flip(data, axis=1)
+        elif flip == 'rows':
+            return np.flip(data, axis=0)
+        elif flip == 'both':
+            return np.flip(data, axis=(0, 1))
+        else:
+            raise ValueError(f"Unknown flip value: '{flip}'")
+
     def _stitch(self, chip):
         """Concatenate raw amplifier arrays into a single display image."""
         chip = chip.upper()
@@ -51,15 +67,27 @@ class PlotL0:
             if chip == 'GREEN':
                 image = np.flipud(image)
         elif namp == 4:
-            bot = np.concatenate(
-                (self.l0.data[f'{chip}_AMP1'], self.l0.data[f'{chip}_AMP2']),
-                axis=1,
-            )
-            top = np.concatenate(
-                (self.l0.data[f'{chip}_AMP3'], self.l0.data[f'{chip}_AMP4']),
-                axis=1,
-            )
+            # In 4-amp mode, each amp has a different readout orientation.
+            # Orient each amp, strip prescan/overscan, then stitch into FFI.
+            amp_cfg = {a['ext_name']: a for a in DETECTOR['amplifiers'][chip]}
+            prescan = DETECTOR['ccd']['prescan']
+            nrow_img = DETECTOR['ccd']['nrow'] // 2
+            ncol_img = DETECTOR['ccd']['ncol'] // 2
+
+            panels = {}
+            for i in range(1, 5):
+                ext = f'{chip}_AMP{i}'
+                raw = self.l0.data[ext]
+                oriented = self._orient(raw, amp_cfg[ext]['flip'])
+                # Strip prescan (left) and overscan (right cols, bottom rows)
+                panels[i] = oriented[:nrow_img, prescan:prescan + ncol_img]
+
+            bot = np.concatenate((panels[1], panels[2]), axis=1)
+            top = np.concatenate((panels[3], panels[4]), axis=1)
             image = np.concatenate((bot, top), axis=0)
+
+            if chip == 'GREEN':
+                image = np.flipud(image)
         else:
             raise ValueError(
                 f"Unsupported amplifier count ({namp}) for {chip} CCD. "

--- a/scripts/qlp.py
+++ b/scripts/qlp.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+"""
+Standalone QLP (quicklook plot) generator.
+
+Usage:
+    python scripts/qlp.py --obs_id KP.20240405.03637.74 --level L0 --config configs/kpf_drp_science.toml
+
+    # Or specify paths directly:
+    python scripts/qlp.py --input /data/kpf/L0/20240405/KP.20240405.03637.74.fits --level L0 --output_dir ./qlp_output
+"""
+
+import argparse
+import os
+import sys
+
+from kpfpipe.data_models.level0 import KPF0
+from kpfpipe.qlp.plot_l0 import PlotL0
+from kpfpipe.utils.config import ConfigHandler
+from kpfpipe.utils.kpf import get_datecode
+from kpfpipe.utils.pipeline import build_filepath
+
+
+def main():
+    parser = argparse.ArgumentParser(description="KPF Quicklook Plot Generator")
+    parser.add_argument("--obs_id", type=str, help="Observation ID (e.g. KP.20240405.03637.74)")
+    parser.add_argument("--input", type=str, help="Direct path to input FITS file")
+    parser.add_argument("--level", type=str, required=True, choices=["L0"], help="Data level to plot")
+    parser.add_argument("--config", type=str, help="Path to TOML config file")
+    parser.add_argument("--output_dir", type=str, help="Output directory for plots")
+    args = parser.parse_args()
+
+    # Determine input file path
+    if args.input:
+        input_file = args.input
+    elif args.obs_id and args.config:
+        config = ConfigHandler(args.config)
+        params = config.get_params(["DATA_DIRS"])
+        data_root = params.get("KPF_DATA_INPUT", "/data/kpf/")
+        input_file = build_filepath(args.obs_id, "L0", data_root=data_root)
+    else:
+        parser.error("Provide either --input or both --obs_id and --config")
+
+    if not os.path.isfile(input_file):
+        print(f"Error: file not found: {input_file}", file=sys.stderr)
+        sys.exit(1)
+
+    # Determine output directory
+    if args.output_dir:
+        output_dir = args.output_dir
+    elif args.config:
+        config = ConfigHandler(args.config)
+        params = config.get_params(["DATA_DIRS"])
+        data_root = params.get("KPF_DATA_OUTPUT", "/data/kpf-next/")
+        obs_id = args.obs_id or KPF0.from_fits(input_file).obs_id
+        datecode = get_datecode(obs_id)
+        output_dir = os.path.join(data_root, "QLP", datecode, obs_id, "L0")
+    else:
+        output_dir = "."
+
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Generate plots
+    if args.level == "L0":
+        l0 = KPF0.from_fits(input_file)
+        print(f"Generating L0 QLP for {l0.obs_id}")
+        qlp = PlotL0(l0, output_dir=output_dir)
+        figs = qlp.all()
+        for name, fig in figs.items():
+            fig.clear()
+        print(f"Plots saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qlp_l0.py
+++ b/tests/test_qlp_l0.py
@@ -87,3 +87,58 @@ class TestPlotL0Constructor:
         from kpfpipe.qlp.plot_l0 import PlotL0
         qlp = PlotL0(synthetic_4amp_l0, output_dir=str(tmp_path))
         assert qlp.output_dir == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Task 2: stitched_image
+# ---------------------------------------------------------------------------
+
+import matplotlib.pyplot as plt
+
+
+class TestStitchedImage4Amp:
+
+    def test_returns_figure(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_title_format(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        ax = fig.axes[0]
+        title = ax.get_title()
+        assert 'L0 - Green CCD' in title
+        assert 'KP.20240405.00001.00' in title
+        assert 'synthetic-4amp' in title
+        plt.close(fig)
+
+    def test_red_chip(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('red')
+        ax = fig.axes[0]
+        assert 'L0 - Red CCD' in ax.get_title()
+        plt.close(fig)
+
+    def test_colorbar_label_adu(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        # Figure should have 2 axes: image + colorbar
+        assert len(fig.axes) == 2
+        plt.close(fig)
+
+    def test_image_shape_4amp(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        ax = fig.axes[0]
+        images = ax.get_images()
+        assert len(images) == 1
+        # 4-amp: 2 amps stacked vertically (2070*2) x 2 amps side by side (2094*2)
+        assert images[0].get_array().shape == (2070 * 2, 2094 * 2)
+        plt.close(fig)

--- a/tests/test_qlp_l0.py
+++ b/tests/test_qlp_l0.py
@@ -1,0 +1,89 @@
+"""Tests for L0 quicklook plots."""
+
+import os
+import numpy as np
+import pytest
+from astropy.io import fits
+
+import matplotlib
+matplotlib.use('Agg')
+
+from kpfpipe.data_models.level0 import KPF0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def synthetic_4amp_l0(tmp_path):
+    """Create a synthetic KPF0 with 4-amp green and red data."""
+    fn = str(tmp_path / "KP.20240405.00001.00.fits")
+    rng = np.random.default_rng(42)
+
+    nrow, ncol = 2070, 2094
+    bias_level = 1000.0
+
+    primary = fits.PrimaryHDU()
+    primary.header["INSTRUME"] = "KPF"
+    primary.header["OBJECT"] = "synthetic-4amp"
+    primary.header["IMTYPE"] = "Bias"
+    primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
+
+    hdus = [primary]
+    for chip in ["GREEN", "RED"]:
+        for amp in range(1, 5):
+            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+
+    hdul = fits.HDUList(hdus)
+    hdul.writeto(fn, overwrite=True)
+    hdul.close()
+    return KPF0.from_fits(fn)
+
+
+@pytest.fixture
+def synthetic_2amp_l0(tmp_path):
+    """Create a synthetic KPF0 with 2-amp green and red data."""
+    fn = str(tmp_path / "KP.20240405.00002.00.fits")
+    rng = np.random.default_rng(99)
+
+    nrow, ncol = 4080, 2094
+    bias_level = 1000.0
+
+    primary = fits.PrimaryHDU()
+    primary.header["INSTRUME"] = "KPF"
+    primary.header["OBJECT"] = "synthetic-2amp"
+    primary.header["IMTYPE"] = "Bias"
+    primary.header["DATE-OBS"] = "2024-04-05T01:00:38"
+
+    hdus = [primary]
+    for chip in ["GREEN", "RED"]:
+        for amp in range(1, 3):
+            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+
+    hdul = fits.HDUList(hdus)
+    hdul.writeto(fn, overwrite=True)
+    hdul.close()
+    return KPF0.from_fits(fn)
+
+
+# ---------------------------------------------------------------------------
+# Task 1: Constructor
+# ---------------------------------------------------------------------------
+
+class TestPlotL0Constructor:
+
+    def test_init_with_l0(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        assert qlp.l0 is synthetic_4amp_l0
+        assert qlp.obs_id == "KP.20240405.00001.00"
+        assert qlp.name == "synthetic-4amp"
+        assert qlp.output_dir is None
+
+    def test_init_with_output_dir(self, synthetic_4amp_l0, tmp_path):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0, output_dir=str(tmp_path))
+        assert qlp.output_dir == str(tmp_path)

--- a/tests/test_qlp_l0.py
+++ b/tests/test_qlp_l0.py
@@ -206,3 +206,68 @@ class TestStitchedImage2To16:
         img_data = ax.get_images()[0].get_array()
         assert np.nanmedian(img_data) == pytest.approx(300, abs=1)
         plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Task 4: File saving and all()
+# ---------------------------------------------------------------------------
+
+class TestPlotL0FileSaving:
+
+    def test_saves_png_when_output_dir_set(self, synthetic_4amp_l0, tmp_path):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0, output_dir=str(tmp_path))
+        fig = qlp.stitched_image('green')
+        expected_path = tmp_path / "KP.20240405.00001.00_L0_stitched_image_green_zoomable.png"
+        assert expected_path.exists()
+        assert expected_path.stat().st_size > 0
+        plt.close(fig)
+
+    def test_no_file_when_output_dir_none(self, synthetic_4amp_l0, tmp_path):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        fig = qlp.stitched_image('green')
+        # No PNG should exist anywhere in tmp_path
+        pngs = list(tmp_path.glob("*.png"))
+        assert pngs == []
+        plt.close(fig)
+
+
+class TestPlotL0All:
+
+    def test_all_returns_dict_of_figures(self, synthetic_4amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        figs = qlp.all()
+        assert isinstance(figs, dict)
+        assert 'L0_stitched_green' in figs
+        assert 'L0_stitched_red' in figs
+        assert all(isinstance(f, plt.Figure) for f in figs.values())
+        for f in figs.values():
+            plt.close(f)
+
+    def test_all_skips_missing_chip(self, tmp_path):
+        """L0 with only green amps should only produce green plot."""
+        fn = str(tmp_path / "KP.20240405.00004.00.fits")
+        rng = np.random.default_rng(7)
+
+        primary = fits.PrimaryHDU()
+        primary.header["OBJECT"] = "green-only"
+        hdus = [primary]
+        for amp in range(1, 5):
+            data = rng.normal(1000, 3, (100, 100)).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"GREEN_AMP{amp}"))
+
+        hdul = fits.HDUList(hdus)
+        hdul.writeto(fn, overwrite=True)
+        hdul.close()
+
+        l0 = KPF0.from_fits(fn)
+
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(l0)
+        figs = qlp.all()
+        assert 'L0_stitched_green' in figs
+        assert 'L0_stitched_red' not in figs
+        for f in figs.values():
+            plt.close(f)

--- a/tests/test_qlp_l0.py
+++ b/tests/test_qlp_l0.py
@@ -139,8 +139,8 @@ class TestStitchedImage4Amp:
         ax = fig.axes[0]
         images = ax.get_images()
         assert len(images) == 1
-        # 4-amp: 2 amps stacked vertically (2070*2) x 2 amps side by side (2094*2)
-        assert images[0].get_array().shape == (2070 * 2, 2094 * 2)
+        # 4-amp: oriented and stripped to imaging area (4080 x 4080)
+        assert images[0].get_array().shape == (4080, 4080)
         plt.close(fig)
 
 

--- a/tests/test_qlp_l0.py
+++ b/tests/test_qlp_l0.py
@@ -142,3 +142,67 @@ class TestStitchedImage4Amp:
         # 4-amp: 2 amps stacked vertically (2070*2) x 2 amps side by side (2094*2)
         assert images[0].get_array().shape == (2070 * 2, 2094 * 2)
         plt.close(fig)
+
+
+# ---------------------------------------------------------------------------
+# Task 3: 2-amp mode and 2^16 scaling
+# ---------------------------------------------------------------------------
+
+class TestStitchedImage2Amp:
+
+    def test_returns_figure(self, synthetic_2amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_2amp_l0)
+        fig = qlp.stitched_image('green')
+        assert isinstance(fig, plt.Figure)
+        plt.close(fig)
+
+    def test_image_shape_2amp(self, synthetic_2amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_2amp_l0)
+        fig = qlp.stitched_image('red')
+        ax = fig.axes[0]
+        images = ax.get_images()
+        # 2-amp: full height (4080) x 2 amps side by side (2094*2)
+        assert images[0].get_array().shape == (4080, 2094 * 2)
+        plt.close(fig)
+
+    def test_title_2amp(self, synthetic_2amp_l0):
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(synthetic_2amp_l0)
+        fig = qlp.stitched_image('green')
+        ax = fig.axes[0]
+        assert 'synthetic-2amp' in ax.get_title()
+        plt.close(fig)
+
+
+class TestStitchedImage2To16:
+
+    def test_scales_high_values(self, tmp_path):
+        """Data with median > 200 * 2^16 should be divided by 2^16."""
+        fn = str(tmp_path / "KP.20240405.00003.00.fits")
+        high_val = 300 * 2**16
+
+        primary = fits.PrimaryHDU()
+        primary.header["OBJECT"] = "high-value"
+        hdus = [primary]
+        for chip in ["GREEN", "RED"]:
+            for amp in range(1, 5):
+                data = np.full((100, 100), high_val, dtype=np.float64)
+                hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+
+        hdul = fits.HDUList(hdus)
+        hdul.writeto(fn, overwrite=True)
+        hdul.close()
+
+        l0 = KPF0.from_fits(fn)
+
+        from kpfpipe.qlp.plot_l0 import PlotL0
+        qlp = PlotL0(l0)
+        fig = qlp.stitched_image('green')
+
+        # Image data should be scaled down to ~300
+        ax = fig.axes[0]
+        img_data = ax.get_images()[0].get_array()
+        assert np.nanmedian(img_data) == pytest.approx(300, abs=1)
+        plt.close(fig)


### PR DESCRIPTION
## Summary

Adds the first quicklook plotting (QLP) module for KPF-Pipeline v3 — replicates v2.12 L0 stitched detector image plots.

## Architecture

This PR establishes the v3 QLP/QC architecture:
- **No Diagnostics module.** Pipeline modules compute metrics and store them in data products (e.g. read noise in L1 headers).
- **QLP is pure visualization.** Reads data products and renders plots — no computation.
- **QC will be pure validation.** Reads data products and makes pass/fail checks (future work).

See `docs/superpowers/specs/2026-04-14-qlp-l0-design.md` for full design rationale.

## What's included

- `kpfpipe/qlp/` package with `PlotL0` class
- `stitched_image(chip)` method — replicates v2.12 `plot_L0_stitched_image`
  - Handles both 2-amp and 4-amp readout modes
  - 4-amp mode applies per-amp orientation (from `detector.toml`) and strips prescan/overscan for coherent display
  - Legacy 2^16 scaling preserved for backward compatibility
  - matplotlib rendering: viridis, 1st-99.5th percentile, 600 DPI
- `all()` convenience method that plots all present chips
- `scripts/qlp.py` — standalone CLI (`--obs_id`, `--input`, `--level`, `--config`, `--output_dir`)
- 15 unit tests in `tests/test_qlp_l0.py`
- Design spec and implementation plan in `docs/superpowers/`

## Test plan

- [x] 15/15 unit tests pass (synthetic 2-amp and 4-amp fixtures)
- [x] No regressions in existing test suite
- [x] Verified against v2.12 reference plots from cadence for 4-amp observation KP.20250419.84046.71
- [x] Verified 2-amp rendering against real flat KP.20240923.00022.16
- [ ] Recipe integration (future PR)

## Next steps

PlotL1 (equivalent to v2 "2D" plots — assembled FFI with read noise annotations from L1 headers), then PlotL2, then QC framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)