### PR TITLE
Kpf next cleanup

### DIFF
--- a/configs/kpf_drp_masters.toml
+++ b/configs/kpf_drp_masters.toml
@@ -7,10 +7,13 @@ chips = ["GREEN", "RED"]
 fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 
 [BIAS]
+stack_sigma = 5.0
 
 [DARK]
+stack_sigma = 5.0
 
 [FLAT]
+stack_sigma = 5.0
 
 [WLS]
 lineprofile = "gaussian"

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -50,33 +50,18 @@ class KPF0(KPFDataModel):
             if row["Required"] and row["Name"] not in self.extensions:
                 self.create_extension(row["Name"], row["DataType"])
 
-    @classmethod
-    def from_fits(cls, fn, **kwargs):
+    def read(self, hdul, instrument=None, overwrite=False, **kwargs):
+        """Route L0 FITS reads to KPF0._read.
+
+        RVDataModel.read has no lvl==0 dispatch branch, so the inherited
+        from_fits would never call into _read without this override.
         """
-        Create a KPF0 instance from a FITS file.
-
-        Overrides RVDataModel.from_fits() to bypass the base class read()
-        dispatch, which only handles levels 2-4.
-        """
-        if not os.path.isfile(fn):
-            raise IOError(f"{fn} does not exist.")
-        if not fn.endswith(".fits") and not fn.endswith(".fit"):
-            raise IOError("Input file must be a FITS file.")
-
-        this_data = cls()
-
-        with fits.open(fn) as hdul:
-            this_data.filename = os.path.basename(fn)
-            this_data.dirname = os.path.dirname(fn)
-            this_data._read(hdul)
-
-        try:
-            this_data.obs_id = get_obs_id(fn)
-        except ValueError:
-            pass
-
-        this_data.receipt_add_entry("from_fits", "PASS")
-        return this_data
+        self._read(hdul)
+        if self.filename is not None:
+            try:
+                self.obs_id = get_obs_id(self.filename)
+            except ValueError:
+                pass
 
     def _read(self, hdul):
         """

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -60,33 +60,18 @@ class KPF1(KPFDataModel):
             if row["Required"] and row["Name"] not in self.extensions:
                 self.create_extension(row["Name"], row["DataType"])
 
-    @classmethod
-    def from_fits(cls, fn, **kwargs):
+    def read(self, hdul, instrument=None, overwrite=False, **kwargs):
+        """Route L1 FITS reads to KPF1._read.
+
+        RVDataModel.read has no lvl==1 dispatch branch, so the inherited
+        from_fits would never call into _read without this override.
         """
-        Create a KPF1 instance from a FITS file.
-
-        Overrides RVDataModel.from_fits() to bypass the base class read()
-        dispatch, which only handles levels 2-4.
-        """
-        if not os.path.isfile(fn):
-            raise IOError(f"{fn} does not exist.")
-        if not fn.endswith(".fits") and not fn.endswith(".fit"):
-            raise IOError("Input file must be a FITS file.")
-
-        this_data = cls()
-
-        with fits.open(fn) as hdul:
-            this_data.filename = os.path.basename(fn)
-            this_data.dirname = os.path.dirname(fn)
-            this_data._read(hdul)
-
-        try:
-            this_data.obs_id = get_obs_id(fn)
-        except ValueError:
-            pass
-
-        this_data.receipt_add_entry("from_fits", "PASS")
-        return this_data
+        self._read(hdul)
+        if self.filename is not None:
+            try:
+                self.obs_id = get_obs_id(self.filename)
+            except ValueError:
+                pass
 
     def _read(self, hdul):
         """

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -16,7 +16,6 @@ Filename convention: masters products follow WMKO filename format
 """
 
 import importlib.resources
-import os
 import warnings
 
 import numpy as np
@@ -57,29 +56,14 @@ class KPFMasterL2(KPFMasterModel, KPF2):
             if row["Required"] and row["Name"] not in self.extensions:
                 self.create_extension(row["Name"], row["DataType"])
 
-    @classmethod
-    def from_fits(cls, fn, **kwargs):
+    def read(self, hdul, instrument=None, overwrite=False, **kwargs):
+        """Route Masters L2 FITS reads to KPFMasterL2._read.
+
+        RVDataModel.read dispatches lvl==2 to RV2._read, which only knows
+        the EPRV standard L2 extensions and would KeyError on masters-
+        specific ones (INPUT_FILES, *_WLS_COEFFS).
         """
-        Create a KPFMasterL2 instance from a FITS file.
-
-        Overrides RVDataModel.from_fits() to bypass the base class read()
-        dispatch, which hardcodes RV2._read for level==2 and does not know
-        about masters-specific extensions (e.g., INPUT_FILES).
-        """
-        if not os.path.isfile(fn):
-            raise IOError(f"{fn} does not exist.")
-        if not fn.endswith(".fits") and not fn.endswith(".fit"):
-            raise IOError("Input file must be a FITS file.")
-
-        this_data = cls()
-
-        with fits.open(fn) as hdul:
-            this_data.filename = os.path.basename(fn)
-            this_data.dirname = os.path.dirname(fn)
-            this_data._read(hdul)
-
-        this_data.receipt_add_entry("from_fits", "PASS")
-        return this_data
+        self._read(hdul)
 
     def _read(self, hdul):
         """

--- a/kpfpipe/exceptions.py
+++ b/kpfpipe/exceptions.py
@@ -1,5 +1,0 @@
-# KPFError is a lightweight wrapper around Exception.
-# Raise a KPFError to indicate failures related to
-# peculiar quirks of KPF data and data processing.
-class KPFError(Exception):
-    pass

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -63,7 +63,7 @@ class CalibrationAssociation:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _find_master_files(self, cal_type, date_obs, search_window=None):
+    def _find_master_files(self, cal_type, date_obs, masters_search_window_days=None):
         """
         Return a list of (filepath, timestamp) tuples for all available
         masters of the given calibration type within the search window.
@@ -75,7 +75,7 @@ class CalibrationAssociation:
         date_obs : str
             ISO-format observation datetime from the frame's PRIMARY header
             (e.g. '2024-04-05T11:08:33').
-        search_window : [int, int], optional
+        masters_search_window_days : [int, int], optional
             Search window as [days_before, days_after]. Defaults to
             self.masters_search_window_days.
 
@@ -84,8 +84,11 @@ class CalibrationAssociation:
         list of (str, str)
             Sorted list of (filepath, kpf_timestamp) tuples.
         """
+        if masters_search_window_days is None:
+            masters_search_window_days = self.masters_search_window_days
+
         obs_date = datetime.fromisoformat(date_obs).date()
-        days_before, days_after = search_window if search_window is not None else self.masters_search_window_days
+        days_before, days_after = masters_search_window_days
 
         master_files = []
         for delta in range(days_before, days_after + 1):
@@ -137,7 +140,7 @@ class CalibrationAssociation:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, cal_types, search_window=None):
+    def perform(self, cal_types, masters_search_window_days=None):
         """
         Run calibration association for the given calibration types.
 
@@ -145,7 +148,7 @@ class CalibrationAssociation:
         ----------
         cal_types : list of str
             Calibration types to associate (e.g. ['bias', 'dark', 'flat', 'thar-wls']).
-        search_window : [int, int], optional
+        masters_search_window_days : [int, int], optional
             Search window as [days_before, days_after]. Defaults to
             self.masters_search_window_days.
 
@@ -160,19 +163,21 @@ class CalibrationAssociation:
         FileNotFoundError
             If no master file is found for any requested calibration type.
         """
+        if masters_search_window_days is None:
+            masters_search_window_days = self.masters_search_window_days
+
         date_obs = self.l1_obj.headers['PRIMARY']['DATE-OBS']
         obs_date = datetime.fromisoformat(date_obs).date()
-        active_window = search_window if search_window is not None else self.masters_search_window_days
 
         _header_prefix = {'bias': 'BIAS', 'dark': 'DARK', 'flat': 'FLAT'}
 
         for cal_type in cal_types:
-            master_files = self._find_master_files(cal_type, date_obs, search_window)
+            master_files = self._find_master_files(cal_type, date_obs, masters_search_window_days)
             filepath = self._select_nearest(date_obs, master_files)
             if filepath is None:
                 raise FileNotFoundError(
                     f"No '{cal_type}' master found for {date_obs} "
-                    f"within window {active_window} days"
+                    f"within window {masters_search_window_days} days"
                 )
 
             prefix = _header_prefix.get(cal_type)

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -4,7 +4,7 @@ KPF Image Assembly module.
 import numpy as np
 import pandas as pd
 
-from kpfpipe import REPO_ROOT, DEFAULTS, DETECTOR
+from kpfpipe import DEFAULTS
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.stats import flag_outliers
 
@@ -12,8 +12,6 @@ DEFAULTS.update({
     'overscan_method': 'rowmedian',
     'readnoise_sigma': 10.0,
 })
-
-DEFAULTS.update(DETECTOR)
 
 _RN_KEYS = {
     'GREEN_AMP1': ['RNGREEN1', 'RNNGGR1'],

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -39,7 +39,6 @@ class ImageProcessing:
         for k, v in DEFAULTS.items():
             setattr(self, k, params.get(k, v))
 
-        self.chips = params.get('chips', ['GREEN', 'RED'])
         self._bias_path = None  # set by load_bias()
         self._results = None    # populated by perform()
 

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -7,13 +7,20 @@ from kpfpipe import DEFAULTS
 from kpfpipe.data_models.masters.level1 import KPFMasterL1
 from kpfpipe.utils.config import ConfigHandler
 
+DEFAULTS.update({
+    'bias': True,
+    'dark': False,
+    'flat': False,
+})
+
 
 class ImageProcessing:
     """
     Apply calibration corrections to an assembled KPF L1 frame.
 
     Currently implements bias subtraction only. Dark subtraction and
-    flat division will be added in future updates.
+    flat division will be added in future updates; requesting them now
+    raises NotImplementedError.
 
     Parameters
     ----------
@@ -21,7 +28,8 @@ class ImageProcessing:
         Assembled L1 frame. The PRIMARY header must contain BIASFILE
         and BIASDIR keywords (written by CalibrationAssociation).
     config : None | dict | ConfigHandler
-        Module configuration. No module-specific keys at this time.
+        Module configuration. Recognized keys: bias, dark, flat
+        (boolean flags toggling each correction).
     """
 
     def __init__(self, l1_obj, config=None):
@@ -113,7 +121,7 @@ class ImageProcessing:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, chips=None):
+    def perform(self, chips=None, bias=None, dark=None, flat=None):
         """
         Run image processing corrections on the L1 frame.
 
@@ -121,6 +129,14 @@ class ImageProcessing:
         ----------
         chips : list of str, optional
             CCD chips to process. Defaults to self.chips.
+        bias : bool, optional
+            If True (default from config), subtract the master bias.
+        dark : bool, optional
+            If True, subtract the master dark. Not yet implemented;
+            passing True raises NotImplementedError.
+        flat : bool, optional
+            If True, divide by the master flat. Not yet implemented;
+            passing True raises NotImplementedError.
 
         Returns
         -------
@@ -132,18 +148,31 @@ class ImageProcessing:
         ------
         FileNotFoundError
             Propagated from load_bias() if the master bias cannot be located.
+        NotImplementedError
+            If dark or flat is True.
         """
         if chips is None:
             chips = self.chips
+        if bias is None:
+            bias = self.bias
+        if dark is None:
+            dark = self.dark
+        if flat is None:
+            flat = self.flat
 
-        master_bias = self.load_bias()
+        if dark:
+            raise NotImplementedError("dark subtraction not yet implemented")
+        if flat:
+            raise NotImplementedError("flat division not yet implemented")
 
         self._results = {}
-        for chip in chips:
-            self.subtract_bias(master_bias, chip)
-        self._results['bias'] = self._bias_path
+        if bias:
+            master_bias = self.load_bias()
+            for chip in chips:
+                self.subtract_bias(master_bias, chip)
+            self._results['bias'] = self._bias_path
 
-        self.l1_obj.headers['PRIMARY']['BIASUB'] = (True, 'Bias subtraction applied')
+        self.l1_obj.headers['PRIMARY']['BIASUB'] = (bias, 'Bias subtraction applied')
         self.l1_obj.receipt_add_entry('image_processing', 'PASS')
 
         return self.l1_obj

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -51,6 +51,29 @@ class ImageProcessing:
         self._results = None    # populated by perform()
 
     # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_bias(self, value):
+        """Resolve a `bias` kwarg into a KPFMasterL1 instance.
+
+        See perform() for accepted input types. Updates self._bias_path
+        so downstream reporting reflects what was actually used.
+        """
+        if isinstance(value, KPFMasterL1):
+            dirname = getattr(value, 'dirname', '') or ''
+            filename = getattr(value, 'filename', None)
+            self._bias_path = os.path.join(dirname, filename) if filename else None
+            return value
+        if isinstance(value, str):
+            return self.load_bias(bias_path=value)
+        if value is True:
+            return self.load_bias()
+        raise TypeError(
+            f"bias must be bool, filepath str, or KPFMasterL1; got {type(value).__name__}"
+        )
+
+    # ------------------------------------------------------------------
     # Algorithm steps
     # ------------------------------------------------------------------
 
@@ -98,7 +121,7 @@ class ImageProcessing:
         self._bias_path = bias_path
         return KPFMasterL1.from_fits(bias_path)
 
-    def subtract_bias(self, master_bias, chip):
+    def subtract_bias(self, bias_l1, chip):
         """
         Subtract master bias image from the CCD data for a single chip.
 
@@ -115,7 +138,7 @@ class ImageProcessing:
             Modifies l1_obj.data['{chip}_CCD'] in-place.
         """
         chip = chip.upper()
-        self.l1_obj.data[f'{chip}_CCD'] -= master_bias.data[f'{chip}_IMG']
+        self.l1_obj.data[f'{chip}_CCD'] -= bias_l1.data[f'{chip}_IMG']
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -129,14 +152,17 @@ class ImageProcessing:
         ----------
         chips : list of str, optional
             CCD chips to process. Defaults to self.chips.
-        bias : bool, optional
-            If True (default from config), subtract the master bias.
-        dark : bool, optional
-            If True, subtract the master dark. Not yet implemented;
-            passing True raises NotImplementedError.
-        flat : bool, optional
-            If True, divide by the master flat. Not yet implemented;
-            passing True raises NotImplementedError.
+        bias : bool | str | KPFMasterL1, optional
+            How to source the master bias. Falsy → skip. True → load via
+            BIASFILE/BIASDIR in the PRIMARY header. str → treat as an
+            explicit filepath. KPFMasterL1 → use this object directly
+            (no disk I/O). Defaults to self.bias.
+        dark : bool | str | KPFMasterL1, optional
+            Same shape as `bias`. Any truthy value raises
+            NotImplementedError until dark subtraction is built out.
+        flat : bool | str | KPFMasterL1, optional
+            Same shape as `bias`. Any truthy value raises
+            NotImplementedError until flat division is built out.
 
         Returns
         -------
@@ -149,7 +175,9 @@ class ImageProcessing:
         FileNotFoundError
             Propagated from load_bias() if the master bias cannot be located.
         NotImplementedError
-            If dark or flat is True.
+            If dark or flat is truthy.
+        TypeError
+            If `bias` is not bool, str, or KPFMasterL1.
         """
         if chips is None:
             chips = self.chips
@@ -167,12 +195,12 @@ class ImageProcessing:
 
         self._results = {}
         if bias:
-            master_bias = self.load_bias()
+            master_bias = self._resolve_bias(bias)
             for chip in chips:
                 self.subtract_bias(master_bias, chip)
             self._results['bias'] = self._bias_path
 
-        self.l1_obj.headers['PRIMARY']['BIASUB'] = (bias, 'Bias subtraction applied')
+        self.l1_obj.headers['PRIMARY']['BIASUB'] = (bool(bias), 'Bias subtraction applied')
         self.l1_obj.receipt_add_entry('image_processing', 'PASS')
 
         return self.l1_obj

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -150,7 +150,7 @@ class BaseMasterModule:
             raise ValueError(f"elapsed time - requested time > {exptime_tolerance}")
 
 
-    def _compute_stats_from_datacube(self, l0_file_list=None, nframe=None, sigma=None):
+    def _compute_stats_from_datacube(self, l0_file_list=None, nframe=None, sigma=None, verbose=True):
         """
         Compute stacked statistics using an in-memory data cube.
 
@@ -162,6 +162,9 @@ class BaseMasterModule:
             Maximum number of successfully loaded frames to include.
         sigma : float, optional
             Sigma threshold for outlier rejection across frames.
+        verbose : bool, optional
+            If True (default), emit per-frame progress prints and load
+            failure warnings from `_load_frame`.
 
         Returns
         -------
@@ -208,7 +211,7 @@ class BaseMasterModule:
             if i >= nframe:
                 break
 
-            l1_obj, success = self._load_frame(fn)
+            l1_obj, success = self._load_frame(fn, verbose=verbose)
 
             if not success:
                 failure += 1
@@ -279,7 +282,7 @@ class BaseMasterModule:
         return stats, exptime_total
 
 
-    def _compute_stats_from_stream(self, l0_file_list=None, ndirect=None, sigma=None):
+    def _compute_stats_from_stream(self, l0_file_list=None, ndirect=None, sigma=None, verbose=True):
         """
         Compute stacked statistics using streaming Welford accumulation.
 
@@ -292,6 +295,9 @@ class BaseMasterModule:
             for defining clipping thresholds.
         sigma : float, optional
             Sigma threshold for outlier rejection.
+        verbose : bool, optional
+            If True (default), emit per-frame progress prints and load
+            failure warnings from `_load_frame`.
 
         Returns
         -------
@@ -325,7 +331,8 @@ class BaseMasterModule:
             self._compute_stats_from_datacube(
                 l0_file_list=l0_file_list,
                 nframe=ndirect,
-                sigma=sigma
+                sigma=sigma,
+                verbose=verbose,
             )
         )
 
@@ -356,7 +363,7 @@ class BaseMasterModule:
         valid = np.ones((NROW, NCOL), dtype=bool)
 
         for fn in l0_file_list:
-            l1_obj, success = self._load_frame(fn)
+            l1_obj, success = self._load_frame(fn, verbose=verbose)
 
             if not success:
                 failure += 1
@@ -435,7 +442,7 @@ class BaseMasterModule:
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def stack_frames(self, l0_file_list=None, nstream=None, sigma=None):
+    def stack_frames(self, l0_file_list=None, nstream=None, sigma=None, verbose=True):
         """
         Stack full-frame images to produce masters L1.
 
@@ -447,6 +454,9 @@ class BaseMasterModule:
             Threshold number of frames above which streaming statistics are used.
         sigma : float, optional
             Sigma threshold for frame-to-frame outlier rejection.
+        verbose : bool, optional
+            If True (default), emit per-frame progress prints and load
+            failure warnings during stacking.
 
         Returns
         -------
@@ -479,9 +489,9 @@ class BaseMasterModule:
             raise ValueError(f"Stacking requires at least two frames, got {nframe}")
 
         if nframe < nstream:
-            stats, exptime = self._compute_stats_from_datacube(l0_file_list, nstream - 1, sigma)
+            stats, exptime = self._compute_stats_from_datacube(l0_file_list, nstream - 1, sigma, verbose=verbose)
         else:
-            stats, exptime = self._compute_stats_from_stream(l0_file_list, nstream - 1, sigma)
+            stats, exptime = self._compute_stats_from_stream(l0_file_list, nstream - 1, sigma, verbose=verbose)
 
         # TODO: add check that nframe is consistent between CCD and VAR
         for chip in self.chips:

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -19,8 +19,6 @@ DEFAULTS.update({
 NROW = DETECTOR['ccd']['nrow']
 NCOL = DETECTOR['ccd']['ncol']
 
-# TODO: line profile and remove uneccessary array allocations
-# TODO: decide how to handle ImageAssembly config
 # TODO: throw out first frame in stack?
 # TODO: use start, middle, end of stack for initial datacube
 

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -13,7 +13,6 @@ from kpfpipe.utils.stats import flag_outliers
 DEFAULTS.update({
     'nframe_stream': 6,
     'stack_sigma': 5.0,
-    'exptime_tolerance': 0.1,
 })
 
 NROW = DETECTOR['ccd']['nrow']
@@ -56,7 +55,7 @@ class BaseMasterModule:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _load_frame(self, fn, ncache=None, exptime_tolerance=None, verbose=True):
+    def _load_frame(self, fn, ncache=None, exptime_tolerance=0.1, verbose=True):
         """
         Load an L0 file and perform image assembly to produce an L1 object.
 
@@ -66,6 +65,9 @@ class BaseMasterModule:
             Path to L0 FITS file.
         ncache : int, optional
             Maximum number of L1 objects to retain in internal cache.
+        exptime_tolerance : float
+            Maximum allowed excess of elapsed time over requested exposure time, 
+            in seconds (default = 0.1).
         verbose : bool, optional
             If True (default), emit a progress print and propagate load /
             exptime-check failures as UserWarnings. If False, all such
@@ -90,8 +92,6 @@ class BaseMasterModule:
 
         if ncache is None:
             ncache = self.nframe_stream - 1
-        if exptime_tolerance is None:
-            exptime_tolerance = self.exptime_tolerance
 
         success = True
         failure = False

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -56,7 +56,7 @@ class BaseMasterModule:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _load_frame(self, fn, ncache=None, exptime_tolerance=None):
+    def _load_frame(self, fn, ncache=None, exptime_tolerance=None, verbose=True):
         """
         Load an L0 file and perform image assembly to produce an L1 object.
 
@@ -66,6 +66,11 @@ class BaseMasterModule:
             Path to L0 FITS file.
         ncache : int, optional
             Maximum number of L1 objects to retain in internal cache.
+        verbose : bool, optional
+            If True (default), emit a progress print and propagate load /
+            exptime-check failures as UserWarnings. If False, all such
+            output is suppressed; the (None, False) failure return value
+            still signals the caller.
 
         Returns
         -------
@@ -80,7 +85,8 @@ class BaseMasterModule:
         recomputation. Cache size is limited by `ncache`, which defaults to
         `nframe_stream - 1`.
         """
-        print(f"loading {fn}")
+        if verbose:
+            print(f"loading {fn}")
 
         if ncache is None:
             ncache = self.nframe_stream - 1
@@ -102,13 +108,15 @@ class BaseMasterModule:
                     self._l1_obj_cache[fn] = l1_obj
 
             except (FileNotFoundError, IOError, OSError) as e:
-                warnings.warn(f"Failed to load {fn}: {e}")
+                if verbose:
+                    warnings.warn(f"Failed to load {fn}: {e}")
                 return None, failure
 
         try:
             self._check_exptime_vs_elapsed(l1_obj, exptime_tolerance)
         except ValueError as e:
-            warnings.warn(f"Exptime check failed for {fn}: {e}")
+            if verbose:
+                warnings.warn(f"Exptime check failed for {fn}: {e}")
             return None, failure
 
         return l1_obj, success

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -89,7 +89,8 @@ class Bias(BaseMasterModule):
 
         self._results = {
             chip: {
-                'bad_pixels': int(np.sum(~l1_arrays[f'{chip}_MASK'])),
+                'bad_tot': int(np.sum(~l1_arrays[f'{chip}_MASK'])),
+                'bad_pct':    float(100.0 * np.mean(~l1_arrays[f'{chip}_MASK'])),
                 'median':     float(np.nanmedian(l1_arrays[f'{chip}_IMG'])),
                 'rms':        float(np.nanstd(l1_arrays[f'{chip}_IMG'])),
             }
@@ -110,7 +111,7 @@ class Bias(BaseMasterModule):
             print("  make_master_l1() has not been called")
             return
 
-        print(f"\n  {'chip':<8s} {'bad pixels':<14s} {'median [e-]':<15s} {'rms [e-]'}")
-        print("  " + "-" * 50)
+        print(f"\n  {'chip':<8s} {'median [e-]':<15s} {'rms [e-]':<10s} {'bad pixels'}")
+        print("  " + "-" * 56)
         for chip, stats in self._results.items():
-            print(f"  {chip:<8s} {stats['bad_pixels']:<14d} {stats['median']:<15.4f} {stats['rms']:.4f}")
+            print(f"  {chip:<8s} {stats['median']:<15.4f} {stats['rms']:<10.4f} {stats['bad_tot']} ({stats['bad_pct']:.3f}%)")

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -89,10 +89,10 @@ class Bias(BaseMasterModule):
 
         self._results = {
             chip: {
-                'bad_tot': int(np.sum(~l1_arrays[f'{chip}_MASK'])),
-                'bad_pct':    float(100.0 * np.mean(~l1_arrays[f'{chip}_MASK'])),
-                'median':     float(np.nanmedian(l1_arrays[f'{chip}_IMG'])),
-                'rms':        float(np.nanstd(l1_arrays[f'{chip}_IMG'])),
+                'num_bad':   int(np.sum(~l1_arrays[f'{chip}_MASK'])),
+                'pct_bad': float(100.0 * np.mean(~l1_arrays[f'{chip}_MASK'])),
+                'median':  float(np.nanmedian(l1_arrays[f'{chip}_IMG'])),
+                'rms':     float(np.nanstd(l1_arrays[f'{chip}_IMG'])),
             }
             for chip in self.chips
         }
@@ -114,4 +114,4 @@ class Bias(BaseMasterModule):
         print(f"\n  {'chip':<8s} {'median [e-]':<15s} {'rms [e-]':<10s} {'bad pixels'}")
         print("  " + "-" * 56)
         for chip, stats in self._results.items():
-            print(f"  {chip:<8s} {stats['median']:<15.4f} {stats['rms']:<10.4f} {stats['bad_tot']} ({stats['bad_pct']:.3f}%)")
+            print(f"  {chip:<8s} {stats['median']:<15.4f} {stats['rms']:<10.4f} {stats['num_bad']} ({stats['pct_bad']:.3f}%)")

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -1,20 +1,13 @@
 """
 KPF Master Bias construction module.
 """
-from kpfpipe import DEFAULTS, DETECTOR
+from kpfpipe import DEFAULTS
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.base import BaseMasterModule
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.stats import flag_outliers, interpolate_bad_pixels
 
-DEFAULTS.update({
-    'nframe_stream': 6,
-    'stack_sigma': 5.0,
-    'exptime_tolerance': 0.1,
-})
-
-NROW = DETECTOR['ccd']['nrow']
-NCOL = DETECTOR['ccd']['ncol']
+DEFAULTS.update({'stack_sigma': 5.0})
 
 
 class Bias(BaseMasterModule):
@@ -34,9 +27,15 @@ class Bias(BaseMasterModule):
         exptime_tolerance, chips.
     """
     def __init__(self, l0_file_list, config=None):
-        if isinstance(config, ConfigHandler):
-            config = config.get_params(["DATA_DIRS", "KPFPIPE", "BIAS"])
-        super().__init__(l0_file_list, config)
+        if config is None:
+            params = {}
+        elif isinstance(config, dict):
+            params = config
+        elif isinstance(config, ConfigHandler):
+            params = config.get_params(["DATA_DIRS", "KPFPIPE", "BIAS"])
+        else:
+            raise TypeError("config must be None, dict, or ConfigHandler")
+        super().__init__(l0_file_list, params)
 
 
     # ------------------------------------------------------------------

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -42,7 +42,7 @@ class Bias(BaseMasterModule):
     # Public entry point
     # ------------------------------------------------------------------
 
-    def make_master_l1(self, l0_file_list=None, nstream=None, sigma=None):
+    def make_master_l1(self, l0_file_list=None, nstream=None, sigma=None, verbose=True):
         """
         Build master bias from stack
         """
@@ -54,9 +54,10 @@ class Bias(BaseMasterModule):
             sigma = self.stack_sigma
 
         l1_arrays = self.stack_frames(
-            l0_file_list=l0_file_list, 
-            nstream=nstream, 
-            sigma=sigma
+            l0_file_list=l0_file_list,
+            nstream=nstream,
+            sigma=sigma,
+            verbose=verbose,
         )
 
         for chip in self.chips:

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -1,6 +1,8 @@
 """
 KPF Master Bias construction module.
 """
+import numpy as np
+
 from kpfpipe import DEFAULTS
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.base import BaseMasterModule
@@ -36,6 +38,8 @@ class Bias(BaseMasterModule):
         else:
             raise TypeError("config must be None, dict, or ConfigHandler")
         super().__init__(l0_file_list, params)
+
+        self._results = None  # populated by make_master_l1()
 
 
     # ------------------------------------------------------------------
@@ -83,4 +87,30 @@ class Bias(BaseMasterModule):
         self.ml1_obj.set_input_files(l0_file_list)
         self.ml1_obj.receipt_add_entry('master_bias', 'PASS')
 
+        self._results = {
+            chip: {
+                'bad_pixels': int(np.sum(~l1_arrays[f'{chip}_MASK'])),
+                'median':     float(np.nanmedian(l1_arrays[f'{chip}_IMG'])),
+                'rms':        float(np.nanstd(l1_arrays[f'{chip}_IMG'])),
+            }
+            for chip in self.chips
+        }
+
         return self.ml1_obj
+
+    def info(self):
+        """Print a summary of the module configuration and stacking results."""
+        print("Bias")
+        print(f"  l0_file_list:")
+        for fn in self.l0_file_list:
+            print(f"    {fn}")
+        print(f"  chips:  {self.chips}")
+
+        if self._results is None:
+            print("  make_master_l1() has not been called")
+            return
+
+        print(f"\n  {'chip':<8s} {'bad pixels':<14s} {'median [e-]':<15s} {'rms [e-]'}")
+        print("  " + "-" * 50)
+        for chip, stats in self._results.items():
+            print(f"  {chip:<8s} {stats['bad_pixels']:<14d} {stats['median']:<15.4f} {stats['rms']:.4f}")

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -60,6 +60,8 @@ class WLS(BaseMasterModule):
         self._load_rough_wls()
         self._load_linelist()
 
+        self._results = None  # populated by make_master_l2()
+
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
@@ -822,8 +824,11 @@ class WLS(BaseMasterModule):
 
         coeffs_by_chip = {}
         lines_by_chip = {}
+        self._results = {}
 
         for chip in self.chips:
+            # Always request stacks internally so we can populate self._results
+            # for info(); only package them into HDF5 when the caller asks.
             result = self.compute_wls_from_stack(
                 chip=chip,
                 fibers=self.fibers,
@@ -831,16 +836,19 @@ class WLS(BaseMasterModule):
                 polyorder_x=polyorder_x,
                 polyorder_m=polyorder_m,
                 polyorder_f=polyorder_f,
-                return_stacks=return_stacks,
+                return_stacks=True,
                 verbose=verbose,
             )
+            W, coeffs, coeffs_stack, lines_stack = result
+
+            self._results[chip] = {
+                'n_total': sum(len(frame['wav']) for frame in lines_stack),
+                'n_fit':   sum(int(np.sum(~frame['bad'])) for frame in lines_stack),
+            }
 
             if return_stacks:
-                W, coeffs, coeffs_stack, lines_stack = result
                 coeffs_by_chip[chip] = coeffs_stack
                 lines_by_chip[chip] = lines_stack
-            else:
-                W, coeffs = result
 
             for i, fiber in enumerate(self.fibers):
                 if W.ndim == 2:
@@ -877,3 +885,27 @@ class WLS(BaseMasterModule):
             return self.ml2_obj, stacks_hdf5
 
         return self.ml2_obj
+
+    def info(self):
+        """Print a summary of the module configuration and WLS results."""
+        print("WLS")
+        print(f"  l0_file_list:")
+        for fn in self.l0_file_list:
+            print(f"    {fn}")
+        print(f"  chips:           {self.chips}")
+        print(f"  fibers:          {self.fibers}")
+        print(f"  linelist:        {self.linelist}")
+        print(f"  rough_wls_file:  {self.rough_wls_file}")
+        print(f"  lineprofile:     {self.lineprofile}")
+        print(f"  polyorder:       x={self.polyorder_x}, m={self.polyorder_m}, f={self.polyorder_f}")
+
+        if self._results is None:
+            print("  make_master_l2() has not been called")
+            return
+
+        print(f"\n  {'chip':<8s} {'n lines fit/total'}")
+        print("  " + "-" * 40)
+        for chip, stats in self._results.items():
+            n_fit, n_total = stats['n_fit'], stats['n_total']
+            pct = 100.0 * n_fit / n_total if n_total else 0.0
+            print(f"  {chip:<8s} {n_fit} / {n_total} ({pct:.1f}%)")

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -42,7 +42,9 @@ class WLS(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to process.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: KPF_DATA_INPUT.
+        Module configuration. Recognized keys: linelist, lineprofile,
+        polyorder_x, polyorder_m, polyorder_f, chips, fibers,
+        KPF_DATA_INPUT.
     """
     def __init__(self, l0_file_list, config=None):
         if config is None:

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -119,11 +119,7 @@ class WLS(BaseMasterModule):
         return self.rough_wls
     
 
-    def _load_frame(self, fn, ncache=0, exptime_tolerance=None):
-        return super()._load_frame(fn, ncache=ncache, exptime_tolerance=exptime_tolerance)
-
-
-    def _extract_frame(self, l1_obj):
+    def _extract_frame(self, l1_obj, verbose=True):
         calibration_association = CalibrationAssociation(l1_obj, {'KPF_DATA_INPUT': self._data_root})
         l1_obj = calibration_association.perform(['bias'])
 
@@ -131,7 +127,7 @@ class WLS(BaseMasterModule):
         l1_obj = image_processing.perform()
 
         spectral_extraction = SpectralExtraction(l1_obj)
-        l2_obj = spectral_extraction.perform()
+        l2_obj = spectral_extraction.perform(verbose=verbose)
 
         return l2_obj
 
@@ -170,7 +166,7 @@ class WLS(BaseMasterModule):
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def process_stack_l0_to_l2(self, l0_file_list=None):
+    def process_stack_l0_to_l2(self, l0_file_list=None, verbose=True):
         """
         Run each L0 frame in the stack through the L0→L2 pipeline.
 
@@ -178,6 +174,9 @@ class WLS(BaseMasterModule):
         ----------
         l0_file_list : list of str, optional
             L0 files to process. Defaults to self.l0_file_list.
+        verbose : bool, optional
+            If True (default), emit progress prints and per-frame warnings
+            from the underlying L0 → L1 → L2 calls.
 
         Returns
         -------
@@ -197,7 +196,7 @@ class WLS(BaseMasterModule):
         failure = 0
 
         for fn in l0_file_list:
-            l1_obj, success = self._load_frame(fn, ncache=0)
+            l1_obj, success = self._load_frame(fn, ncache=0, verbose=verbose)
 
             if not success:
                 failure += 1
@@ -205,7 +204,7 @@ class WLS(BaseMasterModule):
                     raise ValueError(f"more than 20% of frames in stack failed to load")
                 continue
 
-            l2_obj = self._extract_frame(l1_obj)
+            l2_obj = self._extract_frame(l1_obj, verbose=verbose)
             
             if not hasattr(self, '_l2_obj_cache'):
                 self._l2_obj_cache = []
@@ -416,7 +415,7 @@ class WLS(BaseMasterModule):
                 )
 
                 nlines = len(line_dict['wav'])
-                if nlines == 0:
+                if nlines == 0 and verbose:
                     warnings.warn(
                         f"{chip} {fiber} order {o + 1}: orderlet skipped "
                         f"(no fittable lines; flux likely NaN-filled)"
@@ -434,7 +433,7 @@ class WLS(BaseMasterModule):
             n_good = int(np.sum(~lines['bad'][i]))
             if verbose:
                 print(f"  {chip} {fiber}: {n_good}/{n_total} good lines")
-            if n_good == 0:
+            if n_good == 0 and verbose:
                 warnings.warn(
                     f"{chip} {fiber}: no good lines retained "
                     f"({n_total} attempted; all rejected or NaN-filled)"
@@ -742,6 +741,7 @@ class WLS(BaseMasterModule):
                        polyorder_m=None,
                        polyorder_f=None,
                        return_stacks=False,
+                       verbose=True,
                       ):
         """
         Build a master wavelength solution from a stack of L0 frames.
@@ -772,6 +772,10 @@ class WLS(BaseMasterModule):
         return_stacks : bool, optional
             If True, also return an in-memory HDF5 file containing per-frame
             coefficient and line stacks for every chip.
+        verbose : bool, optional
+            If True (default), emit progress prints and informational
+            warnings from frame loading, spectral extraction, and the
+            per-frame WLS fit. Hard failures still raise.
 
         Returns
         -------
@@ -812,7 +816,7 @@ class WLS(BaseMasterModule):
         self._load_linelist(linelist)
 
         self._l2_obj_cache = []
-        self.process_stack_l0_to_l2(l0_file_list=l0_file_list)
+        self.process_stack_l0_to_l2(l0_file_list=l0_file_list, verbose=verbose)
 
         self.ml2_obj = KPFMasterL2()
 
@@ -828,6 +832,7 @@ class WLS(BaseMasterModule):
                 polyorder_m=polyorder_m,
                 polyorder_f=polyorder_f,
                 return_stacks=return_stacks,
+                verbose=verbose,
             )
 
             if return_stacks:

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -306,7 +306,7 @@ class SpectralExtraction:
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def extract_orderlet(self, chip, fiber, order, method=None):
+    def extract_orderlet(self, chip, fiber, order, method=None, verbose=True):
         """
         Extract a single orderlet as a 1D spectrum.
 
@@ -320,6 +320,10 @@ class SpectralExtraction:
             Spectral order number.
         method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
+        verbose : bool, optional
+            If True (default), emit warnings from per-orderlet array
+            validation (NaN / negative / non-finite flux). If False,
+            those warnings are suppressed.
 
         Returns
         -------
@@ -347,13 +351,14 @@ class SpectralExtraction:
         # TODO: add bad pixel masking
         flux_1d, var_1d = extraction_fxn(D, V, W=W)
 
-        validate_array(flux_1d, context=f'flux_1d array: {chip} {fiber} {order}', response='warn')
-        validate_array(var_1d, context=f'var_1d array: {chip} {fiber} {order}', response='warn')
+        response = 'warn' if verbose else 'silent'
+        validate_array(flux_1d, context=f'flux_1d array: {chip} {fiber} {order}', response=response)
+        validate_array(var_1d, context=f'var_1d array: {chip} {fiber} {order}', response=response)
 
         return flux_1d, var_1d
 
 
-    def extract_ffi(self, chip, fibers=None, method=None):
+    def extract_ffi(self, chip, fibers=None, method=None, verbose=True):
         """
         Extract all spectral orders from a full-frame image (FFI).
 
@@ -365,6 +370,10 @@ class SpectralExtraction:
             Fibers identifiers, e.g. 'SCI2'
         method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
+        verbose : bool, optional
+            If True (default), emit informational warnings (per-orderlet
+            validation, expected single-orderlet failure). Hard failures
+            (>1 orderlet missing) still raise regardless.
 
         Returns
         -------
@@ -398,7 +407,7 @@ class SpectralExtraction:
         for order in range(1,norder+1):
             for fiber in fibers:
                 try:
-                    flux_1d, var_1d = self.extract_orderlet(chip, fiber, order, method)
+                    flux_1d, var_1d = self.extract_orderlet(chip, fiber, order, method, verbose=verbose)
                 except KPFError:
                     failure += 1
                     flux_1d = np.full(ncol, np.nan, dtype=np.float32)
@@ -411,21 +420,21 @@ class SpectralExtraction:
         # In this case a single failure is expected from this method. Allowing
         # the loop to continue through all orders provides useful diagnostic
         # information for cases where the algorithm truly fails.
-        if failure == 1:
+        if failure == 1 and verbose:
             warnings.warn(
                 f"1 orderlet failed to extract from the {chip} CCD; filled with NaN.",
                 UserWarning,
             )
         elif failure > 1:
             raise KPFError(f"Failed to extract {failure} orders from the {chip} CCD")
-        
+
         return l2_arrays
 
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, chips=None, fibers=None, method=None):
+    def perform(self, chips=None, fibers=None, method=None, verbose=True):
         """
         Execute spectral extraction. Optional keyword arguments
         default to config settings.
@@ -438,6 +447,10 @@ class SpectralExtraction:
             Fiber identifiers, e.g. 'SCI2'
         method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
+        verbose : bool, optional
+            If True (default), emit informational warnings during
+            extraction (per-orderlet array validation, expected
+            single-orderlet failure). Hard errors still raise.
 
         Returns
         -------
@@ -459,7 +472,7 @@ class SpectralExtraction:
         l2_obj = self.l1_obj.to_kpf2()
 
         for chip in chips:
-            l2_arrays = self.extract_ffi(chip, fibers, method)
+            l2_arrays = self.extract_ffi(chip, fibers, method, verbose=verbose)
             for fiber in fibers:
                 l2_obj.set_data(f'{chip}_{fiber}_FLUX', l2_arrays[f'{chip}_{fiber}_FLUX'])
                 l2_obj.set_data(f'{chip}_{fiber}_VAR',  l2_arrays[f'{chip}_{fiber}_VAR'])

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -306,7 +306,7 @@ class SpectralExtraction:
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def extract_orderlet(self, chip, fiber, order, method=None, verbose=True):
+    def extract_orderlet(self, chip, fiber, order, extraction_method=None, verbose=True):
         """
         Extract a single orderlet as a 1D spectrum.
 
@@ -318,7 +318,7 @@ class SpectralExtraction:
             Fiber identifier, e.g. 'SCI2'
         order : int
             Spectral order number.
-        method : str, optional
+        extraction_method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
         verbose : bool, optional
             If True (default), emit warnings from per-orderlet array
@@ -337,13 +337,13 @@ class SpectralExtraction:
         Retrieves the orderlet pixel region and dispatches to the selected
         extraction method.
         """
-        if method is None:
-            method = self.extraction_method
+        if extraction_method is None:
+            extraction_method = self.extraction_method
 
         try:
-            extraction_fxn = self.__getattribute__(f'_{method}_extraction')
+            extraction_fxn = self.__getattribute__(f'_{extraction_method}_extraction')
         except AttributeError:
-            raise AttributeError(f"Unsupported extraction method: '{method}'")
+            raise AttributeError(f"Unsupported extraction method: '{extraction_method}'")
 
         D, V, W, row_min, row_max = self._get_orderlet_pixels(chip, fiber, order, return_coords=True)
 
@@ -358,7 +358,7 @@ class SpectralExtraction:
         return flux_1d, var_1d
 
 
-    def extract_ffi(self, chip, fibers=None, method=None, verbose=True):
+    def extract_ffi(self, chip, fibers=None, extraction_method=None, verbose=True):
         """
         Extract all spectral orders from a full-frame image (FFI).
 
@@ -368,7 +368,7 @@ class SpectralExtraction:
             Chip identifier, i.e. 'GREEN' or 'RED'
         fibers : list of str, optional
             Fibers identifiers, e.g. 'SCI2'
-        method : str, optional
+        extraction_method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
         verbose : bool, optional
             If True (default), emit informational warnings (per-orderlet
@@ -389,8 +389,8 @@ class SpectralExtraction:
         """
         if fibers is None:
             fibers = self.fibers
-        if method is None:
-            method = self.extraction_method
+        if extraction_method is None:
+            extraction_method = self.extraction_method
 
         chip = chip.upper()
         fibers = [f.upper() for f in fibers]
@@ -407,7 +407,7 @@ class SpectralExtraction:
         for order in range(1,norder+1):
             for fiber in fibers:
                 try:
-                    flux_1d, var_1d = self.extract_orderlet(chip, fiber, order, method, verbose=verbose)
+                    flux_1d, var_1d = self.extract_orderlet(chip, fiber, order, extraction_method, verbose=verbose)
                 except LookupError:
                     failure += 1
                     flux_1d = np.full(ncol, np.nan, dtype=np.float32)
@@ -434,7 +434,7 @@ class SpectralExtraction:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, chips=None, fibers=None, method=None, verbose=True):
+    def perform(self, chips=None, fibers=None, extraction_method=None, verbose=True):
         """
         Execute spectral extraction. Optional keyword arguments
         default to config settings.
@@ -445,7 +445,7 @@ class SpectralExtraction:
             Chip identifiers, i.e. 'GREEN' or 'RED'
         fibers : list of str, optional
             Fiber identifiers, e.g. 'SCI2'
-        method : str, optional
+        extraction_method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
         verbose : bool, optional
             If True (default), emit informational warnings during
@@ -466,13 +466,13 @@ class SpectralExtraction:
             chips = self.chips
         if fibers is None:
             fibers = self.fibers
-        if method is None:
-            method = self.extraction_method
+        if extraction_method is None:
+            extraction_method = self.extraction_method
 
         l2_obj = self.l1_obj.to_kpf2()
 
         for chip in chips:
-            l2_arrays = self.extract_ffi(chip, fibers, method, verbose=verbose)
+            l2_arrays = self.extract_ffi(chip, fibers, extraction_method, verbose=verbose)
             for fiber in fibers:
                 l2_obj.set_data(f'{chip}_{fiber}_FLUX', l2_arrays[f'{chip}_{fiber}_FLUX'])
                 l2_obj.set_data(f'{chip}_{fiber}_VAR',  l2_arrays[f'{chip}_{fiber}_VAR'])

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -7,7 +7,6 @@ import warnings
 from numpy.polynomial import polynomial
 
 from kpfpipe import REPO_ROOT, DEFAULTS
-from kpfpipe.exceptions import KPFError
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.qc import validate_array
 
@@ -133,13 +132,14 @@ class SpectralExtraction:
         try:
             trace = self.order_trace[chip].loc[(fiber, order)]
         except KeyError:
-            raise KPFError(f"No trace found for {chip} {fiber} Order {order}")
+            raise LookupError(f"No trace found for {chip} {fiber} Order {order}")
 
         if trace.ndim != 1:
-            raise KPFError(
+            raise ValueError(
                 f"Expected exactly one row for {chip} {fiber} Order {order} "
-                f"but found {trace.shape[0]}"
-        )
+                f"but found {trace.shape[0]} (likely duplicate entries in the "
+                f"order trace reference file)"
+            )
 
         # track the trace position
         coeffs = np.array(trace[[f'Coeff{i}' for i in range(4)]], dtype=np.float32)
@@ -408,7 +408,7 @@ class SpectralExtraction:
             for fiber in fibers:
                 try:
                     flux_1d, var_1d = self.extract_orderlet(chip, fiber, order, method, verbose=verbose)
-                except KPFError:
+                except LookupError:
                     failure += 1
                     flux_1d = np.full(ncol, np.nan, dtype=np.float32)
                     var_1d  = np.full(ncol, np.nan, dtype=np.float32)
@@ -426,7 +426,7 @@ class SpectralExtraction:
                 UserWarning,
             )
         elif failure > 1:
-            raise KPFError(f"Failed to extract {failure} orders from the {chip} CCD")
+            raise LookupError(f"Failed to extract {failure} orders from the {chip} CCD")
 
         return l2_arrays
 

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -426,7 +426,7 @@ class SpectralExtraction:
                 UserWarning,
             )
         elif failure > 1:
-            raise LookupError(f"Failed to extract {failure} orders from the {chip} CCD")
+            raise LookupError(f"Failed to extract {failure} orderlets from the {chip} CCD")
 
         return l2_arrays
 

--- a/tests/test_calibration_association.py
+++ b/tests/test_calibration_association.py
@@ -74,13 +74,13 @@ class TestFindMasterFiles:
 
         assert result == []
 
-    def test_search_window_override_expands_range(self, tmp_path):
+    def test_masters_search_window_days_override_expands_range(self, tmp_path):
         d = tmp_path / 'masters' / '20240403'
         d.mkdir(parents=True)
         _stub_master(d, 'KP.20240403.03637.74', 'bias')
 
         mod = _make_module(tmp_path)
-        result = mod._find_master_files('bias', '2024-04-05T11:08:33', search_window=[-2, 0])
+        result = mod._find_master_files('bias', '2024-04-05T11:08:33', masters_search_window_days=[-2, 0])
 
         assert len(result) == 1
 
@@ -238,7 +238,7 @@ class TestPerform:
         with pytest.raises(FileNotFoundError, match="dark"):
             mod.perform(['bias', 'dark'])
 
-    def test_search_window_override(self, tmp_path):
+    def test_masters_search_window_days_override(self, tmp_path):
         # Master is 2 days before the science frame; only found with wider window.
         d = tmp_path / 'masters' / '20240403'
         d.mkdir(parents=True)
@@ -249,5 +249,5 @@ class TestPerform:
             mod.perform(['bias'])  # default window doesn't reach 2 days back
 
         mod2 = _make_module(tmp_path)
-        mod2.perform(['bias'], search_window=[-2, 0])  # should succeed
+        mod2.perform(['bias'], masters_search_window_days=[-2, 0])  # should succeed
         assert 'BIASFILE' in mod2.l1_obj.headers['PRIMARY']

--- a/tests/test_data_models.py
+++ b/tests/test_data_models.py
@@ -767,6 +767,10 @@ class TestKPFMasterL2:
         assert "TRACE3_WAVE" in m.extensions
         assert m.data["TRACE3_WAVE"].shape == (NORDER_GREEN + NORDER_RED, 64)
 
+    def test_from_fits_adds_receipt_entry(self, synthetic_masters_l2_file):
+        m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
+        assert "from_fits" in m.receipt["Module_Name"].values
+
     def test_round_trip(self, synthetic_masters_l2_file, tmp_path):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
         original = m.data["TRACE3_WAVE"].copy()

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -268,3 +268,18 @@ class TestPerform:
         mod = _make_module()
         with pytest.raises(TypeError, match="bias must be"):
             mod.perform(bias=42)
+
+    def test_dark_filepath_raises_not_implemented(self, mod_with_bias, tmp_path):
+        # Any truthy form (including a filepath string) should hit the dark stub.
+        dark_path = str(tmp_path / 'master_dark.fits')
+        _write_master_bias(dark_path)
+        with pytest.raises(NotImplementedError, match="dark"):
+            mod_with_bias.perform(dark=dark_path)
+
+    def test_flat_master_l1_raises_not_implemented(self, mod_with_bias, tmp_path):
+        # KPFMasterL1 instance should also trip the flat stub.
+        flat_path = str(tmp_path / 'master_flat.fits')
+        _write_master_bias(flat_path)
+        flat_master = KPFMasterL1.from_fits(flat_path)
+        with pytest.raises(NotImplementedError, match="flat"):
+            mod_with_bias.perform(flat=flat_master)

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -240,3 +240,31 @@ class TestPerform:
     def test_flat_true_raises_not_implemented(self, mod_with_bias):
         with pytest.raises(NotImplementedError, match="flat"):
             mod_with_bias.perform(flat=True)
+
+    def test_bias_filepath_overrides_headers(self, tmp_path):
+        # explicit filepath should be used even when headers point elsewhere
+        bias_path = str(tmp_path / 'explicit_bias.fits')
+        _write_master_bias(bias_path)
+        mod = _make_module(bias_file='wrong.fits', bias_dir='/wrong/dir')
+        result = mod.perform(bias=bias_path)
+        np.testing.assert_allclose(result.data['GREEN_CCD'], _CCD_VALUE - _BIAS_VALUE)
+        np.testing.assert_allclose(result.data['RED_CCD'], _CCD_VALUE - _BIAS_VALUE)
+        assert result.headers['PRIMARY']['BIASUB'][0] is True
+        assert mod._results['bias'] == bias_path
+
+    def test_bias_master_l1_object_used_directly(self, tmp_path):
+        # supplying a KPFMasterL1 instance should bypass disk I/O entirely
+        bias_path = str(tmp_path / 'preloaded_bias.fits')
+        _write_master_bias(bias_path)
+        preloaded = KPFMasterL1.from_fits(bias_path)
+        mod = _make_module()  # no BIASFILE / BIASDIR needed
+        result = mod.perform(bias=preloaded)
+        np.testing.assert_allclose(result.data['GREEN_CCD'], _CCD_VALUE - _BIAS_VALUE)
+        assert result.headers['PRIMARY']['BIASUB'][0] is True
+        # _bias_path should reflect the in-memory object's filename
+        assert mod._results['bias'] == bias_path
+
+    def test_bias_invalid_type_raises_type_error(self):
+        mod = _make_module()
+        with pytest.raises(TypeError, match="bias must be"):
+            mod.perform(bias=42)

--- a/tests/test_image_processing.py
+++ b/tests/test_image_processing.py
@@ -221,3 +221,22 @@ class TestPerform:
         mod = _make_module()  # no BIASFILE / BIASDIR
         with pytest.raises(FileNotFoundError):
             mod.perform()
+
+    def test_bias_false_skips_subtraction(self):
+        mod = _make_module()  # no BIASFILE / BIASDIR needed when bias is off
+        result = mod.perform(bias=False)
+        # CCDs untouched
+        np.testing.assert_allclose(result.data['GREEN_CCD'], _CCD_VALUE)
+        np.testing.assert_allclose(result.data['RED_CCD'], _CCD_VALUE)
+        # BIASUB header reflects the choice
+        assert result.headers['PRIMARY']['BIASUB'][0] is False
+        # No bias path recorded
+        assert 'bias' not in mod._results
+
+    def test_dark_true_raises_not_implemented(self, mod_with_bias):
+        with pytest.raises(NotImplementedError, match="dark"):
+            mod_with_bias.perform(dark=True)
+
+    def test_flat_true_raises_not_implemented(self, mod_with_bias):
+        with pytest.raises(NotImplementedError, match="flat"):
+            mod_with_bias.perform(flat=True)

--- a/tests/test_master_bias.py
+++ b/tests/test_master_bias.py
@@ -97,6 +97,34 @@ class TestMasterBiasUnit:
 
 
 # ---------------------------------------------------------------------------
+# info() smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestMasterBiasInfo:
+    """Smoke tests for Bias.info() in both pre- and post-perform states."""
+
+    def test_info_before_make_master_l1(self, capsys):
+        bias = Bias(FILE_LIST)
+        bias.info()
+        out = capsys.readouterr().out
+        assert "Bias" in out
+        assert "make_master_l1() has not been called" in out
+
+    def test_info_after_make_master_l1(self, capsys):
+        synthetic = make_l1_arrays()
+        bias = Bias(FILE_LIST)
+        with patch.object(bias, "stack_frames", return_value=synthetic):
+            bias.make_master_l1()
+        bias.info()
+        out = capsys.readouterr().out
+        assert "Bias" in out
+        assert "make_master_l1() has not been called" not in out
+        for chip in CHIPS:
+            assert chip in out
+
+
+# ---------------------------------------------------------------------------
 # FITS round-trip (mocked stack_frames)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -115,20 +115,20 @@ class TestProcessIndividualFrames:
 
     def test_returns_l2_objects_for_all_frames(self, mock_pipeline, monkeypatch):
         wls = WLS(FILE_LIST)
-        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0: (MockL1(), True))
+        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0, **kwargs:(MockL1(), True))
         result = wls.process_stack_l0_to_l2()
         assert len(result) == len(FILE_LIST)
         assert all(r is mock_pipeline for r in result)
 
     def test_file_list_override(self, mock_pipeline, monkeypatch):
         wls = WLS(FILE_LIST)
-        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0: (MockL1(), True))
+        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0, **kwargs:(MockL1(), True))
         result = wls.process_stack_l0_to_l2(l0_file_list=FILE_LIST[:3])
         assert len(result) == 3
 
     def test_raises_when_failures_exceed_threshold(self, monkeypatch):
         wls = WLS(FILE_LIST)
-        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0: (None, False))
+        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0, **kwargs:(None, False))
         with pytest.raises(ValueError, match="20%"):
             wls.process_stack_l0_to_l2()
 
@@ -136,7 +136,7 @@ class TestProcessIndividualFrames:
         # 1 failure out of 8 = 12.5%, below the 20% threshold
         calls = iter([(None, False)] + [(MockL1(), True)] * 7)
         wls = WLS(FILE_LIST)
-        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0: next(calls))
+        monkeypatch.setattr(wls, '_load_frame', lambda fn, ncache=0, **kwargs:next(calls))
         result = wls.process_stack_l0_to_l2()
         assert len(result) == 7
 
@@ -153,9 +153,9 @@ def mock_make_master_l2(monkeypatch):
     synthetic W and coefficient arrays with chip-correct shapes.
     """
     monkeypatch.setattr(WLS, '_load_frame',
-                        lambda self, fn, ncache=0: (MockL1(), True))
+                        lambda self, fn, ncache=0, **kwargs: (MockL1(), True))
     monkeypatch.setattr(WLS, '_extract_frame',
-                        lambda self, l1: MockL2())
+                        lambda self, l1, **kwargs: MockL2())
 
     def mock_compute(self, chip, fibers, lineprofile=None,
                      polyorder_x=None, polyorder_m=None, polyorder_f=None,
@@ -341,7 +341,7 @@ class TestMakeMasterL2:
 
         with pytest.warns(UserWarning, match=r"RED SCI1 order 1: orderlet skipped"):
             result = wls.fit_line_positions_ffi(
-                StubL2(), 'RED', ['SCI1'], verbose=False,
+                StubL2(), 'RED', ['SCI1'],
             )
 
         # The NaN order contributed no lines; remaining orders did.
@@ -473,7 +473,7 @@ class TestFitLinePositions:
 
         with pytest.warns(UserWarning, match=r"RED SCI1: no good lines retained"):
             result = wls.fit_line_positions_ffi(
-                StubL2(), 'RED', ['SCI1'], verbose=False,
+                StubL2(), 'RED', ['SCI1'],
             )
         assert len(result['wav']) == 0
 

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -394,6 +394,39 @@ class TestMakeMasterL2:
         assert 'GREEN_WLS_COEFFS' in ml2.extensions
         assert 'RED_WLS_COEFFS' not in ml2.extensions
 
+    def test_results_populated(self, mock_make_master_l2):
+        """make_master_l2 should populate self._results with per-chip line yields."""
+        wls = WLS(FILE_LIST)
+        assert wls._results is None
+        wls.make_master_l2()
+        assert wls._results is not None
+        for chip in wls.chips:
+            assert chip in wls._results
+            assert 'n_total' in wls._results[chip]
+            assert 'n_fit' in wls._results[chip]
+            assert isinstance(wls._results[chip]['n_total'], int)
+            assert isinstance(wls._results[chip]['n_fit'], int)
+
+    def test_info_before_make_master_l2(self, capsys):
+        """info() before perform should print config and the not-called message."""
+        wls = WLS(FILE_LIST)
+        wls.info()
+        out = capsys.readouterr().out
+        assert "WLS" in out
+        assert "make_master_l2() has not been called" in out
+
+    def test_info_after_make_master_l2(self, mock_make_master_l2, capsys):
+        """info() after perform should print the per-chip line yield table."""
+        wls = WLS(FILE_LIST)
+        wls.make_master_l2()
+        capsys.readouterr()  # discard any output from make_master_l2 itself
+        wls.info()
+        out = capsys.readouterr().out
+        assert "WLS" in out
+        assert "make_master_l2() has not been called" not in out
+        for chip in wls.chips:
+            assert chip in out
+
 
 # ---------------------------------------------------------------------------
 # TestCalculateWlsCoeffs
@@ -476,6 +509,49 @@ class TestFitLinePositions:
                 StubL2(), 'RED', ['SCI1'],
             )
         assert len(result['wav']) == 0
+
+    def test_nan_orderlet_warning_suppressed_when_verbose_false(self, recwarn):
+        """verbose=False should silence the per-orderlet skip warning."""
+        wls = WLS(FILE_LIST)
+        ncol = wls.ccd['ncol']
+        norder = wls.norder['RED']
+
+        flux = np.ones((norder, ncol))
+        flux[0, :] = np.nan  # one orderlet NaN-filled
+
+        class StubL2:
+            data = {'RED_SCI1_FLUX': flux}
+
+        wls.rough_wls['RED_SCI1_WAVE'] = np.tile(
+            np.linspace(6500.0, 6510.0, ncol), (norder, 1)
+        )
+        wls._linelist_array = np.array([6502.0, 6505.0, 6508.0])
+
+        wls.fit_line_positions_ffi(StubL2(), 'RED', ['SCI1'], verbose=False)
+
+        skipped = [w for w in recwarn if "orderlet skipped" in str(w.message)]
+        assert len(skipped) == 0
+
+    def test_all_nan_fiber_warning_suppressed_when_verbose_false(self, recwarn):
+        """verbose=False should silence the fiber-level no-good-lines warning."""
+        wls = WLS(FILE_LIST)
+        ncol = wls.ccd['ncol']
+        norder = wls.norder['RED']
+
+        flux = np.full((norder, ncol), np.nan)
+
+        class StubL2:
+            data = {'RED_SCI1_FLUX': flux}
+
+        wls.rough_wls['RED_SCI1_WAVE'] = np.tile(
+            np.linspace(6500.0, 6510.0, ncol), (norder, 1)
+        )
+        wls._linelist_array = np.array([6502.0, 6505.0])
+
+        wls.fit_line_positions_ffi(StubL2(), 'RED', ['SCI1'], verbose=False)
+
+        fiber_level = [w for w in recwarn if "no good lines retained" in str(w.message)]
+        assert len(fiber_level) == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_spectral_extraction.py
+++ b/tests/test_spectral_extraction.py
@@ -146,7 +146,7 @@ class TestPerformShapes:
 
     def test_returns_kpf2(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method, **kwargs: {
+                            lambda self, chip, fibers, extraction_method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -157,7 +157,7 @@ class TestPerformShapes:
 
     def test_green_trace_shape(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method, **kwargs: {
+                            lambda self, chip, fibers, extraction_method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -167,7 +167,7 @@ class TestPerformShapes:
 
     def test_red_trace_shape(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method, **kwargs: {
+                            lambda self, chip, fibers, extraction_method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -177,7 +177,7 @@ class TestPerformShapes:
 
     def test_full_trace_shape(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method, **kwargs: {
+                            lambda self, chip, fibers, extraction_method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -187,7 +187,7 @@ class TestPerformShapes:
 
     def test_all_fibers_populated(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method, **kwargs: {
+                            lambda self, chip, fibers, extraction_method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -199,7 +199,7 @@ class TestPerformShapes:
 
     def test_green_red_slices_independent(self, minimal_l1, monkeypatch):
         """GREEN and RED slices should contain distinct values."""
-        def mock_extract(self, chip, fibers, method, **kwargs):
+        def mock_extract(self, chip, fibers, extraction_method, **kwargs):
             fill = 1.0 if chip == 'GREEN' else 2.0
             n = NORDER_GREEN if chip == 'GREEN' else NORDER_RED
             return {
@@ -216,7 +216,7 @@ class TestPerformShapes:
 
     def test_receipt_chain(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method, **kwargs: {
+                            lambda self, chip, fibers, extraction_method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })

--- a/tests/test_spectral_extraction.py
+++ b/tests/test_spectral_extraction.py
@@ -146,7 +146,7 @@ class TestPerformShapes:
 
     def test_returns_kpf2(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method: {
+                            lambda self, chip, fibers, method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -157,7 +157,7 @@ class TestPerformShapes:
 
     def test_green_trace_shape(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method: {
+                            lambda self, chip, fibers, method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -167,7 +167,7 @@ class TestPerformShapes:
 
     def test_red_trace_shape(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method: {
+                            lambda self, chip, fibers, method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -177,7 +177,7 @@ class TestPerformShapes:
 
     def test_full_trace_shape(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method: {
+                            lambda self, chip, fibers, method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -187,7 +187,7 @@ class TestPerformShapes:
 
     def test_all_fibers_populated(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method: {
+                            lambda self, chip, fibers, method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })
@@ -199,7 +199,7 @@ class TestPerformShapes:
 
     def test_green_red_slices_independent(self, minimal_l1, monkeypatch):
         """GREEN and RED slices should contain distinct values."""
-        def mock_extract(self, chip, fibers, method):
+        def mock_extract(self, chip, fibers, method, **kwargs):
             fill = 1.0 if chip == 'GREEN' else 2.0
             n = NORDER_GREEN if chip == 'GREEN' else NORDER_RED
             return {
@@ -216,7 +216,7 @@ class TestPerformShapes:
 
     def test_receipt_chain(self, minimal_l1, mock_ffi_arrays, monkeypatch):
         monkeypatch.setattr(SpectralExtraction, 'extract_ffi',
-                            lambda self, chip, fibers, method: {
+                            lambda self, chip, fibers, method, **kwargs: {
                                 k: v for k, v in mock_ffi_arrays.items()
                                 if k.startswith(chip)
                             })

--- a/tests/test_spectral_extraction.py
+++ b/tests/test_spectral_extraction.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 from astropy.io import fits
 
@@ -273,3 +274,50 @@ class TestSpectralExtractionRealData:
         modules = l2.receipt['Module_Name'].values
         assert 'image_assembly' in modules
         assert 'spectral_extraction' in modules
+
+
+# ---------------------------------------------------------------------------
+# TestOrderTraceErrors
+# ---------------------------------------------------------------------------
+
+class TestOrderTraceErrors:
+    """Errors raised from _get_orderlet_pixels via extract_orderlet."""
+
+    _TRACE_COLS = ['TopEdge', 'BottomEdge', 'Coeff0', 'Coeff1', 'Coeff2', 'Coeff3']
+
+    def _make_se(self, rows):
+        """Build a SpectralExtraction with a pre-populated order_trace cache."""
+        class StubL1:
+            data = {
+                'GREEN_CCD': np.zeros((100, 100), dtype=np.float32),
+                'GREEN_VAR': np.ones((100, 100), dtype=np.float32),
+            }
+            headers = {'PRIMARY': {}}
+
+        df = pd.DataFrame(rows).set_index(['Fiber', 'Order']).sort_index()
+        se = SpectralExtraction(StubL1())
+        se.order_trace = {'GREEN': df}
+        se.order_trace_path = {'GREEN': '<stub>'}
+        return se
+
+    def test_missing_trace_raises_lookup_error(self):
+        # Table has SCI1 order 1 only; asking for order 2 misses.
+        rows = [
+            {'Fiber': 'SCI1', 'Order': 1, 'TopEdge': 5.0, 'BottomEdge': 5.0,
+             'Coeff0': 50.0, 'Coeff1': 0.0, 'Coeff2': 0.0, 'Coeff3': 0.0},
+        ]
+        se = self._make_se(rows)
+        with pytest.raises(LookupError, match="No trace found"):
+            se.extract_orderlet('GREEN', 'SCI1', 2)
+
+    def test_duplicate_trace_raises_value_error(self):
+        # Two rows for the same (Fiber, Order) — a corrupt reference file.
+        rows = [
+            {'Fiber': 'SCI1', 'Order': 1, 'TopEdge': 5.0, 'BottomEdge': 5.0,
+             'Coeff0': 50.0, 'Coeff1': 0.0, 'Coeff2': 0.0, 'Coeff3': 0.0},
+            {'Fiber': 'SCI1', 'Order': 1, 'TopEdge': 5.0, 'BottomEdge': 5.0,
+             'Coeff0': 50.0, 'Coeff1': 0.0, 'Coeff2': 0.0, 'Coeff3': 0.0},
+        ]
+        se = self._make_se(rows)
+        with pytest.raises(ValueError, match="Expected exactly one row"):
+            se.extract_orderlet('GREEN', 'SCI1', 1)


### PR DESCRIPTION
## Summary

  Cleanup pass over the vNext masters / science modules. No behavior changes to default-kwarg public calls;
  everything below is either dedup, naming alignment with `kpf_drp_masters.toml`, new opt-in functionality,
  or test coverage for paths that already existed.
  
  ## Changes

  ### Data models — `from_fits` dedup
  - `KPF0`, `KPF1`, `KPFMasterL2` each duplicated ~25 lines of `RVDataModel.from_fits` only to bypass the
  level dispatch in `RVDataModel.read` (no `lvl==0/1` branch; `lvl==2` routes to `RV2._read` which 
  `KeyError`s on KPF masters extensions). Replaced with a one-line `read()` override that calls 
  `self._read(hdul)`. `from_fits` is now inherited from base.
  - `obs_id` derivation (KPF0/KPF1 only) moves into `read()`. `KPFMasterL2` keeps its prior behavior of not
  deriving `obs_id`.
  - `kpfpipe/exceptions.py` deleted — `KPFError` had only one user (see below).

  ### `KPFError` → standard exceptions
  In `spectral_extraction.py`:
  - Missing trace (`_get_orderlet_pixels`) now raises `LookupError`. `extract_ffi` catches `LookupError` and
  NaN-fills the orderlet (same behavior as before).
  - Duplicate-row order trace now raises `ValueError` with a message naming the likely cause. This is
  intentionally not caught — a corrupt reference file now fails loud instead of being silently NaN-filled per
   affected orderlet.

  ### `verbose` kwarg propagation
  `verbose=True` default added to:
  - `SpectralExtraction.perform / extract_ffi / extract_orderlet` — gates the `validate_array` warnings and
  the "1 orderlet failed" message.
  - `WLS.make_master_l2 / process_stack_l0_to_l2 / _extract_frame / fit_line_positions_ffi` — gates
  per-fiber/per-orderlet print and warning sites.
  - `Bias.make_master_l1` + `BaseMasterModule.stack_frames / _compute_stats_from_datacube /
  _compute_stats_from_stream / _load_frame` — gates the loading print and load-failure warnings.

  Hard failures (`raise`) are never gated.

  ### DEFAULTS / config-kwarg alignment
  - `image_processing.py` now declares `DEFAULTS.update({'bias': True, 'dark': False, 'flat': False})`,
  making the previously-dead `[MODULE_IMAGE_PROCESSING]` toml keys live.
  - `ImageProcessing.perform(bias=, dark=, flat=)` accepts `bool | str | KPFMasterL1`. `True` → header
  lookup, `str` → explicit filepath, `KPFMasterL1` → use directly. `BIASUB` PRIMARY header reflects what was
  actually applied. `dark`/`flat` raise `NotImplementedError` for any truthy value.
  - Renamed kwargs to match toml keys: `CalibrationAssociation.perform(search_window=)` →
  `masters_search_window_days=`; `SpectralExtraction.perform/extract_ffi/extract_orderlet(method=)` →
  `extraction_method=`.
  - Removed redundant `DEFAULTS.update(DETECTOR)` from `image_assembly.py` (already done in
  `kpfpipe/__init__.py`).
  - Removed redundant `self.chips = params.get('chips', ...)` line from `image_processing.py` (DEFAULTS loop
  already sets it).
  - Removed `masters/bias.py`'s duplicate `nframe_stream/stack_sigma/exptime_tolerance` declaration (already
  in `masters/base.py`); kept a minimal `DEFAULTS.update({'stack_sigma': 5.0})` as a structural hook. Removed
   unused `NROW`/`NCOL`/`DETECTOR`. Aligned the config-validation block with the canonical 4-branch form.
  - Added explicit `stack_sigma = 5.0` entries under `[BIAS]/[DARK]/[FLAT]` in the toml.

  ### `info()` methods
  - `Bias.info()` and `WLS.info()` follow the existing science-module shape. Print the input file list and
  config, then a per-chip table after `make_master_l*()` has run.
  - Bias: `num_bad`, `pct_bad`, `median`, `rms` per chip.
  - WLS: `n_fit / n_total (percent)` per chip — total candidate lines vs. lines that survived QC.

  ### WLS docstring
  - `WLS` class docstring's "Recognized keys" expanded from just `KPF_DATA_INPUT` to the full set
  (`linelist`, `lineprofile`, `polyorder_x/m/f`, `chips`, `fibers`, `KPF_DATA_INPUT`).

  ## Test plan

  Full suite: **466 passed** (was 454 before this branch; 12 net new tests).

  - [x] `pytest tests/` green at every commit on the branch.
  - [x] New tests cover:
    - WLS `verbose=False` suppression for the per-orderlet and per-fiber warning paths.
    - WLS `_results[chip]` populated with `n_total`/`n_fit` after `make_master_l2`.
    - `Bias.info()` and `WLS.info()` smoke tests (before and after `perform`).
    - `SpectralExtraction` `LookupError` (missing trace) and `ValueError` (duplicate-row trace) raises via
  `extract_orderlet`.
    - `KPFMasterL2.from_fits` adds the `"from_fits"` receipt entry (previously implicit; explicit now after
  the `read` refactor).
    - `ImageProcessing.perform(dark=<filepath>)` and `perform(flat=<KPFMasterL1>)` correctly hit
  `NotImplementedError`.
  - [x] Existing `extract_ffi` monkeypatches and `_load_frame` monkeypatches widened with `**kwargs` so the
  new `verbose=` and `extraction_method=` names pass through cleanly.
  - [x] (Out of scope for this PR) Verify end-to-end against a real ThAr + bias night of data.

  ## Notes for review

  - The `from_fits` → `read` refactor relies on `RVDataModel.from_fits` opening with `memmap=False` (vs. the
  previous overrides which used astropy's `memmap=True` default). Since `_read` materializes all data via
  `np.array(hdu.data)`, this is benign for downstream usage but worth flagging.
  - `WLS.make_master_l2` now always passes `return_stacks=True` to `compute_wls_from_stack` internally so
  `self._results` can be populated. The caller's `return_stacks` kwarg still controls whether the HDF5 file
  is returned. In-memory stacks are released after each chip iteration if the caller didn't ask for them.
  - Duplicate-row order trace files now hard-fail with a clear `ValueError` message. This is a deliberate
  "fail loud" change — previously such tables would silently NaN-fill every affected orderlet.
  - `nframe_stream` and `exptime_tolerance` remain DEFAULTS-only (not in the toml). This is intentional per
  offline discussion.