### PR TITLE
Kpf next wavecal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,5 +207,6 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
-# KPF test data (large FITS files stored outside the repo)
-tests/testdata/**/*.fits
+# KPF test data — never tracked. FITS files, generated mini-db CSVs,
+# WLS diagnostics HDF5s, etc. all live outside the repo.
+tests/testdata/

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -20,3 +20,5 @@ flat = false
 
 [MODULE_SPECTRAL_EXTRACTION]
 extraction_method = "box"
+
+[MODULE_WAVELENGTH_CALIBRATION]

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -2,7 +2,7 @@
 KPF Calibration Association module.
 
 Given a KPF observation frame, finds the most appropriate master calibration
-file for each calibration type (bias, dark, flat, thar-wls) by searching
+file for each calibration type (bias, dark, flat, wls_thar) by searching
 the masters directory and selecting the nearest-in-time match.
 """
 import glob
@@ -23,7 +23,7 @@ _LEVEL_BY_CAL_TYPE = {
     'bias':     'L1',
     'dark':     'L1',
     'flat':     'L1',
-    'thar-wls': 'L2',
+    'wls_thar': 'L2',
 }
 
 # PRIMARY header prefix written for each supported calibration type.
@@ -31,7 +31,7 @@ _HEADER_PREFIX = {
     'bias':     'BIAS',
     'dark':     'DARK',
     'flat':     'FLAT',
-    'thar-wls': 'WLS',
+    'wls_thar': 'WLS',
 }
 
 
@@ -88,7 +88,7 @@ class CalibrationAssociation:
         Parameters
         ----------
         cal_type : str
-            One of 'bias', 'dark', 'flat', 'thar-wls'.
+            One of 'bias', 'dark', 'flat', 'wls_thar'.
         date_obs : str
             ISO-format observation datetime from the frame's PRIMARY header
             (e.g. '2024-04-05T11:08:33').
@@ -170,7 +170,7 @@ class CalibrationAssociation:
         Parameters
         ----------
         cal_types : list of str
-            Calibration types to associate (e.g. ['bias', 'dark', 'flat', 'thar-wls']).
+            Calibration types to associate (e.g. ['bias', 'dark', 'flat', 'wls_thar']).
         masters_search_window_days : [int, int], optional
             Search window as [days_before, days_after]. Defaults to
             self.masters_search_window_days.
@@ -209,7 +209,7 @@ class CalibrationAssociation:
                     f"within window {masters_search_window_days} days"
                 )
 
-            if cal_type == 'thar-wls':
+            if cal_type == 'wls_thar':
                 # Match legacy WLS header convention exactly: full path in
                 # WLSFILE (no WLSDIR), AGEWLS in fractional days using the
                 # master and obs timestamps (sign convention: master - obs,

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -17,6 +17,23 @@ DEFAULTS.update({
     'masters_search_window_days': [-1, 0],
 })
 
+# Level suffix of the master FITS file for each supported calibration type,
+# used to build the *_master_<cal_type>_<level>.fits glob.
+_LEVEL_BY_CAL_TYPE = {
+    'bias':     'L1',
+    'dark':     'L1',
+    'flat':     'L1',
+    'thar-wls': 'L2',
+}
+
+# PRIMARY header prefix written for each supported calibration type.
+_HEADER_PREFIX = {
+    'bias':     'BIAS',
+    'dark':     'DARK',
+    'flat':     'FLAT',
+    'thar-wls': 'WLS',
+}
+
 
 class CalibrationAssociation:
     """
@@ -83,12 +100,23 @@ class CalibrationAssociation:
         -------
         list of (str, str)
             Sorted list of (filepath, kpf_timestamp) tuples.
+
+        Raises
+        ------
+        ValueError
+            If `cal_type` is not a key of `_LEVEL_BY_CAL_TYPE`.
         """
+        if cal_type not in _LEVEL_BY_CAL_TYPE:
+            raise ValueError(
+                f"unsupported cal_type {cal_type!r}; "
+                f"expected one of {sorted(_LEVEL_BY_CAL_TYPE)}"
+            )
         if masters_search_window_days is None:
             masters_search_window_days = self.masters_search_window_days
 
         obs_date = datetime.fromisoformat(date_obs).date()
         days_before, days_after = masters_search_window_days
+        level = _LEVEL_BY_CAL_TYPE[cal_type]
 
         master_files = []
         for delta in range(days_before, days_after + 1):
@@ -96,7 +124,7 @@ class CalibrationAssociation:
             datecode = search_date.strftime('%Y%m%d')
             pattern = os.path.join(
                 self._data_root, 'masters', datecode,
-                f'*_master_{cal_type}_L1.fits'
+                f'*_master_{cal_type}_{level}.fits'
             )
             for filepath in sorted(glob.glob(pattern)):
                 try:
@@ -166,10 +194,15 @@ class CalibrationAssociation:
         if masters_search_window_days is None:
             masters_search_window_days = self.masters_search_window_days
 
+        unknown = [c for c in cal_types if c not in _HEADER_PREFIX]
+        if unknown:
+            raise ValueError(
+                f"unsupported cal_type(s) {unknown}; "
+                f"expected subset of {sorted(_HEADER_PREFIX)}"
+            )
+
         date_obs = self.l1_obj.headers['PRIMARY']['DATE-OBS']
         obs_date = datetime.fromisoformat(date_obs).date()
-
-        _header_prefix = {'bias': 'BIAS', 'dark': 'DARK', 'flat': 'FLAT'}
 
         for cal_type in cal_types:
             master_files = self._find_master_files(cal_type, date_obs, masters_search_window_days)
@@ -180,16 +213,14 @@ class CalibrationAssociation:
                     f"within window {masters_search_window_days} days"
                 )
 
-            prefix = _header_prefix.get(cal_type)
-            if prefix is not None:
-                master_date = datetime.strptime(get_datecode(filepath), '%Y%m%d').date()
-                self.l1_obj.headers['PRIMARY'][f'{prefix}FILE'] = os.path.basename(filepath)
-                self.l1_obj.headers['PRIMARY'][f'{prefix}DIR'] = os.path.dirname(filepath)
-                self.l1_obj.headers['PRIMARY'][f'AGE{prefix}'] = (obs_date - master_date).days
+            prefix = _HEADER_PREFIX[cal_type]
+            master_date = datetime.strptime(get_datecode(filepath), '%Y%m%d').date()
+            self.l1_obj.headers['PRIMARY'][f'{prefix}FILE'] = os.path.basename(filepath)
+            self.l1_obj.headers['PRIMARY'][f'{prefix}DIR'] = os.path.dirname(filepath)
+            self.l1_obj.headers['PRIMARY'][f'AGE{prefix}'] = (obs_date - master_date).days
 
         self._results = {
-            cal_type: self.l1_obj.headers['PRIMARY'].get(f'{_header_prefix[cal_type]}FILE')
-                      if cal_type in _header_prefix else None
+            cal_type: self.l1_obj.headers['PRIMARY'][f'{_HEADER_PREFIX[cal_type]}FILE']
             for cal_type in cal_types
         }
         self.l1_obj.receipt_add_entry('calibration_association', 'PASS')
@@ -210,14 +241,9 @@ class CalibrationAssociation:
         print(f"\n  {'cal_type':<12s} {'master file'}")
         print("  " + "-" * 60)
         h = self.l1_obj.headers['PRIMARY']
-        _prefix = {'bias': 'BIAS', 'dark': 'DARK', 'flat': 'FLAT'}
         for cal_type, filename in self._results.items():
-            prefix = _prefix.get(cal_type)
-            if prefix is not None:
-                age = h.get(f'AGE{prefix}', 'n/a')
-                print(f"  {cal_type:<12s} {filename}")
-                print(f"  {'':12s} age = {age}d")
-                print()
-            else:
-                print(f"  {cal_type:<12s} (no header written)")
-                print()
+            prefix = _HEADER_PREFIX[cal_type]
+            age = h.get(f'AGE{prefix}', 'n/a')
+            print(f"  {cal_type:<12s} {filename}")
+            print(f"  {'':12s} age = {age}d")
+            print()

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -2,7 +2,7 @@
 KPF Calibration Association module.
 
 Given a KPF observation frame, finds the most appropriate master calibration
-file for each calibration type (bias, dark, flat, wls_thar) by searching
+file for each calibration type (bias, dark, flat, thar) by searching
 the masters directory and selecting the nearest-in-time match.
 """
 import glob
@@ -23,7 +23,7 @@ _LEVEL_BY_CAL_TYPE = {
     'bias':     'L1',
     'dark':     'L1',
     'flat':     'L1',
-    'wls_thar': 'L2',
+    'thar': 'L2',
 }
 
 # PRIMARY header prefix written for each supported calibration type.
@@ -31,7 +31,7 @@ _HEADER_PREFIX = {
     'bias':     'BIAS',
     'dark':     'DARK',
     'flat':     'FLAT',
-    'wls_thar': 'WLS',
+    'thar': 'WLS',
 }
 
 
@@ -88,7 +88,7 @@ class CalibrationAssociation:
         Parameters
         ----------
         cal_type : str
-            One of 'bias', 'dark', 'flat', 'wls_thar'.
+            One of 'bias', 'dark', 'flat', 'thar'.
         date_obs : str
             ISO-format observation datetime from the frame's PRIMARY header
             (e.g. '2024-04-05T11:08:33').
@@ -170,7 +170,7 @@ class CalibrationAssociation:
         Parameters
         ----------
         cal_types : list of str
-            Calibration types to associate (e.g. ['bias', 'dark', 'flat', 'wls_thar']).
+            Calibration types to associate (e.g. ['bias', 'dark', 'flat', 'thar']).
         masters_search_window_days : [int, int], optional
             Search window as [days_before, days_after]. Defaults to
             self.masters_search_window_days.
@@ -209,7 +209,7 @@ class CalibrationAssociation:
                     f"within window {masters_search_window_days} days"
                 )
 
-            if cal_type == 'wls_thar':
+            if cal_type == 'thar':
                 # Match legacy WLS header convention exactly: full path in
                 # WLSFILE (no WLSDIR), AGEWLS in fractional days using the
                 # master and obs timestamps (sign convention: master - obs,

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta
 
 from kpfpipe import DEFAULTS
 from kpfpipe.utils.config import ConfigHandler
-from kpfpipe.utils.kpf import get_datecode, get_timestamp
+from kpfpipe.utils.kpf import get_datecode, get_timestamp, kpf_timestamp_to_datetime
 
 DEFAULTS.update({
     'masters_search_window_days': [-1, 0],
@@ -157,12 +157,7 @@ class CalibrationAssociation:
             return None
 
         obs_dt = datetime.fromisoformat(date_obs)
-
-        def _candidate_dt(ts):
-            date_str, seconds_str, _ = ts.split('.')
-            return datetime.strptime(date_str, '%Y%m%d') + timedelta(seconds=int(seconds_str))
-
-        return min(master_files, key=lambda x: abs((_candidate_dt(x[1]) - obs_dt).total_seconds()))[0]
+        return min(master_files, key=lambda x: abs((kpf_timestamp_to_datetime(x[1]) - obs_dt).total_seconds()))[0]
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -203,6 +198,7 @@ class CalibrationAssociation:
 
         date_obs = self.l1_obj.headers['PRIMARY']['DATE-OBS']
         obs_date = datetime.fromisoformat(date_obs).date()
+        primary = self.l1_obj.headers['PRIMARY']
 
         for cal_type in cal_types:
             master_files = self._find_master_files(cal_type, date_obs, masters_search_window_days)
@@ -213,14 +209,24 @@ class CalibrationAssociation:
                     f"within window {masters_search_window_days} days"
                 )
 
-            prefix = _HEADER_PREFIX[cal_type]
-            master_date = datetime.strptime(get_datecode(filepath), '%Y%m%d').date()
-            self.l1_obj.headers['PRIMARY'][f'{prefix}FILE'] = os.path.basename(filepath)
-            self.l1_obj.headers['PRIMARY'][f'{prefix}DIR'] = os.path.dirname(filepath)
-            self.l1_obj.headers['PRIMARY'][f'AGE{prefix}'] = (obs_date - master_date).days
+            if cal_type == 'thar-wls':
+                # Match legacy WLS header convention exactly: full path in
+                # WLSFILE (no WLSDIR), AGEWLS in fractional days using the
+                # master and obs timestamps (sign convention: master - obs,
+                # so AGEWLS is negative when the master predates the obs).
+                obs_dt = datetime.fromisoformat(date_obs)
+                master_dt = kpf_timestamp_to_datetime(get_timestamp(filepath))
+                primary['WLSFILE'] = filepath
+                primary['AGEWLS']  = (master_dt - obs_dt).total_seconds() / 86400.0
+            else:
+                prefix = _HEADER_PREFIX[cal_type]
+                master_date = datetime.strptime(get_datecode(filepath), '%Y%m%d').date()
+                primary[f'{prefix}FILE'] = os.path.basename(filepath)
+                primary[f'{prefix}DIR']  = os.path.dirname(filepath)
+                primary[f'AGE{prefix}']  = (obs_date - master_date).days
 
         self._results = {
-            cal_type: self.l1_obj.headers['PRIMARY'][f'{_HEADER_PREFIX[cal_type]}FILE']
+            cal_type: primary[f'{_HEADER_PREFIX[cal_type]}FILE']
             for cal_type in cal_types
         }
         self.l1_obj.receipt_add_entry('calibration_association', 'PASS')

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -63,8 +63,8 @@ class WLS(BaseMasterModule):
         self._load_linelist()
 
         self._results = None  # populated by make_master_l2()
-        self._coeffs_by_chip = None  # populated by make_master_l2(); used by save_stacks()
-        self._lines_by_chip  = None  # populated by make_master_l2(); used by save_stacks()
+        self._coeffs_stack = None  # populated by make_master_l2(); used by save_stacks()
+        self._lines_stack  = None  # populated by make_master_l2(); used by save_stacks()
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -152,17 +152,17 @@ class WLS(BaseMasterModule):
         RuntimeError
             If make_master_l2() has not been run yet (no stacks available).
         """
-        if self._coeffs_by_chip is None or self._lines_by_chip is None:
+        if self._coeffs_stack is None or self._lines_stack is None:
             raise RuntimeError("No stacks available; run make_master_l2() first")
 
         str_dt = h5py.string_dtype(encoding='utf-8')
         with h5py.File(path, 'w') as f:
-            for chip, coeffs_stack in self._coeffs_by_chip.items():
+            for chip, coeffs_stack in self._coeffs_stack.items():
                 chip_group = f.create_group(chip)
                 chip_group.create_dataset('coeffs_stack', data=np.asarray(coeffs_stack))
 
                 lines_group = chip_group.create_group('lines_stack')
-                for i, lines in enumerate(self._lines_by_chip[chip]):
+                for i, lines in enumerate(self._lines_stack[chip]):
                     frame_group = lines_group.create_group(f'frame_{i:03d}')
                     for key, value in lines.items():
                         arr = np.asarray(value)
@@ -224,7 +224,7 @@ class WLS(BaseMasterModule):
         return self._l2_obj_cache
     
 
-    def fit_line_positions_1D(self,
+    def fit_line_positions_1d(self,
                               flux1d,
                               wave1d,
                               linelist=None,
@@ -348,7 +348,7 @@ class WLS(BaseMasterModule):
         """
         Fit line positions across all orders and fibers of one chip.
 
-        Loops over the requested fibers, calling `fit_line_positions_1D`
+        Loops over the requested fibers, calling `fit_line_positions_1d`
         on each (order, fiber) extracted spectrum, and concatenates the
         surviving lines into flat arrays tagged with their order number
         and fiber name.
@@ -372,7 +372,7 @@ class WLS(BaseMasterModule):
             Half-width of the per-line fit window, in pixels.
         qc_sigma : float, optional
             Outlier rejection threshold passed through to
-            `fit_line_positions_1D`.
+            `fit_line_positions_1d`.
         verbose : bool, optional
             If True, print a progress line for each fiber.
 
@@ -382,7 +382,7 @@ class WLS(BaseMasterModule):
             Flat 1D arrays, all of equal length. All lines are retained
             regardless of QC status; the caller is responsible for
             filtering on 'bad' before downstream use. All per-line keys
-            produced by `fit_line_positions_1D` are carried through, plus
+            produced by `fit_line_positions_1d` are carried through, plus
             'ord' and 'fib' which tag each line with its source order
             and fiber. Keys:
               'wav' - reference line wavelength
@@ -400,7 +400,7 @@ class WLS(BaseMasterModule):
             lineprofile = self.lineprofile
 
         norder = self.norder[chip]
-        # keys mirror fit_line_positions_1D's output plus per-line provenance tags
+        # keys mirror fit_line_positions_1d's output plus per-line provenance tags
         keys = ('wav', 'pix', 'std', 'amp', 'rms', 'bad', 'ord', 'fib')
         lines = {k: [[None] * norder for _ in fibers] for k in keys}
 
@@ -415,7 +415,7 @@ class WLS(BaseMasterModule):
                 raise ValueError("shape mismatch between flux array and rough WLS")
 
             for o in range(norder):
-                line_dict = self.fit_line_positions_1D(
+                line_dict = self.fit_line_positions_1d(
                     flux_arr[o],
                     wave_arr[o],
                     linelist=linelist,
@@ -542,25 +542,25 @@ class WLS(BaseMasterModule):
         ncol = self.ccd['ncol']
 
         # rescale position variables to [-1,1] for Legendre fitting
-        _x = 2*pix/(ncol - 1) - 1
-        _m = 2*(ord - 1)/(norder - 1) - 1
+        x = 2*pix/(ncol - 1) - 1
+        m = 2*(ord - 1)/(norder - 1) - 1
 
         if len(fibers) != 1:
             # map fibers to their positional rank then rescale to [-1, 1]
-            canonical = sorted(expected_fibers, key=lambda f: self.fiber_positions[f])
-            fiber_pos = {f: i for i, f in enumerate(canonical)}
-            _f = np.array([fiber_pos[f] for f in fib], dtype=int)
-            _f = 2*_f/(len(canonical) - 1) - 1
+            canonical = sorted(expected_fibers, key=lambda fb: self.fiber_positions[fb])
+            fiber_pos = {fb: i for i, fb in enumerate(canonical)}
+            f = np.array([fiber_pos[fb] for fb in fib], dtype=int)
+            f = 2*f/(len(canonical) - 1) - 1
 
 
         if len(fibers) == 1:
-            V = legendre.legvander2d(_x, _m, deg=[polyorder_x, polyorder_m])
+            V = legendre.legvander2d(x, m, deg=[polyorder_x, polyorder_m])
 
             coeffs, *_ = np.linalg.lstsq(V, wav, rcond=None)
             coeffs = coeffs.reshape(polyorder_x+1, polyorder_m+1)
 
         else:
-            V = legendre.legvander3d(_x, _m, _f, deg=[polyorder_x, polyorder_m, polyorder_f])
+            V = legendre.legvander3d(x, m, f, deg=[polyorder_x, polyorder_m, polyorder_f])
 
             coeffs, *_ = np.linalg.lstsq(V, wav, rcond=None)
             coeffs = coeffs.reshape(polyorder_x+1, polyorder_m+1, polyorder_f+1)
@@ -592,16 +592,16 @@ class WLS(BaseMasterModule):
             Wavelength array of shape (norder, ncol) for 2D `coeffs`, or
             (norder, ncol, nfiber) for 3D `coeffs`.
         """
-        _x = np.linspace(-1, 1, ncol)
-        _y = np.linspace(-1, 1, norder)
-        _z = np.linspace(-1, 1, nfiber)
+        x = np.linspace(-1, 1, ncol)
+        y = np.linspace(-1, 1, norder)
+        z = np.linspace(-1, 1, nfiber)
 
         if coeffs.ndim == 2:
-            X, Y = np.meshgrid(_x, _y)
+            X, Y = np.meshgrid(x, y)
             W = legendre.legval2d(X, Y, coeffs)
-        
+
         elif coeffs.ndim == 3:
-            X, Y, Z = np.meshgrid(_x, _y, _z)
+            X, Y, Z = np.meshgrid(x, y, z)
             W = legendre.legval3d(X, Y, Z, coeffs)
 
         else:
@@ -650,7 +650,7 @@ class WLS(BaseMasterModule):
         qc_sigma : float, optional
             Outlier rejection threshold applied to per-frame Legendre
             coefficients, and passed through to the per-line QC in
-            `fit_line_positions_1D`.
+            `fit_line_positions_1d`.
         polyorder_x : int, optional
             Polynomial degree along the pixel axis.
         polyorder_m : int, optional
@@ -762,7 +762,7 @@ class WLS(BaseMasterModule):
         written to the per-fiber _WAVE extensions of a KPFMasterL2 object,
         which is returned and cached on `self.ml2_obj`. Per-frame
         coefficient and line stacks are always stashed on
-        `self._coeffs_by_chip` / `self._lines_by_chip`; pass `stacks_path`
+        `self._coeffs_stack` / `self._lines_stack`; pass `stacks_path`
         to also persist them to disk via `save_stacks()`.
 
         Parameters
@@ -821,8 +821,8 @@ class WLS(BaseMasterModule):
 
         self.ml2_obj = KPFMasterL2()
 
-        self._coeffs_by_chip = {}
-        self._lines_by_chip  = {}
+        self._coeffs_stack = {}
+        self._lines_stack  = {}
         self._results = {}
 
         for chip in self.chips:
@@ -836,14 +836,14 @@ class WLS(BaseMasterModule):
                 return_stacks=True,
                 verbose=verbose,
             )
-            W, coeffs, coeffs_stack, lines_stack = result
+            W, coeffs_mean, coeffs_stack, lines_stack = result
 
             self._results[chip] = {
                 'n_total': sum(len(frame['wav']) for frame in lines_stack),
                 'n_fit':   sum(int(np.sum(~frame['bad'])) for frame in lines_stack),
             }
-            self._coeffs_by_chip[chip] = coeffs_stack
-            self._lines_by_chip[chip]  = lines_stack
+            self._coeffs_stack[chip] = coeffs_stack
+            self._lines_stack[chip]  = lines_stack
 
             for i, fiber in enumerate(self.fibers):
                 if W.ndim == 2:
@@ -854,7 +854,7 @@ class WLS(BaseMasterModule):
             coeffs_ext = f'{chip}_WLS_COEFFS'
             if coeffs_ext not in self.ml2_obj.extensions:
                 self.ml2_obj.create_extension(coeffs_ext, 'ImageHDU')
-            self.ml2_obj.set_data(coeffs_ext, coeffs)
+            self.ml2_obj.set_data(coeffs_ext, coeffs_mean)
 
             coeffs_hdr = self.ml2_obj.headers[coeffs_ext]
             coeffs_hdr['POLYORDX'] = (polyorder_x, 'WLS polynomial degree, pixel axis')

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -63,8 +63,8 @@ class WLS(BaseMasterModule):
         self._load_linelist()
 
         self._results = None  # populated by make_master_l2()
-        self._coeffs_stack = None  # populated by make_master_l2(); used by save_stacks()
-        self._lines_stack  = None  # populated by make_master_l2(); used by save_stacks()
+        self._coeffs_stack = None  # populated by make_master_l2(); used by save_diagnostics()
+        self._lines_stack  = None  # populated by make_master_l2(); used by save_diagnostics()
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -716,7 +716,7 @@ class WLS(BaseMasterModule):
                        polyorder_x=None,
                        polyorder_m=None,
                        polyorder_f=None,
-                       stacks_path=None,
+                       diagnostics_path=None,
                        verbose=True,
                       ):
         """
@@ -728,8 +728,8 @@ class WLS(BaseMasterModule):
         written to the per-fiber _WAVE extensions of a KPFMasterL2 object,
         which is returned and cached on `self.ml2_obj`. Per-frame
         coefficient and line stacks are always stashed on
-        `self._coeffs_stack` / `self._lines_stack`; pass `stacks_path`
-        to also persist them to disk via `save_stacks()`.
+        `self._coeffs_stack` / `self._lines_stack`; pass `diagnostics_path`
+        to also persist them to disk via `save_diagnostics()`.
 
         Parameters
         ----------
@@ -748,10 +748,10 @@ class WLS(BaseMasterModule):
         polyorder_f : int, optional
             Polynomial degree along the fiber axis (used for 3- and 5-fiber fits).
             Defaults to self.polyorder_f.
-        stacks_path : str, optional
-            If provided, calls `self.save_stacks(stacks_path)` at the end to
-            persist the per-frame coefficient and line stacks to an HDF5
-            file at this path.
+        diagnostics_path : str, optional
+            If provided, calls `self.save_diagnostics(diagnostics_path)`
+            at the end to persist the per-frame coefficient and line stacks
+            to an HDF5 file at this path.
         verbose : bool, optional
             If True (default), emit progress prints and informational
             warnings from frame loading, spectral extraction, and the
@@ -841,13 +841,13 @@ class WLS(BaseMasterModule):
 
         self.ml2_obj.receipt_add_entry('master_wls', 'PASS')
 
-        if stacks_path is not None:
-            self.save_stacks(stacks_path)
+        if diagnostics_path is not None:
+            self.save_diagnostics(diagnostics_path)
 
         return self.ml2_obj
 
 
-    def save_stacks(self, path):
+    def save_diagnostics(self, path):
         """
         Write the per-frame WLS diagnostic stacks to an HDF5 file at `path`.
 
@@ -859,10 +859,10 @@ class WLS(BaseMasterModule):
         Raises
         ------
         RuntimeError
-            If make_master_l2() has not been run yet (no stacks available).
+            If make_master_l2() has not been run yet (no diagnostics available).
         """
         if self._coeffs_stack is None or self._lines_stack is None:
-            raise RuntimeError("No stacks available; run make_master_l2() first")
+            raise RuntimeError("No diagnostics available; run make_master_l2() first")
 
         str_dt = h5py.string_dtype(encoding='utf-8')
         with h5py.File(path, 'w') as f:

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -823,9 +823,9 @@ class WLS(BaseMasterModule):
             self.ml2_obj.set_data(coeffs_ext, coeffs_mean)
 
             coeffs_hdr = self.ml2_obj.headers[coeffs_ext]
-            coeffs_hdr['POLYORDX'] = (polyorder_x, 'WLS polynomial degree, pixel axis')
-            coeffs_hdr['POLYORDM'] = (polyorder_m, 'WLS polynomial degree, order axis')
-            coeffs_hdr['POLYORDF'] = (polyorder_f, 'WLS polynomial degree, fiber axis')
+            coeffs_hdr['POLYORDX'] = polyorder_x
+            coeffs_hdr['POLYORDM'] = polyorder_m
+            coeffs_hdr['POLYORDF'] = polyorder_f
 
         self.ml2_obj.set_input_files(l0_file_list)
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -138,40 +138,6 @@ class WLS(BaseMasterModule):
         return l2_obj
 
 
-    def save_stacks(self, path):
-        """
-        Write the per-frame WLS diagnostic stacks to an HDF5 file at `path`.
-
-        Layout: /<chip>/coeffs_stack as a dataset, /<chip>/lines_stack/
-        frame_<NNN>/<key> as per-frame subgroups, with every key from
-        the per-frame `lines` dict (e.g. wav, pix, ord, fib, bad, plus
-        diagnostics like std, amp, rms).
-
-        Raises
-        ------
-        RuntimeError
-            If make_master_l2() has not been run yet (no stacks available).
-        """
-        if self._coeffs_stack is None or self._lines_stack is None:
-            raise RuntimeError("No stacks available; run make_master_l2() first")
-
-        str_dt = h5py.string_dtype(encoding='utf-8')
-        with h5py.File(path, 'w') as f:
-            for chip, coeffs_stack in self._coeffs_stack.items():
-                chip_group = f.create_group(chip)
-                chip_group.create_dataset('coeffs_stack', data=np.asarray(coeffs_stack))
-
-                lines_group = chip_group.create_group('lines_stack')
-                for i, lines in enumerate(self._lines_stack[chip]):
-                    frame_group = lines_group.create_group(f'frame_{i:03d}')
-                    for key, value in lines.items():
-                        arr = np.asarray(value)
-                        if arr.dtype.kind in ('U', 'S', 'O'):
-                            frame_group.create_dataset(key, data=arr.astype(object), dtype=str_dt)
-                        else:
-                            frame_group.create_dataset(key, data=arr)
-
-
     # ------------------------------------------------------------------
     # Algorithm steps
     # ------------------------------------------------------------------
@@ -879,6 +845,41 @@ class WLS(BaseMasterModule):
             self.save_stacks(stacks_path)
 
         return self.ml2_obj
+
+
+    def save_stacks(self, path):
+        """
+        Write the per-frame WLS diagnostic stacks to an HDF5 file at `path`.
+
+        Layout: /<chip>/coeffs_stack as a dataset, /<chip>/lines_stack/
+        frame_<NNN>/<key> as per-frame subgroups, with every key from
+        the per-frame `lines` dict (e.g. wav, pix, ord, fib, bad, plus
+        diagnostics like std, amp, rms).
+
+        Raises
+        ------
+        RuntimeError
+            If make_master_l2() has not been run yet (no stacks available).
+        """
+        if self._coeffs_stack is None or self._lines_stack is None:
+            raise RuntimeError("No stacks available; run make_master_l2() first")
+
+        str_dt = h5py.string_dtype(encoding='utf-8')
+        with h5py.File(path, 'w') as f:
+            for chip, coeffs_stack in self._coeffs_stack.items():
+                chip_group = f.create_group(chip)
+                chip_group.create_dataset('coeffs_stack', data=np.asarray(coeffs_stack))
+
+                lines_group = chip_group.create_group('lines_stack')
+                for i, lines in enumerate(self._lines_stack[chip]):
+                    frame_group = lines_group.create_group(f'frame_{i:03d}')
+                    for key, value in lines.items():
+                        arr = np.asarray(value)
+                        if arr.dtype.kind in ('U', 'S', 'O'):
+                            frame_group.create_dataset(key, data=arr.astype(object), dtype=str_dt)
+                        else:
+                            frame_group.create_dataset(key, data=arr)
+
 
     def info(self):
         """Print a summary of the module configuration and WLS results."""

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -822,6 +822,8 @@ class WLS(BaseMasterModule):
                 self.ml2_obj.create_extension(coeffs_ext, 'ImageHDU')
             self.ml2_obj.set_data(coeffs_ext, coeffs_mean)
 
+            # (value, comment) tuples are rejected for non-PRIMARY headers
+            # by rvdata's fits.Header(dict) round-trip; keep these plain.
             coeffs_hdr = self.ml2_obj.headers[coeffs_ext]
             coeffs_hdr['POLYORDX'] = polyorder_x
             coeffs_hdr['POLYORDM'] = polyorder_m
@@ -859,9 +861,10 @@ class WLS(BaseMasterModule):
         Raises
         ------
         RuntimeError
-            If make_master_l2() has not been run yet (no diagnostics available).
+            If make_master_l2() has not been run yet, or raised before
+            populating any chip.
         """
-        if self._coeffs_stack is None or self._lines_stack is None:
+        if not self._coeffs_stack or not self._lines_stack:
             raise RuntimeError("No diagnostics available; run make_master_l2() first")
 
         str_dt = h5py.string_dtype(encoding='utf-8')

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -63,6 +63,8 @@ class WLS(BaseMasterModule):
         self._load_linelist()
 
         self._results = None  # populated by make_master_l2()
+        self._coeffs_by_chip = None  # populated by make_master_l2(); used by save_stacks()
+        self._lines_by_chip  = None  # populated by make_master_l2(); used by save_stacks()
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -136,34 +138,38 @@ class WLS(BaseMasterModule):
         return l2_obj
 
 
-    @staticmethod
-    def _package_stacks_hdf5(coeffs_by_chip, lines_by_chip):
+    def save_stacks(self, path):
         """
-        Package per-chip WLS stacks into an in-memory HDF5 file.
+        Write the per-frame WLS diagnostic stacks to an HDF5 file at `path`.
 
         Layout: /<chip>/coeffs_stack as a dataset, /<chip>/lines_stack/
         frame_<NNN>/<key> as per-frame subgroups, with every key from
         the per-frame `lines` dict (e.g. wav, pix, ord, fib, bad, plus
         diagnostics like std, amp, rms).
+
+        Raises
+        ------
+        RuntimeError
+            If make_master_l2() has not been run yet (no stacks available).
         """
-        f = h5py.File('wls_stacks.h5', 'w', driver='core', backing_store=False)
+        if self._coeffs_by_chip is None or self._lines_by_chip is None:
+            raise RuntimeError("No stacks available; run make_master_l2() first")
+
         str_dt = h5py.string_dtype(encoding='utf-8')
+        with h5py.File(path, 'w') as f:
+            for chip, coeffs_stack in self._coeffs_by_chip.items():
+                chip_group = f.create_group(chip)
+                chip_group.create_dataset('coeffs_stack', data=np.asarray(coeffs_stack))
 
-        for chip, coeffs_stack in coeffs_by_chip.items():
-            chip_group = f.create_group(chip)
-            chip_group.create_dataset('coeffs_stack', data=np.asarray(coeffs_stack))
-
-            lines_group = chip_group.create_group('lines_stack')
-            for i, lines in enumerate(lines_by_chip[chip]):
-                frame_group = lines_group.create_group(f'frame_{i:03d}')
-                for key, value in lines.items():
-                    arr = np.asarray(value)
-                    if arr.dtype.kind in ('U', 'S', 'O'):
-                        frame_group.create_dataset(key, data=arr.astype(object), dtype=str_dt)
-                    else:
-                        frame_group.create_dataset(key, data=arr)
-
-        return f
+                lines_group = chip_group.create_group('lines_stack')
+                for i, lines in enumerate(self._lines_by_chip[chip]):
+                    frame_group = lines_group.create_group(f'frame_{i:03d}')
+                    for key, value in lines.items():
+                        arr = np.asarray(value)
+                        if arr.dtype.kind in ('U', 'S', 'O'):
+                            frame_group.create_dataset(key, data=arr.astype(object), dtype=str_dt)
+                        else:
+                            frame_group.create_dataset(key, data=arr)
 
 
     # ------------------------------------------------------------------
@@ -744,7 +750,7 @@ class WLS(BaseMasterModule):
                        polyorder_x=None,
                        polyorder_m=None,
                        polyorder_f=None,
-                       return_stacks=False,
+                       stacks_path=None,
                        verbose=True,
                       ):
         """
@@ -754,7 +760,10 @@ class WLS(BaseMasterModule):
         computes per-chip Legendre wavelength solutions using
         `compute_wls_from_stack`. The resulting wavelength arrays are
         written to the per-fiber _WAVE extensions of a KPFMasterL2 object,
-        which is returned and cached on `self.ml2_obj`.
+        which is returned and cached on `self.ml2_obj`. Per-frame
+        coefficient and line stacks are always stashed on
+        `self._coeffs_by_chip` / `self._lines_by_chip`; pass `stacks_path`
+        to also persist them to disk via `save_stacks()`.
 
         Parameters
         ----------
@@ -773,9 +782,10 @@ class WLS(BaseMasterModule):
         polyorder_f : int, optional
             Polynomial degree along the fiber axis (used for 3- and 5-fiber fits).
             Defaults to self.polyorder_f.
-        return_stacks : bool, optional
-            If True, also return an in-memory HDF5 file containing per-frame
-            coefficient and line stacks for every chip.
+        stacks_path : str, optional
+            If provided, calls `self.save_stacks(stacks_path)` at the end to
+            persist the per-frame coefficient and line stacks to an HDF5
+            file at this path.
         verbose : bool, optional
             If True (default), emit progress prints and informational
             warnings from frame loading, spectral extraction, and the
@@ -787,19 +797,6 @@ class WLS(BaseMasterModule):
             Master L2 object with per-fiber _WAVE extensions populated for
             every chip in self.chips, INPUT_FILES recording the stacked
             L0 files, and a 'master_wls' receipt entry.
-        h5py.File, optional
-            In-memory HDF5 file (core driver, no backing store) packaging
-            per-frame WLS diagnostics for every chip. Layout:
-              /<chip>/coeffs_stack                    per-frame Legendre coefficients
-              /<chip>/lines_stack/frame_<NNN>/wav     reference line wavelength
-              /<chip>/lines_stack/frame_<NNN>/pix     fitted pixel position
-              /<chip>/lines_stack/frame_<NNN>/std     fitted line sigma
-              /<chip>/lines_stack/frame_<NNN>/amp     fitted line amplitude
-              /<chip>/lines_stack/frame_<NNN>/rms     normalized fit residual RMS
-              /<chip>/lines_stack/frame_<NNN>/bad     boolean QC flag
-              /<chip>/lines_stack/frame_<NNN>/ord     1-indexed order number
-              /<chip>/lines_stack/frame_<NNN>/fib     fiber name
-            Returned only if `return_stacks=True`.
 
         Notes
         -----
@@ -824,13 +821,11 @@ class WLS(BaseMasterModule):
 
         self.ml2_obj = KPFMasterL2()
 
-        coeffs_by_chip = {}
-        lines_by_chip = {}
+        self._coeffs_by_chip = {}
+        self._lines_by_chip  = {}
         self._results = {}
 
         for chip in self.chips:
-            # Always request stacks internally so we can populate self._results
-            # for info(); only package them into HDF5 when the caller asks.
             result = self.compute_wls_from_stack(
                 chip=chip,
                 fibers=self.fibers,
@@ -847,10 +842,8 @@ class WLS(BaseMasterModule):
                 'n_total': sum(len(frame['wav']) for frame in lines_stack),
                 'n_fit':   sum(int(np.sum(~frame['bad'])) for frame in lines_stack),
             }
-
-            if return_stacks:
-                coeffs_by_chip[chip] = coeffs_stack
-                lines_by_chip[chip] = lines_stack
+            self._coeffs_by_chip[chip] = coeffs_stack
+            self._lines_by_chip[chip]  = lines_stack
 
             for i, fiber in enumerate(self.fibers):
                 if W.ndim == 2:
@@ -882,9 +875,8 @@ class WLS(BaseMasterModule):
 
         self.ml2_obj.receipt_add_entry('master_wls', 'PASS')
 
-        if return_stacks:
-            stacks_hdf5 = self._package_stacks_hdf5(coeffs_by_chip, lines_by_chip)
-            return self.ml2_obj, stacks_hdf5
+        if stacks_path is not None:
+            self.save_stacks(stacks_path)
 
         return self.ml2_obj
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -161,7 +161,8 @@ class WLS(BaseMasterModule):
 
         Notes
         -----
-        Raises ValueError if more than 20% of frames fail to load.
+        Resets self._l2_obj_cache at entry. Raises ValueError if more than
+        20% of frames fail to load.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -169,6 +170,7 @@ class WLS(BaseMasterModule):
         if len(l0_file_list) == 0:
             raise ValueError("Empty l0_file_list; must supply at least one valid file")
 
+        self._l2_obj_cache = []
         failure = 0
 
         for fn in l0_file_list:
@@ -181,10 +183,6 @@ class WLS(BaseMasterModule):
                 continue
 
             l2_obj = self._extract_frame(l1_obj, verbose=verbose)
-            
-            if not hasattr(self, '_l2_obj_cache'):
-                self._l2_obj_cache = []
-            
             self._l2_obj_cache.append(l2_obj)
 
         return self._l2_obj_cache
@@ -587,7 +585,6 @@ class WLS(BaseMasterModule):
                                polyorder_m=None,
                                polyorder_f=None,
                                verbose=True,
-                               return_stacks=True,
                                ):
         """
         Compute a master wavelength solution from a stack of extracted L2 frames.
@@ -625,8 +622,6 @@ class WLS(BaseMasterModule):
             Polynomial degree along the fiber axis (only used for 3-fiber fits).
         verbose : bool, optional
             If True, print progress for each frame and fiber.
-        return_stacks : bool, optional
-            If True, also return the per-frame line and coefficient stacks.
 
         Returns
         -------
@@ -635,11 +630,10 @@ class WLS(BaseMasterModule):
             (norder, ncol, nfiber).
         coeffs_mean : ndarray
             Outlier-rejected mean Legendre coefficient array.
-        coeffs_stack : ndarray, optional
-            Per-frame coefficient arrays, returned only if `return_stacks=True`.
-        lines_stack : list of dict, optional
-            Per-frame line dicts from `fit_line_positions_ffi`, returned only
-            if `return_stacks=True`.
+        coeffs_stack : ndarray
+            Per-frame coefficient arrays (stacked).
+        lines_stack : list of dict
+            Per-frame line dicts from `fit_line_positions_ffi`.
 
         Notes
         -----
@@ -700,10 +694,7 @@ class WLS(BaseMasterModule):
 
         W = self.evaluate_wls_coeffs(coeffs_mean, self.ccd['ncol'], self.norder[chip], len(fibers))
 
-        if return_stacks:
-            return W, coeffs_mean, coeffs_stack, lines_stack
-
-        return W, coeffs_mean
+        return W, coeffs_mean, coeffs_stack, lines_stack
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -782,7 +773,7 @@ class WLS(BaseMasterModule):
 
         self._load_linelist(linelist)
 
-        self._l2_obj_cache = []
+        # process_stack_l0_to_l2 resets self._l2_obj_cache at entry.
         self.process_stack_l0_to_l2(l0_file_list=l0_file_list, verbose=verbose)
 
         self.ml2_obj = KPFMasterL2()
@@ -799,7 +790,6 @@ class WLS(BaseMasterModule):
                 polyorder_x=polyorder_x,
                 polyorder_m=polyorder_m,
                 polyorder_f=polyorder_f,
-                return_stacks=True,
                 verbose=verbose,
             )
             W, coeffs_mean, coeffs_stack, lines_stack = result

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -9,6 +9,8 @@ this module reads it from.
 """
 import os
 
+import numpy as np
+
 from kpfpipe import DEFAULTS
 from kpfpipe.data_models.masters.level2 import KPFMasterL2
 from kpfpipe.utils.config import ConfigHandler
@@ -139,7 +141,13 @@ class WavelengthCalibration:
         for chip in chips:
             for fiber in fibers:
                 key = f'{chip}_{fiber}_WAVE'
-                self.l2_obj.set_data(key, master.data[key])
+                src = master.data[key]
+                if src is None or np.size(src) == 0:
+                    raise KeyError(
+                        f"WLS master has no data for {key}; "
+                        f"cannot apply wavelength solution"
+                    )
+                self.l2_obj.set_data(key, src)
 
         self.l2_obj.receipt_add_entry('wavelength_calibration', 'PASS')
 

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -170,4 +170,8 @@ class WavelengthCalibration:
             print("  perform() has not been called")
             return
 
+        inst = self.l2_obj.headers.get('INSTRUMENT_HEADER', {})
+        agewls = inst.get('AGEWLS')
         print(f"  wls_path: {self._results['wls_path']}")
+        if agewls is not None:
+            print(f"  AGEWLS:   {agewls:+.4f} d  (master - obs)")

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -3,8 +3,9 @@ KPF Wavelength Calibration module.
 
 Copies the per-fiber wavelength solution from a precomputed master WLS L2
 product onto a science L2. The master is located by CalibrationAssociation,
-which writes the full WLSFILE path to the L1 PRIMARY header (and which
-propagates into the L2 PRIMARY via KPF1.to_kpf2()).
+which writes the full WLSFILE path to the L1 PRIMARY header. KPF1.to_kpf2()
+preserves the full L1 PRIMARY in the L2 INSTRUMENT_HEADER extension, where
+this module reads it from.
 """
 import os
 
@@ -17,16 +18,17 @@ class WavelengthCalibration:
     """
     Apply a precomputed wavelength solution to an extracted KPF L2 frame.
 
-    Reads `WLSFILE` (full path, legacy convention) from the L2 PRIMARY
-    header (populated by CalibrationAssociation), loads the corresponding
+    Reads `WLSFILE` (full path, legacy convention) from the L2
+    INSTRUMENT_HEADER extension (populated by CalibrationAssociation on
+    the L1 PRIMARY and carried through by to_kpf2), loads the corresponding
     KPFMasterL2, and copies each per-fiber {CHIP}_{FIBER}_WAVE array onto
     the science L2.
 
     Parameters
     ----------
     l2_obj : KPF2
-        Extracted L2 frame. The PRIMARY header must contain a WLSFILE
-        keyword.
+        Extracted L2 frame. The INSTRUMENT_HEADER extension must contain
+        a WLSFILE keyword.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: chips, fibers.
     """

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -85,7 +85,7 @@ class WavelengthCalibration:
             if 'WLSFILE' not in primary:
                 raise KeyError(
                     "WLSFILE missing from L2 PRIMARY header; "
-                    "run CalibrationAssociation with 'wls_thar' first"
+                    "run CalibrationAssociation with 'thar' first"
                 )
             wls_path = primary['WLSFILE']
 

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -58,9 +58,10 @@ class WavelengthCalibration:
         Load the master wavelength solution from disk.
 
         If `wls_path` is provided it is used directly, bypassing the header
-        lookup. Otherwise the path is read from `WLSFILE` in the L2 PRIMARY
-        header (written as a full path by CalibrationAssociation, per the
-        legacy WLS convention).
+        lookup. Otherwise the path is read from `WLSFILE` in the L2
+        INSTRUMENT_HEADER extension (which preserves the L1 PRIMARY, where
+        CalibrationAssociation wrote WLSFILE as a full path per the legacy
+        WLS convention).
 
         Parameters
         ----------
@@ -76,18 +77,18 @@ class WavelengthCalibration:
         ------
         KeyError
             If neither `wls_path` is given nor WLSFILE is present in the L2
-            PRIMARY header.
+            INSTRUMENT_HEADER.
         FileNotFoundError
             If the resolved path does not exist.
         """
         if wls_path is None:
-            primary = self.l2_obj.headers['PRIMARY']
-            if 'WLSFILE' not in primary:
+            inst_header = self.l2_obj.headers.get('INSTRUMENT_HEADER', {})
+            if 'WLSFILE' not in inst_header:
                 raise KeyError(
-                    "WLSFILE missing from L2 PRIMARY header; "
-                    "run CalibrationAssociation with 'thar' first"
+                    "WLSFILE missing from L2 INSTRUMENT_HEADER; "
+                    "run CalibrationAssociation with 'thar' on the L1 first"
                 )
-            wls_path = primary['WLSFILE']
+            wls_path = inst_header['WLSFILE']
 
         if not os.path.isfile(wls_path):
             raise FileNotFoundError(f"Master WLS file not found: {wls_path}")

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -85,7 +85,7 @@ class WavelengthCalibration:
             if 'WLSFILE' not in primary:
                 raise KeyError(
                     "WLSFILE missing from L2 PRIMARY header; "
-                    "run CalibrationAssociation with 'thar-wls' first"
+                    "run CalibrationAssociation with 'wls_thar' first"
                 )
             wls_path = primary['WLSFILE']
 

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -118,15 +118,14 @@ class WavelengthCalibration:
             Defaults to self.fibers.
         wls_path : str, optional
             Direct path to the master WLS L2 file. If omitted, the path is
-            resolved from WLSDIR/WLSFILE on the L2 PRIMARY header.
+            read from WLSFILE on the L2 INSTRUMENT_HEADER extension.
 
         Returns
         -------
         l2_obj : KPF2
-            The input L2 with per-fiber _WAVE extensions populated, the
-            master filename recorded in PRIMARY['WLSFILE'] (already present
-            from CalibrationAssociation, left untouched), and a
-            'wavelength_calibration' receipt entry.
+            The input L2 with per-fiber _WAVE extensions populated and a
+            'wavelength_calibration' receipt entry. WLSFILE on
+            INSTRUMENT_HEADER is left untouched.
         """
         if chips is None:
             chips = self.chips

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -1,9 +1,38 @@
+"""
+KPF Wavelength Calibration module.
+
+Copies the per-fiber wavelength solution from a precomputed master WLS L2
+product onto a science L2. The master is located by CalibrationAssociation,
+which writes the full WLSFILE path to the L1 PRIMARY header (and which
+propagates into the L2 PRIMARY via KPF1.to_kpf2()).
+"""
+import os
+
+from kpfpipe import DEFAULTS
+from kpfpipe.data_models.masters.level2 import KPFMasterL2
 from kpfpipe.utils.config import ConfigHandler
 
 
 class WavelengthCalibration:
-    def __init__(self, l1_obj, config=None):
-        self.l1_obj = l1_obj
+    """
+    Apply a precomputed wavelength solution to an extracted KPF L2 frame.
+
+    Reads `WLSFILE` (full path, legacy convention) from the L2 PRIMARY
+    header (populated by CalibrationAssociation), loads the corresponding
+    KPFMasterL2, and copies each per-fiber {CHIP}_{FIBER}_WAVE array onto
+    the science L2.
+
+    Parameters
+    ----------
+    l2_obj : KPF2
+        Extracted L2 frame. The PRIMARY header must contain a WLSFILE
+        keyword.
+    config : None | dict | ConfigHandler
+        Module configuration. Recognized keys: chips, fibers.
+    """
+
+    def __init__(self, l2_obj, config=None):
+        self.l2_obj = l2_obj
 
         if config is None:
             params = {}
@@ -13,3 +42,122 @@ class WavelengthCalibration:
             params = config.get_params(["DATA_DIRS", "KPFPIPE", "MODULE_WAVELENGTH_CALIBRATION"])
         else:
             raise TypeError("config must be None, dict, or ConfigHandler")
+
+        for k, v in DEFAULTS.items():
+            setattr(self, k, params.get(k, v))
+
+        self._wls_path = None  # set by load_wls()
+        self._results = None   # populated by perform()
+
+    # ------------------------------------------------------------------
+    # Algorithm steps
+    # ------------------------------------------------------------------
+
+    def load_wls(self, wls_path=None):
+        """
+        Load the master wavelength solution from disk.
+
+        If `wls_path` is provided it is used directly, bypassing the header
+        lookup. Otherwise the path is read from `WLSFILE` in the L2 PRIMARY
+        header (written as a full path by CalibrationAssociation, per the
+        legacy WLS convention).
+
+        Parameters
+        ----------
+        wls_path : str, optional
+            Direct path to a master WLS L2 FITS file.
+
+        Returns
+        -------
+        KPFMasterL2
+            The loaded master WLS data model.
+
+        Raises
+        ------
+        KeyError
+            If neither `wls_path` is given nor WLSFILE is present in the L2
+            PRIMARY header.
+        FileNotFoundError
+            If the resolved path does not exist.
+        """
+        if wls_path is None:
+            primary = self.l2_obj.headers['PRIMARY']
+            if 'WLSFILE' not in primary:
+                raise KeyError(
+                    "WLSFILE missing from L2 PRIMARY header; "
+                    "run CalibrationAssociation with 'thar-wls' first"
+                )
+            wls_path = primary['WLSFILE']
+
+        if not os.path.isfile(wls_path):
+            raise FileNotFoundError(f"Master WLS file not found: {wls_path}")
+
+        self._wls_path = wls_path
+        return KPFMasterL2.from_fits(wls_path)
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def perform(self, chips=None, fibers=None, wls_path=None):
+        """
+        Copy the master wavelength solution onto the science L2.
+
+        For every (chip, fiber) in the configured chips × fibers, copies
+        `{CHIP}_{FIBER}_WAVE` from the master L2 onto the science L2. The
+        chip-prefix keys resolve through the KPF2 alias system into slices
+        of the underlying concatenated TRACE{n}_WAVE arrays.
+
+        Parameters
+        ----------
+        chips : list of str, optional
+            Chip identifiers, e.g. ['GREEN', 'RED']. Defaults to self.chips.
+        fibers : list of str, optional
+            Fiber identifiers, e.g. ['SKY', 'SCI1', 'SCI2', 'SCI3', 'CAL'].
+            Defaults to self.fibers.
+        wls_path : str, optional
+            Direct path to the master WLS L2 file. If omitted, the path is
+            resolved from WLSDIR/WLSFILE on the L2 PRIMARY header.
+
+        Returns
+        -------
+        l2_obj : KPF2
+            The input L2 with per-fiber _WAVE extensions populated, the
+            master filename recorded in PRIMARY['WLSFILE'] (already present
+            from CalibrationAssociation, left untouched), and a
+            'wavelength_calibration' receipt entry.
+        """
+        if chips is None:
+            chips = self.chips
+        if fibers is None:
+            fibers = self.fibers
+
+        master = self.load_wls(wls_path=wls_path)
+
+        for chip in chips:
+            for fiber in fibers:
+                key = f'{chip}_{fiber}_WAVE'
+                self.l2_obj.set_data(key, master.data[key])
+
+        self.l2_obj.receipt_add_entry('wavelength_calibration', 'PASS')
+
+        self._results = {
+            'wls_path': self._wls_path,
+            'chips': list(chips),
+            'fibers': list(fibers),
+        }
+
+        return self.l2_obj
+
+    def info(self):
+        """Print a summary of the module configuration and association results."""
+        print("WavelengthCalibration")
+        print(f"  obs_id:  {self.l2_obj.obs_id}")
+        print(f"  chips:   {self.chips}")
+        print(f"  fibers:  {self.fibers}")
+
+        if self._results is None:
+            print("  perform() has not been called")
+            return
+
+        print(f"  wls_path: {self._results['wls_path']}")

--- a/kpfpipe/utils/kpf.py
+++ b/kpfpipe/utils/kpf.py
@@ -189,12 +189,16 @@ def get_seconds_since_j2000(s):
     KPF timestamp embedded in s. Suitable as a monotonic scalar for sorting
     and gap detection.
 
+    Note: arithmetic is naive UTC; leap seconds are ignored. Fine for frame
+    ordering and cluster-gap detection but does not give TT/TAI precision
+    and should not be used for astronomical timing.
+
     Args:
         s: a KPF timestamp ('YYYYMMDD.SSSSS.FF'), an obs_id
            ('KP.YYYYMMDD.SSSSS.FF'), or any filename or path containing one.
 
     Returns:
-        int: seconds since J2000.0.
+        int: seconds since J2000.0 (naive UTC).
 
     Raises:
         ValueError: if no valid KPF timestamp is found in s.

--- a/kpfpipe/utils/kpf.py
+++ b/kpfpipe/utils/kpf.py
@@ -90,6 +90,24 @@ def get_timestamp(input_str):
     raise ValueError(f"No KPF timestamp found in: {input_str}")
 
 
+def kpf_timestamp_to_datetime(timestamp):
+    """
+    Parse a KPF UTC timestamp string into a `datetime`.
+
+    Args:
+        timestamp: KPF timestamp string of the form 'YYYYMMDD.SSSSS.FF'
+                   (the sub-second frame field is ignored).
+
+    Returns:
+        datetime: naive UTC datetime at the timestamp's seconds-past-midnight.
+
+    Example:
+        kpf_timestamp_to_datetime('20240405.40113.57') -> datetime(2024, 4, 5, 11, 8, 33)
+    """
+    date_str, seconds_str, _ = timestamp.split('.')
+    return datetime.strptime(date_str, '%Y%m%d') + timedelta(seconds=int(seconds_str))
+
+
 def utc_to_hst(timestamp):
     """
     Convert a KPF UTC timestamp to HST (Hawaii Standard Time, UTC-10).

--- a/kpfpipe/utils/kpf.py
+++ b/kpfpipe/utils/kpf.py
@@ -8,86 +8,239 @@ _DATECODE_PATTERN  = re.compile(r'\d{8}')
 _KPF_TIMESTAMP_PATTERN  = re.compile(r'(\d{8}\.\d{5}\.\d{2})')
 _EPRV_TIMESTAMP_PATTERN = re.compile(r'\d{8}T\d{6}')
 
+# Seconds per day
+_SECONDS_PER_DAY = 86400
+
 # Hawaii Standard Time is UTC-10 (KPF timestamps are UTC)
 _HST_UTC_OFFSET_SECONDS = 36000
+
+# J2000.0 epoch (2000-01-01 12:00 UTC)
+_J2000_EPOCH = datetime(2000, 1, 1, 12, 0, 0)
+
+
+def _validate_kpf_timestamp(timestamp):
+    """
+    Validate that `timestamp` is a well-formed KPF timestamp string of the
+    form 'YYYYMMDD.SSSSS.FF' with a real calendar date and SSSSS in
+    [0, 86399]. Raises ValueError otherwise.
+    """
+    if not isinstance(timestamp, str):
+        raise ValueError(
+            f"KPF timestamp must be a string; got {type(timestamp).__name__}"
+        )
+    if not _KPF_TIMESTAMP_PATTERN.fullmatch(timestamp):
+        raise ValueError(
+            f"Invalid KPF timestamp format {timestamp!r}; expected 'YYYYMMDD.SSSSS.FF'"
+        )
+    date_str, seconds_str, _ = timestamp.split('.')
+    try:
+        datetime.strptime(date_str, '%Y%m%d')
+    except ValueError as e:
+        raise ValueError(f"Invalid date in KPF timestamp {timestamp!r}: {date_str!r}") from e
+    seconds = int(seconds_str)
+    if seconds >= _SECONDS_PER_DAY:
+        raise ValueError(
+            f"Invalid seconds-past-midnight in KPF timestamp {timestamp!r}: "
+            f"{seconds} not in [0, {_SECONDS_PER_DAY - 1}]"
+        )
+
+
+def _validate_eprv_timestamp(timestamp):
+    """
+    Validate that `timestamp` is a well-formed EPRV timestamp string of the
+    form 'YYYYMMDDTHHMMSS' with a real calendar date and HH/MM/SS in their
+    standard ranges. Raises ValueError otherwise.
+    """
+    if not isinstance(timestamp, str):
+        raise ValueError(
+            f"EPRV timestamp must be a string; got {type(timestamp).__name__}"
+        )
+    if not _EPRV_TIMESTAMP_PATTERN.fullmatch(timestamp):
+        raise ValueError(
+            f"Invalid EPRV timestamp format {timestamp!r}; expected 'YYYYMMDDTHHMMSS'"
+        )
+    date_str = timestamp[:8]
+    try:
+        datetime.strptime(date_str, '%Y%m%d')
+    except ValueError as e:
+        raise ValueError(f"Invalid date in EPRV timestamp {timestamp!r}: {date_str!r}") from e
+    hh = int(timestamp[9:11])
+    mm = int(timestamp[11:13])
+    ss = int(timestamp[13:15])
+    if hh >= 24 or mm >= 60 or ss >= 60:
+        raise ValueError(
+            f"Invalid time-of-day in EPRV timestamp {timestamp!r}: "
+            f"got HH={hh}, MM={mm}, SS={ss}"
+        )
 
 
 def is_obs_id(s):
     """
-    Returns True if s is a valid KPF observation ID, e.g. 'KP.20240113.23249.10'
+    Returns True if s is a valid KPF observation ID, e.g. 'KP.20240113.23249.10'.
+    Both the format and the embedded date/seconds are checked.
     """
-    return bool(_OBS_ID_PATTERN.fullmatch(s))
+    if not isinstance(s, str) or not _OBS_ID_PATTERN.fullmatch(s):
+        return False
+    try:
+        _validate_kpf_timestamp(s[3:])
+    except ValueError:
+        return False
+    return True
 
 
 def is_datecode(s):
     """
-    Returns True if s is a valid 8-digit datecode, e.g. '20240405'
+    Returns True if s is a valid 8-digit datecode that parses as a real
+    calendar date, e.g. '20240405'.
     """
-    return bool(_DATECODE_PATTERN.fullmatch(s))
+    if not isinstance(s, str) or not _DATECODE_PATTERN.fullmatch(s):
+        return False
+    try:
+        datetime.strptime(s, '%Y%m%d')
+    except ValueError:
+        return False
+    return True
 
 
 def is_timestamp(s):
     """
-    Returns True if s is a valid KPF timestamp, e.g. '20240113.23249.10'
+    Returns True if s is a valid KPF timestamp, e.g. '20240113.23249.10'.
+    Both the format and the embedded date/seconds are checked.
     """
-    return bool(_KPF_TIMESTAMP_PATTERN.fullmatch(s))
+    try:
+        _validate_kpf_timestamp(s)
+    except ValueError:
+        return False
+    return True
 
 
-def get_obs_id(filename):
+def get_obs_id(fn):
     """
     Extract obs_id from a filename or path.
 
     Args:
-        filename: e.g. '/data/L1/20240113/KP.20240113.23249.10_L1.fits'
+        fn: e.g. '/data/L1/20240113/KP.20240113.23249.10_L1.fits'
 
     Returns:
         obs_id: e.g. 'KP.20240113.23249.10'
 
     Raises:
-        ValueError: if no obs_id pattern found in filename
+        ValueError: if no valid obs_id is found in fn.
     """
-    match = _OBS_ID_PATTERN.search(os.path.basename(filename))
-    if match:
-        return match.group(1)
-    raise ValueError(f"No obs_id found in: {filename}")
+    if not isinstance(fn, str):
+        raise ValueError(f"input must be a string; got {type(fn).__name__}")
+    match = _OBS_ID_PATTERN.search(os.path.basename(fn))
+    if not match:
+        raise ValueError(f"No obs_id found in: {fn}")
+    obs_id = match.group(1)
+    _validate_kpf_timestamp(obs_id[3:])
+    return obs_id
 
 
-def get_datecode(input_str):
+def get_datecode(s):
     """
     Extract datecode from an obs_id or filename.
 
     Args:
-        input_str: e.g. 'KP.20230708.04519.63' or 'KP.20230708.04519.63_L1.fits'
+        s: e.g. 'KP.20230708.04519.63' or 'KP.20230708.04519.63_L1.fits'
 
     Returns:
         datecode: e.g. '20230708'
 
     Raises:
-        ValueError: if no obs_id pattern found in input_str
+        ValueError: if no valid obs_id is found in s.
     """
-    match = _OBS_ID_PATTERN.search(input_str)
-    if match:
-        return match.group(1).split('.')[1]
-    raise ValueError(f"Cannot extract datecode from: {input_str}")
+    if not isinstance(s, str):
+        raise ValueError(f"input must be a string; got {type(s).__name__}")
+    match = _OBS_ID_PATTERN.search(s)
+    if not match:
+        raise ValueError(f"Cannot extract datecode from: {s}")
+    obs_id = match.group(1)
+    _validate_kpf_timestamp(obs_id[3:])
+    return obs_id.split('.')[1]
 
 
-def get_timestamp(input_str):
+def get_timestamp(s):
     """
     Extract KPF timestamp from an obs_id, filename, or path.
 
     Args:
-        input_str: e.g. 'KP.20240113.23249.10' or '/data/L0/20240113/KP.20240113.23249.10.fits'
+        s: e.g. 'KP.20240113.23249.10' or '/data/L0/20240113/KP.20240113.23249.10.fits'
 
     Returns:
         timestamp: e.g. '20240113.23249.10'
 
     Raises:
-        ValueError: if no KPF timestamp pattern found in input_str
+        ValueError: if no valid KPF timestamp is found in s.
     """
-    match = _KPF_TIMESTAMP_PATTERN.search(os.path.basename(input_str))
-    if match:
-        return match.group(1)
-    raise ValueError(f"No KPF timestamp found in: {input_str}")
+    if not isinstance(s, str):
+        raise ValueError(f"input must be a string; got {type(s).__name__}")
+    match = _KPF_TIMESTAMP_PATTERN.search(os.path.basename(s))
+    if not match:
+        raise ValueError(f"No KPF timestamp found in: {s}")
+    timestamp = match.group(1)
+    _validate_kpf_timestamp(timestamp)
+    return timestamp
+
+
+def get_seconds_since_j2000(s):
+    """
+    Compute seconds since the J2000.0 epoch (2000-01-01 12:00 UTC) for the
+    KPF timestamp embedded in s. Suitable as a monotonic scalar for sorting
+    and gap detection.
+
+    Args:
+        s: a KPF timestamp ('YYYYMMDD.SSSSS.FF'), an obs_id
+           ('KP.YYYYMMDD.SSSSS.FF'), or any filename or path containing one.
+
+    Returns:
+        int: seconds since J2000.0.
+
+    Raises:
+        ValueError: if no valid KPF timestamp is found in s.
+    """
+    dt = kpf_timestamp_to_datetime(get_timestamp(s))
+    return int((dt - _J2000_EPOCH).total_seconds())
+
+
+def utc_to_hst(timestamp):
+    """
+    Convert a KPF UTC timestamp to HST (Hawaii Standard Time, UTC-10).
+
+    Args:
+        timestamp: KPF timestamp string of the form 'YYYYMMDD.SSSSS.FF'
+
+    Returns:
+        str: HST timestamp in the same KPF format
+    """
+    _validate_kpf_timestamp(timestamp)
+    date_str, seconds_str, frame_str = timestamp.split('.')
+    hst_seconds = int(seconds_str) - _HST_UTC_OFFSET_SECONDS
+    date = datetime.strptime(date_str, '%Y%m%d')
+    if hst_seconds < 0:
+        hst_seconds += _SECONDS_PER_DAY
+        date -= timedelta(days=1)
+    return f'{date.strftime("%Y%m%d")}.{hst_seconds:05d}.{frame_str}'
+
+
+def hst_to_utc(timestamp):
+    """
+    Convert a KPF HST timestamp to UTC.
+
+    Args:
+        timestamp: KPF timestamp string of the form 'YYYYMMDD.SSSSS.FF'
+
+    Returns:
+        str: UTC timestamp in the same KPF format
+    """
+    _validate_kpf_timestamp(timestamp)
+    date_str, seconds_str, frame_str = timestamp.split('.')
+    utc_seconds = int(seconds_str) + _HST_UTC_OFFSET_SECONDS
+    date = datetime.strptime(date_str, '%Y%m%d')
+    if utc_seconds >= _SECONDS_PER_DAY:
+        utc_seconds -= _SECONDS_PER_DAY
+        date += timedelta(days=1)
+    return f'{date.strftime("%Y%m%d")}.{utc_seconds:05d}.{frame_str}'
 
 
 def kpf_timestamp_to_datetime(timestamp):
@@ -104,46 +257,9 @@ def kpf_timestamp_to_datetime(timestamp):
     Example:
         kpf_timestamp_to_datetime('20240405.40113.57') -> datetime(2024, 4, 5, 11, 8, 33)
     """
+    _validate_kpf_timestamp(timestamp)
     date_str, seconds_str, _ = timestamp.split('.')
     return datetime.strptime(date_str, '%Y%m%d') + timedelta(seconds=int(seconds_str))
-
-
-def utc_to_hst(timestamp):
-    """
-    Convert a KPF UTC timestamp to HST (Hawaii Standard Time, UTC-10).
-
-    Args:
-        timestamp: KPF timestamp string of the form 'YYYYMMDD.SSSSS.FF'
-
-    Returns:
-        str: HST timestamp in the same KPF format
-    """
-    date_str, seconds_str, frame_str = timestamp.split('.')
-    hst_seconds = int(seconds_str) - _HST_UTC_OFFSET_SECONDS
-    date = datetime.strptime(date_str, '%Y%m%d')
-    if hst_seconds < 0:
-        hst_seconds += 86400
-        date -= timedelta(days=1)
-    return f'{date.strftime("%Y%m%d")}.{hst_seconds:05d}.{frame_str}'
-
-
-def hst_to_utc(timestamp):
-    """
-    Convert a KPF HST timestamp to UTC.
-
-    Args:
-        timestamp: KPF timestamp string of the form 'YYYYMMDD.SSSSS.FF'
-
-    Returns:
-        str: UTC timestamp in the same KPF format
-    """
-    date_str, seconds_str, frame_str = timestamp.split('.')
-    utc_seconds = int(seconds_str) + _HST_UTC_OFFSET_SECONDS
-    date = datetime.strptime(date_str, '%Y%m%d')
-    if utc_seconds >= 86400:
-        utc_seconds -= 86400
-        date += timedelta(days=1)
-    return f'{date.strftime("%Y%m%d")}.{utc_seconds:05d}.{frame_str}'
 
 
 def kpf_timestamp_to_eprv_timestamp(timestamp):
@@ -162,6 +278,7 @@ def kpf_timestamp_to_eprv_timestamp(timestamp):
     Example:
         kpf_timestamp_to_eprv_timestamp('20240405.40113.57') -> '20240405T110833'
     """
+    _validate_kpf_timestamp(timestamp)
     date_str, seconds_str, _ = timestamp.split('.')
     total_seconds = int(seconds_str)
     hh = total_seconds // 3600
@@ -186,10 +303,10 @@ def eprv_timestamp_to_kpf_timestamp(timestamp):
     Example:
         eprv_timestamp_to_kpf_timestamp('20240405T110833') -> '20240405.40113.00'
     """
+    _validate_eprv_timestamp(timestamp)
     date_str = timestamp[:8]
-    time_str = timestamp[9:]
-    hh = int(time_str[0:2])
-    mm = int(time_str[2:4])
-    ss = int(time_str[4:6])
+    hh = int(timestamp[9:11])
+    mm = int(timestamp[11:13])
+    ss = int(timestamp[13:15])
     total_seconds = hh * 3600 + mm * 60 + ss
     return f'{date_str}.{total_seconds:05d}.00'

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -136,8 +136,11 @@ def build_l0_file_lists(imtype, *, min_file_count=5, cluster_gap_seconds=7200,
 
         if os.path.isfile(csv_path):
             mini_db = pd.read_csv(csv_path)
-            on_disk = set(glob.glob(os.path.join(data_dir, '*.fits')))
-            cached = set(mini_db['FILENAME']) if 'FILENAME' in mini_db.columns else set()
+            # Normalize both sides via realpath so symlinks and relative
+            # paths don't trigger gratuitous rebuilds.
+            on_disk = {os.path.realpath(p) for p in glob.glob(os.path.join(data_dir, '*.fits'))}
+            cached = {os.path.realpath(p) for p in mini_db['FILENAME']} \
+                if 'FILENAME' in mini_db.columns else set()
             if on_disk != cached:
                 added = on_disk - cached
                 removed = cached - on_disk

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -4,12 +4,17 @@ import warnings
 
 import pandas as pd
 from astropy.io import fits
-from datetime import datetime
 
-from kpfpipe.utils.kpf import get_datecode, is_obs_id, get_timestamp, kpf_timestamp_to_eprv_timestamp
+from kpfpipe.utils.kpf import (
+    get_datecode,
+    get_seconds_since_j2000,
+    get_timestamp,
+    is_obs_id,
+    kpf_timestamp_to_eprv_timestamp,
+)
 
 
-_METADATA_KEYS = ['FILENAME', 'TARGNAME', 'IMTYPE', 'OBJECT', 'EXPTIME', 'ELAPSED']
+_MINI_DB_KEYS = ['FILENAME', 'TARGNAME', 'IMTYPE', 'OBJECT', 'EXPTIME', 'ELAPSED']
 
 _OBJECT_MAP = {
     'bias':     ['autocal-bias'],
@@ -24,51 +29,39 @@ _OBJECT_MAP = {
     ],
 }
 
-# 2-hour gap threshold: KPF calibration sequences within a night are
-# separated by science observations; a gap >2hr reliably distinguishes
-# morning vs. evening calibration clusters.
-_CALIBRATION_CLUSTER_GAP_SECONDS = 7200
-
-
-def _detect_calibration_stack_clusters(df):
+def _detect_calibration_stack_clusters(df, cluster_gap_seconds=7200):
     """
     Assign CAL_START and CAL_END columns to calibration frames in df.
 
     Calibration frames are grouped by OBJECT, sorted by UTC seconds, and
     split into clusters wherever the gap between consecutive frames exceeds
-    _CALIBRATION_CLUSTER_GAP_SECONDS. Every frame in a cluster receives
-    the UTC timestamp of the first frame as CAL_START and the UTC timestamp
-    of the last frame as CAL_END. Science frames (IMTYPE == 'Object') receive
-    an empty string for both columns.
+    cluster_gap_seconds. Every frame in a cluster receives the UTC timestamp
+    of the first frame as CAL_START and the UTC timestamp of the last frame
+    as CAL_END. Science frames (IMTYPE == 'Object') receive an empty string
+    for both columns.
 
     Args:
-        df: DataFrame with FILENAME, IMTYPE, and OBJECT columns.
+        df:                  DataFrame with FILENAME, IMTYPE, and OBJECT columns.
+        cluster_gap_seconds: gap between consecutive frames that splits a
+                             calibration sequence into separate clusters.
+                             Default 7200s (2 hours) reliably distinguishes
+                             morning vs. evening KPF calibration clusters,
+                             which are separated by science observations.
 
     Returns:
         df with CAL_START and CAL_END columns added (same row order as input).
     """
-    def _timestamp_to_seconds(ts):
-        date_str, seconds_str, _ = ts.split('.')
-        date_ordinal = datetime.strptime(date_str, '%Y%m%d').toordinal()
-        return date_ordinal * 86400 + int(seconds_str)
-
-    def _safe_seconds(f):
-        try:
-            return _timestamp_to_seconds(get_timestamp(f))
-        except ValueError:
-            raise ValueError(f"Cannot parse timestamp from filename: {f}")
-
     cal_start = pd.Series('', index=df.index)
     cal_end   = pd.Series('', index=df.index)
 
     cal_objects = {obj for objs in _OBJECT_MAP.values() for obj in objs}
     cal_df = df[df['OBJECT'].isin(cal_objects)].copy()
-    cal_df['_UTC_TOTAL'] = [_safe_seconds(f) for f in cal_df['FILENAME']]
+    cal_df['_UTC_TOTAL'] = [get_seconds_since_j2000(f) for f in cal_df['FILENAME']]
 
     for _, group in cal_df.groupby('OBJECT', dropna=False):
         group = group.sort_values('_UTC_TOTAL')
         gaps = group['_UTC_TOTAL'].diff()
-        cluster_id = (gaps > _CALIBRATION_CLUSTER_GAP_SECONDS).cumsum()
+        cluster_id = (gaps > cluster_gap_seconds).cumsum()
 
         for _, cluster_rows in group.groupby(cluster_id):
             start_time = get_timestamp(cluster_rows.iloc[0]['FILENAME'])
@@ -84,7 +77,7 @@ def _detect_calibration_stack_clusters(df):
 
 def build_mini_database(data_dir, write=True):
     """
-    Build a metadata table for all FITS files in a directory and write
+    Build the mini database for all FITS files in a directory and write
     it to disk as KP.{datecode}_{level}.csv in that directory.
 
     Reads the PRIMARY header of each FITS file and extracts a standard
@@ -122,7 +115,7 @@ def build_mini_database(data_dir, write=True):
     if not file_list:
         raise ValueError(f"No FITS files found in {data_dir}")
 
-    metadata = {k: [] for k in _METADATA_KEYS}
+    mini_db = {k: [] for k in _MINI_DB_KEYS}
 
     for fn in file_list:
         try:
@@ -131,12 +124,12 @@ def build_mini_database(data_dir, write=True):
             warnings.warn(f"Could not read header from {fn}: {e}")
             continue
 
-        metadata['FILENAME'].append(fn)
+        mini_db['FILENAME'].append(fn)
 
-        for k in _METADATA_KEYS[1:]:
-            metadata[k].append(header.get(k, None))
+        for k in _MINI_DB_KEYS[1:]:
+            mini_db[k].append(header.get(k, None))
 
-    df = pd.DataFrame(metadata)
+    df = pd.DataFrame(mini_db)
     df = _detect_calibration_stack_clusters(df)
 
     if write:
@@ -183,27 +176,25 @@ def build_l0_file_lists(imtype, min_file_count=5, *, data_dir=None, mini_db=None
     if (data_dir is None) == (mini_db is None):
         raise ValueError("Exactly one of data_dir or mini_db must be provided")
 
-    if mini_db is not None:
-        metadata = mini_db
-    else:
+    if mini_db is None:
         data_dir = os.path.normpath(data_dir)
         datecode = os.path.basename(data_dir)
         level = os.path.basename(os.path.dirname(data_dir))
         csv_path = os.path.join(data_dir, f'KP.{datecode}_{level}.csv')
 
         if os.path.isfile(csv_path):
-            metadata = pd.read_csv(csv_path)
-            if 'CAL_START' not in metadata.columns:
+            mini_db = pd.read_csv(csv_path)
+            if 'CAL_START' not in mini_db.columns:
                 warnings.warn(
                     f"Mini database at {csv_path} is missing CAL_START column; rebuilding.",
                     UserWarning,
                 )
-                metadata = build_mini_database(data_dir)
+                mini_db = build_mini_database(data_dir)
         else:
-            metadata = build_mini_database(data_dir)
+            mini_db = build_mini_database(data_dir)
 
-    mask = metadata['OBJECT'].isin(_OBJECT_MAP[imtype]) & (metadata['CAL_START'] != '')
-    cal_df = metadata[mask]
+    mask = mini_db['OBJECT'].isin(_OBJECT_MAP[imtype]) & (mini_db['CAL_START'] != '')
+    cal_df = mini_db[mask]
 
     if cal_df.empty:
         raise ValueError(

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -29,61 +29,14 @@ _OBJECT_MAP = {
     ],
 }
 
-def _detect_calibration_stack_clusters(df, cluster_gap_seconds=7200):
-    """
-    Assign CAL_START and CAL_END columns to calibration frames in df.
-
-    Calibration frames are grouped by OBJECT, sorted by UTC seconds, and
-    split into clusters wherever the gap between consecutive frames exceeds
-    cluster_gap_seconds. Every frame in a cluster receives the UTC timestamp
-    of the first frame as CAL_START and the UTC timestamp of the last frame
-    as CAL_END. Science frames (IMTYPE == 'Object') receive an empty string
-    for both columns.
-
-    Args:
-        df:                  DataFrame with FILENAME, IMTYPE, and OBJECT columns.
-        cluster_gap_seconds: gap between consecutive frames that splits a
-                             calibration sequence into separate clusters.
-                             Default 7200s (2 hours) reliably distinguishes
-                             morning vs. evening KPF calibration clusters,
-                             which are separated by science observations.
-
-    Returns:
-        df with CAL_START and CAL_END columns added (same row order as input).
-    """
-    cal_start = pd.Series('', index=df.index)
-    cal_end   = pd.Series('', index=df.index)
-
-    cal_objects = {obj for objs in _OBJECT_MAP.values() for obj in objs}
-    cal_df = df[df['OBJECT'].isin(cal_objects)].copy()
-    cal_df['_UTC_TOTAL'] = [get_seconds_since_j2000(f) for f in cal_df['FILENAME']]
-
-    for _, group in cal_df.groupby('OBJECT', dropna=False):
-        group = group.sort_values('_UTC_TOTAL')
-        gaps = group['_UTC_TOTAL'].diff()
-        cluster_id = (gaps > cluster_gap_seconds).cumsum()
-
-        for _, cluster_rows in group.groupby(cluster_id):
-            start_time = get_timestamp(cluster_rows.iloc[0]['FILENAME'])
-            end_time   = get_timestamp(cluster_rows.iloc[-1]['FILENAME'])
-            cal_start.loc[cluster_rows.index] = start_time
-            cal_end.loc[cluster_rows.index]   = end_time
-
-    df = df.copy()
-    df['CAL_START'] = cal_start
-    df['CAL_END']   = cal_end
-    return df
-
-
 def build_mini_database(data_dir, write=True):
     """
     Build the mini database for all FITS files in a directory and write
     it to disk as KP.{datecode}_{level}.csv in that directory.
 
     Reads the PRIMARY header of each FITS file and extracts a standard
-    set of keys used for frame selection (e.g. filtering by OBJECT type
-    to identify bias, dark, or flat frames). Also detects calibration stack
-    clusters and records the start and end timestamps of each cluster.
+    set of keys used for frame selection (e.g. filtering by OBJECT to
+    identify bias, dark, flat, or thar frames).
 
     Assumes data_dir follows the convention .../{level}/{datecode}/.
 
@@ -92,16 +45,12 @@ def build_mini_database(data_dir, write=True):
 
     Returns:
         pandas DataFrame with columns:
-            FILENAME  -- absolute path to the FITS file
-            TARGNAME  -- target name
-            IMTYPE    -- image type
-            OBJECT    -- object identifier (e.g. 'autocal-bias')
-            EXPTIME   -- requested exposure time (s)
-            ELAPSED   -- actual elapsed time (s)
-            CAL_START -- UTC timestamp of the first frame in the calibration
-                         stack cluster; empty string for science frames
-            CAL_END   -- UTC timestamp of the last frame in the calibration
-                         stack cluster; empty string for science frames
+            FILENAME -- absolute path to the FITS file
+            TARGNAME -- target name
+            IMTYPE   -- image type
+            OBJECT   -- object identifier (e.g. 'autocal-bias')
+            EXPTIME  -- requested exposure time (s)
+            ELAPSED  -- actual elapsed time (s)
 
         Rows where a header key is missing are included with NaN for
         that column and a warning is issued.
@@ -130,7 +79,6 @@ def build_mini_database(data_dir, write=True):
             mini_db[k].append(header.get(k, None))
 
     df = pd.DataFrame(mini_db)
-    df = _detect_calibration_stack_clusters(df)
 
     if write:
         csv_path = os.path.join(data_dir, f'KP.{datecode}_{level}.csv')
@@ -138,24 +86,62 @@ def build_mini_database(data_dir, write=True):
     return df
 
 
-def build_l0_file_lists(imtype, min_file_count=5, *, data_dir=None, mini_db=None):
+def _split_into_clusters(filenames, cluster_gap_seconds):
+    """
+    Group filenames into time-contiguous clusters.
+
+    Sorts by UTC seconds and splits wherever the gap between consecutive
+    frames exceeds cluster_gap_seconds.
+
+    Args:
+        filenames:           iterable of KPF L0 FITS paths.
+        cluster_gap_seconds: gap threshold (seconds) between consecutive
+                             frames that splits a calibration sequence
+                             into separate clusters.
+
+    Returns:
+        list of lists of filenames, each inner list sorted by timestamp.
+    """
+    timed = sorted(((get_seconds_since_j2000(fn), fn) for fn in filenames),
+                   key=lambda t: t[0])
+    if not timed:
+        return []
+
+    clusters = [[timed[0][1]]]
+    for (prev_t, _), (t, fn) in zip(timed, timed[1:]):
+        if t - prev_t > cluster_gap_seconds:
+            clusters.append([fn])
+        else:
+            clusters[-1].append(fn)
+    return clusters
+
+
+def build_l0_file_lists(imtype, *, min_file_count=5, cluster_gap_seconds=7200,
+                        data_dir=None, mini_db=None):
     """
     Return sorted file lists for all calibration clusters of the requested type.
 
     Exactly one of data_dir or mini_db must be provided. When data_dir is given,
     loads the mini database CSV if it exists, otherwise calls build_mini_database
     to scan headers and write it. When mini_db is given, uses it directly to
-    avoid redundant I/O. Groups calibration frames into clusters. Clusters with
-    at least min_file_count files are returned as individual lists. If any
+    avoid redundant I/O. Filters by OBJECT, then groups frames into clusters by
+    detecting >cluster_gap_seconds gaps between consecutive timestamps. Clusters
+    with at least min_file_count files are returned as individual lists. If any
     cluster falls below min_file_count, all clusters of that type are merged
     into a single list with a warning.
 
     Args:
-        imtype:          calibration frame type. One of 'bias', 'dark', 'flat', 'thar'.
-        min_file_count:  minimum number of files required per returned list.
-                         Default is 5.
-        data_dir:        path to directory containing L0 FITS files.
-        mini_db:         DataFrame returned by build_mini_database.
+        imtype:              calibration frame type. One of 'bias', 'dark',
+                             'flat', 'thar'.
+        min_file_count:      minimum number of files required per returned list.
+                             Default is 5.
+        cluster_gap_seconds: gap (seconds) between consecutive frames that
+                             splits a calibration sequence into separate
+                             clusters. Default 7200 (2 hours) reliably
+                             distinguishes morning vs. evening KPF calibration
+                             clusters, which are separated by science obs.
+        data_dir:            path to directory containing L0 FITS files.
+        mini_db:             DataFrame returned by build_mini_database.
 
     Returns:
         List of sorted file lists, one per cluster or one merged list if any
@@ -186,13 +172,7 @@ def build_l0_file_lists(imtype, min_file_count=5, *, data_dir=None, mini_db=None
             mini_db = pd.read_csv(csv_path)
             on_disk = set(glob.glob(os.path.join(data_dir, '*.fits')))
             cached = set(mini_db['FILENAME']) if 'FILENAME' in mini_db.columns else set()
-            if 'CAL_START' not in mini_db.columns:
-                warnings.warn(
-                    f"Mini database at {csv_path} is missing CAL_START column; rebuilding.",
-                    UserWarning,
-                )
-                mini_db = build_mini_database(data_dir)
-            elif on_disk != cached:
+            if on_disk != cached:
                 added = on_disk - cached
                 removed = cached - on_disk
                 warnings.warn(
@@ -204,18 +184,19 @@ def build_l0_file_lists(imtype, min_file_count=5, *, data_dir=None, mini_db=None
         else:
             mini_db = build_mini_database(data_dir)
 
-    mask = mini_db['OBJECT'].isin(_OBJECT_MAP[imtype]) & (mini_db['CAL_START'] != '')
-    cal_df = mini_db[mask]
+    cal_df = mini_db[mini_db['OBJECT'].isin(_OBJECT_MAP[imtype])]
 
     if cal_df.empty:
         raise ValueError(
             f"No '{imtype}' calibration frames found in {data_dir or 'the provided mini_db'}"
         )
 
-    clusters = [
-        sorted(group['FILENAME'].tolist())
-        for _, group in cal_df.groupby('CAL_START')
-    ]
+    # Cluster per-OBJECT (morning vs. evening thar etc. have different OBJECT
+    # suffixes), then flatten and sort chronologically by first frame.
+    clusters = []
+    for _, group in cal_df.groupby('OBJECT', dropna=False):
+        clusters.extend(_split_into_clusters(group['FILENAME'], cluster_gap_seconds))
+    clusters.sort(key=lambda c: get_seconds_since_j2000(c[0]))
 
     if all(len(c) >= min_file_count for c in clusters):
         return clusters

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -258,7 +258,7 @@ def build_filepath(obs_id, level, *, data_root=None, master=None):
                    returns an absolute path. When omitted, returns the bare
                    filename only.
         master:    master calibration type, one of 'bias', 'dark', 'flat',
-                   'thar-wls'. If provided, builds a master calibration path.
+                   'wls_thar'. If provided, builds a master calibration path.
                    If omitted, builds a science data path.
 
     Returns:
@@ -276,8 +276,8 @@ def build_filepath(obs_id, level, *, data_root=None, master=None):
     if master is not None:
         # Masters: {data_root}/masters/{datecode}/{obs_id}_master_{master}_{level}.fits
         # Level is in the filename only — no level subdirectory.
-        if master not in ('bias', 'dark', 'flat', 'thar-wls'):
-            raise ValueError(f"'master' must be 'bias', 'dark', 'flat', or 'thar-wls'; got '{master}'")
+        if master not in ('bias', 'dark', 'flat', 'wls_thar'):
+            raise ValueError(f"'master' must be 'bias', 'dark', 'flat', or 'wls_thar'; got '{master}'")
         if level not in ('L1', 'L2', 'L4'):
             raise ValueError(f"'level' for master products must be 'L1', 'L2', or 'L4'; got '{level}'")
         filename = f'{obs_id}_master_{master}_{level}.fits'

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -184,9 +184,20 @@ def build_l0_file_lists(imtype, min_file_count=5, *, data_dir=None, mini_db=None
 
         if os.path.isfile(csv_path):
             mini_db = pd.read_csv(csv_path)
+            on_disk = set(glob.glob(os.path.join(data_dir, '*.fits')))
+            cached = set(mini_db['FILENAME']) if 'FILENAME' in mini_db.columns else set()
             if 'CAL_START' not in mini_db.columns:
                 warnings.warn(
                     f"Mini database at {csv_path} is missing CAL_START column; rebuilding.",
+                    UserWarning,
+                )
+                mini_db = build_mini_database(data_dir)
+            elif on_disk != cached:
+                added = on_disk - cached
+                removed = cached - on_disk
+                warnings.warn(
+                    f"Mini database at {csv_path} is stale "
+                    f"(+{len(added)} added, -{len(removed)} removed on disk); rebuilding.",
                     UserWarning,
                 )
                 mini_db = build_mini_database(data_dir)

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -12,9 +12,16 @@ from kpfpipe.utils.kpf import get_datecode, is_obs_id, get_timestamp, kpf_timest
 _METADATA_KEYS = ['FILENAME', 'TARGNAME', 'IMTYPE', 'OBJECT', 'EXPTIME', 'ELAPSED']
 
 _OBJECT_MAP = {
-    'bias': 'autocal-bias',
-    'dark': 'autocal-dark',
-    'flat': 'autocal-flat-all',
+    'bias':     ['autocal-bias'],
+    'dark':     ['autocal-dark'],
+    'flat':     ['autocal-flat-all'],
+    'thar': [
+        'autocal-thar-all-morn',
+        'autocal-thar-all-midday',
+        'autocal-thar-all-eve',
+        'autocal-thar-all-night',
+        'autocal-thar-all-midnight',
+    ],
 }
 
 # 2-hour gap threshold: KPF calibration sequences within a night are
@@ -54,7 +61,7 @@ def _detect_calibration_stack_clusters(df):
     cal_start = pd.Series('', index=df.index)
     cal_end   = pd.Series('', index=df.index)
 
-    cal_objects = set(_OBJECT_MAP.values())
+    cal_objects = {obj for objs in _OBJECT_MAP.values() for obj in objs}
     cal_df = df[df['OBJECT'].isin(cal_objects)].copy()
     cal_df['_UTC_TOTAL'] = [_safe_seconds(f) for f in cal_df['FILENAME']]
 
@@ -151,7 +158,7 @@ def build_l0_file_lists(imtype, min_file_count=5, *, data_dir=None, mini_db=None
     into a single list with a warning.
 
     Args:
-        imtype:          calibration frame type. One of 'bias', 'dark', 'flat'.
+        imtype:          calibration frame type. One of 'bias', 'dark', 'flat', 'thar'.
         min_file_count:  minimum number of files required per returned list.
                          Default is 5.
         data_dir:        path to directory containing L0 FITS files.
@@ -195,7 +202,7 @@ def build_l0_file_lists(imtype, min_file_count=5, *, data_dir=None, mini_db=None
         else:
             metadata = build_mini_database(data_dir)
 
-    mask = (metadata['OBJECT'] == _OBJECT_MAP[imtype]) & (metadata['CAL_START'] != '')
+    mask = metadata['OBJECT'].isin(_OBJECT_MAP[imtype]) & (metadata['CAL_START'] != '')
     cal_df = metadata[mask]
 
     if cal_df.empty:
@@ -258,7 +265,7 @@ def build_filepath(obs_id, level, *, data_root=None, master=None):
                    returns an absolute path. When omitted, returns the bare
                    filename only.
         master:    master calibration type, one of 'bias', 'dark', 'flat',
-                   'wls_thar'. If provided, builds a master calibration path.
+                   'thar'. If provided, builds a master calibration path.
                    If omitted, builds a science data path.
 
     Returns:
@@ -276,8 +283,8 @@ def build_filepath(obs_id, level, *, data_root=None, master=None):
     if master is not None:
         # Masters: {data_root}/masters/{datecode}/{obs_id}_master_{master}_{level}.fits
         # Level is in the filename only — no level subdirectory.
-        if master not in ('bias', 'dark', 'flat', 'wls_thar'):
-            raise ValueError(f"'master' must be 'bias', 'dark', 'flat', or 'wls_thar'; got '{master}'")
+        if master not in ('bias', 'dark', 'flat', 'thar'):
+            raise ValueError(f"'master' must be 'bias', 'dark', 'flat', or 'thar'; got '{master}'")
         if level not in ('L1', 'L2', 'L4'):
             raise ValueError(f"'level' for master products must be 'L1', 'L2', or 'L4'; got '{level}'")
         filename = f'{obs_id}_master_{master}_{level}.fits'

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -247,8 +247,11 @@ def build_qlp_dir(obs_id, level, *, data_root):
         Absolute path: {data_root}/QLP/{datecode}/{obs_id}/{level}/
 
     Raises:
-        ValueError: if obs_id is not a valid observation ID.
+        ValueError: if obs_id is not a valid observation ID, or if
+                    data_root is not a non-empty string.
     """
+    if not isinstance(data_root, str) or not data_root:
+        raise ValueError(f"data_root must be a non-empty string; got {data_root!r}")
     if not is_obs_id(obs_id):
         raise ValueError(f"obs_id must be a valid observation ID (e.g. 'KP.20240405.49597.71'); got '{obs_id}'")
     return os.path.join(data_root, 'QLP', get_datecode(obs_id), obs_id, level)
@@ -263,20 +266,24 @@ def build_filepath(obs_id, level, *, data_root=None, master=None):
                    products this should be the obs_id of the first frame in
                    the stack.
         level:     data level string, one of 'L0', 'L1', 'L2', 'L4'.
-        data_root: root data directory (e.g. '/data/kpf/'). When provided,
-                   returns an absolute path. When omitted, returns the bare
-                   filename only.
+        data_root: root data directory (e.g. '/data/kpf/'). When None (the
+                   default), returns the bare filename. Otherwise must be a
+                   non-empty string and a full path is returned.
         master:    master calibration type, one of 'bias', 'dark', 'flat',
                    'thar'. If provided, builds a master calibration path.
                    If omitted, builds a science data path.
 
     Returns:
-        Absolute filepath as a string if data_root is given, else bare filename.
+        Filepath as a string (full path if data_root is set, bare filename
+        if data_root is None).
 
     Raises:
         ValueError: if level is unrecognized, if obs_id is not a valid
-                    observation ID, or if master type is unrecognized.
+                    observation ID, if master type is unrecognized, or if
+                    data_root is not None and not a non-empty string.
     """
+    if data_root is not None and (not isinstance(data_root, str) or not data_root):
+        raise ValueError(f"data_root must be None or a non-empty string; got {data_root!r}")
     if not is_obs_id(obs_id):
         raise ValueError(f"obs_id must be a valid observation ID (e.g. 'KP.20240405.49597.71'); got '{obs_id}'")
 

--- a/kpfpipe/utils/pipeline.py
+++ b/kpfpipe/utils/pipeline.py
@@ -86,36 +86,6 @@ def build_mini_database(data_dir, write=True):
     return df
 
 
-def _split_into_clusters(filenames, cluster_gap_seconds):
-    """
-    Group filenames into time-contiguous clusters.
-
-    Sorts by UTC seconds and splits wherever the gap between consecutive
-    frames exceeds cluster_gap_seconds.
-
-    Args:
-        filenames:           iterable of KPF L0 FITS paths.
-        cluster_gap_seconds: gap threshold (seconds) between consecutive
-                             frames that splits a calibration sequence
-                             into separate clusters.
-
-    Returns:
-        list of lists of filenames, each inner list sorted by timestamp.
-    """
-    timed = sorted(((get_seconds_since_j2000(fn), fn) for fn in filenames),
-                   key=lambda t: t[0])
-    if not timed:
-        return []
-
-    clusters = [[timed[0][1]]]
-    for (prev_t, _), (t, fn) in zip(timed, timed[1:]):
-        if t - prev_t > cluster_gap_seconds:
-            clusters.append([fn])
-        else:
-            clusters[-1].append(fn)
-    return clusters
-
-
 def build_l0_file_lists(imtype, *, min_file_count=5, cluster_gap_seconds=7200,
                         data_dir=None, mini_db=None):
     """
@@ -125,15 +95,13 @@ def build_l0_file_lists(imtype, *, min_file_count=5, cluster_gap_seconds=7200,
     loads the mini database CSV if it exists, otherwise calls build_mini_database
     to scan headers and write it. When mini_db is given, uses it directly to
     avoid redundant I/O. Filters by OBJECT, then groups frames into clusters by
-    detecting >cluster_gap_seconds gaps between consecutive timestamps. Clusters
-    with at least min_file_count files are returned as individual lists. If any
-    cluster falls below min_file_count, all clusters of that type are merged
-    into a single list with a warning.
+    detecting >cluster_gap_seconds gaps between consecutive timestamps. Every
+    returned cluster must have at least min_file_count files; otherwise raises.
 
     Args:
         imtype:              calibration frame type. One of 'bias', 'dark',
                              'flat', 'thar'.
-        min_file_count:      minimum number of files required per returned list.
+        min_file_count:      minimum number of files required per cluster.
                              Default is 5.
         cluster_gap_seconds: gap (seconds) between consecutive frames that
                              splits a calibration sequence into separate
@@ -144,15 +112,13 @@ def build_l0_file_lists(imtype, *, min_file_count=5, cluster_gap_seconds=7200,
         mini_db:             DataFrame returned by build_mini_database.
 
     Returns:
-        List of sorted file lists, one per cluster or one merged list if any
-        cluster fell below min_file_count.
+        List of sorted file lists, one per cluster.
 
     Raises:
         ValueError: if imtype is not a recognized calibration type, if exactly
                     one of data_dir or mini_db is not provided, if no
                     calibration frames of the requested type are found, or if
-                    the merged total still contains fewer than min_file_count
-                    files.
+                    any cluster contains fewer than min_file_count files.
     """
     if imtype not in _OBJECT_MAP:
         raise ValueError(
@@ -192,27 +158,30 @@ def build_l0_file_lists(imtype, *, min_file_count=5, cluster_gap_seconds=7200,
         )
 
     # Cluster per-OBJECT (morning vs. evening thar etc. have different OBJECT
-    # suffixes), then flatten and sort chronologically by first frame.
+    # suffixes), splitting wherever consecutive frames are more than
+    # cluster_gap_seconds apart. Final list sorted chronologically.
     clusters = []
     for _, group in cal_df.groupby('OBJECT', dropna=False):
-        clusters.extend(_split_into_clusters(group['FILENAME'], cluster_gap_seconds))
+        timed = sorted((get_seconds_since_j2000(fn), fn) for fn in group['FILENAME'])
+        if not timed:
+            continue
+        cluster = [timed[0][1]]
+        for (prev_t, _), (t, fn) in zip(timed, timed[1:]):
+            if t - prev_t > cluster_gap_seconds:
+                clusters.append(cluster)
+                cluster = [fn]
+            else:
+                cluster.append(fn)
+        clusters.append(cluster)
     clusters.sort(key=lambda c: get_seconds_since_j2000(c[0]))
 
-    if all(len(c) >= min_file_count for c in clusters):
-        return clusters
-
-    merged = sorted(f for c in clusters for f in c)
-    if len(merged) < min_file_count:
+    short = [c for c in clusters if len(c) < min_file_count]
+    if short:
         raise ValueError(
-            f"Only {len(merged)} '{imtype}' frame(s) found in {data_dir or 'the provided mini_db'}; "
-            f"need at least {min_file_count}"
+            f"'{imtype}' has {len(short)} cluster(s) below "
+            f"min_file_count={min_file_count}; sizes: {[len(c) for c in short]}"
         )
-    warnings.warn(
-        f"'{imtype}' clusters below min_file_count={min_file_count}; "
-        f"merged into one list of {len(merged)} files.",
-        UserWarning,
-    )
-    return [merged]
+    return clusters
 
 
 def build_qlp_dir(obs_id, level, *, data_root):

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -1,7 +1,5 @@
 import os
 
-import h5py
-
 from kpfpipe.modules.masters.bias import Bias
 #from kpfpipe.modules.masters.dark import Dark
 #from kpfpipe.modules.masters.flat import Flat
@@ -50,19 +48,13 @@ def main(config, args):
 
     # master wavelength solution (ThAr)
     for files in build_l0_file_lists('thar', mini_db=mini_db):
-        wls_handler = WLS(files, config)
-        wls_l2, wls_stack_h5 = wls_handler.make_master_l2(return_stacks=True)
-
-        out_path = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
-        os.makedirs(os.path.dirname(out_path), exist_ok=True)
-        wls_l2.to_fits(out_path)
-
-        # Persist the in-memory diagnostic stacks alongside the L2 master.
+        out_path    = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
         stacks_path = out_path[:-len('_L2.fits')] + '_stacks.h5'
-        with h5py.File(stacks_path, 'w') as fout:
-            for name in wls_stack_h5:
-                wls_stack_h5.copy(name, fout)
-        wls_stack_h5.close()
+        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+
+        wls_handler = WLS(files, config)
+        wls_l2 = wls_handler.make_master_l2(stacks_path=stacks_path)
+        wls_l2.to_fits(out_path)
 
     print("\n\n=== exiting kpf_drp_masters pipeline ===\n\n")
 

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -47,10 +47,10 @@ def main(config, args):
     #    flat_l1.to_fits(build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='flat'))
 
     # master wavelength solution (ThAr)
-    for files in build_l0_file_lists('thar-wls', mini_db=mini_db):
+    for files in build_l0_file_lists('wls_thar', mini_db=mini_db):
         wls_handler = WLS(files, config)
         wls_l2 = wls_handler.make_master_l2()
-        out_path = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar-wls')
+        out_path = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='wls_thar')
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
         wls_l2.to_fits(out_path)
 

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -1,5 +1,7 @@
 import os
 
+import h5py
+
 from kpfpipe.modules.masters.bias import Bias
 #from kpfpipe.modules.masters.dark import Dark
 #from kpfpipe.modules.masters.flat import Flat
@@ -49,10 +51,18 @@ def main(config, args):
     # master wavelength solution (ThAr)
     for files in build_l0_file_lists('thar', mini_db=mini_db):
         wls_handler = WLS(files, config)
-        wls_l2 = wls_handler.make_master_l2()
+        wls_l2, wls_stack_h5 = wls_handler.make_master_l2(return_stacks=True)
+
         out_path = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
         wls_l2.to_fits(out_path)
+
+        # Persist the in-memory diagnostic stacks alongside the L2 master.
+        stacks_path = out_path[:-len('_L2.fits')] + '_stacks.h5'
+        with h5py.File(stacks_path, 'w') as fout:
+            for name in wls_stack_h5:
+                wls_stack_h5.copy(name, fout)
+        wls_stack_h5.close()
 
     print("\n\n=== exiting kpf_drp_masters pipeline ===\n\n")
 

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -47,10 +47,10 @@ def main(config, args):
     #    flat_l1.to_fits(build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='flat'))
 
     # master wavelength solution (ThAr)
-    for files in build_l0_file_lists('wls_thar', mini_db=mini_db):
+    for files in build_l0_file_lists('thar', mini_db=mini_db):
         wls_handler = WLS(files, config)
         wls_l2 = wls_handler.make_master_l2()
-        out_path = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='wls_thar')
+        out_path = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
         wls_l2.to_fits(out_path)
 

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -48,12 +48,12 @@ def main(config, args):
 
     # master wavelength solution (ThAr)
     for files in build_l0_file_lists('thar', mini_db=mini_db):
-        out_path    = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
-        stacks_path = out_path[:-len('_L2.fits')] + '_stacks.h5'
+        out_path         = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
+        diagnostics_path = out_path[:-len('_L2.fits')] + '_diagnostics.h5'
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
         wls_handler = WLS(files, config)
-        wls_l2 = wls_handler.make_master_l2(stacks_path=stacks_path)
+        wls_l2 = wls_handler.make_master_l2(diagnostics_path=diagnostics_path)
         wls_l2.to_fits(out_path)
 
     print("\n\n=== exiting kpf_drp_masters pipeline ===\n\n")

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -56,7 +56,7 @@ def main(config, args):
 
     # assign calibration masters (bias, dark, flat, wls) to this frame
     calibration_association = CalibrationAssociation(l1, config)
-    l1 = calibration_association.perform(['bias', 'dark', 'flat', 'wls_thar'])
+    l1 = calibration_association.perform(['bias', 'dark', 'flat', 'thar'])
 
     # apply stardard FFI image processing (bias, dark, flat)
     image_processing = ImageProcessing(l1, config)

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -16,6 +16,7 @@ from kpfpipe.quality_control.diagnostics import DiagL1, DiagL2
 from kpfpipe.quality_control.qc_binaries import QCL1, QCL2
 from kpfpipe.quality_control.quicklook.level0 import PlotL0
 from kpfpipe.quality_control.quicklook.level1 import PlotL1
+
 from kpfpipe.utils.pipeline import build_filepath, build_qlp_dir
 
 

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -56,7 +56,7 @@ def main(config, args):
 
     # assign calibration masters (bias, dark, flat, wls) to this frame
     calibration_association = CalibrationAssociation(l1, config)
-    l1 = calibration_association.perform(['bias', 'dark', 'flat', 'thar-wls'])
+    l1 = calibration_association.perform(['bias', 'dark', 'flat', 'wls_thar'])
 
     # apply stardard FFI image processing (bias, dark, flat)
     image_processing = ImageProcessing(l1, config)

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -9,7 +9,7 @@ from kpfpipe.modules.image_assembly import ImageAssembly
 from kpfpipe.modules.calibration_association import CalibrationAssociation
 from kpfpipe.modules.image_processing import ImageProcessing
 from kpfpipe.modules.spectral_extraction import SpectralExtraction
-#from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
+from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
 #from kpfpipe.modules.barycentric_correction import BarycentricCorrection
 
 from kpfpipe.quality_control.diagnostics import DiagL1, DiagL2
@@ -56,7 +56,7 @@ def main(config, args):
 
     # assign calibration masters (bias, dark, flat, wls) to this frame
     calibration_association = CalibrationAssociation(l1, config)
-    l1 = calibration_association.perform(['bias', 'dark', 'flat'])
+    l1 = calibration_association.perform(['bias', 'dark', 'flat', 'thar-wls'])
 
     # apply stardard FFI image processing (bias, dark, flat)
     image_processing = ImageProcessing(l1, config)
@@ -70,13 +70,13 @@ def main(config, args):
     spectral_extraction = SpectralExtraction(l1, config)
     l2 = spectral_extraction.perform()
 
+    # apply precomputed wavelength solution (per-fiber WAVE arrays from WLS master)
+    wavelength_calibration = WavelengthCalibration(l2, config)
+    l2 = wavelength_calibration.perform()
+
     # Run L2 diagnostics (compute NaN counts and zero-flux fraction) and QC
     DiagL2(l2).run()
     QCL2(l2).run()
-
-    # determine wavelength calibration using WLS master
-    #wavelength_calibration = WavelengthCalibration(l2, config)
-    #l2 = wavelength_calibration.perform()
 
     # calculate barycentric correction
     #barycentric_correction = BarycentricCorrection(l2, config)

--- a/reference/legacy_data_format.rst
+++ b/reference/legacy_data_format.rst
@@ -1,0 +1,1294 @@
+KPF Data Format
+===============
+
+Overview
+--------
+
+KPF data products are defined for these data levels:
+
+* **Level 0 (L0)**: Raw data products produced by KPF at the W. M. Keck Observatory
+* **2D**: Assembled CCD images with minimal processing.  This data product is produced by the DRP during processing from L0 to L1 but is not fundamental and is frequently not archived.
+* **Level 1 (L1)**: Extracted, wavelength-calibrated spectra
+* **Level 2 (L2)**: Derived data products including cross-correlation functions, radial velocities, and activity indicators.
+
+Each of these data levels is a standardized, multi-extension FITS format, and can be read using standard fits tools (e.g., `astropy.fits.io <https://docs.astropy.org/en/stable/io/fits/>`_) and the `KPF-Pipeline <https://github.com/Keck-DataReductionPipelines/KPF-Pipeline>`_.
+
+KPF L0 files follow the naming convention: KP.YYYYMMDD.SSSSS.ss.fits, where YYYYMMDD is a date and SSSSS.ss is the number of decimal seconds after UT midnight corresponding to the start of the exposure.  2D/L1/L2 files have similar file names, but with '_2D', '_L1', or '_L2' before '.fits'.  For example, KP.YYYYMMDD.SSSSS.ss_2D.fits is a 2D file name.
+
+See the section titled :ref:`label-tutorials` for a set of tutorials on the various KPF data files.
+
+In addition, the DRP is able to produce WLS Dictionaries that contain detailed diagnostic information about the fits of individual lines, orders, and orderlets for the wavelength solutions.  These are described at the bottom of this page.
+
+Data Format of KPF Files
+------------------------
+
+L0 FITS Extensions
+^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+GREEN_AMP1           image      4110 x 2094     CCD image from Green amplifier 1   
+GREEN_AMP2           image      4110 x 2094     CCD image from Green amplifier 2 [a]       
+RED_AMP1             image      4110 x 2094     CCD image from Red amplifier 1   
+RED_AMP2             image      4110 x 2094     CCD image from Red amplifier 2    
+CA_HK                image      255 x 1024      CCD image from Ca H&K Spectrometer    
+EXPMETER_SCI         table      variable        Table of Exposure Meter measurements for SCI channel
+EXPMETER_SKY         table      variable        Table of Exposure Meter measurements for SKY channel
+TELEMETRY            table      variable        Table of telemetry measurements
+SOLAR_IRRADIANCE     table      variable        Table of pyrheliometer measurements (for SoCal spectra)
+GUIDER_AVG           image      512 x 640       Average image from the guide camera
+GUIDER_CUBE_ORIGINS  table      variable        Table of time-series guide camera measurements            
+===================  =========  ==============  =======
+
+[a] - the example shown above is for two-amplifier mode.  When KPF is operated in fast' read mode, four amplifiers per CCD will be used and there will be a corresponding number of AMP extensions.
+
+
+2D File FITS Extensions
+^^^^^^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+RECEIPT              table      variable        Receipt of DRP processing
+CONFIG               table      variable        Configuration parameters
+GREEN_CCD            image      4080 x 4080     Assembled Green CCD image with bias/dark correction   
+RED_CCD              image      4080 x 4080     Assembled Red CCD image with bias/dark correction   
+CA_HK                image      255 x 1024      Same as in L0 file    
+EXPMETER_SCI         table      variable        Same as in L0 file 
+EXPMETER_SKY         table      variable        Same as in L0 file 
+TELEMETRY            table      variable        Same as in L0 file 
+SOLAR_IRRADIANCE     table      variable        Same as in L0 file 
+GUIDER_AVG           image      512 x 640       Same as in L0 file 
+GUIDER_CUBE_ORIGINS  table      variable        Same as in L0 file          
+===================  =========  ==============  =======
+
+
+L1 FITS Extensions
+^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+RECEIPT              table      variable        Receipt of DRP processing
+CONFIG               table      variable        Configuration parameters
+TELEMETRY            table      variable        Table of telemetry measurements
+GREEN_SCI_FLUX1      image      35 x 4080       1D spectra for 35 GREEN CCD orders of SCI1 orderlet
+GREEN_SCI_FLUX2      image      35 x 4080       1D spectra for 35 GREEN CCD orders of SCI2 orderlet
+GREEN_SCI_FLUX3      image      35 x 4080       1D spectra for 35 GREEN CCD orders of SCI3 orderlet
+GREEN_SKY_FLUX       image      35 x 4080       1D spectra for 35 GREEN CCD orders of SKY orderlet
+GREEN_CAL_FLUX       image      35 x 4080       1D spectra for 35 GREEN CCD orders of CAL orderlet
+GREEN_SCI_VAR1       image      35 x 4080       Variance vs. pixel for GREEN_SCI_FLUX1
+GREEN_SCI_VAR2       image      35 x 4080       Variance vs. pixel for GREEN_SCI_FLUX2
+GREEN_SCI_VAR3       image      35 x 4080       Variance vs. pixel for GREEN_SCI_FLUX3
+GREEN_SKY_VAR        image      35 x 4080       Variance vs. pixel for GREEN_SKY_FLUX
+GREEN_CAL_VAR        image      35 x 4080       Variance vs. pixel for GREEN_CAL_FLUX
+GREEN_SCI_WAVE1      image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX1
+GREEN_SCI_WAVE2      image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX2
+GREEN_SCI_WAVE3      image      35 x 4080       Wavelength vs. pixel for GREEN_SCI_FLUX3
+GREEN_SKY_WAVE       image      35 x 4080       Wavelength vs. pixel for GREEN_SKY_FLUX
+GREEN_CAL_WAVE       image      35 x 4080       Wavelength vs. pixel for GREEN_CAL_FLUX
+GREEN_TELLURIC       table      n/a             Not used yet (will include telluric spectrum)
+GREEN_SKY            table      n/a             Not used yet (will include modeled sky spectrum)
+RED_SCI_FLUX1        image      32 x 4080       1D spectra for 32 RED CCD orders of SCI1 orderlet
+RED_SCI_FLUX2        image      32 x 4080       1D spectra for 32 RED CCD orders of SCI2 orderlet
+RED_SCI_FLUX3        image      32 x 4080       1D spectra for 32 RED CCD orders of SCI3 orderlet
+RED_SKY_FLUX         image      32 x 4080       1D spectra for 32 RED CCD orders of SKY orderlet
+RED_CAL_FLUX         image      32 x 4080       1D spectra for 32 RED CCD orders of CAL orderlet
+RED_SCI_VAR1         image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX1
+RED_SCI_VAR2         image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX2
+RED_SCI_VAR3         image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX3
+RED_SKY_VAR          image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX
+RED_CAL_VAR          image      32 x 4080       Variance vs. pixel for RED_SCI_FLUX
+RED_SCI_WAVE1        image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX1
+RED_SCI_WAVE2        image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX2
+RED_SCI_WAVE3        image      32 x 4080       Wavelength vs. pixel for RED_SCI_FLUX3
+RED_SKY_WAVE         image      32 x 4080       Wavelength vs. pixel for RED_SKY_FLUX
+RED_CAL_WAVE         image      32 x 4080       Wavelength vs. pixel for RED_CAL_FLUX
+RED_TELLURIC         table      n/a             Not used yet (will include telluric spectrum)
+RED_SKY              table      n/a             Not used yet (will include modeled sky spectrum)
+CA_HK_SCI            image      6 x 1024        1D spectra (6 orders) of SCI in Ca H&K spectrometer
+CA_HK_SKY            image      6 x 1024        1D spectra (6 orders) of SKY in Ca H&K spectrometer
+CA_HK_SCI_WAVE       image      6 x 1024        Wavelength vs. pixel for CA_HK_SCI
+CA_HK_SKY_WAVE       image      6 x 1024        Wavelength vs. pixel for CA_HK_SKY
+BARY_CORR            table      67              Table of barycentric corrections by spectral order
+===================  =========  ==============  =======
+
+
+L2 FITS Extensions
+^^^^^^^^^^^^^^^^^^
+
+===================  =========  ==============  =======
+Extension Name       Data Type  Data Dimension  Description    
+===================  =========  ==============  =======
+RECEIPT              table      variable        Receipt of DRP processing
+CONFIG               table      variable        Configuration parameters
+TELEMETRY            table      variable        Table of telemetry measurements
+GREEN_CCF            image      5 x 52 x 804    CCFs (orderlet x order x RV step) for GREEN
+RED_CCF              image      5 x 52 x 804    CCFs (orderlet x order x RV step) for RED
+GREEN_CCF            image      5 x 52 x 804    Reweighted CCFs (orderlet x order x RV step) for GREEN
+RED_CCF              image      5 x 52 x 804    Reweighted CCFs (orderlet x order x RV step) for RED
+RV                   table      67              Table of RVs by spectral order (described below)
+ACTIVITY             table      n/a             Not used yet (will include activity measurements)
+===================  =========  ==============  =======
+
+Primary Extension Header Keywords
+---------------------------------
+
+L0 Primary Extension Header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Most of the important keywords are stored in the primary extension of the Level 0 file, which is written immediately after each KPF exposure.
+
+========  ==========================================  =========
+Keyword   Value (example)                             Comment
+========  ==========================================  =========
+DATE-BEG  2023-10-22T15:30:01.056733                  Start of exposure from kpfexpose
+DATE-MID  2023-10-22T15:32:31.065                     Halfway point of the exposure (unweighted)
+DATE-END  2023-10-22T15:35:01.072797                  End of exposure
+EXPTIME   300.0                                       Requested exposure time
+ELAPSED   300.0                                       Actual exposure time
+PROGNAME  N226                                        Program name from kpfexpose
+OBJECT    42813                                       Object name
+TARGRA    06:12:13.80                                 Right ascension [hr] from DCS
+TARGDEC   -14:38:56.0                                 Declination [deg] from DCS
+TARGEPOC  2000.0                                      Target epoch from DCS
+TARGEQUI  2000.0                                      Target equinox from DCS
+TARGPLAX  14.7                                        Target parallax [arcsec] from DCS
+TARGPMDC  0.0                                         Target proper motion [arcsec/yr] in declination from DCS
+TARGPMRA  0.0                                         Target proper motion [s/yr] in right ascension from DCS
+TARGRADV  81.87                                       Target radial velocity [km/s]
+TARGFRAM  FK5                                         Target frame
+AIRMASS   1.26                                        Airmass from DCS
+PARANTEL  23.58                                       Parallactic angle of the telescope from DCS
+HA        +01:01:37.22                                Hour angle
+EL        52.46                                       Elevation [deg]
+AZ        204.46                                      Azimuth [deg]
+LST       07:13:51.02                                 Local sidereal time
+RA        06:12:13.80                                 [h] Right ascension
+DEC       -14:38:56.0                                 [deg] Declination
+EQUINOX   2000.0                                      DCS Equinox
+MJD-OBS   60310.21291                                 Modified Julian days
+GAIAID    DR3 2993561629444856960                     GAIA Target name
+2MASSID   J06121397-1439002                           2MASS Target name
+GAIAMAG   9.28                                        GAIA G band magnitude
+2MASSMAG  8.06                                        2MASS J band magnitude
+TARGTEFF  5398.0                                      Target effective temperature (K)
+OCTAGON   EtalonFiber                                 Selected octagon calibration source (not necessarily powered on)
+TRIGTARG  Green,Red,Ca_HK,ExpMeter,Guide              Cameras that were sent triggers
+SRCSHTTR  SciSelect,SkySelect,SoCalSci                Source shutters commanded
+TIMSHTTR  Scrambler,SimulCal                          Timed shutters commanded
+OTIMSHTR  Scrambler,SimulCal                          Timed shutters open exp. midpoint
+SCISEL    open                                        Science Select shutter at exp. midpoint
+SKYSEL    open                                        Sky Select Shutter at exp. midpoint
+FFSHTR    closed                                      Flat field fiber shutter at exp. midpoint
+SCRAMSHT  open                                        Scrambler shutter at exp. midpoint
+SIMCALSH  open                                        Simult Cal shutter at exp. midpoint
+CAHKSHT   closed                                      CaHK shutter at exp. midpoint
+SOLSCISH  open                                        SoCal Sci shutter at exp. midpoint
+SOLCALSH  closed                                      SoCal Cal shutter at exp. midpoint
+CALSSSHT  closed                                      Cal SciSky shutter at exp. midpoint
+AOHATCH   False                                       AO hatch at exp. midpoint
+FIUHTCH   False                                       FIU hatch at exp. midpoint
+IMTYPE    Object                                      Image Type
+TARGNAME  42813                                       KPF Target Name
+DCSNAME   42813                                       DCS Target Name
+FULLTARG  42813                                       Full Target name from kpfconfig
+CAL-OBJ   None                                        Calibration fiber source
+SKY-OBJ   Sky                                         Sky fiber source
+SCI-OBJ   Target                                      Science fiber source
+AGITSTA   Running                                     Agitator status
+FIUMODE   Observing                                   FIU operating mode
+FFFB      Yes                                         Flatfield fiber on
+TOTCNTS   1.1299e+08 1.959e+08 1.8185e+08 1.1561e+08  Total Exp. Meter counts (DN) - four channels (445.0-551.25, 551.25-657.5, 657.5-763.75, 763.75-870.0 nm) 
+TOTCORR   2.3994e+08 4.1319e+08 3.8088e+08 2.403e+08  Total Exp. Meter counts (DN), corrected for dead time - four channels (445.0-551.25, 551.25-657.5, 657.5-763.75, 763.75-870.0 nm) 
+ETAV1C1T  23.990154                                   Etalon Vescent 1 Ch 1 temp (Housing)
+ETAV1C2T  23.79949                                    Etalon Vescent 1 Ch 2 temp (Inner Side Shield)
+ETAV1C3T  23.599987                                   Etalon Vescent 1 Ch 3 temp (Inner Bottom Lid)
+ETAV1C4T  23.900118                                   Etalon Vescent 1 Ch 4 temp (Outer Etalon Chamber)
+ETAV2C3T  24.000668                                   Etalon Vescent 2 Ch 3 temp (Inner Top Lid Temp)
+ETAV1C1S  24.000000                                   Etalon Vescent 1 Ch 1 temp set point (Housing)
+ETAV1C2S  23.800000                                   Etalon Vescent 1 Ch 2 temp set point (Inner Side Shield)
+ETAV1C3S  23.600000                                   Etalon Vescent 1 Ch 3 temp set point (Inner Bottom Lid)
+ETAV1C4S  23.900000                                   Etalon Vescent 1 Ch 4 temp set point (Outer Etalon Chamber)
+ETAV2C3S  24.000000                                   Etalon Vescent 2 Ch 3 temp set point (Inner Top Lid Temp)
+PTHDAY    1.422E-05                                   Last ThAr Daily power meter measurement (Watts)
+PTHAU     1.422E-05                                   Last ThAr Gold power meter measurement (Watts)
+PUDAY     1.422E-05                                   Last UNe Daily power meter measurement (Watts)
+PUAU      1.422E-05                                   Last UNe Gold power meter measurement (Watts)
+PLFC      1.422E-05                                   Last LFC power meter measurement (Watts)
+PETAL     1.422E-05                                   Last Etalon power meter measurement (Watts)
+PBRB      1.422E-05                                   Last Broadband power meter measurement (Watts)
+PSOL      1.422E-05                                   Last SoCal-CalFib power meter measurement (Watts)
+PTHDAYT   '20250108T08:37:44 HST'                     Time of last ThAr Daily power measurement
+PTHAUT    '20250108T08:37:44 HST'                     Time of last ThAr Gold power measurement
+PUDAYT    '20250108T08:37:44 HST'                     Time of last UNe Daily power measurement
+PUAUT     '20250108T08:37:44 HST'                     Time of last UNe Gold power measurement
+PLFCT     '20250108T08:37:44 HST'                     Time of last LFC power measurement
+PETALT    '20250108T08:37:44 HST'                     Time of last Etalon power measurement
+PBRBT     '20250108T08:37:44 HST'                     Time of last Broadband power measurement
+PSOLT     '20250108T08:37:44 HST'                     Time of last SoCal-CalFib power measurement
+TIMEERR   'ok 2 3 {NTP time correct to within 3 ms}'  NTP time server response (needs interpretation)
+VIGNETTE  'false '                                    Dome vignetting (true/false)
+STVIGNE   'false '                                    Top shutter vignetting (true/false)
+SBVIGNE   'false '                                    Bottom shutter vignetting (true/false)
+SBELEV    23.99                                       Bottom shutter elevation (deg)
+STELEV    23.99                                       Top shutter elevation (deg)
+LFCMODE   'StandbyHigh'                               LFC Operation Mode
+AMPON     27635202.107                                LFC: Amount of time amplifier on (sec)
+LFCFO     250000000.0                                 LFC filtered Offset Freq RR Comb counted (Hz)
+LFCFREF   250000000.0                                 LFC filtered Offset Freq RR Comb setpoint (Hz)
+LFCFR     19999999999.9963                            LFC filtered Offset Freq RR Filter counted (Hz)
+LFCFRREF  20000000000.0                               LFC filtered Offset Freq RR Filter setpoint(Hz)
+LFCCEOFR  5220000000.0                                LFC CEO Filtered Setpoint Freq (Hz)
+LFCCWFRF  288005220000000.0                           LFC CW Freq Reference (Hz)
+LFCCWFRQ  288005220406302.0                           LFC CW Freq (Hz)
+LFCCWFER  406302.0                                    LFC CW Freq Error: Ref-Actual (Hz)
+LFCCWMDN  1152021                                     LFC CW mode number
+LFCBIACT  0.033                                       LFC Blue cut amp diode current (A)
+LFCBISET  0.0                                         LFC Blue cut amp diode setting (A)
+========  ==========================================  =========
+
+2D Primary Extension Header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The 2D file inherits all L0 keywords.  Below are additional keywords.
+
+========  ==========================================  =========
+Keyword   Value (example)                             Comment
+========  ==========================================  =========
+DRPTAG    v2.5.2                                      Git version number of KPF-Pipeline used to make 2D (in the time series database, DRPTAG is listed as DRPTAG2D)
+DRPHSH    'ccf5f6ebe0c9ae7d43706cc57fed2ecdeb540a17'  Git commit hash version of KPF-Pipeline used to make 2D (in the time series database, DRPHSH is listed as DRPHSH2D)
+DRPTAGMF  v2.5.2                                      DRPTAG of master flat file used to make 2D
+DRPTAGMB  v2.5.2                                      DRPTAG of master bias file used to make 2D
+DRPTAGMD  v2.5.2                                      DRPTAG of master dark file used to make 2D
+NOTJUNK   1                                           QC: 1 = not in the list of junk files check; this QC is rerun on L1 and L2
+DATAPRL0  1                                           QC: 1 = L0 data products present with non-zero array sizes
+KWRDPRL0  1                                           QC: 1 = L0 expected keywords present 
+TIMCHKL0  1                                           QC: 1 = Consistent times in L0 file
+EMSAT     1                                           QC: 1 = Exp Meter not saturated; 0 = 2+ reduced EM pixels within 90% of saturation in EM-SCI or EM-SKY 
+EMNEG     1                                           QC: 1 = Exp Meter not negative flux; 0 = 20+ consecutive pixels in summed spectra with negative flux 
+DATAPR2D  1                                           QC: 1 = 2D data products present with non-zero array sizes
+CAHKPR2D  1                                           QC: 1 = 2D CaHK data present with non-zero array sizes
+TELEPRL0  1                                           QC: 1 = TELEMETRY extension present in L0
+GOODREAD  1                                           QC: 1 = Exposure time not consistent with CCD readout error (~6 sec)
+POS2DSNR  1                                           QC: 1 = 2D Red and Green SNR (data/var^0.5) not significantly negative
+LOWBIAS   1                                           QC: 1 = 2D bias flux not low
+LOWDARK   1                                           QC: 1 = 2D dark flux not low
+LFC2DFOK  1                                           QC: 1 = LFC flux meets threshold of 4000 counts
+OLDBIAS   1                                           QC: 1 = Master bias within 5 days of this obs
+OLDDARK   1                                           QC: 1 = Master dark within 5 days of this obs
+OLDFLAT   1                                           QC: 1 = Master flat within 5 days of this obs
+NTPGOOD   1                                           QC: 1 = NTP time within 100 ms
+GUIDGOOD  1                                           QC: 1 = Guider RMS and bias within 50 mas RMS
+GUIDSAT   1                                           QC: 1 = Guider avg frame not saturated and <10% of frames have a sat pixel
+TARGPLAU  1                                           QC: 1 = TARG kwds present with plausible values
+AGITOK    1                                           QC: 1 = Agitator running with speed above minimum
+NOTVIGN   1                                           QC: 1 = Telescope not vignetted by dome
+GOODEL    1                                           QC: 1 = Telescope elevation above 30 deg (for ADC)
+ETASTEMP  1                                           QC: 1 = Etalon inner chamber temps near set points
+FLXSTATS  1                                           QC: 1 = Flux stats in/out of order trace as expected
+HKSHTOPN  1                                           QC: 1 = HK shutter open and HK image requested; not bias/dark exposure
+GRCCD10T  1                                           QC: 1 = Green CCD > 10 mK from temp set point
+GRCCD1T   1                                           QC: 1 = Green CCD > 1000 mK (1 C) from temp set point
+RDCCD10T  1                                           QC: 1 = Red CCD > 10 mK from temp set point
+RDCCD1T   1                                           QC: 1 = Red CCD > 1000 mK (1 C) from temp set point
+ISGOOD    1                                           QC: 1 = all other QC tests passed
+CLEARSKY  1                                           QC: 1 = Clear sky conditions for SoCal
+RNGREEN1  4.85283                                     Read noise for GREEN_AMP1 [e-] (first amplifier region on Green CCD)
+RNGREEN2  4.14966                                     Read noise for GREEN_AMP2 [e-] (second amplifier region on Green CCD)
+RNGREEN3  4.85283                                     Read noise for GREEN_AMP3 [e-] (third amplifier region on Green CCD)
+RNGREEN4  4.14966                                     Read noise for GREEN_AMP4 [e-] (fourth amplifier region on Green CCD)
+RNRED1    4.0376                                      Read noise for RED_AMP1 [e-] (first amplifier region on Red CCD)
+RNRED2    4.12717                                     Read noise for RED_AMP2 [e-] (second amplifier region on Red CCD)
+RNRED3    4.0376                                      Read noise for RED_AMP3 [e-] (third amplifier region on Red CCD)
+RNRED4    4.12717                                     Read noise for RED_AMP4 [e-] (fourth amplifier region on Red CCD)
+RNNGGR1   1.0                                         Non-Gaussian read noise GREEN1, 0.8*stddev/mad of overscan
+RNNGGR2   1.0                                         Non-Gaussian read noise GREEN2, 0.8*stddev/mad of overscan
+RNNGGR3   1.0                                         Non-Gaussian read noise GREEN3, 0.8*stddev/mad of overscan
+RNNGGR4   1.0                                         Non-Gaussian read noise GREEN4, 0.8*stddev/mad of overscan
+RNNGRD1   1.0                                         Non-Gaussian read noise RED1, 0.8*stddev/mad of overscan
+RNNGRD2   1.0                                         Non-Gaussian read noise RED2, 0.8*stddev/mad of overscan
+RNNGRD3   1.0                                         Non-Gaussian read noise RED3, 0.8*stddev/mad of overscan
+RNNGRD4   1.0                                         Non-Gaussian read noise RED4, 0.8*stddev/mad of overscan
+GREENTRT  46.804                                      Green CCD read time [sec]
+REDTRT    46.839                                      Red CCD read time [sec]
+READSPED  'regular '                                  Categorization of CCD read speed ('regular' or 'fast')
+FLXREG1G  1.00                                        Dark current [e-/hr] - Green CCD region 1 - coords = [1690:1990,1690:1990]
+FLXREG2G  1.00                                        Dark current [e-/hr] - Green CCD region 2 - coords = [1690:1990,2090:2390]
+FLXREG3G  1.00                                        Dark current [e-/hr] - Green CCD region 3 - coords = [2090:2390,1690:1990]
+FLXREG4G  1.00                                        Dark current [e-/hr] - Green CCD region 4 - coords = [2090:2390,2090:2390]
+FLXREG5G  1.00                                        Dark current [e-/hr] - Green CCD region 5 - coords = [80:380,3080:3380]
+FLXREG6G  1.00                                        Dark current [e-/hr] - Green CCD region 6 - coords = [1690:1990,1690:1990]
+FLXAMP1G  1.00                                        Dark current [e-/hr] - Green CCD amplifier region 1 - coords = [3700:4000,700:1000]
+FLXAMP2G  1.00                                        Dark current [e-/hr] - Green CCD amplifier region 2 - coords = [3700:4000,3080:3380]
+FLXCOLLG  1.00                                        Dark current [e-/hr] - Green CCD collimator-side region = [3700:4000,700:1000]
+FLXECHG   1.00                                        Dark current [e-/hr] - Green CCD echelle-side region = [3700:4000,700:1000]
+FLXREG1R  1.00                                        Dark current [e-/hr] - Red CCD region 1 - coords = [1690:1990,1690:1990]
+FLXREG2R  1.00                                        Dark current [e-/hr] - Red CCD region 2 - coords = [1690:1990,2090:2390]
+FLXREG3R  1.00                                        Dark current [e-/hr] - Red CCD region 3 - coords = [2090:2390,1690:1990]
+FLXREG4R  1.00                                        Dark current [e-/hr] - Red CCD region 4 - coords = [2090:2390,2090:2390]
+FLXREG5R  1.00                                        Dark current [e-/hr] - Red CCD region 5 - coords = [80:380,3080:3380]
+FLXREG6R  1.00                                        Dark current [e-/hr] - Red CCD region 6 - coords = [1690:1990,1690:1990]
+FLXAMP1R  1.00                                        Dark current [e-/hr] - Red CCD amplifier region 1 = [3700:4000,700:1000]
+FLXAMP2R  1.00                                        Dark current [e-/hr] - Red CCD amplifier region 2 = [3700:4000,3080:3380]
+FLXCOLLR  1.00                                        Dark current [e-/hr] - Red CCD collimator-side region = [3700:4000,700:1000]
+FLXECHR   1.00                                        Dark current [e-/hr] - Red CCD echelle-side region = [3700:4000,700:1000]
+GDRXRMS   10.123                                      Guider: x-coordinate RMS guiding error in milliarcsec (mas)
+GDRYRMS   10.123                                      Guider: y-coordinate RMS guiding error in milliarcsec (mas)
+GDRRRMS   10.123                                      Guider: r-coordinate RMS guiding error in milliarcsec (mas)
+GDRXBIAS  0.0010                                      Guider: x-coordinate bias guiding error in milliarcsec (mas)
+GDRYBIAS  0.0010                                      Guider: y-coordinate bias guiding error in milliarcsec (mas)
+GDRSEEJZ  0.450                                       Guider: Seeing (arcsec) in J+Z-band from Moffat func fit
+GDRSEEV   0.450                                       Guider: Scaled seeing (arcsec) in V-band from J+Z-band
+GDRFWMD   208.1                                       Guider frames: median(FWHM)[mas]
+GDRFWSTD  20.5                                        Guider frames: std(FWHM)[mas]
+GDRFXMD   218074.0                                    Guider frames: median(flux) [ADU]
+GDRFXSTD  98306.5                                     Guider frames: std(flux)[ADU]
+GDRPKMD   2729.5                                      Guider frames: median(peak_flux) [ADU]
+GDRPKSTD  1221.8                                      Guider frames: std(peak_flux)[ADU]
+GDRFRSAT  0.0                                         Guider: frac of frames w/in 90% saturated
+GDRNSAT   10                                          Guider: number of 90% saturated pix in co-added image
+MOONSEP   55.0                                        Separation between Moon and target star (deg)
+SUNALT    -45.0                                       Altitude of Sun (deg); negative = below horizon
+MEDGRN1   3.9642348e+07                               Median for GREEN_AMP1 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P16GRN1   3.9340188e+07                               16th-percentile for GREEN_AMP1 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P84GRN1   3.9340188e+07                               84th-percentile for GREEN_AMP1 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+MEDGRN2   3.9642348e+07                               Median for GREEN_AMP2 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P16GRN2   3.9340188e+07                               16th-percentile for GREEN_AMP2 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P84GRN2   3.9340188e+07                               84th-percentile for GREEN_AMP2 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+MEDGRN3   3.9642348e+07                               Median for GREEN_AMP3 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P16GRN3   3.9340188e+07                               16th-percentile for GREEN_AMP3 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P84GRN3   3.9340188e+07                               84th-percentile for GREEN_AMP3 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+MEDGRN4   3.9642348e+07                               Median for GREEN_AMP4 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P16GRN4   3.9340188e+07                               16th-percentile for GREEN_AMP4 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P84GRN4   3.9340188e+07                               84th-percentile for GREEN_AMP4 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+MEDRED1   3.9642348e+07                               Median for RED_AMP1 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P16RED1   3.9340188e+07                               16th-percentile for RED_AMP1 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P84RED1   3.9340188e+07                               84th-percentile for RED_AMP1 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+MEDRED2   3.9642348e+07                               Median for RED_AMP2 in L0 [e-] (includes overscan region, excludes NaNs explicitly)
+P16RED2   3.9340188e+07                               16th-percentile for RED_AMP2 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P84RED2   3.9340188e+07                               84th-percentile for RED_AMP2 in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+MEDCAHK   3.9642348e+07                               Median for CA_HK_AMP in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P16CAHK   3.9340188e+07                               16th-percentile for CA_HK_AMP in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+P84CAHK   3.9340188e+07                               84th-percentile for CA_HK_AMP in L0 [DN] (includes overscan region, excludes NaNs explicitly)
+GR2DF99P  30552.46                                    99th percentile flux in 2D Green image (e-)
+GR2DF90P  14860.21                                    90th percentile flux in 2D Green image (e-)
+GR2DF50P  234.62                                      50th percentile flux in 2D Green image (e-)
+GR2DF10P  42.05                                       10th percentile flux in 2D Green image (e-)
+RD2DF99P  62520.97                                    99th percentile flux in 2D Red image (e-)
+RD2DF90P  40589.16                                    90th percentile flux in 2D Red image (e-)
+RD2DF50P  613.23                                      50th percentile flux in 2D Red image (e-)
+RD2DF10P  128.83                                      10th percentile flux in 2D Red image (e-)
+HK2DF99P  62520.97                                    99th percentile flux in HK image (e-)
+HK2DF90P  40589.16                                    90th percentile flux in HK image (e-)
+HK2DF50P  613.23                                      50th percentile flux in HK image (e-)
+HK2DF10P  128.83                                      10th percentile flux in HK image (e-)
+FINTRG9F  44792.59462213099                           Flux inside 2D padded order trace regions (Green, 99.5th %ile, e-)
+FOUTRG9F  42712.30999372024                           Flux outside 2D padded order trace regions (Green, 99.5th %ile, e-)
+FRATRG9F  39266.75287925928                           Flux ratio (in/out) in 2D padded order trace regions (Green, 99.5th %ile)
+FINTRG99  32499.71441714234                           Flux inside 2D padded order trace regions (Green, 99th %ile, e-)
+FOUTRG99  24305.818315405733                          Flux outside 2D padded order trace regions (Green, 99th %ile, e-)
+FRATRG99  2111.0515642358464                          Flux ratio (in/out) in 2D padded order trace regions (Green, 99th %ile)
+FINTRG98  112.77464436023686                          Flux inside 2D padded order trace regions (Green, 98th %ile, e-)
+FOUTRG98  269.6901086358044                           Flux outside 2D padded order trace regions (Green, 98th %ile, e-)
+FRATRG98  255.33818562687816                          Flux ratio (in/out) in 2D padded order trace regions (Green, 98th %ile)
+FINTRG95  242.61130151516446                          Flux inside 2D padded order trace regions (Green, 95th %ile, e-)
+FOUTRG95  225.50535785752024                          Flux outside 2D padded order trace regions (Green, 95th %ile, e-)
+FRATRG95  210.497150778097                            Flux ratio (in/out) in 2D padded order trace regions (Green, 95th %ile)
+FINTRG90  139.25304642797374                          Flux inside 2D padded order trace regions (Green, 90th %ile, e-)
+FOUTRG90  52.17332932663871                           Flux outside 2D padded order trace regions (Green, 90th %ile, e-)
+FRATRG90  166.0891266969673                           Flux ratio (in/out) in 2D padded order trace regions (Green, 90th %ile)
+FINTRG50  167.27740854293958                          Flux inside 2D padded order trace regions (Green, median, e-)
+FOUTRG50  161.85046877053625                          Flux outside 2D padded order trace regions (Green, median, e-)
+FRATRG50  144.119477807159                            Flux ratio (in/out) in 2D padded order trace regions (Green, median)
+FINTRG10  115.4686333071965                           Flux inside 2D padded order trace regions (Green, 10th %ile, e-)
+FOUTRG10  15.15982320234374                           Flux outside 2D padded order trace regions (Green, 10th %ile, e-)
+FRATRG10  2.161538199990934                           Flux ratio (in/out) in 2D padded order trace regions (Green, 10th %ile)
+FINTRR9F  95470.82761046116                           Flux inside 2D padded order trace regions (Red, 99.5th %ile, e-)
+FOUTRR9F  92136.58954051501                           Flux outside 2D padded order trace regions (Red, 99.5th %ile, e-)
+FRATRR9F  88512.13858512425                           Flux ratio (in/out) in 2D padded order trace regions (Red, 99.5th %ile)
+FINTRR99  79526.37170911182                           Flux inside 2D padded order trace regions (Red, 99th %ile, e-)
+FOUTRR99  67332.19863683594                           Flux outside 2D padded order trace regions (Red, 99th %ile, e-)
+FRATRR99  12250.720295831863                          Flux ratio (in/out) in 2D padded order trace regions (Red, 99th %ile)
+FINTRR98  448.7579839841067                           Flux inside 2D padded order trace regions (Red, 98th %ile, e-)
+FOUTRR98  659.4143686055465                           Flux outside 2D padded order trace regions (Red, 98th %ile, e-)
+FRATRR98  573.7167008946659                           Flux ratio (in/out) in 2D padded order trace regions (Red, 98th %ile)
+FINTRR95  536.7420868538279                           Flux inside 2D padded order trace regions (Red, 95th %ile, e-)
+FOUTRR95  492.4004219159836                           Flux outside 2D padded order trace regions (Red, 95th %ile, e-)
+FRATRR95  449.5952349484368                           Flux ratio (in/out) in 2D padded order trace regions (Red, 95th %ile)
+FINTRR90  275.84219353528556                          Flux inside 2D padded order trace regions (Red, 90th %ile, e-)
+FOUTRR90  157.7923244678131                           Flux outside 2D padded order trace regions (Red, 90th %ile, e-)
+FRATRR90  144.78123643613023                          Flux ratio (in/out) in 2D padded order trace regions (Red, 90th %ile)
+FINTRR50  160.59596905029133                          Flux inside 2D padded order trace regions (Red, median, e-)
+FOUTRR50  164.9062757570359                           Flux outside 2D padded order trace regions (Red, median, e-()
+FRATRR50  161.50752145919384                          Flux ratio (in/out) in 2D padded order trace regions (Red, median)
+FINTRR10  149.7618155240416                           Flux inside 2D padded order trace regions (Red, 10th %ile, e-)
+FOUTRR10  44.41206089185467                           Flux outside 2D padded order trace regions (Red, 10th %ile, e-)
+FRATRR10  2.843978536330172                           Flux ratio (in/out) in 2D padded order trace regions (Red, 10th %ile)
+BIASFILE  kpf_20250510_master_bias_autocal-bias.fits  Master bias file used to process this 2D file
+DARKFILE  kpf_20250510_master_dark_autocal-dark.fits  Master dark file used to process this 2D file
+FLATFILE  kpf_20250510_master_flat.fits               Master flat file used to process this 2D file
+BIASDIR   '/data/masters/20250510/'                   Directory for BIASFILE
+DARKDIR   '/data/masters/20250510/'                   Directory for DARKFILE
+FLATDIR   '/data/masters/20250510/'                   Directory for FLATFILE
+BIASDONE  1                                           Bias subtracted
+DARKDONE  1                                           Dark subtracted
+FLATDONE  1                                           Flat divided
+AGEBIAS   0                                           Age of master bias file compared to this file (whole days)
+AGEDARK   0                                           Age of master dark file compared to this file (whole days)
+AGEFLAT   0                                           Age of master flat file compared to this file (whole days)
+XDSPDYG1  -15.93355                                   Green cross-dispersion offset [pix] compared to master reference
+XDSPDYR1  -15.86130                                   Red cross-dispersion offset [pix] compared to master reference
+XDSPDYG2  0.02673                                     Green cross-dispersion offset [pix] compared to reference in era
+XDSPDYR2  0.05026                                     Red cross-dispersion offset [pix] compared to reference in era
+XDSPSYG1  0.00133                                     Uncertainty [pix] in XDSPDYG1
+XDSPSYR1  0.00217                                     Uncertainty [pix] in XDSPDYR1
+XDSPSYG2  0.00144                                     Uncertainty [pix] in XDSPDYG2
+XDSPSYR2  0.00058                                     Uncertainty [pix] in XDSPDYR2
+DNIMEAS   500.0                                       Mean DNI from pyrheliometer during the exposure [W/m^2]
+DNICLR    500.0                                       Theoretical DNI in perfect conditions [W/m^2]
+DNIRMS    1.0                                         RMS of DNIMEAS during the exposure [W/m^2]
+CLEARIDX  3.0                                         SoCal clearness index (<4==CLEARSKY)
+========  ==========================================  =========
+
+Keywords related to read noise are only computed for the amplifiers used.  In regular read mode, two amplifiers are used (AMP1 and AMP2), while in fast read mode, four amplifiers are used (AMP1, AMP2, AMP3, and AMP4).
+
+Keywords related to dark current (starting with FLX) are only added for 2D files of Dark observations (no illumination and exposure time > 0). The regions for those keywords refer to the CCD coordinates where the dark current measurements were made (using modules/quicklook/arc/analyze_2d.py).  The image below (click to enlarge) shows the regions and dark current estimates for a 2D spectrum taken when the dark current was high.
+
+Keywords related to the Guider are only added for 2D files that have Guider data products.  Similar for Exposure Meter data products.
+
+Keywords related to L0 amplifier-image statistics (e.g., MEDGRN1) are only added to 2D files.  A robust estimator of data dispersion width is
+sigma = 0.5 * (P84 - P16), equivalent to one standard deviation for normally distributed data.
+
+.. image:: dark_current_example.png
+   :alt: Image of KPF Green CCD showing regions where dark current is measured
+   :align: center
+   :height: 400px
+   :width: 500px
+
+L1 Primary Extension Header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The L1 file inherits all L0 and 2D keywords.  Below are additional important keywords.
+
+========  =======================================================================  =========
+Keyword   Value (example)                                                          Comment
+========  =======================================================================  =========
+DRPTAG    v2.5.2                                                                   Git version number of KPF-Pipeline used to make L1 (in the time series database, DRPTAG is listed as DRPTAGL1 for L1 files)
+DRPHSH    'ccf5f6ebe0c9ae7d43706cc57fed2ecdeb540a17'                               Git commit hash version of KPF-Pipeline used to make L1 (in the time series database, DRPHSH is listed as DRPHSHL1 for L1 files)
+WLSFILE   /masters/20231230/kpf_20231230_master_WLS_autocal-lfc-all-eve_L1.fits    First wavelength interpolation reference for this L1 file
+WLSFILE2  /masters/20231231/kpf_20231231_master_WLS_autocal-lfc-all-morn_L1.fits   Second wavelength interpolation reference for this L1 file
+TRACFILE	 /masters/20250522/kpf_20250522_order_mask.fits                           Order trace file used to extract this L1 file
+TRACFGRN  /masters/20250522/kpf_20250522_master_flat_GREEN_CCD.csv                 Order trace file used to extract GREEN orders for this L1 file
+TRACFGRN  /masters/20250522/kpf_20250522_master_flat_RED_CCD.csv                   Order trace file used to extract RED orders for this L1 file
+EXTMETHK  'optimal'                                                                Extraction method used for SKY fibers
+EXTMETHS  'optimal'                                                                Extraction method used for SCI fibers
+EXTMETHC  'box'                                                                    Extraction method used for CAL fibers
+LAMPFILE  /masters/20250522/kpf_20250522_smooth_lamp.fits                          Smooth lamp file used to extract this L1 file
+MONOTWLS  1                                                                        QC: 1 = L1 wavelength solution is monotonic
+DATAPRL1  1                                                                        QC: 1 = L1 red and green data present
+CAHKPRL1  1                                                                        QC: 1 = CaHK data present in L1 with expected shape
+WLSL1     1                                                                        QC: 1 = L1 WLS file check passed
+LFCSAT    1                                                                        QC: 1 = L1 LFC spectrum not saturated
+OLDWLS    1                                                                        QC: 1 = WLSFILE within 2 days of this obs
+OLDWLS2   1                                                                        QC: 1 = WLSFILE2 within 2 days of this obs
+OLDTRAC   1                                                                        QC: 1 = TRACFILE within 5 days of this obs
+OLDLAMP   1                                                                        QC: 1 = LAMPFILE within 5 days of this obs
+FLATSNR   1                                                                        QC: 1 = SNR of flat greater minimum threshold and less than maximum threshold
+LFCLINES  1                                                                        QC: 1 = Number and distribution of LFC lines above threshold ampltidue is sufficient for all orders 2-34 (Green), 1-31 (Red)
+LFCLINEP  1                                                                        QC: 1 = Number and distribution of LFC lines above threshold ampltidue is sufficient for all orders 15-34 (Green), 1-31 (Red) - partial wavelength coverage
+ETALINES  1                                                                        QC: 1 = Number and distribution of Etalon lines above threshold ampltidue is sufficient for all orders/orderlets available
+WILDWSCI  1                                                                        QC: 1 = SCI WLS not wild (stdev compared to reference < 5 pixels)
+WILDWSKY  1                                                                        QC: 1 = SKY WLS not wild (stdev compared to reference < 5 pixels)
+WILDWCAL  1                                                                        QC: 1 = CAL WLS not wild (stdev compared to reference < 5 pixels)
+NANL1OK   1                                                                        QC: 1 = Number of NaNs in L1 (all orders, both chips) < 50
+NSATGS2   23                                                                       Number of saturated lines in Green SCI2
+NSATGC    23                                                                       Number of saturated lines in Green CAL
+NSATGK    23                                                                       Number of saturated lines in Green SKY
+NSATRS2   23                                                                       Number of saturated lines in Red SCI2
+NSATRC    23                                                                       Number of saturated lines in Red CAL
+NSATRK    23                                                                       Number of saturated lines in Red SKY
+SNRSC452  250.0                                                                    SNR of L1 SCI spectrum (SCI1+SCI2+SCI3; 95th %ile) near 452 nm (second bluest order); on Green CCD
+SNRSK452  250.0                                                                    SNR of L1 SKY spectrum (95th %ile) near 452 nm (second bluest order); on Green CCD
+SNRCL452  250.0                                                                    SNR of L1 CAL spectrum (95th %ile) near 452 nm (second bluest order); on Green CCD
+SNRSC548  250.0                                                                    SNR of L1 SCI spectrum (SCI1+SCI2+SCI3; 95th %ile) near 548 nm; on Green CCD
+SNRSK548  250.0                                                                    SNR of L1 SKY spectrum (95th %ile) near 548 nm; on Green CCD
+SNRCL548  250.0                                                                    SNR of L1 CAL spectrum (95th %ile) near 548 nm; on Green CCD
+SNRSC652  250.0                                                                    SNR of L1 SCI spectrum (SCI1+SCI2+SCI3; 95th %ile) near 652 nm; on Red CCD
+SNRSK652  250.0                                                                    SNR of L1 SKY spectrum (95th %ile) near 652 nm; on Red CCD
+SNRCL652  250.0                                                                    SNR of L1 CAL spectrum (95th %ile) near 652 nm; on Red CCD
+SNRSC747  250.0                                                                    SNR of L1 SCI spectrum (SCI1+SCI2+SCI3; 95th %ile) near 747 nm; on Red CCD
+SNRSK747  250.0                                                                    SNR of L1 SKY spectrum (95th %ile) near 747 nm; on Red CCD
+SNRCL747  250.0                                                                    SNR of L1 CAL spectrum (95th %ile) near 747 nm; on Red CCD
+SNRSC852  250.0                                                                    SNR of L1 SCI (SCI1+SCI2+SCI3; 95th %ile) near 852 nm (second reddest order); on Red CCD
+SNRSK852  250.0                                                                    SNR of L1 SKY spectrum (95th %ile) near 852 nm (second reddest order); on Red CCD
+SNRCL852  250.0                                                                    SNR of L1 CAL spectrum (95th %ile) near 852 nm (second reddest order); on Red CCD
+FR452652  1.2345                                                                   Peak flux ratio between orders (452nm/652nm) using SCI2
+FR548652  1.2345                                                                   Peak flux ratio between orders (548nm/652nm) using SCI2
+FR747652  1.2345                                                                   Peak flux ratio between orders (747nm/652nm) using SCI2
+FR852652  1.2345                                                                   Peak flux ratio between orders (852nm/652nm) using SCI2
+FR12M452  0.9000                                                                   median(SCI1/SCI2) flux ratio near 452 nm; on Green CCD
+FR12U452  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 452 nm; on Green CCD
+FR32M452  0.9000                                                                   median(SCI3/SCI2) flux ratio near 452 nm; on Green CCD
+FR32U452  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 452 nm; on Green CCD
+FRS2M452  0.9000                                                                   median(SKY/SCI2) flux ratio near 452 nm; on Green CCD
+FRS2U452  0.0010                                                                   uncertainty on the median(SKY/SCI2) flux ratio near 452 nm; on Green CCD
+FRC2M452  0.9000                                                                   median(CAL/SCI2) flux ratio near 452 nm; on Green CCD
+FRC2U452  0.0010                                                                   uncertainty on the median(CAL/SCI2) flux ratio near 452 nm; on Green CCD
+FR12M548  0.9000                                                                   median(SCI1/SCI2) flux ratio near 548 nm; on Green CCD
+FR12U548  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 548 nm; on Green CCD
+FR32M548  0.9000                                                                   median(SCI3/SCI2) flux ratio near 548 nm; on Green CCD
+FR32U548  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 548 nm; on Green CCD
+FRS2M548  0.9000                                                                   median(SKY/SCI2) flux ratio near 548 nm; on Green CCD
+FRS2U548  0.0010                                                                   uncertainty on the median(SKY/SCI2) flux ratio near 548 nm; on Green CCD
+FRC2M548  0.9000                                                                   median(CAL/SCI2) flux ratio near 548 nm; on Green CCD
+FRC2U548  0.0010                                                                   uncertainty on the median(CAL/SCI2) flux ratio near 548 nm; on Green CCD
+FR12M652  0.9000                                                                   median(SCI1/SCI2) flux ratio near 652 nm; on Red CCD
+FR12U652  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 652 nm; on Red CCD
+FR32M652  0.9000                                                                   median(SCI3/SCI2) flux ratio near 652 nm; on Red CCD
+FR32U652  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 652 nm; on Red CCD
+FRS2M652  0.9000                                                                   median(SKY/SCI2) flux ratio near 652 nm; on Red CCD
+FRS2U652  0.0010                                                                   uncertainty on the median(SKY/SCI2) flux ratio near 652 nm; on Red CCD
+FRC2M652  0.9000                                                                   median(CAL/SCI2) flux ratio near 652 nm; on Red CCD
+FRC2U652  0.0010                                                                   uncertainty on the median(CAL/SCI2) flux ratio near 652 nm; on Red CCD
+FR12M747  0.9000                                                                   median(SCI1/SCI2) flux ratio near 747 nm; on Red CCD
+FR12U747  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 747 nm; on Red CCD
+FR32M747  0.9000                                                                   median(SCI3/SCI2) flux ratio near 747 nm; on Red CCD
+FR32U747  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 747 nm; on Red CCD
+FRS2M747  0.9000                                                                   median(SKY/SCI2) flux ratio near 747 nm; on Red CCD
+FRS2U747  0.0010                                                                   uncertainty on the median(SKY/SCI2) flux ratio near 747 nm; on Red CCD
+FRC2M747  0.9000                                                                   median(CAL/SCI2) flux ratio near 747 nm; on Red CCD
+FRC2U747  0.0010                                                                   uncertainty on the median(CAL/SCI2) flux ratio near 747 nm; on Red CCD
+FR12M852  0.9000                                                                   median(SCI1/SCI2) flux ratio near 852 nm; on Red CCD
+FR12U852  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 852 nm; on Red CCD
+FR32M852  0.9000                                                                   median(SCI3/SCI2) flux ratio near 852 nm; on Red CCD
+FR32U852  0.0010                                                                   uncertainty on the median(SCI1/SCI2) flux ratio near 852 nm; on Red CCD
+FRS2M852  0.9000                                                                   median(SKY/SCI2) flux ratio near 852 nm; on Red CCD
+FRS2U852  0.0010                                                                   uncertainty on the median(SKY/SCI2) flux ratio near 852 nm; on Red CCD
+FRC2M852  0.9000                                                                   median(CAL/SCI2) flux ratio near 852 nm; on Red CCD
+FRC2U852  0.0010                                                                   uncertainty on the median(CAL/SCI2) flux ratio near 852 nm; on Red CCD
+SKYSCIMS  0.0000123                                                                SKY/SCI flux ratio in main spectrometer scaled from EM data. 
+EMSCCT48  100000000.1234                                                           cumulative EM counts [ADU] in SCI in 445-870 nm
+EMSCCT45  100000000.1234                                                           cumulative EM counts [ADU] in SCI in 445-551 nm
+EMSCCT56  100000000.1234                                                           cumulative EM counts [ADU] in SCI in 551-658 nm
+EMSCCT67  100000000.1234                                                           cumulative EM counts [ADU] in SCI in 658-764 nm
+EMSCCT78  100000000.1234                                                           cumulative EM counts [ADU] in SCI in 764-870 nm
+EMSKCT48  100000000.1234                                                           cumulative EM counts [ADU] in SKY in 445-870 nm
+EMSKCT45  100000000.1234                                                           cumulative EM counts [ADU] in SKY in 445-551 nm
+EMSKCT56  100000000.1234                                                           cumulative EM counts [ADU] in SKY in 551-658 nm
+EMSKCT67  100000000.1234                                                           cumulative EM counts [ADU] in SKY in 658-764 nm
+EMSKCT78  100000000.1234                                                           cumulative EM counts [ADU] in SKY in 764-870 nm
+LFCLGS0   0                                                                        Min SCI Green order with good LFC lines
+LFCLGS1   34                                                                       Max SCI Green order with good LFC lines
+LFCLGC0   0                                                                        Min CAL Green order with good LFC lines
+LFCLGC1   34                                                                       Max CAL Green order with good LFC lines
+LFCLGK0   0                                                                        Min SKY Green order with good LFC lines
+LFCLGK1   34                                                                       Max SKY Green order with good LFC lines
+LFCLRS0   0                                                                        Min SCI Red order with good LFC lines
+LFCLRS1   31                                                                       Max SCI Red order with good LFC lines
+LFCLRC0   0                                                                        Min CAL Red order with good LFC lines
+LFCLRC1   31                                                                       Max CAL Red order with good LFC lines
+LFCLRK0   0                                                                        Min SKY Red order with good LFC lines
+LFCLRK1   31                                                                       Max SKY Red order with good LFC lines
+ETALGS0   0                                                                        Min SCI Green order with good Etalon lines
+ETALGS1   34                                                                       Max SCI Green order with good Etalon lines
+ETALGC0   0                                                                        Min CAL Green order with good Etalon lines
+ETALGC1   34                                                                       Max CAL Green order with good Etalon lines
+ETALGK0   0                                                                        Min SKY Green order with good Etalon lines
+ETALGK1   34                                                                       Max SKY Green order with good Etalon lines
+ETALRS0   0                                                                        Min SCI Red order with good Etalon lines
+ETALRS1   31                                                                       Max SCI Red order with good Etalon lines
+ETALRC0   0                                                                        Min CAL Red order with good Etalon lines
+ETALRC1   31                                                                       Max CAL Red order with good Etalon lines
+ETALRK0   0                                                                        Min SKY Red order with good Etalon lines
+ETALRK1   31                                                                       Max SKY Red order with good Etalon lines
+AGEWLS    -0.2205656666666667                                                      Approx age of WLSFILE compared to this file (days)
+AGEWLS2   0.14193433333333330                                                      Approx age of WLSFILE2 compared to this file (days)
+AGETRAC   -0.2205656666666667                                                      Approx age of TRACFILE compared to this file (days)
+AGELAMP   0.14193433333333330                                                      Approx age of LAMPFILE compared to this file (days)
+STATWREF  /data/reference_fits/430LFCWLS.fits                                      filename of ref for median/stdev(WLS-ref)
+NANL1GS1  0                                                                        Number of NaNs in all orders of L1 Green SCI1
+NANL1GS2  0                                                                        Number of NaNs in all orders of L1 Green SCI2
+NANL1GS3  0                                                                        Number of NaNs in all orders of L1 Green SCI3
+NANL1GCL  0                                                                        Number of NaNs in all orders of L1 Green CAL
+NANL1GSK  0                                                                        Number of NaNs in all orders of L1 Green SKY
+NANL1RS1  0                                                                        Number of NaNs in all orders of L1 Red SCI1
+NANL1RS2  0                                                                        Number of NaNs in all orders of L1 Red SCI2
+NANL1RS3  0                                                                        Number of NaNs in all orders of L1 Red SCI3
+NANL1RCL  0                                                                        Number of NaNs in all orders of L1 Red CAL
+NANL1RSK  0                                                                        Number of NaNs in all orders of L1 Red SKY
+MEDWGS00  0.09425503797584399                                                      median(WLS-ref) [pix], Green SCI order 00       
+MEDWGS01  0.08849442069640202                                                      median(WLS-ref) [pix], Green SCI order 01       
+MEDWGS02  0.08371697673720710                                                      median(WLS-ref) [pix], Green SCI order 02       
+MEDWGS03  0.07230817847702598                                                      median(WLS-ref) [pix], Green SCI order 03       
+MEDWGS04  0.07193348907142433                                                      median(WLS-ref) [pix], Green SCI order 04       
+MEDWGS05  0.06293971912283422                                                      median(WLS-ref) [pix], Green SCI order 05       
+MEDWGS06  0.05077530529576392                                                      median(WLS-ref) [pix], Green SCI order 06       
+MEDWGS07  0.04623384357483791                                                      median(WLS-ref) [pix], Green SCI order 07       
+MEDWGS08  0.04122733863942630                                                      median(WLS-ref) [pix], Green SCI order 08       
+MEDWGS09  0.04133073040155002                                                      median(WLS-ref) [pix], Green SCI order 09       
+MEDWGS10  0.04083729926838733                                                      median(WLS-ref) [pix], Green SCI order 10       
+MEDWGS11  0.04227960238675732                                                      median(WLS-ref) [pix], Green SCI order 11       
+MEDWGS12  0.08484872198316575                                                      median(WLS-ref) [pix], Green SCI order 12       
+MEDWGS13  0.08393586844081193                                                      median(WLS-ref) [pix], Green SCI order 13       
+MEDWGS14  0.08276874070896721                                                      median(WLS-ref) [pix], Green SCI order 14       
+MEDWGS15  0.08521370837150342                                                      median(WLS-ref) [pix], Green SCI order 15       
+MEDWGS16  0.08327132770466454                                                      median(WLS-ref) [pix], Green SCI order 16       
+MEDWGS17  0.08582583111034116                                                      median(WLS-ref) [pix], Green SCI order 17       
+MEDWGS18  0.08304781196470204                                                      median(WLS-ref) [pix], Green SCI order 18       
+MEDWGS19  0.08315949296736645                                                      median(WLS-ref) [pix], Green SCI order 19       
+MEDWGS20  0.01080036766826940                                                      median(WLS-ref) [pix], Green SCI order 20       
+MEDWGS21  0.00971051734467042                                                      median(WLS-ref) [pix], Green SCI order 21       
+MEDWGS22  0.01159860516701642                                                      median(WLS-ref) [pix], Green SCI order 22       
+MEDWGS23  0.01184356604724085                                                      median(WLS-ref) [pix], Green SCI order 23       
+MEDWGS24  0.01154525605513285                                                      median(WLS-ref) [pix], Green SCI order 24       
+MEDWGS25  0.01147245109164928                                                      median(WLS-ref) [pix], Green SCI order 25       
+MEDWGS26  0.01092980897956587                                                      median(WLS-ref) [pix], Green SCI order 26       
+MEDWGS27  0.01147811995537022                                                      median(WLS-ref) [pix], Green SCI order 27       
+MEDWGS28  0.01290072360591021                                                      median(WLS-ref) [pix], Green SCI order 28       
+MEDWGS29  0.01082521041557961                                                      median(WLS-ref) [pix], Green SCI order 29       
+MEDWGS30  0.01187839614600258                                                      median(WLS-ref) [pix], Green SCI order 30       
+MEDWGS31  0.01217203007446422                                                      median(WLS-ref) [pix], Green SCI order 31       
+MEDWGS32  0.01114056458430155                                                      median(WLS-ref) [pix], Green SCI order 32       
+MEDWGS33  0.01028957107757591                                                      median(WLS-ref) [pix], Green SCI order 33       
+MEDWGS34  0.01339571095931450                                                      median(WLS-ref) [pix], Green SCI order 34       
+MEDWGK00                    0                                                      median(WLS-ref) [pix], Green SKY order 00       
+MEDWGK01                    0                                                      median(WLS-ref) [pix], Green SKY order 01       
+MEDWGK02                    0                                                      median(WLS-ref) [pix], Green SKY order 02       
+MEDWGK03                    0                                                      median(WLS-ref) [pix], Green SKY order 03       
+MEDWGK04                    0                                                      median(WLS-ref) [pix], Green SKY order 04       
+MEDWGK05                    0                                                      median(WLS-ref) [pix], Green SKY order 05       
+MEDWGK06                    0                                                      median(WLS-ref) [pix], Green SKY order 06       
+MEDWGK07                    0                                                      median(WLS-ref) [pix], Green SKY order 07       
+MEDWGK08                    0                                                      median(WLS-ref) [pix], Green SKY order 08       
+MEDWGK09                    0                                                      median(WLS-ref) [pix], Green SKY order 09       
+MEDWGK10                    0                                                      median(WLS-ref) [pix], Green SKY order 10       
+MEDWGK11                    0                                                      median(WLS-ref) [pix], Green SKY order 11       
+MEDWGK12                    0                                                      median(WLS-ref) [pix], Green SKY order 12       
+MEDWGK13                    0                                                      median(WLS-ref) [pix], Green SKY order 13       
+MEDWGK14                    0                                                      median(WLS-ref) [pix], Green SKY order 14       
+MEDWGK15                    0                                                      median(WLS-ref) [pix], Green SKY order 15       
+MEDWGK16                    0                                                      median(WLS-ref) [pix], Green SKY order 16       
+MEDWGK17                    0                                                      median(WLS-ref) [pix], Green SKY order 17       
+MEDWGK18                    0                                                      median(WLS-ref) [pix], Green SKY order 18       
+MEDWGK19                    0                                                      median(WLS-ref) [pix], Green SKY order 19       
+MEDWGK20                    0                                                      median(WLS-ref) [pix], Green SKY order 20       
+MEDWGK21                    0                                                      median(WLS-ref) [pix], Green SKY order 21       
+MEDWGK22                    0                                                      median(WLS-ref) [pix], Green SKY order 22       
+MEDWGK23                    0                                                      median(WLS-ref) [pix], Green SKY order 23       
+MEDWGK24                    0                                                      median(WLS-ref) [pix], Green SKY order 24       
+MEDWGK25                    0                                                      median(WLS-ref) [pix], Green SKY order 25       
+MEDWGK26                    0                                                      median(WLS-ref) [pix], Green SKY order 26       
+MEDWGK27                    0                                                      median(WLS-ref) [pix], Green SKY order 27       
+MEDWGK28                    0                                                      median(WLS-ref) [pix], Green SKY order 28       
+MEDWGK29                    0                                                      median(WLS-ref) [pix], Green SKY order 29       
+MEDWGK30                    0                                                      median(WLS-ref) [pix], Green SKY order 30       
+MEDWGK31                    0                                                      median(WLS-ref) [pix], Green SKY order 31       
+MEDWGK32                    0                                                      median(WLS-ref) [pix], Green SKY order 32       
+MEDWGK33                    0                                                      median(WLS-ref) [pix], Green SKY order 33       
+MEDWGK34                    0                                                      median(WLS-ref) [pix], Green SKY order 34       
+MEDWGC00                    0                                                      median(WLS-ref) [pix], Green CAL order 00       
+MEDWGC01                    0                                                      median(WLS-ref) [pix], Green CAL order 01       
+MEDWGC02                    0                                                      median(WLS-ref) [pix], Green CAL order 02       
+MEDWGC03                    0                                                      median(WLS-ref) [pix], Green CAL order 03       
+MEDWGC04                    0                                                      median(WLS-ref) [pix], Green CAL order 04       
+MEDWGC05                    0                                                      median(WLS-ref) [pix], Green CAL order 05       
+MEDWGC06                    0                                                      median(WLS-ref) [pix], Green CAL order 06       
+MEDWGC07                    0                                                      median(WLS-ref) [pix], Green CAL order 07       
+MEDWGC08                    0                                                      median(WLS-ref) [pix], Green CAL order 08       
+MEDWGC09                    0                                                      median(WLS-ref) [pix], Green CAL order 09       
+MEDWGC10                    0                                                      median(WLS-ref) [pix], Green CAL order 10       
+MEDWGC11                    0                                                      median(WLS-ref) [pix], Green CAL order 11       
+MEDWGC12  0.05655946244029121                                                      median(WLS-ref) [pix], Green CAL order 12       
+MEDWGC13  0.05512974209761621                                                      median(WLS-ref) [pix], Green CAL order 13       
+MEDWGC14  0.05620368994990578                                                      median(WLS-ref) [pix], Green CAL order 14       
+MEDWGC15  0.06086452902834840                                                      median(WLS-ref) [pix], Green CAL order 15       
+MEDWGC16  0.05689659903075574                                                      median(WLS-ref) [pix], Green CAL order 16       
+MEDWGC17  0.05799796936635278                                                      median(WLS-ref) [pix], Green CAL order 17       
+MEDWGC18  0.05977858081323324                                                      median(WLS-ref) [pix], Green CAL order 18       
+MEDWGC19  0.05933011664552964                                                      median(WLS-ref) [pix], Green CAL order 19       
+MEDWGC20  0.02039557347271826                                                      median(WLS-ref) [pix], Green CAL order 20       
+MEDWGC21  0.01469071164451269                                                      median(WLS-ref) [pix], Green CAL order 21       
+MEDWGC22  0.01556792950074907                                                      median(WLS-ref) [pix], Green CAL order 22       
+MEDWGC23  0.02567657109459727                                                      median(WLS-ref) [pix], Green CAL order 23       
+MEDWGC24  0.01886271649343081                                                      median(WLS-ref) [pix], Green CAL order 24       
+MEDWGC25  0.02467545689967796                                                      median(WLS-ref) [pix], Green CAL order 25       
+MEDWGC26  0.02253866767322533                                                      median(WLS-ref) [pix], Green CAL order 26       
+MEDWGC27  0.02413396211524686                                                      median(WLS-ref) [pix], Green CAL order 27       
+MEDWGC28  0.02614400310330867                                                      median(WLS-ref) [pix], Green CAL order 28       
+MEDWGC29  0.02065120343963631                                                      median(WLS-ref) [pix], Green CAL order 29       
+MEDWGC30  0.02496588560225525                                                      median(WLS-ref) [pix], Green CAL order 30       
+MEDWGC31  0.02372334722007593                                                      median(WLS-ref) [pix], Green CAL order 31       
+MEDWGC32  0.02298588484514256                                                      median(WLS-ref) [pix], Green CAL order 32       
+MEDWGC33  0.03174963955370602                                                      median(WLS-ref) [pix], Green CAL order 33       
+MEDWGC34  0.02994077329192967                                                      median(WLS-ref) [pix], Green CAL order 34       
+MEDWRS00  0.14737441778381707                                                      median(WLS-ref) [pix], Red SCI order 00         
+MEDWRS01  0.01605011658399845                                                      median(WLS-ref) [pix], Red SCI order 01         
+MEDWRS02  0.01251027957709054                                                      median(WLS-ref) [pix], Red SCI order 02         
+MEDWRS03  0.01208984476219253                                                      median(WLS-ref) [pix], Red SCI order 03         
+MEDWRS04  0.01404063413351495                                                      median(WLS-ref) [pix], Red SCI order 04         
+MEDWRS05  0.01120664703576910                                                      median(WLS-ref) [pix], Red SCI order 05         
+MEDWRS06  0.01216095722727351                                                      median(WLS-ref) [pix], Red SCI order 06         
+MEDWRS07  0.01235166659555654                                                      median(WLS-ref) [pix], Red SCI order 07         
+MEDWRS08  0.00949950978717383                                                      median(WLS-ref) [pix], Red SCI order 08         
+MEDWRS09  0.01021892014684022                                                      median(WLS-ref) [pix], Red SCI order 09         
+MEDWRS10  0.00980646922019491                                                      median(WLS-ref) [pix], Red SCI order 10         
+MEDWRS11  0.01101049313441161                                                      median(WLS-ref) [pix], Red SCI order 11         
+MEDWRS12  0.00919413709072650                                                      median(WLS-ref) [pix], Red SCI order 12         
+MEDWRS13  0.01056749073994317                                                      median(WLS-ref) [pix], Red SCI order 13         
+MEDWRS14  0.00968151304526763                                                      median(WLS-ref) [pix], Red SCI order 14         
+MEDWRS15  0.00747020456927852                                                      median(WLS-ref) [pix], Red SCI order 15         
+MEDWRS16  0.00900807961360823                                                      median(WLS-ref) [pix], Red SCI order 16         
+MEDWRS17  0.00793336762441429                                                      median(WLS-ref) [pix], Red SCI order 17         
+MEDWRS18  0.00809367089243644                                                      median(WLS-ref) [pix], Red SCI order 18         
+MEDWRS19  0.00817346044941215                                                      median(WLS-ref) [pix], Red SCI order 19         
+MEDWRS20  0.00810784393605007                                                      median(WLS-ref) [pix], Red SCI order 20         
+MEDWRS21  0.00863543252631332                                                      median(WLS-ref) [pix], Red SCI order 21         
+MEDWRS22  0.00667107242352223                                                      median(WLS-ref) [pix], Red SCI order 22         
+MEDWRS23  0.00964459955074390                                                      median(WLS-ref) [pix], Red SCI order 23         
+MEDWRS24  0.00782950831958490                                                      median(WLS-ref) [pix], Red SCI order 24         
+MEDWRS25  0.00818671288856180                                                      median(WLS-ref) [pix], Red SCI order 25         
+MEDWRS26  0.01089524201074648                                                      median(WLS-ref) [pix], Red SCI order 26         
+MEDWRS27  0.00942019614768527                                                      median(WLS-ref) [pix], Red SCI order 27         
+MEDWRS28  0.01388440717847755                                                      median(WLS-ref) [pix], Red SCI order 28         
+MEDWRS29  0.01300712812182218                                                      median(WLS-ref) [pix], Red SCI order 29         
+MEDWRS30  0.01196466888834003                                                      median(WLS-ref) [pix], Red SCI order 30         
+MEDWRS31  0.01086453356594114                                                      median(WLS-ref) [pix], Red SCI order 31         
+MEDWRK00                    0                                                      median(WLS-ref) [pix], Red SKY order 00         
+MEDWRK01                    0                                                      median(WLS-ref) [pix], Red SKY order 01         
+MEDWRK02                    0                                                      median(WLS-ref) [pix], Red SKY order 02         
+MEDWRK03                    0                                                      median(WLS-ref) [pix], Red SKY order 03         
+MEDWRK04                    0                                                      median(WLS-ref) [pix], Red SKY order 04         
+MEDWRK05                    0                                                      median(WLS-ref) [pix], Red SKY order 05         
+MEDWRK06                    0                                                      median(WLS-ref) [pix], Red SKY order 06         
+MEDWRK07                    0                                                      median(WLS-ref) [pix], Red SKY order 07         
+MEDWRK08                    0                                                      median(WLS-ref) [pix], Red SKY order 08         
+MEDWRK09                    0                                                      median(WLS-ref) [pix], Red SKY order 09         
+MEDWRK10                    0                                                      median(WLS-ref) [pix], Red SKY order 10         
+MEDWRK11                    0                                                      median(WLS-ref) [pix], Red SKY order 11         
+MEDWRK12                    0                                                      median(WLS-ref) [pix], Red SKY order 12         
+MEDWRK13                    0                                                      median(WLS-ref) [pix], Red SKY order 13         
+MEDWRK14                    0                                                      median(WLS-ref) [pix], Red SKY order 14         
+MEDWRK15                    0                                                      median(WLS-ref) [pix], Red SKY order 15         
+MEDWRK16                    0                                                      median(WLS-ref) [pix], Red SKY order 16         
+MEDWRK17                    0                                                      median(WLS-ref) [pix], Red SKY order 17         
+MEDWRK18                    0                                                      median(WLS-ref) [pix], Red SKY order 18         
+MEDWRK19                    0                                                      median(WLS-ref) [pix], Red SKY order 19         
+MEDWRK20                    0                                                      median(WLS-ref) [pix], Red SKY order 20         
+MEDWRK21                    0                                                      median(WLS-ref) [pix], Red SKY order 21         
+MEDWRK22                    0                                                      median(WLS-ref) [pix], Red SKY order 22         
+MEDWRK23                    0                                                      median(WLS-ref) [pix], Red SKY order 23         
+MEDWRK24                    0                                                      median(WLS-ref) [pix], Red SKY order 24         
+MEDWRK25                    0                                                      median(WLS-ref) [pix], Red SKY order 25         
+MEDWRK26                    0                                                      median(WLS-ref) [pix], Red SKY order 26         
+MEDWRK27                    0                                                      median(WLS-ref) [pix], Red SKY order 27         
+MEDWRK28                    0                                                      median(WLS-ref) [pix], Red SKY order 28         
+MEDWRK29                    0                                                      median(WLS-ref) [pix], Red SKY order 29         
+MEDWRK30                    0                                                      median(WLS-ref) [pix], Red SKY order 30         
+MEDWRK31                    0                                                      median(WLS-ref) [pix], Red SKY order 31         
+MEDWRC00                    0                                                      median(WLS-ref) [pix], Red CAL order 00         
+MEDWRC01  0.00686690781209765                                                      median(WLS-ref) [pix], Red CAL order 01         
+MEDWRC02  0.00545110970696466                                                      median(WLS-ref) [pix], Red CAL order 02         
+MEDWRC03  0.00689834810735561                                                      median(WLS-ref) [pix], Red CAL order 03         
+MEDWRC04  0.00539207715117377                                                      median(WLS-ref) [pix], Red CAL order 04         
+MEDWRC05  0.00906479431244748                                                      median(WLS-ref) [pix], Red CAL order 05         
+MEDWRC06  0.00955249018678067                                                      median(WLS-ref) [pix], Red CAL order 06         
+MEDWRC07  0.00686994366306185                                                      median(WLS-ref) [pix], Red CAL order 07         
+MEDWRC08  0.00697442855631850                                                      median(WLS-ref) [pix], Red CAL order 08         
+MEDWRC09  0.00841597646023265                                                      median(WLS-ref) [pix], Red CAL order 09         
+MEDWRC10  0.00710531878888686                                                      median(WLS-ref) [pix], Red CAL order 10         
+MEDWRC11  0.00882915651570540                                                      median(WLS-ref) [pix], Red CAL order 11         
+MEDWRC12  0.00844617425860556                                                      median(WLS-ref) [pix], Red CAL order 12         
+MEDWRC13  0.00392342808050990                                                      median(WLS-ref) [pix], Red CAL order 13         
+MEDWRC14  0.00855715540991054                                                      median(WLS-ref) [pix], Red CAL order 14         
+MEDWRC15  0.00636581146728872                                                      median(WLS-ref) [pix], Red CAL order 15         
+MEDWRC16  0.00756114195177540                                                      median(WLS-ref) [pix], Red CAL order 16         
+MEDWRC17  0.00614750391822687                                                      median(WLS-ref) [pix], Red CAL order 17         
+MEDWRC18  0.00653978088701918                                                      median(WLS-ref) [pix], Red CAL order 18         
+MEDWRC19  0.00543963863511228                                                      median(WLS-ref) [pix], Red CAL order 19         
+MEDWRC20  0.01389914991279786                                                      median(WLS-ref) [pix], Red CAL order 20         
+MEDWRC21  0.01080129994161541                                                      median(WLS-ref) [pix], Red CAL order 21         
+MEDWRC22  0.01100053582456254                                                      median(WLS-ref) [pix], Red CAL order 22         
+MEDWRC23  0.00760929632622137                                                      median(WLS-ref) [pix], Red CAL order 23         
+MEDWRC24  0.01795581160788173                                                      median(WLS-ref) [pix], Red CAL order 24         
+MEDWRC25  0.01264008430028203                                                      median(WLS-ref) [pix], Red CAL order 25         
+MEDWRC26  0.00793447409812340                                                      median(WLS-ref) [pix], Red CAL order 26         
+MEDWRC27  0.00781423522196742                                                      median(WLS-ref) [pix], Red CAL order 27         
+MEDWRC28  0.01379038876707553                                                      median(WLS-ref) [pix], Red CAL order 28         
+MEDWRC29  0.00914032555395159                                                      median(WLS-ref) [pix], Red CAL order 29         
+MEDWRC30  0.01440898205622853                                                      median(WLS-ref) [pix], Red CAL order 30         
+MEDWRC31  0.00899757354138056                                                      median(WLS-ref) [pix], Red CAL order 31         
+STDWGS00  0.09425503797584399                                                      stddev(WLS-ref) [pix], Green SCI order 00       
+STDWGS01  0.08849442069640202                                                      stddev(WLS-ref) [pix], Green SCI order 01       
+STDWGS02  0.08371697673720710                                                      stddev(WLS-ref) [pix], Green SCI order 02       
+STDWGS03  0.07230817847702598                                                      stddev(WLS-ref) [pix], Green SCI order 03       
+STDWGS04  0.07193348907142433                                                      stddev(WLS-ref) [pix], Green SCI order 04       
+STDWGS05  0.06293971912283422                                                      stddev(WLS-ref) [pix], Green SCI order 05       
+STDWGS06  0.05077530529576392                                                      stddev(WLS-ref) [pix], Green SCI order 06       
+STDWGS07  0.04623384357483791                                                      stddev(WLS-ref) [pix], Green SCI order 07       
+STDWGS08  0.04122733863942630                                                      stddev(WLS-ref) [pix], Green SCI order 08       
+STDWGS09  0.04133073040155002                                                      stddev(WLS-ref) [pix], Green SCI order 09       
+STDWGS10  0.04083729926838733                                                      stddev(WLS-ref) [pix], Green SCI order 10       
+STDWGS11  0.04227960238675732                                                      stddev(WLS-ref) [pix], Green SCI order 11       
+STDWGS12  0.08484872198316575                                                      stddev(WLS-ref) [pix], Green SCI order 12       
+STDWGS13  0.08393586844081193                                                      stddev(WLS-ref) [pix], Green SCI order 13       
+STDWGS14  0.08276874070896721                                                      stddev(WLS-ref) [pix], Green SCI order 14       
+STDWGS15  0.08521370837150342                                                      stddev(WLS-ref) [pix], Green SCI order 15       
+STDWGS16  0.08327132770466454                                                      stddev(WLS-ref) [pix], Green SCI order 16       
+STDWGS17  0.08582583111034116                                                      stddev(WLS-ref) [pix], Green SCI order 17       
+STDWGS18  0.08304781196470204                                                      stddev(WLS-ref) [pix], Green SCI order 18       
+STDWGS19  0.08315949296736645                                                      stddev(WLS-ref) [pix], Green SCI order 19       
+STDWGS20  0.01080036766826940                                                      stddev(WLS-ref) [pix], Green SCI order 20       
+STDWGS21  0.00971051734467042                                                      stddev(WLS-ref) [pix], Green SCI order 21       
+STDWGS22  0.01159860516701642                                                      stddev(WLS-ref) [pix], Green SCI order 22       
+STDWGS23  0.01184356604724085                                                      stddev(WLS-ref) [pix], Green SCI order 23       
+STDWGS24  0.01154525605513285                                                      stddev(WLS-ref) [pix], Green SCI order 24       
+STDWGS25  0.01147245109164928                                                      stddev(WLS-ref) [pix], Green SCI order 25       
+STDWGS26  0.01092980897956587                                                      stddev(WLS-ref) [pix], Green SCI order 26       
+STDWGS27  0.01147811995537022                                                      stddev(WLS-ref) [pix], Green SCI order 27       
+STDWGS28  0.01290072360591021                                                      stddev(WLS-ref) [pix], Green SCI order 28       
+STDWGS29  0.01082521041557961                                                      stddev(WLS-ref) [pix], Green SCI order 29       
+STDWGS30  0.01187839614600258                                                      stddev(WLS-ref) [pix], Green SCI order 30       
+STDWGS31  0.01217203007446422                                                      stddev(WLS-ref) [pix], Green SCI order 31       
+STDWGS32  0.01114056458430155                                                      stddev(WLS-ref) [pix], Green SCI order 32       
+STDWGS33  0.01028957107757591                                                      stddev(WLS-ref) [pix], Green SCI order 33       
+STDWGS34  0.01339571095931450                                                      stddev(WLS-ref) [pix], Green SCI order 34       
+STDWGK00                    0                                                      stddev(WLS-ref) [pix], Green SKY order 00       
+STDWGK01                    0                                                      stddev(WLS-ref) [pix], Green SKY order 01       
+STDWGK02                    0                                                      stddev(WLS-ref) [pix], Green SKY order 02       
+STDWGK03                    0                                                      stddev(WLS-ref) [pix], Green SKY order 03       
+STDWGK04                    0                                                      stddev(WLS-ref) [pix], Green SKY order 04       
+STDWGK05                    0                                                      stddev(WLS-ref) [pix], Green SKY order 05       
+STDWGK06                    0                                                      stddev(WLS-ref) [pix], Green SKY order 06       
+STDWGK07                    0                                                      stddev(WLS-ref) [pix], Green SKY order 07       
+STDWGK08                    0                                                      stddev(WLS-ref) [pix], Green SKY order 08       
+STDWGK09                    0                                                      stddev(WLS-ref) [pix], Green SKY order 09       
+STDWGK10                    0                                                      stddev(WLS-ref) [pix], Green SKY order 10       
+STDWGK11                    0                                                      stddev(WLS-ref) [pix], Green SKY order 11       
+STDWGK12                    0                                                      stddev(WLS-ref) [pix], Green SKY order 12       
+STDWGK13                    0                                                      stddev(WLS-ref) [pix], Green SKY order 13       
+STDWGK14                    0                                                      stddev(WLS-ref) [pix], Green SKY order 14       
+STDWGK15                    0                                                      stddev(WLS-ref) [pix], Green SKY order 15       
+STDWGK16                    0                                                      stddev(WLS-ref) [pix], Green SKY order 16       
+STDWGK17                    0                                                      stddev(WLS-ref) [pix], Green SKY order 17       
+STDWGK18                    0                                                      stddev(WLS-ref) [pix], Green SKY order 18       
+STDWGK19                    0                                                      stddev(WLS-ref) [pix], Green SKY order 19       
+STDWGK20                    0                                                      stddev(WLS-ref) [pix], Green SKY order 20       
+STDWGK21                    0                                                      stddev(WLS-ref) [pix], Green SKY order 21       
+STDWGK22                    0                                                      stddev(WLS-ref) [pix], Green SKY order 22       
+STDWGK23                    0                                                      stddev(WLS-ref) [pix], Green SKY order 23       
+STDWGK24                    0                                                      stddev(WLS-ref) [pix], Green SKY order 24       
+STDWGK25                    0                                                      stddev(WLS-ref) [pix], Green SKY order 25       
+STDWGK26                    0                                                      stddev(WLS-ref) [pix], Green SKY order 26       
+STDWGK27                    0                                                      stddev(WLS-ref) [pix], Green SKY order 27       
+STDWGK28                    0                                                      stddev(WLS-ref) [pix], Green SKY order 28       
+STDWGK29                    0                                                      stddev(WLS-ref) [pix], Green SKY order 29       
+STDWGK30                    0                                                      stddev(WLS-ref) [pix], Green SKY order 30       
+STDWGK31                    0                                                      stddev(WLS-ref) [pix], Green SKY order 31       
+STDWGK32                    0                                                      stddev(WLS-ref) [pix], Green SKY order 32       
+STDWGK33                    0                                                      stddev(WLS-ref) [pix], Green SKY order 33       
+STDWGK34                    0                                                      stddev(WLS-ref) [pix], Green SKY order 34       
+STDWGC00                    0                                                      stddev(WLS-ref) [pix], Green CAL order 00       
+STDWGC01                    0                                                      stddev(WLS-ref) [pix], Green CAL order 01       
+STDWGC02                    0                                                      stddev(WLS-ref) [pix], Green CAL order 02       
+STDWGC03                    0                                                      stddev(WLS-ref) [pix], Green CAL order 03       
+STDWGC04                    0                                                      stddev(WLS-ref) [pix], Green CAL order 04       
+STDWGC05                    0                                                      stddev(WLS-ref) [pix], Green CAL order 05       
+STDWGC06                    0                                                      stddev(WLS-ref) [pix], Green CAL order 06       
+STDWGC07                    0                                                      stddev(WLS-ref) [pix], Green CAL order 07       
+STDWGC08                    0                                                      stddev(WLS-ref) [pix], Green CAL order 08       
+STDWGC09                    0                                                      stddev(WLS-ref) [pix], Green CAL order 09       
+STDWGC10                    0                                                      stddev(WLS-ref) [pix], Green CAL order 10       
+STDWGC11                    0                                                      stddev(WLS-ref) [pix], Green CAL order 11       
+STDWGC12  0.05655946244029121                                                      stddev(WLS-ref) [pix], Green CAL order 12       
+STDWGC13  0.05512974209761621                                                      stddev(WLS-ref) [pix], Green CAL order 13       
+STDWGC14  0.05620368994990578                                                      stddev(WLS-ref) [pix], Green CAL order 14       
+STDWGC15  0.06086452902834840                                                      stddev(WLS-ref) [pix], Green CAL order 15       
+STDWGC16  0.05689659903075574                                                      stddev(WLS-ref) [pix], Green CAL order 16       
+STDWGC17  0.05799796936635278                                                      stddev(WLS-ref) [pix], Green CAL order 17       
+STDWGC18  0.05977858081323324                                                      stddev(WLS-ref) [pix], Green CAL order 18       
+STDWGC19  0.05933011664552964                                                      stddev(WLS-ref) [pix], Green CAL order 19       
+STDWGC20  0.02039557347271826                                                      stddev(WLS-ref) [pix], Green CAL order 20       
+STDWGC21  0.01469071164451269                                                      stddev(WLS-ref) [pix], Green CAL order 21       
+STDWGC22  0.01556792950074907                                                      stddev(WLS-ref) [pix], Green CAL order 22       
+STDWGC23  0.02567657109459727                                                      stddev(WLS-ref) [pix], Green CAL order 23       
+STDWGC24  0.01886271649343081                                                      stddev(WLS-ref) [pix], Green CAL order 24       
+STDWGC25  0.02467545689967796                                                      stddev(WLS-ref) [pix], Green CAL order 25       
+STDWGC26  0.02253866767322533                                                      stddev(WLS-ref) [pix], Green CAL order 26       
+STDWGC27  0.02413396211524686                                                      stddev(WLS-ref) [pix], Green CAL order 27       
+STDWGC28  0.02614400310330867                                                      stddev(WLS-ref) [pix], Green CAL order 28       
+STDWGC29  0.02065120343963631                                                      stddev(WLS-ref) [pix], Green CAL order 29       
+STDWGC30  0.02496588560225525                                                      stddev(WLS-ref) [pix], Green CAL order 30       
+STDWGC31  0.02372334722007593                                                      stddev(WLS-ref) [pix], Green CAL order 31       
+STDWGC32  0.02298588484514256                                                      stddev(WLS-ref) [pix], Green CAL order 32       
+STDWGC33  0.03174963955370602                                                      stddev(WLS-ref) [pix], Green CAL order 33       
+STDWGC34  0.02994077329192967                                                      stddev(WLS-ref) [pix], Green CAL order 34       
+STDWRS00  0.14737441778381707                                                      stddev(WLS-ref) [pix], Red SCI order 00         
+STDWRS01  0.01605011658399845                                                      stddev(WLS-ref) [pix], Red SCI order 01         
+STDWRS02  0.01251027957709054                                                      stddev(WLS-ref) [pix], Red SCI order 02         
+STDWRS03  0.01208984476219253                                                      stddev(WLS-ref) [pix], Red SCI order 03         
+STDWRS04  0.01404063413351495                                                      stddev(WLS-ref) [pix], Red SCI order 04         
+STDWRS05  0.01120664703576910                                                      stddev(WLS-ref) [pix], Red SCI order 05         
+STDWRS06  0.01216095722727351                                                      stddev(WLS-ref) [pix], Red SCI order 06         
+STDWRS07  0.01235166659555654                                                      stddev(WLS-ref) [pix], Red SCI order 07         
+STDWRS08  0.00949950978717383                                                      stddev(WLS-ref) [pix], Red SCI order 08         
+STDWRS09  0.01021892014684022                                                      stddev(WLS-ref) [pix], Red SCI order 09         
+STDWRS10  0.00980646922019491                                                      stddev(WLS-ref) [pix], Red SCI order 10         
+STDWRS11  0.01101049313441161                                                      stddev(WLS-ref) [pix], Red SCI order 11         
+STDWRS12  0.00919413709072650                                                      stddev(WLS-ref) [pix], Red SCI order 12         
+STDWRS13  0.01056749073994317                                                      stddev(WLS-ref) [pix], Red SCI order 13         
+STDWRS14  0.00968151304526763                                                      stddev(WLS-ref) [pix], Red SCI order 14         
+STDWRS15  0.00747020456927852                                                      stddev(WLS-ref) [pix], Red SCI order 15         
+STDWRS16  0.00900807961360823                                                      stddev(WLS-ref) [pix], Red SCI order 16         
+STDWRS17  0.00793336762441429                                                      stddev(WLS-ref) [pix], Red SCI order 17         
+STDWRS18  0.00809367089243644                                                      stddev(WLS-ref) [pix], Red SCI order 18         
+STDWRS19  0.00817346044941215                                                      stddev(WLS-ref) [pix], Red SCI order 19         
+STDWRS20  0.00810784393605007                                                      stddev(WLS-ref) [pix], Red SCI order 20         
+STDWRS21  0.00863543252631332                                                      stddev(WLS-ref) [pix], Red SCI order 21         
+STDWRS22  0.00667107242352223                                                      stddev(WLS-ref) [pix], Red SCI order 22         
+STDWRS23  0.00964459955074390                                                      stddev(WLS-ref) [pix], Red SCI order 23         
+STDWRS24  0.00782950831958490                                                      stddev(WLS-ref) [pix], Red SCI order 24         
+STDWRS25  0.00818671288856180                                                      stddev(WLS-ref) [pix], Red SCI order 25         
+STDWRS26  0.01089524201074648                                                      stddev(WLS-ref) [pix], Red SCI order 26         
+STDWRS27  0.00942019614768527                                                      stddev(WLS-ref) [pix], Red SCI order 27         
+STDWRS28  0.01388440717847755                                                      stddev(WLS-ref) [pix], Red SCI order 28         
+STDWRS29  0.01300712812182218                                                      stddev(WLS-ref) [pix], Red SCI order 29         
+STDWRS30  0.01196466888834003                                                      stddev(WLS-ref) [pix], Red SCI order 30         
+STDWRS31  0.01086453356594114                                                      stddev(WLS-ref) [pix], Red SCI order 31         
+STDWRK00                    0                                                      stddev(WLS-ref) [pix], Red SKY order 00         
+STDWRK01                    0                                                      stddev(WLS-ref) [pix], Red SKY order 01         
+STDWRK02                    0                                                      stddev(WLS-ref) [pix], Red SKY order 02         
+STDWRK03                    0                                                      stddev(WLS-ref) [pix], Red SKY order 03         
+STDWRK04                    0                                                      stddev(WLS-ref) [pix], Red SKY order 04         
+STDWRK05                    0                                                      stddev(WLS-ref) [pix], Red SKY order 05         
+STDWRK06                    0                                                      stddev(WLS-ref) [pix], Red SKY order 06         
+STDWRK07                    0                                                      stddev(WLS-ref) [pix], Red SKY order 07         
+STDWRK08                    0                                                      stddev(WLS-ref) [pix], Red SKY order 08         
+STDWRK09                    0                                                      stddev(WLS-ref) [pix], Red SKY order 09         
+STDWRK10                    0                                                      stddev(WLS-ref) [pix], Red SKY order 10         
+STDWRK11                    0                                                      stddev(WLS-ref) [pix], Red SKY order 11         
+STDWRK12                    0                                                      stddev(WLS-ref) [pix], Red SKY order 12         
+STDWRK13                    0                                                      stddev(WLS-ref) [pix], Red SKY order 13         
+STDWRK14                    0                                                      stddev(WLS-ref) [pix], Red SKY order 14         
+STDWRK15                    0                                                      stddev(WLS-ref) [pix], Red SKY order 15         
+STDWRK16                    0                                                      stddev(WLS-ref) [pix], Red SKY order 16         
+STDWRK17                    0                                                      stddev(WLS-ref) [pix], Red SKY order 17         
+STDWRK18                    0                                                      stddev(WLS-ref) [pix], Red SKY order 18         
+STDWRK19                    0                                                      stddev(WLS-ref) [pix], Red SKY order 19         
+STDWRK20                    0                                                      stddev(WLS-ref) [pix], Red SKY order 20         
+STDWRK21                    0                                                      stddev(WLS-ref) [pix], Red SKY order 21         
+STDWRK22                    0                                                      stddev(WLS-ref) [pix], Red SKY order 22         
+STDWRK23                    0                                                      stddev(WLS-ref) [pix], Red SKY order 23         
+STDWRK24                    0                                                      stddev(WLS-ref) [pix], Red SKY order 24         
+STDWRK25                    0                                                      stddev(WLS-ref) [pix], Red SKY order 25         
+STDWRK26                    0                                                      stddev(WLS-ref) [pix], Red SKY order 26         
+STDWRK27                    0                                                      stddev(WLS-ref) [pix], Red SKY order 27         
+STDWRK28                    0                                                      stddev(WLS-ref) [pix], Red SKY order 28         
+STDWRK29                    0                                                      stddev(WLS-ref) [pix], Red SKY order 29         
+STDWRK30                    0                                                      stddev(WLS-ref) [pix], Red SKY order 30         
+STDWRK31                    0                                                      stddev(WLS-ref) [pix], Red SKY order 31         
+STDWRC00                    0                                                      stddev(WLS-ref) [pix], Red CAL order 00         
+STDWRC01  0.00686690781209765                                                      stddev(WLS-ref) [pix], Red CAL order 01         
+STDWRC02  0.00545110970696466                                                      stddev(WLS-ref) [pix], Red CAL order 02         
+STDWRC03  0.00689834810735561                                                      stddev(WLS-ref) [pix], Red CAL order 03         
+STDWRC04  0.00539207715117377                                                      stddev(WLS-ref) [pix], Red CAL order 04         
+STDWRC05  0.00906479431244748                                                      stddev(WLS-ref) [pix], Red CAL order 05         
+STDWRC06  0.00955249018678067                                                      stddev(WLS-ref) [pix], Red CAL order 06         
+STDWRC07  0.00686994366306185                                                      stddev(WLS-ref) [pix], Red CAL order 07         
+STDWRC08  0.00697442855631850                                                      stddev(WLS-ref) [pix], Red CAL order 08         
+STDWRC09  0.00841597646023265                                                      stddev(WLS-ref) [pix], Red CAL order 09         
+STDWRC10  0.00710531878888686                                                      stddev(WLS-ref) [pix], Red CAL order 10         
+STDWRC11  0.00882915651570540                                                      stddev(WLS-ref) [pix], Red CAL order 11         
+STDWRC12  0.00844617425860556                                                      stddev(WLS-ref) [pix], Red CAL order 12         
+STDWRC13  0.00392342808050990                                                      stddev(WLS-ref) [pix], Red CAL order 13         
+STDWRC14  0.00855715540991054                                                      stddev(WLS-ref) [pix], Red CAL order 14         
+STDWRC15  0.00636581146728872                                                      stddev(WLS-ref) [pix], Red CAL order 15         
+STDWRC16  0.00756114195177540                                                      stddev(WLS-ref) [pix], Red CAL order 16         
+STDWRC17  0.00614750391822687                                                      stddev(WLS-ref) [pix], Red CAL order 17         
+STDWRC18  0.00653978088701918                                                      stddev(WLS-ref) [pix], Red CAL order 18         
+STDWRC19  0.00543963863511228                                                      stddev(WLS-ref) [pix], Red CAL order 19         
+STDWRC20  0.01389914991279786                                                      stddev(WLS-ref) [pix], Red CAL order 20         
+STDWRC21  0.01080129994161541                                                      stddev(WLS-ref) [pix], Red CAL order 21         
+STDWRC22  0.01100053582456254                                                      stddev(WLS-ref) [pix], Red CAL order 22         
+STDWRC23  0.00760929632622137                                                      stddev(WLS-ref) [pix], Red CAL order 23         
+STDWRC24  0.01795581160788173                                                      stddev(WLS-ref) [pix], Red CAL order 24         
+STDWRC25  0.01264008430028203                                                      stddev(WLS-ref) [pix], Red CAL order 25         
+STDWRC26  0.00793447409812340                                                      stddev(WLS-ref) [pix], Red CAL order 26         
+STDWRC27  0.00781423522196742                                                      stddev(WLS-ref) [pix], Red CAL order 27         
+STDWRC28  0.01379038876707553                                                      stddev(WLS-ref) [pix], Red CAL order 28         
+STDWRC29  0.00914032555395159                                                      stddev(WLS-ref) [pix], Red CAL order 29         
+STDWRC30  0.01440898205622853                                                      stddev(WLS-ref) [pix], Red CAL order 30         
+STDWRC31  0.00899757354138056                                                      stddev(WLS-ref) [pix], Red CAL order 31         
+========  =======================================================================  =========
+
+The keywords above related to the signal-to-noise ratio in L1 spectra all start with 'SNR'.  These measurements were made using modules/quicklook/src/analyze_l1.py.  The image below (click to enlarge) shows the spectral orders and wavelengths at which SNR is measured.
+
+Keywords related to flux ratios between orders (FR452652, FR548652, FR747652, FR852652) are the ratios between the 95th percentile in flux for the spectral orders containing 452 nm, 548 nm, 747 nm, and 852 nm, all normalized by the spectral order containing 652 nm.  These are the same spectral orders used for the SNR calculations and use the SCI2 orderlet.
+
+Keywords related to orderlet flux ratios (e.g., FR12M452 and its uncertainty FR12U452) are computed in 500-pixel regions in the centers in the same spectral orders as are used for the SNR calculations.
+
+.. image:: KPF_L1_SNR.png
+   :alt: L1 Spectrum show wavelengths where SNR is measured
+   :align: center
+   :height: 400px
+   :width: 600px
+
+L2 Primary Extension Header
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The L2 file inherits all L0, 2D, and L1 keywords.  Below are additional important keywords.
+
+========  ==========================================  =========
+Keyword   Value (example)                             Comment
+========  ==========================================  =========
+DRPTAG    v2.5.2                                      Git version number of KPF-Pipeline used to make L2 (in the time series database, DRPTAG is listed as DRPTAGL2 for L2 files)
+DRPHSH    'ccf5f6ebe0c9ae7d43706cc57fed2ecdeb540a17'  Git commit hash version of KPF-Pipeline used to make L2 (in the time series database, DRPHSH is listed as DRPHSHL2 for L2 files)
+TIMCHKL2  1                                           QC: 1 = consistent times in L2 file
+DATAPRL2  1                                           QC: 1 = L2 data is present
+QCPCBCV   1                                           QC: 1 = PCBCV values within acceptable range
+CCFRV     19.4247572623                               Average of CCD1RV and CCD2RV using weights from RV table
+CCFERV    0.001175044                                 Error on CCFRV
+CCFRVC    19.4247572623                               Average of CCD1RVC and CCD2RVC using weights from RV table
+CCFERVC   0.001175044                                 Error on CCFRVC
+CCFBJD    2460662.094073044                           Weighted average of BJD times for spectral orders (for solar observations, HJD is used)
+CCFBCV    21.751977696646478                          Weighted average of barycentric RV (km/s) for spectral orders
+BJDSTD    41.66004757176901                           Weighted stddev of BJD for spectral orders (sec) (for solar observations, HJD is used)
+BJDRNG    147.1386909484863                           Range(BJD) for non-zero-weight spectral orders (sec)
+BCVSTD    0.7123626558325037                          Weighted stddev of BCV for spectral orders (m/s)
+BCVRNG    2.516760888678249                           Range(BCV) for non-zero-weight spectral orders (m/s)
+MAXPCBCV  0.6894375932041458                          Maximum % change from CCFBCV for non-zero-weight spectral orders (%)
+MINPCBCV  -0.47031634755679774                        Minimum % change from CCFBCV for non-zero-weight spectral orders (%)
+DRFTOBS   KP.20250708.20189.17                        ObsID of 1st reference drift observation
+DRFTOBS2  KP.20250708.20189.17                        ObsID of 2nd reference drift observation
+DRFTDEL   1.2114297222222221                          Time to 1st drift correction observation (hr)
+DRFTDEL2  1.2114297222222221                          Time to 2nd drift correction observation (hr)
+DRFTCOR   1                                           Drift correction applied (true/false)
+DRFTRV    0.2738220612333333                          Drift correction RV (m/s)
+DRFTMETH  nearest_interpolation                       Drift correction method name
+AGESLFC   0.621                                       Days since last good LFC frame (depends on processing order)
+AGEULFC   0.621                                       Days until next good LFC frame (depends on processing order)
+AGESETA   0.621                                       Days since last good Etalon frame (depends on processing order)
+AGEUETA   0.621                                       Days until next good Etalon frame (depends on processing order)
+========  ==========================================  =========
+
+L2 RV Extension Header
+^^^^^^^^^^^^^^^^^^^^^^
+
+The header to the RV extension (not the primary extension) contains this information about RVs computed using the CCF technique. CCD1 refers to the Green CCD (445-600 nm) and CCD2 refers to the Red CCD (600-870 nm).
+
+To-do, add notes on: 
+
+- recommendations for which RVs to use in papers
+- how the orders are averaged using weights.  
+- precisely how the RVs are computed (refer to a paper on the CCF algorithm that we're using)
+- how the errors are computed
+- is BJD = BJD :sub:`TBD`? 
+- Test equation for rst syntax: :math:`y = x^2`
+
+=============  =================  =========
+Keyword        Value (example)    Comment
+=============  =================  =========
+CCD1ROW        0                  Row number in the RV table (below) of the bluest order on the Green CCD
+CCD1RV1        19.4247572623      RV (km/s) of SCI1 (all orders, Green CCD); corrected for barycentric RV
+CCD1ERV1       0.0013815112       Error on CCD1RV1
+CCD1RV2        19.3879442221      RV (km/s) of SCI2 (all orders, Green CCD); corrected for barycentric RV
+CCD1ERV2       0.001175044        Error on CCD1RV2
+CCD1RV3        19.3740241724      RV (km/s) of SCI3 (all orders, Green CCD); corrected for barycentric RV
+CCD1ERV3       0.0012185926       Error on CCD1RV3
+CCD1RVC        0.0                RV (km/s) of CAL (all orders, Green CCD); corrected for barycentric RV
+CCD1ERVC        0.0                Error on CCD1RVC
+CCD1RVS        18.2490292404      RV (km/s) of SKY (all orders, Green CCD); corrected for barycentric RV
+CCD1ERVS       0.0                Error on CCD1RVS
+CCD1RV         19.395608349       RV (km/s) of average of SCI1/SCI2/SCI3 (all orders, Green CCD); corrected for barycentric RV
+CCD1ERV        0.0007214256       Error on CCD1RV  
+CCD1BJD        2460237.787166463  Photon-weighted mid-time (BJD) for CCD1RV (for solar observations, HJD is used)
+CCD2ROW        35                 Row number in the RV table (below) of the bluest order on the Red CCD
+CCD2RV1        19.4423673077      RV (km/s) of SCI1 (all orders, Red CCD); corrected for barycentric RV
+CCD2ERV1       0.004087698        Error on CCD2RV1
+CCD2RV2        19.3979186805      RV (km/s) of SCI2 (all orders, Red CCD); corrected for barycentric RV
+CCD2ERV2       0.0034324475       Error on CCD2RV2
+CCD2RV3        19.3808011301      RV (km/s) of SCI3 (all orders, Red CCD); corrected for barycentric RV
+CCD2ERV3       0.0035412025       Error on CCD2RV3
+CCD2RVC        0.0                RV (km/s) of CAL (all orders, Red CCD); corrected for barycentric RV
+CCD2ERVC       0.0                Error on CCD2RVC
+CCD2RVS        51.9730319697      RV (km/s) of SKY (all orders, Red CCD); corrected for barycentric RV
+CCD2ERVS       0.0                Error on CCD2RVS
+CCD2RV         19.4069470745      RV (km/s) of average of SCI1/SCI2/SCI3 (all orders, Red CCD); corrected for barycentric RV
+CCD2ERV        0.0021111409       Error on CCD2RV  
+CCD2BJD        2460237.787150946  Photon-weighted mid-time (BJD) for CCD2RV (for solar observations, HJD is used)
+=============  =================  =========
+
+L2 RV Extension
+^^^^^^^^^^^^^^^
+
+The RV extension in an L2 file contains the order-by-order RV information for each orderlet (SCI1, SCI2, SCI3, CAL, SKY) determined by the CCF technique.  This extension is a FITS table that is converted into a Pandas dataframe if the L2 file is read by `kpfpipe.models.level2.KPF2.from_fits()`.  The table rows correspond to the spectral orders, with the values of the keywords `CCD1ROW` and `CCD2ROW` in the RV extension header giving the rows where the Green and Red orders start, respectively.  The table columns are listed below.
+
+=============  =================  =========
+Column         Value (example)    Comment
+=============  =================  =========
+orderlet1      19.250267          RV (km/s) of SCI1 (Green CCD); corrected for barycentric RV
+orderlet2      19.264743          RV (km/s) of SCI2 (Green CCD); corrected for barycentric RV
+orderlet3      19.388630          RV (km/s) of SCI3 (Green CCD); corrected for barycentric RV
+s_wavelength   4505.907677        starting wavelength for order
+e_wavelength   4462.664498        ending wavelength for order
+segment no.    0                  Segment number (for full-order CCF RVs, segment no. = order no.)
+order no.      0                  Order number
+RV             19.306370          RV (km/s) of average of SCI1/SCI2/SCI3 (Green CCD); corrected for barycentric RV
+RV error       0.019248           error on 'RV'
+CAL RV         0.0                RV (km/s) of CAL (Green CCD); corrected for barycentric RV
+CAL error      0.0                error on 'CAL RV'
+SKY RV         0.0                RV (km/s) of sKY (Green CCD); corrected for barycentric RV
+SKY error      0.0                error on 'SKY RV'
+CCFBJD         2.460238e+06       Photon-weighted mid-time (BJD) for CCD1RV (for solar observations, HJD is used)
+Bary_RVC       -8.729925          Barycentric RV (km/s)
+source1        GREEN_SCI_FLUX1    name of array for orderlet1 (SCI1)
+source2        GREEN_SCI_FLUX2    name of array for orderlet2 (SCI2)
+source3        GREEN_SCI_FLUX3    name of array for orderlet3 (SCI3)
+source CAL     GREEN_CAL_FLUX     name of array for CAL
+source SKY     GREEN_SKY_FLUX     name of array for SKY
+CCF Weights    0.2590             weight for this order
+=============  =================  =========
+
+TELEMETRY Extension
+^^^^^^^^^^^^^^^^^^^
+
+Each KPF file (starting with L0) contains a table telemetry on >100 sensors or state values.  The table contains the average, standard deviation, minimum, and maximum values for each measurement.
+
+===================================  ==========================================  
+Keyword                              Description [unit]
+===================================  ==========================================  
+kpfmet.BENCH_BOTTOM_BETWEEN_CAMERAS  Bench bottom between cameras temp (sensor C2) [C]
+kpfmet.BENCH_BOTTOM_COLLIMATOR       Bench bottom collimator temp (sensor C3) [C]
+kpfmet.BENCH_BOTTOM_DCUT             Bench bottom D-cut temp (sensor C4) [C]
+kpfmet.BENCH_BOTTOM_ECHELLE          Bench bottom echelle Cam temp (sensor B) [C]
+kpfmet.BENCH_TOP_BETWEEN_CAMERAS     Bench top between cameras temp (sensor D4) [C]
+kpfmet.BENCH_TOP_COLL                Bench top collimator temp (sensor D5) [C]
+kpfmet.BENCH_TOP_DCUT                Bench top D-cut temp (sensor D3) [C]
+kpfmet.BENCH_TOP_ECHELLE_CAM         Bench top echelle Cam temp (sensor D1) [C]
+kpfmet.CALEM_SCMBLR_CHMBR_END        Cal EM scrambler chamber end temp (sensor C1) [C]
+kpfmet.CALEM_SCMBLR_FIBER_END        Cal EM scrambler fiber end temp (sensor D1) [C]
+kpfmet.CAL_BENCH                     Cal bench temp [C]
+kpfmet.CAL_BENCH_BB_SRC              Cal bench blackbody source temp [C]
+kpfmet.CAL_BENCH_BOT                 Cal bench bottom temp [C]
+kpfmet.CAL_BENCH_ENCL_AIR            Cal bench enclosure air temp [C]
+kpfmet.CAL_BENCH_OCT_MOT             Cal bench octagon motor temp [C]
+kpfmet.CAL_BENCH_TRANS_STG_MOT       Cal bench trans stage motor temp [C]
+kpfmet.CAL_RACK_TOP                  Cal rack top temp [C]
+kpfmet.CHAMBER_EXT_BOTTOM            Chamber exterior Bottom temp (sensor B) [C]
+kpfmet.CHAMBER_EXT_TOP               Chamber exterior Top temp (sensor C1) [C]
+kpfmet.CRYOSTAT_G1                   Within cryostat green temp (sensor D3) [C]
+kpfmet.CRYOSTAT_G2                   Within cryostat green temp (sensor D3) [C]
+kpfmet.CRYOSTAT_G3                   Within cryostat green temp (sensor D4) [C]
+kpfmet.CRYOSTAT_R1                   Within Cryostat red temp (sensor D2) [C]
+kpfmet.CRYOSTAT_R2                   Within Cryostat red temp (sensor D3) [C]
+kpfmet.CRYOSTAT_R3                   Within Cryostat red temp (sensor D4) [C]
+kpfmet.ECHELLE_BOTTOM                Echelle Bottom temp (sensor D1) [C]
+kpfmet.ECHELLE_TOP                   Echelle Top temp (sensor C1) [C]
+kpfmet.FF_SRC                        Flat field source temp [C]
+kpfmet.GREEN_CAMERA_BOTTOM           Green camera bottom temp (sensor C3) [C]
+kpfmet.GREEN_CAMERA_COLLIMATOR       Green camera collimator temp (sensor C4) [C]
+kpfmet.GREEN_CAMERA_ECHELLE          Green camera echelle temp (sensor D5) [C]
+kpfmet.GREEN_CAMERA_TOP              Green camera Top temp (sensor C2) [C]
+kpfmet.GREEN_GRISM_TOP               Green grism Top temp (sensor C5) [C]
+kpfmet.GREEN_LN2_FLANGE              Green LN2 Flange temp (sensor A) [C]
+kpfmet.PRIMARY_COLLIMATOR_TOP        Primary collimator Top temp (sensor D2) [C]
+kpfmet.RED_CAMERA_BOTTOM             Red Camera Bottom temp (sensor D5) [C]
+kpfmet.RED_CAMERA_COLLIMATOR         Red camera collimator temp (sensor C3) [C]
+kpfmet.RED_CAMERA_ECHELLE            Red camera echelle temp (sensor C4) [C]
+kpfmet.RED_CAMERA_TOP                Red camera top temp (sensor C5) [C]
+kpfmet.RED_GRISM_TOP                 Red grism top temp (sensor C2) [C]
+kpfmet.RED_LN2_FLANGE                Red LN2 flange temp (sensor D1) [C]
+kpfmet.REFORMATTER                   Reformatter temp (sensor A) [C]
+kpfmet.SCIENCE_CAL_FIBER_STG         Science Cal fiber stage temp [C]
+kpfmet.SCISKY_SCMBLR_CHMBR_EN        SciSky scrambler chamber end temp (sensor A) [C]
+kpfmet.SCISKY_SCMBLR_FIBER_EN        SciSky scrambler fiber end temp (sensor B) [C]
+kpfmet.SIMCAL_FIBER_STG              SimCal fiber stage temp [C]
+kpfmet.SKYCAL_FIBER_STG              SkyCal fiber stage temp [C]
+kpfmet.TEMP                          Vaisala (Hallway) temp [C]
+kpfmet.TH_DAILY                      ThAr Daily lamp temp [C]
+kpfmet.TH_GOLD                       ThAr Gold lamp temp [C]
+kpfmet.U_DAILY                       UNe Daily lamp temp [C]
+kpfmet.U_GOLD                        UNe Gold lamp temp [C]
+kpfgreen.BPLANE_TEMP                 Green Archon backplane temp [C]
+kpfgreen.BRD10_DRVR_T                Green Archon board 10 (Driver) temp [C]
+kpfgreen.BRD11_DRVR_T                Green Archon board 11 (Driver) temp [C]
+kpfgreen.BRD12_LVXBIAS_T             Green Archon board 12 (LVxBias) temp [C]
+kpfgreen.BRD1_HTRX_T                 Green Archon board 1 (HeaterX) temp [C]
+kpfgreen.BRD2_XVBIAS_T               Green Archon board 2 (XV Bias) temp [C]
+kpfgreen.BRD3_LVDS_T                 Green Archon board 3 (LVDS) temp [C]
+kpfgreen.BRD4_DRVR_T                 Green Archon board 4 (Driver) temp [C]
+kpfgreen.BRD5_AD_T                   Green Archon board 5 (AD) temp [C]
+kpfgreen.BRD7_HTRX_T                 Green Archon board 7 (HeaterX) temp [C]
+kpfgreen.BRD9_HVXBIAS_T              Green Archon board 9 (HVxBias) temp [C]
+kpfgreen.CF_BASE_2WT                 Green tip cold finger temp (2 wire) [C]
+kpfgreen.CF_BASE_T                   Green base cold finger temp [C]
+kpfgreen.CF_BASE_TRG                 Green base cold finger heater 1A target temp [C]
+kpfgreen.CF_TIP_T                    Green tip cold finger temp [C]
+kpfgreen.CF_TIP_TRG                  Green tip cold finger heater 1B target temp [C]
+kpfgreen.COL_PRESS                   Green collimator ion pump pressure                Torr
+kpfgreen.CRYOBODY_T                  Green cryobody temp [C]
+kpfgreen.CRYOBODY_TRG                Green cryobody heater 7B target temp [C]
+kpfgreen.CURRTEMP                    Green cold head temp [C]
+kpfgreen.ECH_PRESS                   Green echelle ion pump pressure [Torr]
+kpfgreen.KPF_CCD_T                   SSL temp sensor on Green CCD [C]
+kpfgreen.STA_CCD_T                   STA temp sensor on Green CCD [C]
+kpfgreen.STA_CCD_TRG                 Green CCD heater 7A target temp [C]
+kpfgreen.TEMPSET                     Green set point for the cold head temp [C]
+kpfred.BPLANE_TEMP                   Red Archon backplane temp [C]
+kpfred.BRD10_DRVR_T                  Red Archon board 10 (Driver) temp [C]
+kpfred.BRD11_DRVR_T                  Red Archon board 11 (Driver) temp [C]
+kpfred.BRD12_LVXBIAS_T               Red Archon board 12 (LVxBias) temp [C]
+kpfred.BRD1_HTRX_T                   Red Archon board 1 (HeaterX) temp [C]
+kpfred.BRD2_XVBIAS_T                 Red Archon board 2 (XV Bias) temp [C]
+kpfred.BRD3_LVDS_T                   Red Archon board 3 (LVDS) temp [C]
+kpfred.BRD4_DRVR_T                   Red Archon board 4 (Driver) temp [C]
+kpfred.BRD5_AD_T                     Red Archon board 5 (AD) temp [C]
+kpfred.BRD7_HTRX_T                   Red board Archon 7 (HeaterX) temp [C]
+kpfred.BRD9_HVXBIAS_T                Red board Archon 9 (HVxBias) temp [C]
+kpfred.CF_BASE_2WT                   Red tip cold finger temp (2 wire) [C]
+kpfred.CF_BASE_T                     Red base cold finger temp [C]
+kpfred.CF_BASE_TRG                   Red base cold finger heater 1A target temp [C]
+kpfred.CF_TIP_T                      Red tip cold finger temp [C]
+kpfred.CF_TIP_TRG                    Red tip cold finger heater 1B target temp [C]
+kpfred.COL_PRESS                     Red Collimator ion pump pressure [Torr]
+kpfred.CRYOBODY_T                    Red Cryo Body temp [C]
+kpfred.CRYOBODY_TRG                  Red Cryo body heater 7B target temp [C]
+kpfred.CURRTEMP                      Red cold head temp [C]
+kpfred.ECH_PRESS                     Red ion pump pressure [Torr]
+kpfred.KPF_CCD_T                     SSL temp sensor on Red CCD [C]
+kpfred.STA_CCD_T                     STA temp sensor on Red CCD [C]
+kpfred.STA_CCD_TRG                   Red CCD heater 7A target temp [C]
+kpfred.TEMPSET                       Set point for the Red cold head temp [C]
+kpfexpose.BENCH_C                    HK Bench temp [C]
+kpfexpose.CAMBARREL_C                HK Camera barrel temp [C]
+kpfexpose.DET_XTRN_C                 HK Detector external temp [C]
+kpfexpose.ECHELLE_C                  HK Echelle temp [C]
+kpfexpose.ENCLOSURE_C                HK Enclosure temp [C]
+kpfexpose.RACK_AIR_C                 HK Rack air temp [C]
+kpfvac.PUMP_TEMP                     Vacuum motor temp [C]
+kpf_hk.COOLTARG                      HK target temp [C]
+kpf_hk.CURRTEMP                      HK current temp [C]
+kpfgreen.COL_CURR                    Green Collimator Ion pump current [A]
+kpfgreen.ECH_CURR                    Green Echelle Ion pump current [A]
+kpfred.COL_CURR                      Red Collimator Ion pump current [A]
+kpfred.ECH_CURR                      Red Echelle Ion pump current [A]
+kpfcal.IRFLUX                        LFC Fiberlock IR Intensity [counts]
+kpfcal.VISFLUX                       LFC Fiberlock Vis Intensity [counts]
+kpfcal.BLUECUTIACT                   Blue cut amplifier 0 current [A]
+kpfmot.AGITSPD                       Agitator motor raw velocity [counts/s]
+kpfmot.AGITTOR                       Agitator motor torque [V]
+kpfmot.AGITAMBI_T                    Agitator ambient temp [C]
+kpfmot.AGITMOT_T                     Agitator motor temp [C]
+kpfpower.OUTLET_A1_Amps              Agitator motor current (Outlet A1) [mA]
+===================================  ==========================================  
+
+WLS Dictionaries
+----------------
+
+See :doc:`../analysis/dictonary_format` for details.
+
+
+Notes on Dates and Times in KPF Files
+-------------------------------------
+* To do: add notes here about how DATE-BEG, DATE-MID, and DATE-END are computed.  There are other datetimes in the header that should be clarified.  Also, explain how exposure midpoints are computed (using the exposure meter and DATE-BEG??), which leads to BJD and ultimately the barycentric corrections.

--- a/scripts/track_thar_lamp_health.py
+++ b/scripts/track_thar_lamp_health.py
@@ -1,2 +1,2 @@
-# reads master_wls_thar files to track lamp health over time
+# reads master_thar files to track lamp health over time
 # produces plots and diagnostics, e.g. line strengths, drifts, etc.

--- a/tests/test_calibration_association.py
+++ b/tests/test_calibration_association.py
@@ -225,15 +225,20 @@ class TestPerform:
             assert f'AGE{prefix}' in mod.l1_obj.headers['PRIMARY']
 
     def test_sets_headers_for_thar_wls(self, masters_dir):
+        # Legacy WLS convention: WLSFILE holds the full path (no WLSDIR), and
+        # AGEWLS is float days with sign = (master_dt - obs_dt). For a master
+        # at 2024-04-05 01:00:37 UTC and obs at 2024-04-05 11:08:33 UTC the
+        # master is ~0.42 days before the obs, so AGEWLS is negative.
         d = masters_dir / 'masters' / '20240405'
         _stub_master(d, 'KP.20240405.03637.74', 'thar-wls')
 
         mod = _make_module(masters_dir)
         mod.perform(['bias', 'thar-wls'])
         h = mod.l1_obj.headers['PRIMARY']
-        assert h['WLSFILE'] == 'KP.20240405.03637.74_master_thar-wls_L2.fits'
-        assert h['WLSDIR'] == str(d)
-        assert h['AGEWLS'] == 0
+        assert h['WLSFILE'] == str(d / 'KP.20240405.03637.74_master_thar-wls_L2.fits')
+        assert 'WLSDIR' not in h
+        assert isinstance(h['AGEWLS'], float)
+        assert -0.5 < h['AGEWLS'] < 0.0
 
     def test_raises_on_unknown_cal_type(self, masters_dir):
         mod = _make_module(masters_dir)

--- a/tests/test_calibration_association.py
+++ b/tests/test_calibration_association.py
@@ -27,9 +27,18 @@ def _make_module(tmp_path, date_obs='2024-04-05T11:08:33'):
     return CalibrationAssociation(l1, config={'KPF_DATA_INPUT': str(tmp_path)})
 
 
+_LEVEL_BY_CAL_TYPE = {
+    'bias':     'L1',
+    'dark':     'L1',
+    'flat':     'L1',
+    'thar-wls': 'L2',
+}
+
+
 def _stub_master(directory, obs_id, cal_type):
     """Create a zero-byte stub master file with the correct naming convention."""
-    path = directory / f'{obs_id}_master_{cal_type}_L1.fits'
+    level = _LEVEL_BY_CAL_TYPE[cal_type]
+    path = directory / f'{obs_id}_master_{cal_type}_{level}.fits'
     path.touch()
     return path
 
@@ -215,13 +224,21 @@ class TestPerform:
             assert f'{prefix}DIR' in mod.l1_obj.headers['PRIMARY']
             assert f'AGE{prefix}' in mod.l1_obj.headers['PRIMARY']
 
-    def test_no_header_written_for_thar_wls(self, masters_dir):
+    def test_sets_headers_for_thar_wls(self, masters_dir):
         d = masters_dir / 'masters' / '20240405'
         _stub_master(d, 'KP.20240405.03637.74', 'thar-wls')
 
         mod = _make_module(masters_dir)
         mod.perform(['bias', 'thar-wls'])
-        assert 'WLSFILE' not in mod.l1_obj.headers['PRIMARY']
+        h = mod.l1_obj.headers['PRIMARY']
+        assert h['WLSFILE'] == 'KP.20240405.03637.74_master_thar-wls_L2.fits'
+        assert h['WLSDIR'] == str(d)
+        assert h['AGEWLS'] == 0
+
+    def test_raises_on_unknown_cal_type(self, masters_dir):
+        mod = _make_module(masters_dir)
+        with pytest.raises(ValueError, match="bogus"):
+            mod.perform(['bogus'])
 
     def test_raises_when_no_master_found(self, tmp_path):
         mod = _make_module(tmp_path)

--- a/tests/test_calibration_association.py
+++ b/tests/test_calibration_association.py
@@ -31,7 +31,7 @@ _LEVEL_BY_CAL_TYPE = {
     'bias':     'L1',
     'dark':     'L1',
     'flat':     'L1',
-    'thar-wls': 'L2',
+    'wls_thar': 'L2',
 }
 
 
@@ -224,18 +224,18 @@ class TestPerform:
             assert f'{prefix}DIR' in mod.l1_obj.headers['PRIMARY']
             assert f'AGE{prefix}' in mod.l1_obj.headers['PRIMARY']
 
-    def test_sets_headers_for_thar_wls(self, masters_dir):
+    def test_sets_headers_for_wls_thar(self, masters_dir):
         # Legacy WLS convention: WLSFILE holds the full path (no WLSDIR), and
         # AGEWLS is float days with sign = (master_dt - obs_dt). For a master
         # at 2024-04-05 01:00:37 UTC and obs at 2024-04-05 11:08:33 UTC the
         # master is ~0.42 days before the obs, so AGEWLS is negative.
         d = masters_dir / 'masters' / '20240405'
-        _stub_master(d, 'KP.20240405.03637.74', 'thar-wls')
+        _stub_master(d, 'KP.20240405.03637.74', 'wls_thar')
 
         mod = _make_module(masters_dir)
-        mod.perform(['bias', 'thar-wls'])
+        mod.perform(['bias', 'wls_thar'])
         h = mod.l1_obj.headers['PRIMARY']
-        assert h['WLSFILE'] == str(d / 'KP.20240405.03637.74_master_thar-wls_L2.fits')
+        assert h['WLSFILE'] == str(d / 'KP.20240405.03637.74_master_wls_thar_L2.fits')
         assert 'WLSDIR' not in h
         assert isinstance(h['AGEWLS'], float)
         assert -0.5 < h['AGEWLS'] < 0.0

--- a/tests/test_calibration_association.py
+++ b/tests/test_calibration_association.py
@@ -31,7 +31,7 @@ _LEVEL_BY_CAL_TYPE = {
     'bias':     'L1',
     'dark':     'L1',
     'flat':     'L1',
-    'wls_thar': 'L2',
+    'thar': 'L2',
 }
 
 
@@ -224,18 +224,18 @@ class TestPerform:
             assert f'{prefix}DIR' in mod.l1_obj.headers['PRIMARY']
             assert f'AGE{prefix}' in mod.l1_obj.headers['PRIMARY']
 
-    def test_sets_headers_for_wls_thar(self, masters_dir):
+    def test_sets_headers_for_thar(self, masters_dir):
         # Legacy WLS convention: WLSFILE holds the full path (no WLSDIR), and
         # AGEWLS is float days with sign = (master_dt - obs_dt). For a master
         # at 2024-04-05 01:00:37 UTC and obs at 2024-04-05 11:08:33 UTC the
         # master is ~0.42 days before the obs, so AGEWLS is negative.
         d = masters_dir / 'masters' / '20240405'
-        _stub_master(d, 'KP.20240405.03637.74', 'wls_thar')
+        _stub_master(d, 'KP.20240405.03637.74', 'thar')
 
         mod = _make_module(masters_dir)
-        mod.perform(['bias', 'wls_thar'])
+        mod.perform(['bias', 'thar'])
         h = mod.l1_obj.headers['PRIMARY']
-        assert h['WLSFILE'] == str(d / 'KP.20240405.03637.74_master_wls_thar_L2.fits')
+        assert h['WLSFILE'] == str(d / 'KP.20240405.03637.74_master_thar_L2.fits')
         assert 'WLSDIR' not in h
         assert isinstance(h['AGEWLS'], float)
         assert -0.5 < h['AGEWLS'] < 0.0

--- a/tests/test_calibration_association.py
+++ b/tests/test_calibration_association.py
@@ -226,9 +226,9 @@ class TestPerform:
 
     def test_sets_headers_for_thar(self, masters_dir):
         # Legacy WLS convention: WLSFILE holds the full path (no WLSDIR), and
-        # AGEWLS is float days with sign = (master_dt - obs_dt). For a master
-        # at 2024-04-05 01:00:37 UTC and obs at 2024-04-05 11:08:33 UTC the
-        # master is ~0.42 days before the obs, so AGEWLS is negative.
+        # AGEWLS is float days with sign = (master_dt - obs_dt). Master at
+        # 2024-04-05 01:00:37 UTC vs obs at 2024-04-05 11:08:33 UTC gives
+        # delta = -10h 07m 56s = -36476 s = -0.422176 days.
         d = masters_dir / 'masters' / '20240405'
         _stub_master(d, 'KP.20240405.03637.74', 'thar')
 
@@ -238,7 +238,7 @@ class TestPerform:
         assert h['WLSFILE'] == str(d / 'KP.20240405.03637.74_master_thar_L2.fits')
         assert 'WLSDIR' not in h
         assert isinstance(h['AGEWLS'], float)
-        assert -0.5 < h['AGEWLS'] < 0.0
+        assert h['AGEWLS'] == pytest.approx(-0.422176, abs=1e-5)
 
     def test_raises_on_unknown_cal_type(self, masters_dir):
         mod = _make_module(masters_dir)

--- a/tests/test_kpf_utils.py
+++ b/tests/test_kpf_utils.py
@@ -9,9 +9,14 @@ from kpfpipe.utils.kpf import (
     hst_to_utc,
     kpf_timestamp_to_eprv_timestamp,
     eprv_timestamp_to_kpf_timestamp,
+    kpf_timestamp_to_datetime,
     get_obs_id,
     get_datecode,
     get_timestamp,
+    get_seconds_since_j2000,
+    is_obs_id,
+    is_datecode,
+    is_timestamp,
 )
 
 
@@ -136,3 +141,221 @@ class TestGetTimestamp:
     def test_no_match_raises(self):
         with pytest.raises(ValueError, match="No KPF timestamp found"):
             get_timestamp("notimestamp.fits")
+
+
+# ---------------------------------------------------------------------------
+# Validation: predicates reject semantically invalid input
+# ---------------------------------------------------------------------------
+
+
+class TestIsObsId:
+
+    def test_valid_obs_id(self):
+        assert is_obs_id("KP.20240405.40113.57") is True
+
+    def test_rejects_bad_date(self):
+        # Format matches but month 99 is not a real date.
+        assert is_obs_id("KP.20249999.40113.57") is False
+
+    def test_rejects_seconds_out_of_range(self):
+        # SSSSS = 99999 > 86399.
+        assert is_obs_id("KP.20240405.99999.57") is False
+
+    def test_rejects_wrong_format(self):
+        assert is_obs_id("20240405.40113.57") is False
+
+    def test_rejects_non_string(self):
+        assert is_obs_id(None) is False
+        assert is_obs_id(12345) is False
+
+
+class TestIsDatecode:
+
+    def test_valid_datecode(self):
+        assert is_datecode("20240405") is True
+
+    def test_rejects_bad_date(self):
+        # Format matches but month 99 is not a real date.
+        assert is_datecode("20249999") is False
+
+    def test_rejects_wrong_format(self):
+        assert is_datecode("2024-04-05") is False
+
+    def test_rejects_non_string(self):
+        assert is_datecode(None) is False
+        assert is_datecode(20240405) is False
+
+
+class TestIsTimestamp:
+
+    def test_valid_timestamp(self):
+        assert is_timestamp("20240405.40113.57") is True
+
+    def test_rejects_bad_date(self):
+        assert is_timestamp("20249999.40113.57") is False
+
+    def test_rejects_seconds_out_of_range(self):
+        assert is_timestamp("20240405.99999.57") is False
+
+    def test_rejects_wrong_format(self):
+        assert is_timestamp("20240405T110833") is False
+
+    def test_rejects_non_string(self):
+        assert is_timestamp(None) is False
+
+
+# ---------------------------------------------------------------------------
+# Validation: extractors raise on semantically invalid embedded timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestGetObsIdValidation:
+
+    def test_raises_on_invalid_date(self):
+        with pytest.raises(ValueError, match="Invalid date"):
+            get_obs_id("KP.20249999.40113.57.fits")
+
+    def test_raises_on_seconds_out_of_range(self):
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            get_obs_id("KP.20240405.99999.57.fits")
+
+    def test_raises_on_non_string(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            get_obs_id(None)
+
+
+class TestGetDatecodeValidation:
+
+    def test_raises_on_invalid_date(self):
+        with pytest.raises(ValueError, match="Invalid date"):
+            get_datecode("KP.20249999.40113.57")
+
+    def test_raises_on_seconds_out_of_range(self):
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            get_datecode("KP.20240405.99999.57")
+
+    def test_raises_on_non_string(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            get_datecode(None)
+
+
+class TestGetTimestampValidation:
+
+    def test_raises_on_invalid_date(self):
+        with pytest.raises(ValueError, match="Invalid date"):
+            get_timestamp("KP.20249999.40113.57.fits")
+
+    def test_raises_on_seconds_out_of_range(self):
+        # The path contains a syntactically-matching but invalid timestamp.
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            get_timestamp("KP.20240405.99999.57.fits")
+
+    def test_raises_on_non_string(self):
+        with pytest.raises(ValueError, match="must be a string"):
+            get_timestamp(None)
+
+
+# ---------------------------------------------------------------------------
+# Validation: converters reject malformed input rather than silently
+# producing wrong output (the day-rollover and hh>=24 slips).
+# ---------------------------------------------------------------------------
+
+
+class TestKpfTimestampToDatetimeValidation:
+
+    def test_raises_on_seconds_out_of_range(self):
+        # Previously: silently rolled over into the next day.
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            kpf_timestamp_to_datetime("20240405.99999.57")
+
+    def test_raises_on_invalid_date(self):
+        with pytest.raises(ValueError, match="Invalid date"):
+            kpf_timestamp_to_datetime("20249999.40113.57")
+
+    def test_raises_on_wrong_format(self):
+        with pytest.raises(ValueError, match="Invalid KPF timestamp format"):
+            kpf_timestamp_to_datetime("not-a-timestamp")
+
+
+class TestUtcToHstValidation:
+
+    def test_raises_on_seconds_out_of_range(self):
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            utc_to_hst("20240405.99999.57")
+
+    def test_raises_on_wrong_format(self):
+        with pytest.raises(ValueError, match="Invalid KPF timestamp format"):
+            utc_to_hst("20240405T110833")
+
+
+class TestHstToUtcValidation:
+
+    def test_raises_on_seconds_out_of_range(self):
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            hst_to_utc("20240405.99999.57")
+
+    def test_raises_on_wrong_format(self):
+        with pytest.raises(ValueError, match="Invalid KPF timestamp format"):
+            hst_to_utc("not-a-timestamp")
+
+
+class TestKpfTimestampToEprvValidation:
+
+    def test_raises_on_seconds_out_of_range(self):
+        # Previously: produced 'YYYYMMDDT273739' with hh=27.
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            kpf_timestamp_to_eprv_timestamp("20240405.99999.57")
+
+    def test_raises_on_invalid_date(self):
+        with pytest.raises(ValueError, match="Invalid date"):
+            kpf_timestamp_to_eprv_timestamp("20249999.40113.57")
+
+
+class TestEprvTimestampToKpfValidation:
+
+    def test_raises_on_non_T_separator(self):
+        # Previously: silently accepted any char at position 8.
+        with pytest.raises(ValueError, match="Invalid EPRV timestamp format"):
+            eprv_timestamp_to_kpf_timestamp("20240405A110833")
+
+    def test_raises_on_hours_out_of_range(self):
+        # Previously: emitted an invalid KPF timestamp going out.
+        with pytest.raises(ValueError, match="time-of-day"):
+            eprv_timestamp_to_kpf_timestamp("20240405T256059")
+
+    def test_raises_on_minutes_out_of_range(self):
+        with pytest.raises(ValueError, match="time-of-day"):
+            eprv_timestamp_to_kpf_timestamp("20240405T126059")
+
+    def test_raises_on_seconds_out_of_range(self):
+        with pytest.raises(ValueError, match="time-of-day"):
+            eprv_timestamp_to_kpf_timestamp("20240405T120060")
+
+    def test_raises_on_invalid_date(self):
+        with pytest.raises(ValueError, match="Invalid date"):
+            eprv_timestamp_to_kpf_timestamp("20249999T110833")
+
+    def test_raises_on_short_input(self):
+        with pytest.raises(ValueError, match="Invalid EPRV timestamp format"):
+            eprv_timestamp_to_kpf_timestamp("short")
+
+
+class TestGetSecondsSinceJ2000:
+
+    def test_basic(self):
+        # J2000.0 itself: 2000-01-01 12:00 UTC = '20000101.43200.00'
+        assert get_seconds_since_j2000("20000101.43200.00") == 0
+
+    def test_monotonic_across_year_boundary(self):
+        # Dec 31 23:59:00 -> Jan 1 00:00:00 should differ by 60s exactly.
+        end = get_seconds_since_j2000("20231231.86340.00")
+        start_next_year = get_seconds_since_j2000("20240101.00000.00")
+        assert start_next_year - end == 60
+
+    def test_raises_on_invalid_timestamp(self):
+        with pytest.raises(ValueError, match="seconds-past-midnight"):
+            get_seconds_since_j2000("KP.20240405.99999.57.fits")
+
+    def test_raises_when_no_timestamp_found(self):
+        with pytest.raises(ValueError, match="No KPF timestamp found"):
+            get_seconds_since_j2000("notimestamp.fits")

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -159,7 +159,7 @@ def mock_make_master_l2(monkeypatch):
 
     def mock_compute(self, chip, fibers, lineprofile=None,
                      polyorder_x=None, polyorder_m=None, polyorder_f=None,
-                     return_stacks=False, **kwargs):
+                     **kwargs):
         polyorder_x = polyorder_x if polyorder_x is not None else self.polyorder_x
         polyorder_m = polyorder_m if polyorder_m is not None else self.polyorder_m
         polyorder_f = polyorder_f if polyorder_f is not None else self.polyorder_f
@@ -174,21 +174,19 @@ def mock_make_master_l2(monkeypatch):
             W = np.full((norder, NCOL_TEST, nfibers), 5500.0)
             coeffs = np.zeros((polyorder_x + 1, polyorder_m + 1, polyorder_f + 1))
 
-        if return_stacks:
-            coeffs_stack = np.array([coeffs] * 3)
-            lines_stack = [
-                {'wav': np.array([5500.0, 5501.0]),
-                 'pix': np.array([100.5, 200.5]),
-                 'ord': np.array([1, 2]),
-                 'fib': np.array([fibers[0]] * 2),
-                 'bad': np.array([False, False]),
-                 'std': np.array([0.5, 0.5]),
-                 'amp': np.array([1.0, 1.0]),
-                 'rms': np.array([0.01, 0.01])}
-                for _ in range(3)
-            ]
-            return W, coeffs, coeffs_stack, lines_stack
-        return W, coeffs
+        coeffs_stack = np.array([coeffs] * 3)
+        lines_stack = [
+            {'wav': np.array([5500.0, 5501.0]),
+             'pix': np.array([100.5, 200.5]),
+             'ord': np.array([1, 2]),
+             'fib': np.array([fibers[0]] * 2),
+             'bad': np.array([False, False]),
+             'std': np.array([0.5, 0.5]),
+             'amp': np.array([1.0, 1.0]),
+             'rms': np.array([0.01, 0.01])}
+            for _ in range(3)
+        ]
+        return W, coeffs, coeffs_stack, lines_stack
 
     monkeypatch.setattr(WLS, 'compute_wls_from_stack', mock_compute)
 

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -244,6 +244,16 @@ class TestMakeMasterL2:
             for key in ['POLYORDX', 'POLYORDM', 'POLYORDF']:
                 assert key in hdr
 
+    def test_to_fits_round_trip(self, mock_make_master_l2, tmp_path):
+        # Regression: rvdata builds non-PRIMARY headers via fits.Header(dict),
+        # which rejects (value, comment) tuple values. Make sure every header
+        # we set survives the round-trip.
+        wls = WLS(FILE_LIST)
+        ml2 = wls.make_master_l2()
+        out_path = tmp_path / "round_trip_master.fits"
+        ml2.to_fits(str(out_path))
+        assert out_path.exists()
+
     def test_polyorder_override_stamped(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)
         override_x = wls.polyorder_x + 4   # ensure different from default

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -290,28 +290,28 @@ class TestMakeMasterL2:
             assert chip in wls._coeffs_stack
             assert chip in wls._lines_stack
 
-    def test_save_stacks_before_make_raises(self):
+    def test_save_diagnostics_before_make_raises(self):
         wls = WLS(FILE_LIST)
         with pytest.raises(RuntimeError, match="run make_master_l2"):
-            wls.save_stacks('/tmp/should_not_be_created.h5')
+            wls.save_diagnostics('/tmp/should_not_be_created.h5')
 
-    def test_stacks_path_writes_hdf5(self, mock_make_master_l2, tmp_path):
+    def test_diagnostics_path_writes_hdf5(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
-        stacks_path = tmp_path / "stacks.h5"
-        wls.make_master_l2(stacks_path=str(stacks_path))
-        assert stacks_path.exists()
+        diagnostics_path = tmp_path / "diagnostics.h5"
+        wls.make_master_l2(diagnostics_path=str(diagnostics_path))
+        assert diagnostics_path.exists()
 
-    def test_save_stacks_post_hoc(self, mock_make_master_l2, tmp_path):
+    def test_save_diagnostics_post_hoc(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
-        wls.make_master_l2()  # no stacks_path; stacks stashed on self
-        stacks_path = tmp_path / "stacks.h5"
-        wls.save_stacks(str(stacks_path))
-        assert stacks_path.exists()
+        wls.make_master_l2()  # no diagnostics_path; stacks stashed on self
+        diagnostics_path = tmp_path / "diagnostics.h5"
+        wls.save_diagnostics(str(diagnostics_path))
+        assert diagnostics_path.exists()
 
     def test_hdf5_structure(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
-        stacks_path = str(tmp_path / "stacks.h5")
-        wls.make_master_l2(stacks_path=stacks_path)
+        diagnostics_path = str(tmp_path / "diagnostics.h5")
+        wls.make_master_l2(diagnostics_path=diagnostics_path)
 
         # mock_compute returns three synthetic frames per chip
         expected_nframes = 3
@@ -322,7 +322,7 @@ class TestMakeMasterL2:
             wls.polyorder_f + 1,
         )
 
-        with h5py.File(stacks_path, 'r') as h5:
+        with h5py.File(diagnostics_path, 'r') as h5:
             for chip in wls.chips:
                 assert chip in h5
                 cs = h5[chip]['coeffs_stack']

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -274,11 +274,11 @@ class TestMakeMasterL2:
     def test_stacks_stashed_on_self(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)
         wls.make_master_l2()
-        assert wls._coeffs_by_chip is not None
-        assert wls._lines_by_chip is not None
+        assert wls._coeffs_stack is not None
+        assert wls._lines_stack is not None
         for chip in wls.chips:
-            assert chip in wls._coeffs_by_chip
-            assert chip in wls._lines_by_chip
+            assert chip in wls._coeffs_stack
+            assert chip in wls._lines_stack
 
     def test_save_stacks_before_make_raises(self):
         wls = WLS(FILE_LIST)
@@ -500,7 +500,7 @@ class TestFitLinePositions:
         wave = np.linspace(5000.0, 5100.0, 100)
         wls._linelist_array = np.array([6000.0, 6100.0])  # entirely outside
 
-        result = wls.fit_line_positions_1D(flux, wave)
+        result = wls.fit_line_positions_1d(flux, wave)
         for key in ['wav', 'pix', 'std', 'amp', 'rms', 'bad']:
             assert len(result[key]) == 0
 

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -295,6 +295,19 @@ class TestMakeMasterL2:
         with pytest.raises(RuntimeError, match="run make_master_l2"):
             wls.save_diagnostics('/tmp/should_not_be_created.h5')
 
+    def test_save_diagnostics_with_empty_stash_raises(self, tmp_path):
+        # make_master_l2 initialises both stash dicts to {} before populating
+        # them. If the chip loop raises before any chip is added, the dicts
+        # stay empty — save_diagnostics must refuse rather than write an
+        # empty HDF5.
+        wls = WLS(FILE_LIST)
+        wls._coeffs_stack = {}
+        wls._lines_stack = {}
+        out_path = tmp_path / "empty.h5"
+        with pytest.raises(RuntimeError, match="run make_master_l2"):
+            wls.save_diagnostics(str(out_path))
+        assert not out_path.exists()
+
     def test_diagnostics_path_writes_hdf5(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
         diagnostics_path = tmp_path / "diagnostics.h5"

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -271,22 +271,37 @@ class TestMakeMasterL2:
         wls.make_master_l2()
         assert len(wls._l2_obj_cache) == len(FILE_LIST)
 
-    def test_return_stacks_false_returns_single(self, mock_make_master_l2):
+    def test_stacks_stashed_on_self(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)
-        result = wls.make_master_l2(return_stacks=False)
-        assert isinstance(result, KPFMasterL2)
+        wls.make_master_l2()
+        assert wls._coeffs_by_chip is not None
+        assert wls._lines_by_chip is not None
+        for chip in wls.chips:
+            assert chip in wls._coeffs_by_chip
+            assert chip in wls._lines_by_chip
 
-    def test_return_stacks_true_returns_tuple(self, mock_make_master_l2):
+    def test_save_stacks_before_make_raises(self):
         wls = WLS(FILE_LIST)
-        result = wls.make_master_l2(return_stacks=True)
-        assert isinstance(result, tuple) and len(result) == 2
-        ml2, h5 = result
-        assert isinstance(ml2, KPFMasterL2)
-        assert isinstance(h5, h5py.File)
+        with pytest.raises(RuntimeError, match="run make_master_l2"):
+            wls.save_stacks('/tmp/should_not_be_created.h5')
 
-    def test_hdf5_structure(self, mock_make_master_l2):
+    def test_stacks_path_writes_hdf5(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
-        ml2, h5 = wls.make_master_l2(return_stacks=True)
+        stacks_path = tmp_path / "stacks.h5"
+        wls.make_master_l2(stacks_path=str(stacks_path))
+        assert stacks_path.exists()
+
+    def test_save_stacks_post_hoc(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        wls.make_master_l2()  # no stacks_path; stacks stashed on self
+        stacks_path = tmp_path / "stacks.h5"
+        wls.save_stacks(str(stacks_path))
+        assert stacks_path.exists()
+
+    def test_hdf5_structure(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        stacks_path = str(tmp_path / "stacks.h5")
+        wls.make_master_l2(stacks_path=stacks_path)
 
         # mock_compute returns three synthetic frames per chip
         expected_nframes = 3
@@ -297,27 +312,28 @@ class TestMakeMasterL2:
             wls.polyorder_f + 1,
         )
 
-        for chip in wls.chips:
-            assert chip in h5
-            cs = h5[chip]['coeffs_stack']
-            assert cs.shape == expected_coeffs_shape
-            assert np.issubdtype(cs.dtype, np.floating)
+        with h5py.File(stacks_path, 'r') as h5:
+            for chip in wls.chips:
+                assert chip in h5
+                cs = h5[chip]['coeffs_stack']
+                assert cs.shape == expected_coeffs_shape
+                assert np.issubdtype(cs.dtype, np.floating)
 
-            assert 'lines_stack' in h5[chip]
-            frame_keys = sorted(h5[chip]['lines_stack'].keys())
-            assert len(frame_keys) == expected_nframes
+                assert 'lines_stack' in h5[chip]
+                frame_keys = sorted(h5[chip]['lines_stack'].keys())
+                assert len(frame_keys) == expected_nframes
 
-            sample = h5[chip]['lines_stack'][frame_keys[0]]
-            for key in ['wav', 'pix', 'ord', 'fib', 'bad', 'std', 'amp', 'rms']:
-                assert key in sample
-            assert np.issubdtype(sample['wav'].dtype, np.floating)
-            assert np.issubdtype(sample['pix'].dtype, np.floating)
-            assert np.issubdtype(sample['ord'].dtype, np.integer)
-            assert sample['bad'].dtype == bool
-            assert h5py.check_string_dtype(sample['fib'].dtype) is not None
-            # finite values for all numeric per-line arrays
-            for key in ['wav', 'pix', 'std', 'amp', 'rms']:
-                assert np.all(np.isfinite(sample[key][...]))
+                sample = h5[chip]['lines_stack'][frame_keys[0]]
+                for key in ['wav', 'pix', 'ord', 'fib', 'bad', 'std', 'amp', 'rms']:
+                    assert key in sample
+                assert np.issubdtype(sample['wav'].dtype, np.floating)
+                assert np.issubdtype(sample['pix'].dtype, np.floating)
+                assert np.issubdtype(sample['ord'].dtype, np.integer)
+                assert sample['bad'].dtype == bool
+                assert h5py.check_string_dtype(sample['fib'].dtype) is not None
+                # finite values for all numeric per-line arrays
+                for key in ['wav', 'pix', 'std', 'amp', 'rms']:
+                    assert np.all(np.isfinite(sample[key][...]))
 
     def test_nan_orderlet_emits_warning_and_does_not_crash(self):
         """

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -366,6 +366,14 @@ class TestBuildFilepath:
         with pytest.raises(ValueError, match="valid observation ID"):
             build_filepath("20240405", "L1")
 
+    def test_invalid_data_root_empty_string_raises(self):
+        with pytest.raises(ValueError, match="data_root must be None or a non-empty string"):
+            build_filepath("KP.20240405.40113.57", "L2", data_root="")
+
+    def test_invalid_data_root_non_string_raises(self):
+        with pytest.raises(ValueError, match="data_root must be None or a non-empty string"):
+            build_filepath("KP.20240405.40113.57", "L2", data_root=12345)
+
 
 # ---------------------------------------------------------------------------
 # build_qlp_dir
@@ -385,6 +393,14 @@ class TestBuildQlpDir:
     def test_invalid_obs_id_raises(self):
         with pytest.raises(ValueError, match="valid observation ID"):
             build_qlp_dir("20240405", "L0", data_root="/data")
+
+    def test_invalid_data_root_none_raises(self):
+        with pytest.raises(ValueError, match="data_root must be a non-empty string"):
+            build_qlp_dir("KP.20240405.40113.57", "L0", data_root=None)
+
+    def test_invalid_data_root_empty_string_raises(self):
+        with pytest.raises(ValueError, match="data_root must be a non-empty string"):
+            build_qlp_dir("KP.20240405.40113.57", "L0", data_root="")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -311,9 +311,9 @@ class TestBuildFilepath:
         name = build_filepath("KP.20240405.40113.57", "L2")
         assert name == "kpf_SL2_20240405T110833.fits"
 
-    def test_master_thar_wls_with_obs_id(self):
-        path = build_filepath("KP.20240405.03600.00", "L1", data_root="/data", master="thar-wls")
-        assert path == "/data/masters/20240405/KP.20240405.03600.00_master_thar-wls_L1.fits"
+    def test_master_wls_thar_with_obs_id(self):
+        path = build_filepath("KP.20240405.03600.00", "L2", data_root="/data", master="wls_thar")
+        assert path == "/data/masters/20240405/KP.20240405.03600.00_master_wls_thar_L2.fits"
 
     def test_invalid_obs_id_raises(self):
         with pytest.raises(ValueError, match="valid observation ID"):

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -17,7 +17,6 @@ import pytest
 from kpfpipe.data_models.masters.level1 import KPFMasterL1
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.pipeline import (
-    _detect_calibration_stack_clusters,
     build_l0_file_lists,
     build_filepath,
     build_mini_database,
@@ -73,7 +72,7 @@ def _make_mini_db():
     df = pd.DataFrame(rows)
     df["EXPTIME"] = 60.0
     df["ELAPSED"] = 60.0
-    return _detect_calibration_stack_clusters(df)
+    return df
 
 
 def _write_test_csv(tmp_path, db):
@@ -99,58 +98,6 @@ def _write_test_csv(tmp_path, db):
 def _at(data_dir, synthetic_paths):
     """Translate /data/L0/... synthetic paths to absolute paths in data_dir."""
     return [os.path.join(data_dir, os.path.basename(p)) for p in synthetic_paths]
-
-
-# ---------------------------------------------------------------------------
-# _detect_calibration_stack_clusters
-# ---------------------------------------------------------------------------
-
-
-class TestDetectCalibrationStackClusters:
-
-    @pytest.fixture(scope="class")
-    def db(self):
-        return _make_mini_db()
-
-    def test_cal_start_columns_exist(self, db):
-        assert "CAL_START" in db.columns
-        assert "CAL_END" in db.columns
-
-    def test_bias_cluster_a_cal_start(self, db):
-        rows = db[db["FILENAME"].isin(_BIAS_A)]
-        assert (rows["CAL_START"] == "20240405.03600.00").all()
-
-    def test_bias_cluster_a_cal_end(self, db):
-        rows = db[db["FILENAME"].isin(_BIAS_A)]
-        assert (rows["CAL_END"] == "20240405.04000.00").all()
-
-    def test_bias_cluster_b_cal_start(self, db):
-        rows = db[db["FILENAME"].isin(_BIAS_B)]
-        assert (rows["CAL_START"] == "20240405.14000.00").all()
-
-    def test_bias_cluster_b_cal_end(self, db):
-        rows = db[db["FILENAME"].isin(_BIAS_B)]
-        assert (rows["CAL_END"] == "20240405.14400.00").all()
-
-    def test_two_bias_clusters_detected(self, db):
-        bias = db[db["OBJECT"] == "autocal-bias"]
-        assert bias["CAL_START"].nunique() == 2
-
-    def test_dark_cluster_cal_start(self, db):
-        rows = db[db["FILENAME"].isin(_DARK_A)]
-        assert (rows["CAL_START"] == "20240405.18000.00").all()
-
-    def test_science_frames_cal_start_empty(self, db):
-        sci = db[db["IMTYPE"] == "Object"]
-        assert (sci["CAL_START"] == "").all()
-
-    def test_science_frames_cal_end_empty(self, db):
-        sci = db[db["IMTYPE"] == "Object"]
-        assert (sci["CAL_END"] == "").all()
-
-    def test_row_order_preserved(self, db):
-        # Science frames should still be at the end
-        assert db.iloc[-1]["IMTYPE"] == "Object"
 
 
 # ---------------------------------------------------------------------------
@@ -415,20 +362,17 @@ class TestBuildMiniDatabase:
         return build_mini_database(str(TESTDATA_L0_DIR), write=False)
 
     def test_has_required_columns(self, mini_db):
-        for col in ("FILENAME", "IMTYPE", "OBJECT", "CAL_START", "CAL_END"):
+        for col in ("FILENAME", "TARGNAME", "IMTYPE", "OBJECT", "EXPTIME", "ELAPSED"):
             assert col in mini_db.columns
+
+    def test_no_cluster_columns(self, mini_db):
+        # CAL_START/CAL_END were moved out of the mini_db; cluster detection
+        # now happens at build_l0_file_lists time.
+        assert "CAL_START" not in mini_db.columns
+        assert "CAL_END" not in mini_db.columns
 
     def test_all_files_are_fits(self, mini_db):
         assert mini_db["FILENAME"].str.endswith(".fits").all()
-
-    def test_cal_start_empty_for_science(self, mini_db):
-        sci = mini_db[mini_db["IMTYPE"] == "Object"]
-        if not sci.empty:
-            assert (sci["CAL_START"] == "").all()
-
-    def test_cal_start_nonempty_for_bias(self, mini_db):
-        bias = mini_db[mini_db["OBJECT"] == "autocal-bias"]
-        assert (bias["CAL_START"] != "").all()
 
     def test_write_false_does_not_write_csv(self):
         csv_path = TESTDATA_L0_DIR / "KP.20240405_L0.csv"

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -129,24 +129,18 @@ class TestBuildL0FileLists:
         for lst in build_l0_file_lists("bias", data_dir=data_dir):
             assert lst == sorted(lst)
 
-    def test_small_clusters_merged_issues_warning(self, data_dir):
-        # min_file_count=6: both bias clusters (5 files each) fall below → merged
-        with pytest.warns(UserWarning, match="merged into one list"):
+    def test_raises_when_any_cluster_below_min(self, data_dir):
+        # min_file_count=6: both bias clusters (5 files each) fall below → raises.
+        with pytest.raises(ValueError, match="below min_file_count=6"):
             build_l0_file_lists("bias", min_file_count=6, data_dir=data_dir)
-
-    def test_small_clusters_merged_returns_one_list(self, data_dir):
-        with pytest.warns(UserWarning):
-            lists = build_l0_file_lists("bias", min_file_count=6, data_dir=data_dir)
-        assert len(lists) == 1
-        assert lists[0] == sorted(_at(data_dir, _BIAS_A + _BIAS_B))
 
     def test_raises_when_no_frames_found(self, data_dir):
         with pytest.raises(ValueError, match="No 'flat' calibration frames found"):
             build_l0_file_lists("flat", data_dir=data_dir)
 
-    def test_raises_when_merged_below_min(self, data_dir):
-        # dark cluster has only 3 files; merged total still < min_file_count=5
-        with pytest.raises(ValueError, match="need at least"):
+    def test_raises_when_dark_cluster_below_default_min(self, data_dir):
+        # dark cluster has only 3 files; default min_file_count=5 → raises.
+        with pytest.raises(ValueError, match="below min_file_count=5"):
             build_l0_file_lists("dark", data_dir=data_dir)
 
     def test_invalid_imtype_raises(self, data_dir):
@@ -225,16 +219,11 @@ class TestBuildL0FileListsRealData:
         assert len(lists[0]) == 5
         assert lists[0] == sorted(lists[0])
 
-    def test_dark_clusters_merged_issues_warning(self, l0_dir):
-        with pytest.warns(UserWarning, match="merged into one list"):
+    def test_dark_raises_on_undersized_clusters(self, l0_dir):
+        # The testdata has two dark clusters of 2 and 3 frames — both below
+        # the default min_file_count=5 → raises.
+        with pytest.raises(ValueError, match="below min_file_count=5"):
             build_l0_file_lists("dark", data_dir=l0_dir)
-
-    def test_dark_clusters_merged_returns_one_list(self, l0_dir):
-        with pytest.warns(UserWarning):
-            lists = build_l0_file_lists("dark", data_dir=l0_dir)
-        assert len(lists) == 1
-        assert len(lists[0]) == 5
-        assert lists[0] == sorted(lists[0])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -51,19 +51,24 @@ def _load_masters_recipe():
 # ---------------------------------------------------------------------------
 
 # Synthetic filenames: KP.YYYYMMDD.SSSSS.FF.fits
-# Two bias clusters separated by a >2hr gap; one dark cluster; science frames.
-_BIAS_A = [f"/data/L0/20240405/KP.20240405.0{3600 + i*100:04d}.00.fits" for i in range(5)]  # 03600–04000
-_BIAS_B = [f"/data/L0/20240405/KP.20240405.{14000 + i*100:05d}.00.fits" for i in range(5)]  # 14000–14400
-_DARK_A = [f"/data/L0/20240405/KP.20240405.{18000 + i*100:05d}.00.fits" for i in range(3)]  # 18000–18200
-_SCI_A  = [f"/data/L0/20240405/KP.20240405.{50000 + i*100:05d}.00.fits" for i in range(2)]  # 50000–50100
+# Two bias clusters separated by a >2hr gap; one dark cluster; two ThAr clusters
+# (morning and evening) with different OBJECT suffixes; science frames.
+_BIAS_A     = [f"/data/L0/20240405/KP.20240405.0{3600 + i*100:04d}.00.fits" for i in range(5)]  # 03600–04000
+_BIAS_B     = [f"/data/L0/20240405/KP.20240405.{14000 + i*100:05d}.00.fits" for i in range(5)]  # 14000–14400
+_DARK_A     = [f"/data/L0/20240405/KP.20240405.{18000 + i*100:05d}.00.fits" for i in range(3)]  # 18000–18200
+_THAR_MORN  = [f"/data/L0/20240405/KP.20240405.{60000 + i*100:05d}.00.fits" for i in range(5)]  # 60000–60400
+_THAR_EVE   = [f"/data/L0/20240405/KP.20240405.{75000 + i*100:05d}.00.fits" for i in range(5)]  # 75000–75400
+_SCI_A      = [f"/data/L0/20240405/KP.20240405.{50000 + i*100:05d}.00.fits" for i in range(2)]  # 50000–50100
 
 
 def _make_mini_db():
     rows = (
-        [{"FILENAME": f, "IMTYPE": "Bias",   "OBJECT": "autocal-bias", "TARGNAME": None} for f in _BIAS_A]
-      + [{"FILENAME": f, "IMTYPE": "Bias",   "OBJECT": "autocal-bias", "TARGNAME": None} for f in _BIAS_B]
-      + [{"FILENAME": f, "IMTYPE": "Dark",   "OBJECT": "autocal-dark", "TARGNAME": None} for f in _DARK_A]
-      + [{"FILENAME": f, "IMTYPE": "Object", "OBJECT": "185144",       "TARGNAME": "185144"} for f in _SCI_A]
+        [{"FILENAME": f, "IMTYPE": "Bias",    "OBJECT": "autocal-bias",           "TARGNAME": None} for f in _BIAS_A]
+      + [{"FILENAME": f, "IMTYPE": "Bias",    "OBJECT": "autocal-bias",           "TARGNAME": None} for f in _BIAS_B]
+      + [{"FILENAME": f, "IMTYPE": "Dark",    "OBJECT": "autocal-dark",           "TARGNAME": None} for f in _DARK_A]
+      + [{"FILENAME": f, "IMTYPE": "Arclamp", "OBJECT": "autocal-thar-all-morn",  "TARGNAME": None} for f in _THAR_MORN]
+      + [{"FILENAME": f, "IMTYPE": "Arclamp", "OBJECT": "autocal-thar-all-eve",   "TARGNAME": None} for f in _THAR_EVE]
+      + [{"FILENAME": f, "IMTYPE": "Object",  "OBJECT": "185144",                 "TARGNAME": "185144"} for f in _SCI_A]
     )
     df = pd.DataFrame(rows)
     df["EXPTIME"] = 60.0
@@ -183,7 +188,21 @@ class TestBuildL0FileLists:
 
     def test_invalid_imtype_raises(self, data_dir):
         with pytest.raises(ValueError, match="imtype must be one of"):
-            build_l0_file_lists("wls", data_dir=data_dir)
+            build_l0_file_lists("bogus", data_dir=data_dir)
+
+    def test_thar_returns_two_clusters(self, data_dir):
+        # Morning and evening ThArs have different OBJECT suffixes and are >2hr
+        # apart; each forms its own cluster.
+        lists = build_l0_file_lists("thar", data_dir=data_dir)
+        assert len(lists) == 2
+
+    def test_thar_morn_cluster(self, data_dir):
+        lists = build_l0_file_lists("thar", data_dir=data_dir)
+        assert lists[0] == sorted(_THAR_MORN)
+
+    def test_thar_eve_cluster(self, data_dir):
+        lists = build_l0_file_lists("thar", data_dir=data_dir)
+        assert lists[1] == sorted(_THAR_EVE)
 
     def test_raises_when_neither_source_provided(self):
         with pytest.raises(ValueError, match="Exactly one of"):
@@ -311,9 +330,9 @@ class TestBuildFilepath:
         name = build_filepath("KP.20240405.40113.57", "L2")
         assert name == "kpf_SL2_20240405T110833.fits"
 
-    def test_master_wls_thar_with_obs_id(self):
-        path = build_filepath("KP.20240405.03600.00", "L2", data_root="/data", master="wls_thar")
-        assert path == "/data/masters/20240405/KP.20240405.03600.00_master_wls_thar_L2.fits"
+    def test_master_thar_with_obs_id(self):
+        path = build_filepath("KP.20240405.03600.00", "L2", data_root="/data", master="thar")
+        assert path == "/data/masters/20240405/KP.20240405.03600.00_master_thar_L2.fits"
 
     def test_invalid_obs_id_raises(self):
         with pytest.raises(ValueError, match="valid observation ID"):

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -77,12 +77,28 @@ def _make_mini_db():
 
 
 def _write_test_csv(tmp_path, db):
-    """Write a mini_db CSV in the expected location for L0/20240405."""
+    """
+    Materialize a synthetic mini_db on disk: touch a stub .fits for every
+    FILENAME row, rewrite the CSV's FILENAME column to point to the stubs,
+    and write the CSV alongside them.
+    """
     data_dir = tmp_path / "L0" / "20240405"
     data_dir.mkdir(parents=True)
+    db = db.copy()
+    new_filenames = []
+    for original in db["FILENAME"]:
+        new_path = str(data_dir / os.path.basename(original))
+        open(new_path, "w").close()
+        new_filenames.append(new_path)
+    db["FILENAME"] = new_filenames
     csv_path = data_dir / "KP.20240405_L0.csv"
     db.to_csv(csv_path, index=False)
     return str(data_dir)
+
+
+def _at(data_dir, synthetic_paths):
+    """Translate /data/L0/... synthetic paths to absolute paths in data_dir."""
+    return [os.path.join(data_dir, os.path.basename(p)) for p in synthetic_paths]
 
 
 # ---------------------------------------------------------------------------
@@ -156,11 +172,11 @@ class TestBuildL0FileLists:
 
     def test_bias_cluster_a_files(self, data_dir):
         lists = build_l0_file_lists("bias", data_dir=data_dir)
-        assert lists[0] == sorted(_BIAS_A)
+        assert lists[0] == sorted(_at(data_dir, _BIAS_A))
 
     def test_bias_cluster_b_files(self, data_dir):
         lists = build_l0_file_lists("bias", data_dir=data_dir)
-        assert lists[1] == sorted(_BIAS_B)
+        assert lists[1] == sorted(_at(data_dir, _BIAS_B))
 
     def test_files_are_sorted(self, data_dir):
         for lst in build_l0_file_lists("bias", data_dir=data_dir):
@@ -175,7 +191,7 @@ class TestBuildL0FileLists:
         with pytest.warns(UserWarning):
             lists = build_l0_file_lists("bias", min_file_count=6, data_dir=data_dir)
         assert len(lists) == 1
-        assert lists[0] == sorted(_BIAS_A + _BIAS_B)
+        assert lists[0] == sorted(_at(data_dir, _BIAS_A + _BIAS_B))
 
     def test_raises_when_no_frames_found(self, data_dir):
         with pytest.raises(ValueError, match="No 'flat' calibration frames found"):
@@ -198,11 +214,11 @@ class TestBuildL0FileLists:
 
     def test_thar_morn_cluster(self, data_dir):
         lists = build_l0_file_lists("thar", data_dir=data_dir)
-        assert lists[0] == sorted(_THAR_MORN)
+        assert lists[0] == sorted(_at(data_dir, _THAR_MORN))
 
     def test_thar_eve_cluster(self, data_dir):
         lists = build_l0_file_lists("thar", data_dir=data_dir)
-        assert lists[1] == sorted(_THAR_EVE)
+        assert lists[1] == sorted(_at(data_dir, _THAR_EVE))
 
     def test_raises_when_neither_source_provided(self):
         with pytest.raises(ValueError, match="Exactly one of"):
@@ -225,6 +241,18 @@ class TestBuildL0FileLists:
             lists = build_l0_file_lists("bias", data_dir=data_dir)
         mock_bmd.assert_called_once_with(data_dir)
         assert len(lists) == 2
+
+    def test_rebuilds_db_if_files_added_on_disk(self, tmp_path):
+        # Materialize a consistent CSV + stubs, then plant an extra .fits
+        # file the CSV does not know about.
+        data_dir = _write_test_csv(tmp_path, _make_mini_db())
+        open(os.path.join(data_dir, "KP.20240405.99999.99.fits"), "w").close()
+
+        with patch("kpfpipe.utils.pipeline.build_mini_database") as mock_bmd:
+            mock_bmd.return_value = _make_mini_db()
+            with pytest.warns(UserWarning, match=r"stale.*\+1 added"):
+                build_l0_file_lists("bias", data_dir=data_dir)
+        mock_bmd.assert_called_once_with(data_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -195,6 +195,18 @@ class TestBuildL0FileLists:
                 build_l0_file_lists("bias", data_dir=data_dir)
         mock_bmd.assert_called_once_with(data_dir)
 
+    def test_rebuilds_db_if_files_removed_from_disk(self, tmp_path):
+        # Materialize a consistent CSV + stubs, then unlink one .fits
+        # the CSV still references.
+        data_dir = _write_test_csv(tmp_path, _make_mini_db())
+        os.unlink(os.path.join(data_dir, os.path.basename(_BIAS_A[0])))
+
+        with patch("kpfpipe.utils.pipeline.build_mini_database") as mock_bmd:
+            mock_bmd.return_value = _make_mini_db()
+            with pytest.warns(UserWarning, match=r"stale.*-1 removed"):
+                build_l0_file_lists("bias", data_dir=data_dir)
+        mock_bmd.assert_called_once_with(data_dir)
+
 
 # ---------------------------------------------------------------------------
 # build_l0_file_lists (real data)

--- a/tests/test_science_recipe.py
+++ b/tests/test_science_recipe.py
@@ -113,14 +113,30 @@ class TestScienceRecipe:
         assert 'image_assembly' in modules
         assert 'calibration_association' in modules
         assert 'spectral_extraction' in modules
+        assert 'wavelength_calibration' in modules
 
     def test_calibration_headers_set(self, recipe_output):
-        """CalibrationAssociation should populate BIASFILE/DIR/AGE headers on L1."""
-        # Verify via the L2 receipt that calibration_association ran; header
-        # inspection requires loading the intermediate L1, which the recipe
-        # doesn't write to disk.  Check at minimum that the receipt entry exists.
+        """CalibrationAssociation's L1 PRIMARY writes survive into L2 INSTRUMENT_HEADER."""
         l2 = KPF2.from_fits(recipe_output)
-        assert 'calibration_association' in l2.receipt['Module_Name'].values
+        inst = l2.headers['INSTRUMENT_HEADER']
+        # bias/dark/flat use basename + DIR + integer AGE
+        for prefix in ('BIAS', 'DARK', 'FLAT'):
+            assert f'{prefix}FILE' in inst
+            assert f'{prefix}DIR'  in inst
+            assert f'AGE{prefix}'  in inst
+        # thar uses legacy convention: WLSFILE = full path (no WLSDIR), AGEWLS = float days
+        assert 'WLSFILE' in inst
+        assert 'WLSDIR' not in inst
+        assert inst['WLSFILE'].endswith('_master_thar_L2.fits')
+        assert isinstance(inst['AGEWLS'], float)
+
+    def test_wave_arrays_populated(self, recipe_output):
+        """WavelengthCalibration should fill the per-fiber WAVE extensions."""
+        l2 = KPF2.from_fits(recipe_output)
+        assert l2.data['GREEN_SCI2_WAVE'].shape == (NORDER_GREEN, NCOL)
+        assert l2.data['RED_SCI2_WAVE'].shape   == (NORDER_RED,   NCOL)
+        assert np.any(l2.data['GREEN_SCI2_WAVE'] != 0)
+        assert np.any(l2.data['RED_SCI2_WAVE']   != 0)
 
     def test_qlp_l0_pngs_exist(self, recipe_output):
         qlp_dir = Path(recipe_output).parents[2] / 'QLP' / '20240405' / OBS_ID / 'L0'

--- a/tests/test_wavelength_calibration.py
+++ b/tests/test_wavelength_calibration.py
@@ -48,7 +48,9 @@ def _make_science_l2(wls_path=None):
     l2.headers['PRIMARY']['INSTRUME'] = 'KPF'
     l2.headers['PRIMARY']['DATE-OBS'] = '2024-04-05T11:08:33'
     if wls_path is not None:
-        l2.headers['PRIMARY']['WLSFILE'] = wls_path
+        # WLSFILE lives in INSTRUMENT_HEADER on L2 (preserves the L1 PRIMARY
+        # written by CalibrationAssociation).
+        l2.headers['INSTRUMENT_HEADER']['WLSFILE'] = wls_path
     return l2
 
 
@@ -110,7 +112,7 @@ class TestLoadWLS:
         with pytest.raises(FileNotFoundError, match='Master WLS file not found'):
             mod.load_wls()
 
-    def test_reads_wlsfile_from_primary(self, master_wls_path):
+    def test_reads_wlsfile_from_instrument_header(self, master_wls_path):
         mod = WavelengthCalibration(_make_science_l2(wls_path=master_wls_path))
         loaded = mod.load_wls()
         assert isinstance(loaded, KPFMasterL2)

--- a/tests/test_wavelength_calibration.py
+++ b/tests/test_wavelength_calibration.py
@@ -1,5 +1,7 @@
 """Tests for the WavelengthCalibration module."""
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -7,6 +9,10 @@ from kpfpipe import DETECTOR
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.masters.level2 import KPFMasterL2
 from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
+from kpfpipe.utils.config import ConfigHandler
+
+
+_SCIENCE_CONFIG_PATH = Path(__file__).parent.parent / 'configs' / 'kpf_drp_science.toml'
 
 
 NORDER_GREEN = DETECTOR['norder']['GREEN']
@@ -82,6 +88,12 @@ class TestConstructor:
         assert mod.chips  == ['GREEN']
         assert mod.fibers == ['SCI2']
 
+    def test_config_handler_accepted(self):
+        config = ConfigHandler(str(_SCIENCE_CONFIG_PATH))
+        mod = WavelengthCalibration(_make_science_l2(), config=config)
+        assert mod.chips  == _CHIPS
+        assert mod.fibers == _FIBERS
+
     def test_invalid_config_type(self):
         with pytest.raises(TypeError):
             WavelengthCalibration(_make_science_l2(), config='not a dict')
@@ -146,11 +158,9 @@ class TestPerform:
         l2 = _make_science_l2(wls_path=master_wls_path)
         mod = WavelengthCalibration(l2)
         mod.perform()
-        assert mod._results == {
-            'wls_path': master_wls_path,
-            'chips':  _CHIPS,
-            'fibers': _FIBERS,
-        }
+        assert mod._results['wls_path'] == master_wls_path
+        assert mod._results['chips']    == _CHIPS
+        assert mod._results['fibers']   == _FIBERS
 
     def test_copies_all_wave_arrays(self, master_wls_path):
         # Every (chip, fiber) WAVE array on the science L2 should match the master.
@@ -174,7 +184,9 @@ class TestPerform:
         )
 
     def test_subset_chips_and_fibers(self, master_wls_path):
-        # Only the requested (chip, fiber) blocks are copied; the rest stay zero.
+        # Only the requested (chip, fiber) blocks are copied; everything
+        # else stays zero — both un-requested fibers within the requested
+        # chip, and un-requested chips entirely.
         l2 = _make_science_l2(wls_path=master_wls_path)
         WavelengthCalibration(l2).perform(chips=['GREEN'], fibers=['SCI2'])
 
@@ -182,11 +194,30 @@ class TestPerform:
         np.testing.assert_array_equal(
             l2.data['GREEN_SCI2_WAVE'], master.data['GREEN_SCI2_WAVE']
         )
-        # An un-requested block remains zero (default fill from KPF2's
-        # _KPF2DataDict alloc on first chip-prefix write).
+        # Un-requested fiber within the requested chip stays zero.
+        assert not np.any(l2.data['GREEN_SCI1_WAVE'])
+        # Un-requested chip stays zero.
         assert not np.any(l2.data['RED_SCI2_WAVE'])
 
     def test_raises_when_wlsfile_missing(self):
         l2 = _make_science_l2()  # no WLSFILE
         with pytest.raises(KeyError, match='WLSFILE'):
+            WavelengthCalibration(l2).perform()
+
+    def test_raises_when_master_missing_requested_fiber(self, tmp_path):
+        # Master only has SCI2; config asks for all 5 fibers → fail loudly.
+        master = KPFMasterL2()
+        master.headers['PRIMARY']['INSTRUME'] = 'KPF'
+        master.headers['PRIMARY']['DATE-OBS'] = '2024-04-05T01:00:37'
+        rng = np.random.default_rng(7)
+        for chip in _CHIPS:
+            norder = NORDER_GREEN if chip == 'GREEN' else NORDER_RED
+            master.data[f'{chip}_SCI2_WAVE'] = rng.uniform(
+                4000.0, 8000.0, size=(norder, NCOL)
+            ).astype(np.float32)
+        master_path = str(tmp_path / 'partial_master.fits')
+        master.to_fits(master_path)
+
+        l2 = _make_science_l2(wls_path=master_path)
+        with pytest.raises(KeyError, match='SKY_WAVE'):
             WavelengthCalibration(l2).perform()

--- a/tests/test_wavelength_calibration.py
+++ b/tests/test_wavelength_calibration.py
@@ -1,0 +1,190 @@
+"""Tests for the WavelengthCalibration module."""
+
+import numpy as np
+import pytest
+
+from kpfpipe import DETECTOR
+from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.data_models.masters.level2 import KPFMasterL2
+from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
+
+
+NORDER_GREEN = DETECTOR['norder']['GREEN']
+NORDER_RED   = DETECTOR['norder']['RED']
+
+_FIBERS = ['SKY', 'SCI1', 'SCI2', 'SCI3', 'CAL']
+_CHIPS  = ['GREEN', 'RED']
+
+# Small detector width for fast tests; the WLS copy is agnostic to NCOL.
+NCOL = 32
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _make_master_l2(seed=42):
+    """Build a KPFMasterL2 with deterministic, distinct per-fiber WAVE arrays.
+
+    Each (chip, fiber) gets its own random-but-reproducible block so we can
+    later confirm that exactly the right block lands on the science L2.
+    """
+    master = KPFMasterL2()
+    master.headers['PRIMARY']['INSTRUME'] = 'KPF'
+    master.headers['PRIMARY']['DATE-OBS'] = '2024-04-05T01:00:37'
+
+    rng = np.random.default_rng(seed)
+    for chip in _CHIPS:
+        norder = NORDER_GREEN if chip == 'GREEN' else NORDER_RED
+        for fiber in _FIBERS:
+            arr = rng.uniform(4000.0, 8000.0, size=(norder, NCOL)).astype(np.float32)
+            master.data[f'{chip}_{fiber}_WAVE'] = arr
+    return master
+
+
+def _make_science_l2(wls_path=None):
+    """Build a minimal KPF2 for wavecal tests."""
+    l2 = KPF2()
+    l2.headers['PRIMARY']['INSTRUME'] = 'KPF'
+    l2.headers['PRIMARY']['DATE-OBS'] = '2024-04-05T11:08:33'
+    if wls_path is not None:
+        l2.headers['PRIMARY']['WLSFILE'] = wls_path
+    return l2
+
+
+@pytest.fixture
+def master_wls_path(tmp_path):
+    """Write a synthetic KPFMasterL2 to disk and return its path."""
+    master = _make_master_l2()
+    path = str(tmp_path / 'kpf_ML2_20240405T010037.fits')
+    master.to_fits(path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Constructor / config plumbing
+# ---------------------------------------------------------------------------
+
+class TestConstructor:
+
+    def test_default_chips_and_fibers(self):
+        mod = WavelengthCalibration(_make_science_l2())
+        assert mod.chips  == _CHIPS
+        assert mod.fibers == _FIBERS
+
+    def test_dict_config_override(self):
+        mod = WavelengthCalibration(
+            _make_science_l2(),
+            config={'chips': ['GREEN'], 'fibers': ['SCI2']},
+        )
+        assert mod.chips  == ['GREEN']
+        assert mod.fibers == ['SCI2']
+
+    def test_invalid_config_type(self):
+        with pytest.raises(TypeError):
+            WavelengthCalibration(_make_science_l2(), config='not a dict')
+
+    def test_results_is_none_before_perform(self):
+        mod = WavelengthCalibration(_make_science_l2())
+        assert mod._results is None
+
+    def test_wls_path_is_none_before_load(self):
+        mod = WavelengthCalibration(_make_science_l2())
+        assert mod._wls_path is None
+
+
+# ---------------------------------------------------------------------------
+# load_wls()
+# ---------------------------------------------------------------------------
+
+class TestLoadWLS:
+
+    def test_raises_when_wlsfile_missing(self):
+        mod = WavelengthCalibration(_make_science_l2())
+        with pytest.raises(KeyError, match='WLSFILE'):
+            mod.load_wls()
+
+    def test_raises_when_file_does_not_exist(self, tmp_path):
+        bogus = str(tmp_path / 'does_not_exist.fits')
+        mod = WavelengthCalibration(_make_science_l2(wls_path=bogus))
+        with pytest.raises(FileNotFoundError, match='Master WLS file not found'):
+            mod.load_wls()
+
+    def test_reads_wlsfile_from_primary(self, master_wls_path):
+        mod = WavelengthCalibration(_make_science_l2(wls_path=master_wls_path))
+        loaded = mod.load_wls()
+        assert isinstance(loaded, KPFMasterL2)
+        assert mod._wls_path == master_wls_path
+
+    def test_explicit_path_overrides_header(self, master_wls_path):
+        # Set WLSFILE to a bogus value to make sure the override wins.
+        mod = WavelengthCalibration(_make_science_l2(wls_path='/tmp/bogus.fits'))
+        loaded = mod.load_wls(wls_path=master_wls_path)
+        assert isinstance(loaded, KPFMasterL2)
+        assert mod._wls_path == master_wls_path
+
+
+# ---------------------------------------------------------------------------
+# perform()
+# ---------------------------------------------------------------------------
+
+class TestPerform:
+
+    def test_returns_l2_obj(self, master_wls_path):
+        l2 = _make_science_l2(wls_path=master_wls_path)
+        mod = WavelengthCalibration(l2)
+        assert mod.perform() is l2
+
+    def test_adds_receipt_entry(self, master_wls_path):
+        l2 = _make_science_l2(wls_path=master_wls_path)
+        WavelengthCalibration(l2).perform()
+        assert (l2.receipt['Module_Name'] == 'wavelength_calibration').any()
+
+    def test_results_populated_after_perform(self, master_wls_path):
+        l2 = _make_science_l2(wls_path=master_wls_path)
+        mod = WavelengthCalibration(l2)
+        mod.perform()
+        assert mod._results == {
+            'wls_path': master_wls_path,
+            'chips':  _CHIPS,
+            'fibers': _FIBERS,
+        }
+
+    def test_copies_all_wave_arrays(self, master_wls_path):
+        # Every (chip, fiber) WAVE array on the science L2 should match the master.
+        l2 = _make_science_l2(wls_path=master_wls_path)
+        WavelengthCalibration(l2).perform()
+
+        master = KPFMasterL2.from_fits(master_wls_path)
+        for chip in _CHIPS:
+            for fiber in _FIBERS:
+                key = f'{chip}_{fiber}_WAVE'
+                np.testing.assert_array_equal(l2.data[key], master.data[key])
+
+    def test_explicit_path_bypasses_header(self, master_wls_path):
+        # WLSFILE header is bogus, but wls_path override is valid → perform() succeeds.
+        l2 = _make_science_l2(wls_path='/tmp/bogus.fits')
+        WavelengthCalibration(l2).perform(wls_path=master_wls_path)
+
+        master = KPFMasterL2.from_fits(master_wls_path)
+        np.testing.assert_array_equal(
+            l2.data['GREEN_SCI2_WAVE'], master.data['GREEN_SCI2_WAVE']
+        )
+
+    def test_subset_chips_and_fibers(self, master_wls_path):
+        # Only the requested (chip, fiber) blocks are copied; the rest stay zero.
+        l2 = _make_science_l2(wls_path=master_wls_path)
+        WavelengthCalibration(l2).perform(chips=['GREEN'], fibers=['SCI2'])
+
+        master = KPFMasterL2.from_fits(master_wls_path)
+        np.testing.assert_array_equal(
+            l2.data['GREEN_SCI2_WAVE'], master.data['GREEN_SCI2_WAVE']
+        )
+        # An un-requested block remains zero (default fill from KPF2's
+        # _KPF2DataDict alloc on first chip-prefix write).
+        assert not np.any(l2.data['RED_SCI2_WAVE'])
+
+    def test_raises_when_wlsfile_missing(self):
+        l2 = _make_science_l2()  # no WLSFILE
+        with pytest.raises(KeyError, match='WLSFILE'):
+            WavelengthCalibration(l2).perform()


### PR DESCRIPTION
# WavelengthCalibration module + supporting infrastructure

  Implements the WavelengthCalibration module for KPF-DRP vNext, which copies the
  per-fiber wavelength solution from a precomputed thar WLS master onto a science L2.
  Includes the supporting changes in CalibrationAssociation, the WLS masters module,
  the pipeline utilities, and the timestamp helpers.

  ## Summary

  ### New module: `WavelengthCalibration`

  `kpfpipe/modules/wavelength_calibration.py` — given an L2 with extracted spectra,
  finds the master WLS L2 referenced by `WLSFILE` on the L2 `INSTRUMENT_HEADER`, then
  copies each `{CHIP}_{FIBER}_WAVE` array onto the science L2. Preflights every
  requested `(chip, fiber)` key against the master and raises a clear `KeyError` if
  anything is missing. Wired into `recipes/kpf_drp_science.py` between
  `SpectralExtraction` and `DiagL2`.

  ### CalibrationAssociation — thar support

  Extends `CalibrationAssociation` to handle a new `'thar'` cal-type. Headers follow
  the legacy v2 convention:

  - `WLSFILE` — full path to the master L2 (no separate `WLSDIR`).
  - `AGEWLS` — float days, sign convention `master_dt − obs_dt`.

  Other cal-types (bias/dark/flat) keep the basename + DIR + integer-day pattern they
  already had.

  ### WLS masters refactor

  `kpfpipe/modules/masters/wls.py`:

  - `make_master_l2(return_stacks=...)` → `make_master_l2(diagnostics_path=...)`.
  Always returns the L2; if `diagnostics_path` is given, calls the new
  `save_diagnostics(path)` method to persist per-frame coefficient and line stacks to
  HDF5. No more open in-memory file handles returned to callers.
  - `save_diagnostics(path)` is a new public method; can be called post-hoc to persist
  stashed stacks without recomputing.
  - `compute_wls_from_stack` simplified: dropped the unused `return_stacks` kwarg,
  always returns the 4-tuple.
  - Variable cleanups: `fit_line_positions_1D` → `1d`, dropped leading-underscore
  prefixes on locals, renamed `_coeffs_by_chip`/`_lines_by_chip` →
  `_coeffs_stack`/`_lines_stack`.
  - Recipe (`recipes/kpf_drp_masters.py`) writes both `{obs_id}_master_thar_L2.fits`
  and `{obs_id}_master_thar_diagnostics.h5` per cluster.

  ### Pipeline utilities (`kpfpipe/utils/pipeline.py`)

  - `_OBJECT_MAP` values are now lists, so `'thar'` fans out to all five
  `autocal-thar-all-{morn,midday,eve,night,midnight}` OBJECT variants.
  - `build_mini_database` is now a pure 6-column file/header index. Cluster detection
  (`CAL_START`/`CAL_END`) moved out into `build_l0_file_lists`, which gains a
  `cluster_gap_seconds=7200` keyword-only kwarg.
  - `build_l0_file_lists` fails loudly when any cluster falls below `min_file_count`.
  The previous silent merge-and-warn fallback is gone — violated the "no implicit
  calibration assumptions" charter.
  - Self-healing CSV: when the cached mini_db's FILENAME set drifts from `glob(*.fits)`
   (after realpath normalization), warn-and-rebuild instead of trusting stale rows.
  - `build_filepath` / `build_qlp_dir` validate `data_root`: `None` means bare-filename
   mode (build_filepath only); any other invalid value (empty string, non-string)
  raises rather than producing a silent relative path.

  ### Timestamp utilities (`kpfpipe/utils/kpf.py`)

  Hardened end-to-end with semantic validation:

  - Two new private validators (`_validate_kpf_timestamp`, `_validate_eprv_timestamp`)
  check format + real-date + seconds-in-range / HH<24 / MM<60 / SS<60.
  - All `is_*`, `get_*`, and converter functions invoke these validators.
  Previously-silent slips (e.g., `'20240405.99999.57'` rolling over into the next day,
  `eprv_to_kpf('20240405T256099')` emitting an invalid KPF timestamp) now raise.
  - New `get_seconds_since_j2000(s)` (replaces `timestamp_to_seconds`); anchored to
  J2000.0 = 2000-01-01 12:00 UTC. Docstring notes the naive-UTC simplification.
  - Param renames for consistency: `input_str` → `s`, `filename` → `fn`.

  ### Reference / tests

  - `reference/legacy_data_format.rst` — mirror of the legacy v2 data-format doc,
  consulted to align WLSFILE/AGEWLS conventions.
  - New `tests/test_kpf_utils.py` validation suite (42 tests).
  - New `tests/test_wavelength_calibration.py` (19 tests).
  - `tests/test_calibration_association.py` extended for thar.
  - `tests/test_masters_recipe.py` extended for thar imtype + staleness check + cluster
   underflow.
  - `tests/test_science_recipe.py` — end-to-end recipe now asserts
  `wavelength_calibration` in the receipt chain, that the per-fiber WAVE arrays are
  populated, and that the bias/dark/flat/thar cal headers survive to L2
  `INSTRUMENT_HEADER`.

  ### Other

  - `.gitignore` broadened from `tests/testdata/**/*.fits` to `tests/testdata/`.
  Nothing under that path was ever tracked; the change is defensive.

  ## Test plan

  - [x] `conda run -n kpfpipe python -m pytest tests/` — 528/528 pass.
  - [x] Science recipe runs end-to-end against
  `tests/testdata/L0/20240405/KP.20240405.40113.57.fits`, producing an L2 with
  populated WAVE arrays and a complete receipt chain.
  - [x] Masters recipe produces `{obs_id}_master_thar_L2.fits` +
  `{obs_id}_master_thar_diagnostics.h5` from the 5 bundled ThAr L0 frames (run locally;
   not exercised in CI).

  ## Notes

  - `BarycentricCorrection` is still commented out in the science recipe (separate
  future PR).
  - LFC and etalon WLS paths are deferred; the cal-type token is already structured to
  extend (`thar`, future `lfc`, `etalon`).
  - Drift correction across multiple WLS references (legacy `WLSFILE2`/`AGEWLS2`) is
  deferred.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)