### PR TITLE
Kpf next masters io

### DIFF
--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -534,7 +534,7 @@ class BaseMasterModule:
     # Public methods
     # ------------------------------------------------------------------
 
-    def save_master(self, level, path):
+    def save_master(self, level, path, *, overwrite=False):
         """
         Write the cached master object to a FITS file at `path`.
 
@@ -546,11 +546,20 @@ class BaseMasterModule:
             subclass's `make_master_l1` / `make_master_l2` entry point.
         path : str
             Output FITS path. Parent directories are created as needed.
+        overwrite : bool, optional
+            If False (default), refuse to clobber an existing file and
+            raise FileExistsError. If True, replace any existing file
+            at `path`. Defaults to False to protect against accidental
+            overwrites when called directly; entry points that pass an
+            output path through `make_master_lN()` should set True
+            explicitly.
 
         Raises
         ------
         ValueError
             If `level` is not a recognized data level.
+        FileExistsError
+            If `path` already exists and `overwrite` is False.
         RuntimeError
             If the corresponding make_master_lN() has not been run yet,
             or raised before constructing the master.
@@ -563,6 +572,11 @@ class BaseMasterModule:
         if obj is None:
             raise RuntimeError(
                 f"No master available; run make_master_{level.lower()}() first"
+            )
+
+        if not overwrite and os.path.exists(path):
+            raise FileExistsError(
+                f"{path} already exists; pass overwrite=True to replace it"
             )
 
         os.makedirs(os.path.dirname(path), exist_ok=True)

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -1,8 +1,10 @@
 """
 Base class for KPF Masters modules.
 """
-import numpy as np
+import os
 import warnings
+
+import numpy as np
 
 from kpfpipe import DEFAULTS, DETECTOR
 from kpfpipe.data_models.level0 import KPF0
@@ -49,6 +51,9 @@ class BaseMasterModule:
             setattr(self, k, params.get(k, v))
 
         self._l1_obj_cache = {}
+
+        self.ml1_obj = None  # populated by subclass make_master_l1(); used by save_master('L1', ...)
+        self.ml2_obj = None  # populated by subclass make_master_l2(); used by save_master('L2', ...)
 
 
     # ------------------------------------------------------------------
@@ -523,3 +528,42 @@ class BaseMasterModule:
             l1_arrays[f'{chip}_MASK'] = good
 
         return l1_arrays
+
+
+    # ------------------------------------------------------------------
+    # Public methods
+    # ------------------------------------------------------------------
+
+    def save_master(self, level, path):
+        """
+        Write the cached master object to a FITS file at `path`.
+
+        Parameters
+        ----------
+        level : str
+            Data level of the master to save; selects which cached
+            object to write. One of 'L1' or 'L2', matching the
+            subclass's `make_master_l1` / `make_master_l2` entry point.
+        path : str
+            Output FITS path. Parent directories are created as needed.
+
+        Raises
+        ------
+        ValueError
+            If `level` is not a recognized data level.
+        RuntimeError
+            If the corresponding make_master_lN() has not been run yet,
+            or raised before constructing the master.
+        """
+        if level not in ('L1', 'L2'):
+            raise ValueError(f"level must be 'L1' or 'L2'; got {level!r}")
+
+        attr = f'ml{level[1]}_obj'
+        obj = getattr(self, attr, None)
+        if obj is None:
+            raise RuntimeError(
+                f"No master available; run make_master_{level.lower()}() first"
+            )
+
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        obj.to_fits(path)

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -46,9 +46,28 @@ class Bias(BaseMasterModule):
     # Public entry point
     # ------------------------------------------------------------------
 
-    def make_master_l1(self, l0_file_list=None, nstream=None, sigma=None, verbose=True):
+    def make_master_l1(self, l0_file_list=None, nstream=None, sigma=None,
+                       master_path=None, verbose=True):
         """
-        Build master bias from stack
+        Build master bias from stack.
+
+        The constructed KPFMasterL1 is returned and cached on
+        `self.ml1_obj`; pass `master_path` to also persist it to disk
+        via `save_master('L1', ...)`.
+
+        Parameters
+        ----------
+        l0_file_list : list of str, optional
+            L0 files to stack. Defaults to self.l0_file_list.
+        nstream : int, optional
+            Stream threshold passed to stack_frames.
+        sigma : float, optional
+            Outlier rejection threshold passed to stack_frames.
+        master_path : str, optional
+            If provided, calls `self.save_master('L1', master_path)` at
+            the end to persist the master L1 to a FITS file at this path.
+        verbose : bool, optional
+            If True (default), emit per-frame progress prints during stacking.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -96,6 +115,9 @@ class Bias(BaseMasterModule):
             }
             for chip in self.chips
         }
+
+        if master_path is not None:
+            self.save_master('L1', master_path, overwrite=True)
 
         return self.ml1_obj
 

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -47,12 +47,12 @@ class Bias(BaseMasterModule):
     # ------------------------------------------------------------------
 
     def make_master_l1(self, l0_file_list=None, nstream=None, sigma=None,
-                       master_path=None, verbose=True):
+                       filepath=None, verbose=True):
         """
         Build master bias from stack.
 
         The constructed KPFMasterL1 is returned and cached on
-        `self.ml1_obj`; pass `master_path` to also persist it to disk
+        `self.ml1_obj`; pass `filepath` to also persist it to disk
         via `save_master('L1', ...)`.
 
         Parameters
@@ -63,9 +63,9 @@ class Bias(BaseMasterModule):
             Stream threshold passed to stack_frames.
         sigma : float, optional
             Outlier rejection threshold passed to stack_frames.
-        master_path : str, optional
-            If provided, calls `self.save_master('L1', master_path)` at
-            the end to persist the master L1 to a FITS file at this path.
+        filepath : str, optional
+            If provided, calls `self.save_master('L1', filepath)` at
+            the end to persist the master L1 to a FITS file at this filepath.
         verbose : bool, optional
             If True (default), emit per-frame progress prints during stacking.
         """
@@ -116,8 +116,8 @@ class Bias(BaseMasterModule):
             for chip in self.chips
         }
 
-        if master_path is not None:
-            self.save_master('L1', master_path, overwrite=True)
+        if filepath is not None:
+            self.save_master('L1', filepath, overwrite=True)
 
         return self.ml1_obj
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -64,7 +64,6 @@ class WLS(BaseMasterModule):
         self._load_linelist()
 
         self._results = None  # populated by make_master_l2()
-        self.ml2_obj       = None  # populated by make_master_l2(); used by save_master_l2()
         self._coeffs_stack = None  # populated by make_master_l2(); used by save_diagnostics()
         self._lines_stack  = None  # populated by make_master_l2(); used by save_diagnostics()
 
@@ -721,7 +720,7 @@ class WLS(BaseMasterModule):
         `compute_wls_from_stack`. The resulting wavelength arrays are
         written to the per-fiber _WAVE extensions of a KPFMasterL2 object,
         which is returned and cached on `self.ml2_obj`; pass `master_path`
-        to also persist it to disk via `save_master_l2()`. Per-frame
+        to also persist it to disk via `save_master('L2', ...)`. Per-frame
         coefficient and line stacks are always stashed on
         `self._coeffs_stack` / `self._lines_stack`; pass `diagnostics_path`
         to also persist them to disk via `save_diagnostics()`.
@@ -744,8 +743,8 @@ class WLS(BaseMasterModule):
             Polynomial degree along the fiber axis (used for 3- and 5-fiber fits).
             Defaults to self.polyorder_f.
         master_path : str, optional
-            If provided, calls `self.save_master_l2(master_path)` at the end
-            to persist the master L2 to a FITS file at this path.
+            If provided, calls `self.save_master('L2', master_path)` at
+            the end to persist the master L2 to a FITS file at this path.
         diagnostics_path : str, optional
             If provided, calls `self.save_diagnostics(diagnostics_path)`
             at the end to persist the per-frame coefficient and line stacks
@@ -841,29 +840,12 @@ class WLS(BaseMasterModule):
         self.ml2_obj.receipt_add_entry('master_wls', 'PASS')
 
         if master_path is not None:
-            self.save_master_l2(master_path)
+            self.save_master('L2', master_path)
 
         if diagnostics_path is not None:
             self.save_diagnostics(diagnostics_path)
 
         return self.ml2_obj
-
-
-    def save_master_l2(self, path):
-        """
-        Write the master L2 to a FITS file at `path`.
-
-        Raises
-        ------
-        RuntimeError
-            If make_master_l2() has not been run yet, or raised before
-            constructing the master.
-        """
-        if self.ml2_obj is None:
-            raise RuntimeError("No master available; run make_master_l2() first")
-
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        self.ml2_obj.to_fits(path)
 
 
     def save_diagnostics(self, path):

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -1,6 +1,7 @@
 """
 KPF Master Wavelength Solution construction module.
 """
+import os
 import warnings
 
 from astropy.stats import mad_std
@@ -63,6 +64,7 @@ class WLS(BaseMasterModule):
         self._load_linelist()
 
         self._results = None  # populated by make_master_l2()
+        self.ml2_obj       = None  # populated by make_master_l2(); used by save_master_l2()
         self._coeffs_stack = None  # populated by make_master_l2(); used by save_diagnostics()
         self._lines_stack  = None  # populated by make_master_l2(); used by save_diagnostics()
 
@@ -707,6 +709,7 @@ class WLS(BaseMasterModule):
                        polyorder_x=None,
                        polyorder_m=None,
                        polyorder_f=None,
+                       master_path=None,
                        diagnostics_path=None,
                        verbose=True,
                       ):
@@ -717,7 +720,8 @@ class WLS(BaseMasterModule):
         computes per-chip Legendre wavelength solutions using
         `compute_wls_from_stack`. The resulting wavelength arrays are
         written to the per-fiber _WAVE extensions of a KPFMasterL2 object,
-        which is returned and cached on `self.ml2_obj`. Per-frame
+        which is returned and cached on `self.ml2_obj`; pass `master_path`
+        to also persist it to disk via `save_master_l2()`. Per-frame
         coefficient and line stacks are always stashed on
         `self._coeffs_stack` / `self._lines_stack`; pass `diagnostics_path`
         to also persist them to disk via `save_diagnostics()`.
@@ -739,6 +743,9 @@ class WLS(BaseMasterModule):
         polyorder_f : int, optional
             Polynomial degree along the fiber axis (used for 3- and 5-fiber fits).
             Defaults to self.polyorder_f.
+        master_path : str, optional
+            If provided, calls `self.save_master_l2(master_path)` at the end
+            to persist the master L2 to a FITS file at this path.
         diagnostics_path : str, optional
             If provided, calls `self.save_diagnostics(diagnostics_path)`
             at the end to persist the per-frame coefficient and line stacks
@@ -833,10 +840,30 @@ class WLS(BaseMasterModule):
 
         self.ml2_obj.receipt_add_entry('master_wls', 'PASS')
 
+        if master_path is not None:
+            self.save_master_l2(master_path)
+
         if diagnostics_path is not None:
             self.save_diagnostics(diagnostics_path)
 
         return self.ml2_obj
+
+
+    def save_master_l2(self, path):
+        """
+        Write the master L2 to a FITS file at `path`.
+
+        Raises
+        ------
+        RuntimeError
+            If make_master_l2() has not been run yet, or raised before
+            constructing the master.
+        """
+        if self.ml2_obj is None:
+            raise RuntimeError("No master available; run make_master_l2() first")
+
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        self.ml2_obj.to_fits(path)
 
 
     def save_diagnostics(self, path):
@@ -857,6 +884,7 @@ class WLS(BaseMasterModule):
         if not self._coeffs_stack or not self._lines_stack:
             raise RuntimeError("No diagnostics available; run make_master_l2() first")
 
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         str_dt = h5py.string_dtype(encoding='utf-8')
         with h5py.File(path, 'w') as f:
             for chip, coeffs_stack in self._coeffs_stack.items():

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -840,7 +840,7 @@ class WLS(BaseMasterModule):
         self.ml2_obj.receipt_add_entry('master_wls', 'PASS')
 
         if master_path is not None:
-            self.save_master('L2', master_path)
+            self.save_master('L2', master_path, overwrite=True)
 
         if diagnostics_path is not None:
             self.save_diagnostics(diagnostics_path)

--- a/kpfpipe/quality_control/quicklook/level0.py
+++ b/kpfpipe/quality_control/quicklook/level0.py
@@ -24,6 +24,8 @@ class PlotL0:
         output_dir: Directory to save PNG files. None = return Figure only.
     """
 
+    _PLOT_METHODS = ('stitched_image',)
+
     def __init__(self, l0_obj, output_dir=None):
         self.l0 = l0_obj
         self.output_dir = output_dir
@@ -149,15 +151,38 @@ class PlotL0:
 
         return fig
 
-    def all(self):
+    def run(self, which):
         """
-        Generate all L0 plots for chips present in the data.
+        Generate the requested plot(s) for every chip that has data,
+        saving each to `output_dir` and closing the matplotlib figure
+        so callers don't accumulate them.
+
+        Args:
+            which: 'all' to run every implemented plot, or the name of a
+                   single plot method (one of self._PLOT_METHODS).
 
         Returns:
-            dict mapping plot name to matplotlib.Figure.
+            dict mapping `{method_name}_{chip}` to matplotlib.Figure
+            (closed; useful for tests/introspection).
         """
+        if which == 'all':
+            names = self._PLOT_METHODS
+        elif which in self._PLOT_METHODS:
+            names = (which,)
+        else:
+            raise ValueError(
+                f"unknown plot {which!r}; expected 'all' or one of {self._PLOT_METHODS}"
+            )
+
+        if self.output_dir is not None:
+            os.makedirs(self.output_dir, exist_ok=True)
+
         figures = {}
         for chip in ['green', 'red']:
-            if self._has_chip(chip):
-                figures[f'L0_stitched_{chip}'] = self.stitched_image(chip)
+            if not self._has_chip(chip):
+                continue
+            for name in names:
+                fig = getattr(self, name)(chip)
+                figures[f'{name}_{chip}'] = fig
+                plt.close(fig)
         return figures

--- a/kpfpipe/quality_control/quicklook/level1.py
+++ b/kpfpipe/quality_control/quicklook/level1.py
@@ -27,6 +27,8 @@ class PlotL1:
         output_dir: Directory to save PNG files. None = return Figure only.
     """
 
+    _PLOT_METHODS = ('image',)
+
     def __init__(self, l1_obj, output_dir=None):
         self.l1 = l1_obj
         self.output_dir = output_dir
@@ -153,15 +155,38 @@ class PlotL1:
             return False
         return np.size(self.l1.data[ext]) > 0
 
-    def all(self):
+    def run(self, which):
         """
-        Generate all implemented L1 plots for chips present in the data.
+        Generate the requested plot(s) for every chip that has data,
+        saving each to `output_dir` and closing the matplotlib figure
+        so callers don't accumulate them.
+
+        Args:
+            which: 'all' to run every implemented plot, or the name of a
+                   single plot method (one of self._PLOT_METHODS).
 
         Returns:
-            dict mapping plot name to matplotlib.Figure.
+            dict mapping `{method_name}_{chip}` to matplotlib.Figure
+            (closed; useful for tests/introspection).
         """
+        if which == 'all':
+            names = self._PLOT_METHODS
+        elif which in self._PLOT_METHODS:
+            names = (which,)
+        else:
+            raise ValueError(
+                f"unknown plot {which!r}; expected 'all' or one of {self._PLOT_METHODS}"
+            )
+
+        if self.output_dir is not None:
+            os.makedirs(self.output_dir, exist_ok=True)
+
         figures = {}
         for chip in ['green', 'red']:
-            if self._has_chip(chip):
-                figures[f'L1_image_{chip}'] = self.image(chip)
+            if not self._has_chip(chip):
+                continue
+            for name in names:
+                fig = getattr(self, name)(chip)
+                figures[f'{name}_{chip}'] = fig
+                plt.close(fig)
         return figures

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -48,13 +48,11 @@ def main(config, args):
 
     # master wavelength solution (ThAr)
     for files in build_l0_file_lists('thar', mini_db=mini_db):
-        out_path         = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
-        diagnostics_path = out_path[:-len('_L2.fits')] + '_diagnostics.h5'
-        os.makedirs(os.path.dirname(out_path), exist_ok=True)
+        master_path      = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
+        diagnostics_path = master_path[:-len('_L2.fits')] + '_diagnostics.h5'
 
         wls_handler = WLS(files, config)
-        wls_l2 = wls_handler.make_master_l2(diagnostics_path=diagnostics_path)
-        wls_l2.to_fits(out_path)
+        wls_handler.make_master_l2(master_path=master_path, diagnostics_path=diagnostics_path)
 
     print("\n\n=== exiting kpf_drp_masters pipeline ===\n\n")
 

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -28,29 +28,29 @@ def main(config, args):
 
     # master bias
     for files in build_l0_file_lists('bias', mini_db=mini_db):
-        master_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='bias')
+        bias_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='bias')
         bias_handler = Bias(files, config)
-        bias_handler.make_master_l1(master_path=master_path)
+        bias_handler.make_master_l1(filepath=bias_path)
 
     # master dark (not yet implemented)
     #for files in build_l0_file_lists('dark', mini_db=mini_db):
-    #    master_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='dark')
+    #    dark_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='dark')
     #    dark_handler = Dark(files, config)
-    #    dark_handler.make_master_l1(master_path=master_path)
+    #    dark_handler.make_master_l1(filepath=dark_path)
 
     # master flat (not yet implemented)
     #for files in build_l0_file_lists('flat', mini_db=mini_db):
-    #    master_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='flat')
+    #    flat_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='flat')
     #    flat_handler = Flat(files, config)
-    #    flat_handler.make_master_l1(master_path=master_path)
+    #    flat_handler.make_master_l1(filepath=flat_path)
 
     # master wavelength solution (ThAr)
     for files in build_l0_file_lists('thar', mini_db=mini_db):
-        master_path      = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
-        diagnostics_path = master_path[:-len('_L2.fits')] + '_diagnostics.h5'
+        wls_master_path      = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
+        wls_diagnostics_path = wls_master_path[:-len('_L2.fits')] + '_diagnostics.h5'
 
         wls_handler = WLS(files, config)
-        wls_handler.make_master_l2(master_path=master_path, diagnostics_path=diagnostics_path)
+        wls_handler.make_master_l2(master_path=wls_master_path, diagnostics_path=wls_diagnostics_path)
 
     print("\n\n=== exiting kpf_drp_masters pipeline ===\n\n")
 

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -28,23 +28,21 @@ def main(config, args):
 
     # master bias
     for files in build_l0_file_lists('bias', mini_db=mini_db):
+        master_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='bias')
         bias_handler = Bias(files, config)
-        bias_l1 = bias_handler.make_master_l1()
-        out_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='bias')
-        os.makedirs(os.path.dirname(out_path), exist_ok=True)
-        bias_l1.to_fits(out_path)
+        bias_handler.make_master_l1(master_path=master_path)
 
     # master dark (not yet implemented)
     #for files in build_l0_file_lists('dark', mini_db=mini_db):
+    #    master_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='dark')
     #    dark_handler = Dark(files, config)
-    #    dark_l1 = dark_handler.make_master_l1()
-    #    dark_l1.to_fits(build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='dark'))
+    #    dark_handler.make_master_l1(master_path=master_path)
 
     # master flat (not yet implemented)
     #for files in build_l0_file_lists('flat', mini_db=mini_db):
+    #    master_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='flat')
     #    flat_handler = Flat(files, config)
-    #    flat_l1 = flat_handler.make_master_l1()
-    #    flat_l1.to_fits(build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='flat'))
+    #    flat_handler.make_master_l1(master_path=master_path)
 
     # master wavelength solution (ThAr)
     for files in build_l0_file_lists('thar', mini_db=mini_db):

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -1,7 +1,5 @@
 import os
 
-import matplotlib.pyplot as plt
-
 from kpfpipe.data_models.level0 import KPF0
 #from kpfpipe.data_models.level1 import KPF1
 
@@ -20,12 +18,6 @@ from kpfpipe.quality_control.quicklook.level1 import PlotL1
 from kpfpipe.utils.pipeline import build_filepath, build_qlp_dir
 
 
-def _run_qlp(plotter):
-    figs = plotter.all()
-    for fig in figs.values():
-        plt.close(fig)
-
-
 def main(config, args):
     print("\n\n=== entering kpf_drp_science pipeline ===\n\n")
 
@@ -41,8 +33,7 @@ def main(config, args):
     l0 = KPF0.from_fits(build_filepath(obs_id, 'L0', data_root=data_root_in))
 
     l0_qlp_dir = build_qlp_dir(obs_id, 'L0', data_root=data_root_out)
-    os.makedirs(l0_qlp_dir, exist_ok=True)
-    _run_qlp(PlotL0(l0, output_dir=l0_qlp_dir))
+    PlotL0(l0, output_dir=l0_qlp_dir).run('all')
 
     # read raw L0 file and assemble into L1 full frame image (FFI)
     image_assembly = ImageAssembly(l0, config)
@@ -51,8 +42,7 @@ def main(config, args):
     # L1 QLP is computed on the assembled (pre-bias-subtraction) image because
     # ImageProcessing mutates GREEN_CCD/RED_CCD in place during bias subtraction.
     l1_qlp_dir = build_qlp_dir(obs_id, 'L1', data_root=data_root_out)
-    os.makedirs(l1_qlp_dir, exist_ok=True)
-    _run_qlp(PlotL1(l1, output_dir=l1_qlp_dir))
+    PlotL1(l1, output_dir=l1_qlp_dir).run('all')
 
     # assign calibration masters (bias, dark, flat, wls) to this frame
     calibration_association = CalibrationAssociation(l1, config)

--- a/tests/test_master_bias.py
+++ b/tests/test_master_bias.py
@@ -193,7 +193,7 @@ class TestMasterBiasSaveMaster:
         bias = Bias(FILE_LIST)
         master_path = tmp_path / "master_bias.fits"
         with patch.object(bias, "stack_frames", return_value=synthetic):
-            bias.make_master_l1(master_path=str(master_path))
+            bias.make_master_l1(filepath=str(master_path))
         assert master_path.exists()
 
     def test_master_path_creates_parent_dir(self, tmp_path):
@@ -201,7 +201,7 @@ class TestMasterBiasSaveMaster:
         bias = Bias(FILE_LIST)
         master_path = tmp_path / "nested" / "subdir" / "master_bias.fits"
         with patch.object(bias, "stack_frames", return_value=synthetic):
-            bias.make_master_l1(master_path=str(master_path))
+            bias.make_master_l1(filepath=str(master_path))
         assert master_path.exists()
 
     def test_master_path_overwrites_existing(self, tmp_path):
@@ -210,7 +210,7 @@ class TestMasterBiasSaveMaster:
         master_path = tmp_path / "master_bias.fits"
         master_path.touch()
         with patch.object(bias, "stack_frames", return_value=synthetic):
-            bias.make_master_l1(master_path=str(master_path))
+            bias.make_master_l1(filepath=str(master_path))
         assert master_path.read_bytes()[:6] == b"SIMPLE"
 
     def test_save_master_before_make_raises(self):

--- a/tests/test_master_bias.py
+++ b/tests/test_master_bias.py
@@ -181,6 +181,55 @@ class TestMasterBiasRoundTrip:
 
 
 # ---------------------------------------------------------------------------
+# master_path integration with save_master
+# ---------------------------------------------------------------------------
+
+
+class TestMasterBiasSaveMaster:
+    """make_master_l1(master_path=...) should write the FITS via save_master."""
+
+    def test_master_path_writes_fits(self, tmp_path):
+        synthetic = make_l1_arrays()
+        bias = Bias(FILE_LIST)
+        master_path = tmp_path / "master_bias.fits"
+        with patch.object(bias, "stack_frames", return_value=synthetic):
+            bias.make_master_l1(master_path=str(master_path))
+        assert master_path.exists()
+
+    def test_master_path_creates_parent_dir(self, tmp_path):
+        synthetic = make_l1_arrays()
+        bias = Bias(FILE_LIST)
+        master_path = tmp_path / "nested" / "subdir" / "master_bias.fits"
+        with patch.object(bias, "stack_frames", return_value=synthetic):
+            bias.make_master_l1(master_path=str(master_path))
+        assert master_path.exists()
+
+    def test_master_path_overwrites_existing(self, tmp_path):
+        synthetic = make_l1_arrays()
+        bias = Bias(FILE_LIST)
+        master_path = tmp_path / "master_bias.fits"
+        master_path.touch()
+        with patch.object(bias, "stack_frames", return_value=synthetic):
+            bias.make_master_l1(master_path=str(master_path))
+        assert master_path.read_bytes()[:6] == b"SIMPLE"
+
+    def test_save_master_before_make_raises(self):
+        bias = Bias(FILE_LIST)
+        with pytest.raises(RuntimeError, match="run make_master_l1"):
+            bias.save_master('L1', '/tmp/should_not_be_created.fits')
+
+    def test_save_master_refuses_overwrite_by_default(self, tmp_path):
+        synthetic = make_l1_arrays()
+        bias = Bias(FILE_LIST)
+        master_path = tmp_path / "master_bias.fits"
+        master_path.touch()
+        with patch.object(bias, "stack_frames", return_value=synthetic):
+            bias.make_master_l1()  # populates ml1_obj
+        with pytest.raises(FileExistsError, match="overwrite=True"):
+            bias.save_master('L1', str(master_path))
+
+
+# ---------------------------------------------------------------------------
 # Regression tests (real L0 data)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -350,6 +350,29 @@ class TestMakeMasterL2:
         wls.save_master('L2', str(master_path))
         assert master_path.exists()
 
+    def test_save_master_refuses_overwrite_by_default(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        wls.make_master_l2()
+        master_path = tmp_path / "master.fits"
+        master_path.touch()
+        with pytest.raises(FileExistsError, match="overwrite=True"):
+            wls.save_master('L2', str(master_path))
+
+    def test_save_master_overwrite_true_replaces(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        wls.make_master_l2()
+        master_path = tmp_path / "master.fits"
+        master_path.write_bytes(b"stale")
+        wls.save_master('L2', str(master_path), overwrite=True)
+        assert master_path.read_bytes()[:6] == b"SIMPLE"
+
+    def test_master_path_overwrites_existing(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        master_path = tmp_path / "master.fits"
+        master_path.touch()
+        wls.make_master_l2(master_path=str(master_path))
+        assert master_path.read_bytes()[:6] == b"SIMPLE"
+
     def test_hdf5_structure(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
         diagnostics_path = str(tmp_path / "diagnostics.h5")

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -319,6 +319,31 @@ class TestMakeMasterL2:
         wls.save_diagnostics(str(diagnostics_path))
         assert diagnostics_path.exists()
 
+    def test_save_master_l2_before_make_raises(self):
+        wls = WLS(FILE_LIST)
+        with pytest.raises(RuntimeError, match="run make_master_l2"):
+            wls.save_master_l2('/tmp/should_not_be_created.fits')
+
+    def test_master_path_writes_fits(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        master_path = tmp_path / "master.fits"
+        wls.make_master_l2(master_path=str(master_path))
+        assert master_path.exists()
+
+    def test_save_master_l2_post_hoc(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        wls.make_master_l2()  # no master_path; ml2_obj stashed on self
+        master_path = tmp_path / "master.fits"
+        wls.save_master_l2(str(master_path))
+        assert master_path.exists()
+
+    def test_save_master_l2_creates_parent_dir(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        wls.make_master_l2()
+        master_path = tmp_path / "nested" / "subdir" / "master.fits"
+        wls.save_master_l2(str(master_path))
+        assert master_path.exists()
+
     def test_hdf5_structure(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
         diagnostics_path = str(tmp_path / "diagnostics.h5")

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -319,10 +319,16 @@ class TestMakeMasterL2:
         wls.save_diagnostics(str(diagnostics_path))
         assert diagnostics_path.exists()
 
-    def test_save_master_l2_before_make_raises(self):
+    def test_save_master_before_make_raises(self):
         wls = WLS(FILE_LIST)
         with pytest.raises(RuntimeError, match="run make_master_l2"):
-            wls.save_master_l2('/tmp/should_not_be_created.fits')
+            wls.save_master('L2', '/tmp/should_not_be_created.fits')
+
+    def test_save_master_rejects_unknown_level(self, mock_make_master_l2, tmp_path):
+        wls = WLS(FILE_LIST)
+        wls.make_master_l2()
+        with pytest.raises(ValueError, match="level"):
+            wls.save_master('L4', str(tmp_path / "master.fits"))
 
     def test_master_path_writes_fits(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
@@ -330,18 +336,18 @@ class TestMakeMasterL2:
         wls.make_master_l2(master_path=str(master_path))
         assert master_path.exists()
 
-    def test_save_master_l2_post_hoc(self, mock_make_master_l2, tmp_path):
+    def test_save_master_post_hoc(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
         wls.make_master_l2()  # no master_path; ml2_obj stashed on self
         master_path = tmp_path / "master.fits"
-        wls.save_master_l2(str(master_path))
+        wls.save_master('L2', str(master_path))
         assert master_path.exists()
 
-    def test_save_master_l2_creates_parent_dir(self, mock_make_master_l2, tmp_path):
+    def test_save_master_creates_parent_dir(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
         wls.make_master_l2()
         master_path = tmp_path / "nested" / "subdir" / "master.fits"
-        wls.save_master_l2(str(master_path))
+        wls.save_master('L2', str(master_path))
         assert master_path.exists()
 
     def test_hdf5_structure(self, mock_make_master_l2, tmp_path):

--- a/tests/test_quicklook_l0.py
+++ b/tests/test_quicklook_l0.py
@@ -233,20 +233,36 @@ class TestPlotL0FileSaving:
         plt.close(fig)
 
 
-class TestPlotL0All:
+class TestPlotL0Run:
 
-    def test_all_returns_dict_of_figures(self, synthetic_4amp_l0):
+    def test_run_all_returns_dict_of_figures(self, synthetic_4amp_l0):
         from kpfpipe.quality_control.quicklook.level0 import PlotL0
         qlp = PlotL0(synthetic_4amp_l0)
-        figs = qlp.all()
+        figs = qlp.run('all')
         assert isinstance(figs, dict)
-        assert 'L0_stitched_green' in figs
-        assert 'L0_stitched_red' in figs
+        assert 'stitched_image_green' in figs
+        assert 'stitched_image_red' in figs
         assert all(isinstance(f, plt.Figure) for f in figs.values())
-        for f in figs.values():
-            plt.close(f)
 
-    def test_all_skips_missing_chip(self, tmp_path):
+    def test_run_single_plot_name(self, synthetic_4amp_l0):
+        from kpfpipe.quality_control.quicklook.level0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        figs = qlp.run('stitched_image')
+        assert set(figs.keys()) == {'stitched_image_green', 'stitched_image_red'}
+
+    def test_run_unknown_which_raises(self, synthetic_4amp_l0):
+        from kpfpipe.quality_control.quicklook.level0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        with pytest.raises(ValueError, match="unknown plot"):
+            qlp.run('bogus')
+
+    def test_run_requires_which(self, synthetic_4amp_l0):
+        from kpfpipe.quality_control.quicklook.level0 import PlotL0
+        qlp = PlotL0(synthetic_4amp_l0)
+        with pytest.raises(TypeError):
+            qlp.run()
+
+    def test_run_skips_missing_chip(self, tmp_path):
         """L0 with only green amps should only produce green plot."""
         fn = str(tmp_path / "KP.20240405.00004.00.fits")
         rng = np.random.default_rng(7)
@@ -266,8 +282,6 @@ class TestPlotL0All:
 
         from kpfpipe.quality_control.quicklook.level0 import PlotL0
         qlp = PlotL0(l0)
-        figs = qlp.all()
-        assert 'L0_stitched_green' in figs
-        assert 'L0_stitched_red' not in figs
-        for f in figs.values():
-            plt.close(f)
+        figs = qlp.run('all')
+        assert 'stitched_image_green' in figs
+        assert 'stitched_image_red' not in figs

--- a/tests/test_quicklook_l1.py
+++ b/tests/test_quicklook_l1.py
@@ -166,19 +166,35 @@ class TestFileSaving:
         plt.close(fig)
 
 
-class TestAll:
+class TestRun:
 
-    def test_all_returns_dict(self, synthetic_l1):
+    def test_run_all_returns_dict(self, synthetic_l1):
         from kpfpipe.quality_control.quicklook.level1 import PlotL1
         qlp = PlotL1(synthetic_l1)
-        figs = qlp.all()
+        figs = qlp.run('all')
         assert isinstance(figs, dict)
-        assert 'L1_image_green' in figs
-        assert 'L1_image_red' in figs
-        for f in figs.values():
-            plt.close(f)
+        assert 'image_green' in figs
+        assert 'image_red' in figs
 
-    def test_all_skips_missing_chip(self, tmp_path):
+    def test_run_single_plot_name(self, synthetic_l1):
+        from kpfpipe.quality_control.quicklook.level1 import PlotL1
+        qlp = PlotL1(synthetic_l1)
+        figs = qlp.run('image')
+        assert set(figs.keys()) == {'image_green', 'image_red'}
+
+    def test_run_unknown_which_raises(self, synthetic_l1):
+        from kpfpipe.quality_control.quicklook.level1 import PlotL1
+        qlp = PlotL1(synthetic_l1)
+        with pytest.raises(ValueError, match="unknown plot"):
+            qlp.run('bogus')
+
+    def test_run_requires_which(self, synthetic_l1):
+        from kpfpipe.quality_control.quicklook.level1 import PlotL1
+        qlp = PlotL1(synthetic_l1)
+        with pytest.raises(TypeError):
+            qlp.run()
+
+    def test_run_skips_missing_chip(self, tmp_path):
         # KPF1 with only green CCD, no red
         fn = str(tmp_path / "KP.20240405.00003.00_L1.fits")
         primary = fits.PrimaryHDU()
@@ -196,11 +212,9 @@ class TestAll:
         l1 = KPF1.from_fits(fn)
         from kpfpipe.quality_control.quicklook.level1 import PlotL1
         qlp = PlotL1(l1)
-        figs = qlp.all()
-        assert 'L1_image_green' in figs
-        assert 'L1_image_red' not in figs
-        for f in figs.values():
-            plt.close(f)
+        figs = qlp.run('all')
+        assert 'image_green' in figs
+        assert 'image_red' not in figs
 
 
 class TestStubs:

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -1,9 +1,19 @@
 """
-KPF pipeline CLI entry point.
+KPF Pipeline CLI entry point.
 
-Usage:
-    kpfpipe -r recipes/kpf_drp_masters.py -c configs/kpf_drp_masters.toml -d 20240405
-    kpfpipe -r recipes/kpf_drp_science.py  -c configs/kpf_drp_science.toml  -o KP.20240405.40113.57
+Recipe + config must be specified via --masters, --science, or an explicit
+-r/-c pair. The shortcuts resolve repo-relative, so they work from any cwd.
+
+When running science recipes, provide an obs_id.
+When running masters recipes, provide a datecode.
+
+The following pairs of invocations are equivalent:
+
+    kpfpipe --masters -d 20240405
+    kpfpipe -r {REPO_ROOT}/recipes/kpf_drp_masters.py -c {REPO_ROOT}/configs/kpf_drp_masters.toml -d 20240405
+
+    kpfpipe --science -o KP.20240405.40113.57
+    kpfpipe -r {REPO_ROOT}/recipes/kpf_drp_science.py  -c {REPO_ROOT}/configs/kpf_drp_science.toml  -o KP.20240405.40113.57
 """
 import argparse
 import importlib.util
@@ -15,21 +25,51 @@ from kpfpipe.utils.config import ConfigHandler
 _REPO_ROOT    = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _TESTDATA_DIR = os.path.join(_REPO_ROOT, 'tests', 'testdata')
 
+_SHORTCUTS = {
+    'masters': ('recipes/kpf_drp_masters.py', 'configs/kpf_drp_masters.toml'),
+    'science': ('recipes/kpf_drp_science.py', 'configs/kpf_drp_science.toml'),
+}
+
 
 def main():
     parser = argparse.ArgumentParser(
         prog='kpfpipe',
-        description='KPF Data Reduction Pipeline',
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument('-r', '--recipe',   required=True, help='path to recipe .py file')
-    parser.add_argument('-c', '--config',   required=True, help='path to TOML config file')
-    parser.add_argument('-d', '--datecode', default=None, help='datecode, e.g. 20240405 (masters recipe)')
-    parser.add_argument('-o', '--obs_id',   default=None, help='obs_id, e.g. KP.20240405.40113.57 (science recipe)')
+    parser.add_argument('-r', '--recipe',   default=None, help='path to recipe.py file')
+    parser.add_argument('-c', '--config',   default=None, help='path to TOML config file')
+    shortcut = parser.add_mutually_exclusive_group()
+    shortcut.add_argument('--masters', dest='shortcut', action='store_const', const='masters',
+                          help='shorthand for default -r/-c masters pair')
+    shortcut.add_argument('--science', dest='shortcut', action='store_const', const='science',
+                          help='shorthand for default -r/-c science pair')
+    target = parser.add_mutually_exclusive_group()
+    target.add_argument('-d', '--datecode', default=None, help='datecode, e.g. 20240405 (masters recipe only; mutually exclusive with -o)')
+    target.add_argument('-o', '--obs_id',   default=None, help='obs_id, e.g. KP.20240405.40113.57 (science recipe only; mutually exclusive with -d)')
     parser.add_argument('--data_input',  default=None, help='override KPF_DATA_INPUT directory')
     parser.add_argument('--data_output', default=None, help='override KPF_DATA_OUTPUT directory')
     parser.add_argument('--test', action='store_true',
-                        help='use tests/testdata/ for input and output')
+                        help='shorthand to use tests/testdata/ for input and output')
     args = parser.parse_args()
+
+    if args.shortcut:
+        if args.recipe or args.config:
+            parser.error("--masters/--science cannot be combined with -r/--recipe or -c/--config")
+        recipe_rel, config_rel = _SHORTCUTS[args.shortcut]
+        args.recipe = os.path.join(_REPO_ROOT, recipe_rel)
+        args.config = os.path.join(_REPO_ROOT, config_rel)
+
+    if not args.recipe or not args.config:
+        parser.error("must specify --masters, --science, or both -r/--recipe and -c/--config")
+
+    recipe_kind = {os.path.basename(r): k for k, (r, _) in _SHORTCUTS.items()}.get(
+        os.path.basename(args.recipe)
+    )
+    if recipe_kind == 'masters' and args.obs_id:
+        parser.error("masters recipe takes -d/--datecode, not -o/--obs_id")
+    if recipe_kind == 'science' and args.datecode:
+        parser.error("science recipe takes -o/--obs_id, not -d/--datecode")
 
     if args.test:
         args.data_input  = args.data_input  or _TESTDATA_DIR


### PR DESCRIPTION
## Summary

  Standardizes file I/O for the masters pipeline and quicklook by moving FITS writes and
  `os.makedirs` calls out of the recipes and into the modules themselves.

  - New `BaseMasterModule.save_master(level, path, *, overwrite=False)` — dispatches to
  `self.ml1_obj` / `self.ml2_obj`, raises `FileExistsError` if the file exists and
  `overwrite=False`, and creates the parent directory before writing.
  - `WLS.make_master_l2(master_path=..., diagnostics_path=...)` and
  `Bias.make_master_l1(filepath=...)` accept a path kwarg and call `save_master(...,
  overwrite=True)` internally. WLS uses `master_path` because it has a sibling
  `diagnostics_path`; bias/dark/flat are uniform on `filepath`.
  - `PlotL0.run(which)` / `PlotL1.run(which)` replace `.all()` to match the `DiagL1`/`QCL1`
  `run()` shape. `which` is required (no default) and accepts `'all'` or a single plot name
  from `_PLOT_METHODS`. `run()` now owns `os.makedirs` and closes figures with `plt.close()` so
   callers don't accumulate them.
  - Recipes (`kpf_drp_masters.py`, `kpf_drp_science.py`) no longer call `os.makedirs` or
  `to_fits` directly, and the `_run_qlp` helper plus its `matplotlib.pyplot` import are gone.

  6 commits, +322 / −65 across 11 files. All 547 tests pass.

  ## Changes

  ### `kpfpipe/modules/masters/`
  - `base.py` — added `save_master(level, path, *, overwrite=False)` as a public method;
  `__init__` initializes `self.ml1_obj = None`, `self.ml2_obj = None`.
  - `wls.py` — `make_master_l2` accepts `master_path=None`; calls `self.save_master('L2',
  master_path, overwrite=True)` at the end. Local `save_master_l2` removed (now on the base
  class).
  - `bias.py` — `make_master_l1` accepts `filepath=None`; calls `self.save_master('L1',
  filepath, overwrite=True)` at the end.

  ### `kpfpipe/quality_control/quicklook/`
  - `level0.py` / `level1.py` — added `_PLOT_METHODS` tuple and `run(which)` method; `run()` 
  owns `os.makedirs` and `plt.close(fig)`. Returns `{method_name}_{chip} → Figure`.

  ### Recipes
  - `kpf_drp_masters.py` — bias/dark/flat use `filepath=` kwarg; WLS uses `master_path=` +
  `diagnostics_path=`. No more `os.makedirs` / `to_fits` calls in the recipe.
  - `kpf_drp_science.py` — `PlotL0(...).run('all')` and `PlotL1(...).run('all')` replace the
  `_run_qlp` helper; helper and `matplotlib.pyplot` import removed.

  ### Tests
  - `test_master_wls.py` (+54 lines) — new `save_master` tests: pre-make raises, unknown level
  rejected, `master_path` writes FITS, post-hoc `save_master`, parent dir created, and three
  overwrite tests.
  - `test_master_bias.py` (+49 lines) — new `TestMasterBiasSaveMaster` class (5 tests, uses
  `filepath=` kwarg).
  - `test_quicklook_l0.py` / `test_quicklook_l1.py` — `TestPlotL0All`/`TestAll` replaced with
  `TestPlotL0Run`/`TestRun`; new `{method_name}_{chip}` key format; added tests for single-plot
   dispatch, unknown plot rejection, and missing `which` raising `TypeError`.

  ## Test plan

  - [x] `python -m pytest tests/ -v` — 547 passing
  - [x] Run `kpf_drp_masters` end-to-end on a sample night; confirm bias and WLS masters land
  at expected paths.
  - [x] Run `kpf_drp_science` end-to-end on a single obs_id; confirm L0/L1 quicklook PNGs are 
  produced under the QLP dir.
  - [x] Confirm `FileExistsError` is raised when calling `save_master` over an existing file
  without `overwrite=True`.