### PR TITLE
Kpf next barycentric correction

### DIFF
--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -24,4 +24,3 @@ extraction_method = "box"
 [MODULE_WAVELENGTH_CALIBRATION]
 
 [MODULE_BARYCENTRIC_CORRECTION]
-fix_bad_exposures = True

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -22,3 +22,6 @@ flat = false
 extraction_method = "box"
 
 [MODULE_WAVELENGTH_CALIBRATION]
+
+[MODULE_BARYCENTRIC_CORRECTION]
+fix_bad_exposures = True

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -18,10 +18,6 @@ from kpfpipe import DEFAULTS
 from kpfpipe.utils.astro import compute_doppler_shift
 from kpfpipe.utils.config import ConfigHandler
 
-DEFAULTS.update({
-    'fix_bad_exposures': True,
-})
-
 
 class BarycentricCorrection:
     """
@@ -346,7 +342,7 @@ class BarycentricCorrection:
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def flux_weighted_midpoint(self, interpolate=True, extrapolate=True, fix_bad_exposures=None):
+    def flux_weighted_midpoint(self, interpolate=True, extrapolate=True, fix_bad_exposures=True):
         """
         Compute the flux-weighted midpoint observation time from EXPMETER_SCI.
 
@@ -372,9 +368,6 @@ class BarycentricCorrection:
         distribution (and therefore the flux-weighted time) varies across
         the exposure meter bandpass.
         """
-        if fix_bad_exposures is None:
-            fix_bad_exposures = self.fix_bad_exposures
-
         t_beg, t_mid, t_end = self._get_timestamps()
         f = self._get_normalized_flux()
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -1,15 +1,515 @@
+"""
+KPF Barycentric Correction module.
+"""
+import re
+
+import numpy as np
+from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.stats import mad_std
+from astropy.time import Time
+import astropy.units as u
+from astroquery.gaia import Gaia
+from barycorrpy import get_BC_vel
+from scipy.interpolate import griddata
+from scipy.ndimage import gaussian_filter, median_filter
+from scipy.special import erfcinv
+
+from kpfpipe import DEFAULTS
+from kpfpipe.utils.astro import compute_doppler_shift
 from kpfpipe.utils.config import ConfigHandler
+
+DEFAULTS.update({
+    'fix_bad_exposures': True,
+})
 
 
 class BarycentricCorrection:
-    def __init__(self, l1_obj, config=None):
-        self.l1_obj = l1_obj
+    """
+    Compute and apply barycentric correction to KPF2 wavelength arrays.
+
+    Reads EXPMETER_SCI from the input KPF2 object to compute a
+    flux-weighted midpoint observation time, queries Gaia DR3 for
+    the target's astrometric solution, and applies a Doppler wavelength
+    shift to all fiber wavelength arrays in-place.
+
+    Notes
+    -----
+    Follows the barycentric correction approach described in:
+    - Wright & Eastman (2014) for the velocity calculation (barycorrpy)
+    - Flux-weighted midpoint time following Butler et al. (1996)
+    """
+
+    def __init__(self, kpf2_obj, config=None):
+        self.kpf2_obj = kpf2_obj
 
         if config is None:
             params = {}
         elif isinstance(config, dict):
             params = config
         elif isinstance(config, ConfigHandler):
-            params = config.get_params(["DATA_DIRS", "KPFPIPE", "MODULE_BARYCENTRIC_CORRECTION"])
+            params = config.get_params(
+                ["DATA_DIRS", "KPFPIPE", "MODULE_BARYCENTRIC_CORRECTION"]
+            )
         else:
             raise TypeError("config must be None, dict, or ConfigHandler")
+
+        for k, v in DEFAULTS.items():
+            setattr(self, k, params.get(k, v))
+
+        self._results = None  # populated by perform()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _get_timestamps(self):
+        """
+        Read start and end timestamps from EXPMETER_SCI.
+
+        Returns
+        -------
+        t_beg : Time
+            Array of exposure start times.
+        t_mid : Time
+            Array of exposure midpoint times.
+        t_end : Time
+            Array of exposure end times.
+
+        Notes
+        -----
+        Prefers corrected timestamps (Date-Beg-Corr / Date-End-Corr) when
+        available, falling back to uncorrected values.
+        """
+        expmeter = self.kpf2_obj.data['EXPMETER_SCI']
+
+        try:
+            t_beg = Time(np.array(expmeter['Date-Beg-Corr']).astype(str), format='isot', scale='utc')
+            t_end = Time(np.array(expmeter['Date-End-Corr']).astype(str), format='isot', scale='utc')
+        except KeyError:
+            t_beg = Time(np.array(expmeter['Date-Beg']).astype(str), format='isot', scale='utc')
+            t_end = Time(np.array(expmeter['Date-End']).astype(str), format='isot', scale='utc')
+
+        if not self._strictly_increasing(t_beg):
+            raise ValueError("EXPMETER_SCI Date-Beg timestamps are not strictly increasing")
+        if not self._strictly_increasing(t_end):
+            raise ValueError("EXPMETER_SCI Date-End timestamps are not strictly increasing")
+
+        t_mid = Time((t_beg.jd + t_end.jd) / 2, format='jd', scale='utc')
+        return t_beg, t_mid, t_end
+
+
+    def _get_normalized_flux(self):
+        """
+        Read EXPMETER_SCI flux and normalize by gain and wavelength dispersion.
+
+        Returns
+        -------
+        f : ndarray, shape (ntime, nwave)
+            Flux in units of photons per Angstrom, normalized by dispersion.
+
+        Notes
+        -----
+        Columns with numeric names are treated as wavelength channels.
+        Non-numeric columns (e.g., timestamps) are skipped.
+        """
+        expmeter = self.kpf2_obj.data['EXPMETER_SCI']
+
+        wave_cols = []
+        for col in expmeter.colnames:
+            try:
+                float(col)
+                wave_cols.append(col)
+            except (ValueError, TypeError):
+                pass
+
+        w = np.array([float(col) for col in wave_cols])
+        f = np.column_stack([np.array(expmeter[col], dtype=float) for col in wave_cols])
+
+        dispersion = np.abs(np.gradient(w))
+        f = f * 1.48424 / dispersion  # 1.48424 e-/ADU: exposure meter detector gain
+
+        return f
+
+
+    @staticmethod
+    def _strictly_increasing(t):
+        """Return True if Time array is strictly increasing."""
+        return bool(np.all(t[:-1].jd < t[1:].jd))
+
+
+    @staticmethod
+    def _fix_bad_exposures(f, kernel_size=5):
+        """
+        Detect and interpolate outlier pixels in the exposure meter array.
+
+        Parameters
+        ----------
+        f : ndarray, shape (ntime, nwave)
+            Exposure meter flux array.
+        kernel_size : int
+            Kernel size for median and Gaussian smoothing filters.
+
+        Returns
+        -------
+        f_fixed : ndarray, shape (ntime, nwave)
+            Flux array with outliers replaced by interpolated values.
+
+        Notes
+        -----
+        Outlier threshold is set adaptively using the expected maximum
+        deviation for the array size (Chauvenet-like criterion).
+        """
+        f_smooth = gaussian_filter(median_filter(f, size=kernel_size), sigma=kernel_size)
+
+        eta = 3 * np.sqrt(2) * erfcinv(1 / np.min(np.shape(f)))
+        bad = np.abs(f - f_smooth) / mad_std(f - f_smooth) > eta
+
+        if np.sum(bad) == 0:
+            return f.copy()
+
+        ny, nx = f.shape
+        y, x = np.indices((ny, nx))
+
+        points = np.column_stack((x[~bad], y[~bad]))
+        values = f[~bad]
+        points_bad = np.column_stack((x[bad], y[bad]))
+
+        f_fixed = f.copy()
+        f_fixed[bad] = griddata(points, values, points_bad, method='linear')
+
+        nan_mask = np.isnan(f_fixed)
+        if np.any(nan_mask):
+            f_fixed[nan_mask] = griddata(
+                points, values,
+                np.column_stack((x[nan_mask], y[nan_mask])),
+                method='nearest'
+            )
+
+        return f_fixed
+
+
+    @staticmethod
+    def _interpolate(t_beg, t_end, f):
+        """
+        Estimate flux during gaps between consecutive exposure meter readings.
+
+        Parameters
+        ----------
+        t_beg : Time, shape (ntime,)
+            Exposure start times.
+        t_end : Time, shape (ntime,)
+            Exposure end times.
+        f : ndarray, shape (ntime, nwave)
+            Flux during each exposure.
+
+        Returns
+        -------
+        t_gap : Time, shape (ngap,)
+            Midpoint time of each inter-exposure gap.
+        f_gap : ndarray, shape (ngap, nwave)
+            Estimated flux during each gap.
+
+        Notes
+        -----
+        Gap flux is estimated as the average count rate of adjacent
+        exposures multiplied by the gap duration.
+        """
+        dt_exp = (t_end - t_beg).jd[:, None]     # (ntime, 1)
+        dt_gap = (t_beg[1:] - t_end[:-1]).jd     # (ngap,)
+
+        rate = f / dt_exp                         # flux per day
+        rate_gap = 0.5 * (rate[1:] + rate[:-1])  # (ngap, nwave)
+
+        t_gap = Time(t_end[:-1].jd + dt_gap / 2, format='jd', scale='utc')
+        f_gap = rate_gap * dt_gap[:, None]
+
+        return t_gap, f_gap
+
+
+    @staticmethod
+    def _extrapolate(t0, t_beg, t_end, f):
+        """
+        Estimate flux for a gap before the first or after the last expmeter reading.
+
+        Parameters
+        ----------
+        t0 : Time
+            True start or end of the exposure (shutter open / close).
+        t_beg : Time
+            Start of the first or last exposure meter reading.
+        t_end : Time
+            End of the first or last exposure meter reading.
+        f : ndarray, shape (nwave,)
+            Flux during the reference exposure meter reading.
+
+        Returns
+        -------
+        t_ext : Time
+            Midpoint of the extrapolated gap.
+        f_ext : ndarray, shape (nwave,)
+            Estimated flux during the gap.
+        """
+        dt_exp = (t_end - t_beg).jd
+        rate = f / dt_exp
+
+        if t0 < t_beg:
+            dt_gap = (t_beg - t0).jd
+            t_ext = Time(t0.jd + dt_gap / 2, format='jd', scale='utc')
+        elif t0 > t_end:
+            dt_gap = (t0 - t_end).jd
+            t_ext = Time(t_end.jd + dt_gap / 2, format='jd', scale='utc')
+        else:
+            raise ValueError("t0 must be before t_beg or after t_end")
+
+        f_ext = rate * dt_gap
+        return t_ext, f_ext
+
+
+    @staticmethod
+    def _query_gaia(gaia_id):
+        """
+        Query Gaia DR3 for the astrometric solution of a target.
+
+        Parameters
+        ----------
+        gaia_id : int or str
+            Gaia DR3 source ID (numeric).
+
+        Returns
+        -------
+        skycoord : SkyCoord
+            Target coordinates including proper motion and distance.
+        """
+        query = f"""
+        SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
+        FROM gaiadr3.gaia_source
+        WHERE source_id = {gaia_id}
+        """
+        job = Gaia.launch_job(query)
+        result = job.get_results()[0]
+
+        skycoord = SkyCoord(
+            ra=result['ra'] * u.deg,
+            dec=result['dec'] * u.deg,
+            pm_ra_cosdec=result['pmra'] * u.mas / u.yr,
+            pm_dec=result['pmdec'] * u.mas / u.yr,
+            distance=(1e3 / result['parallax']) * u.pc,
+            obstime=Time(result['ref_epoch'], format='jyear'),
+            frame='icrs',
+        )
+        return skycoord
+
+
+    @staticmethod
+    def _compute_barycorr_rv(skycoord, obs_time, location):
+        """
+        Compute barycentric radial velocity correction using barycorrpy.
+
+        Parameters
+        ----------
+        skycoord : SkyCoord
+            Target coordinates with proper motion and distance.
+        obs_time : Time
+            Observation time (scalar).
+        location : EarthLocation
+            Observatory location.
+
+        Returns
+        -------
+        delta_rv : Quantity
+            Barycentric velocity correction (m/s).
+        """
+        icrs = skycoord.icrs
+        ra  = icrs.ra.to(u.deg).value
+        dec = icrs.dec.to(u.deg).value
+        pmra  = icrs.pm_ra_cosdec.to(u.mas / u.yr).value if icrs.pm_ra_cosdec is not None else 0.0
+        pmdec = icrs.pm_dec.to(u.mas / u.yr).value if icrs.pm_dec is not None else 0.0
+        px    = (1 / icrs.distance.to(u.pc).value * 1e3) if icrs.distance is not None else 0.0
+        epoch = icrs.obstime.jyear
+
+        lat = location.lat.to(u.deg).value
+        lon = location.lon.to(u.deg).value
+        alt = location.height.to(u.m).value
+
+        bc_vel, *_ = get_BC_vel(
+            JDUTC=obs_time.utc.jd,
+            ra=ra, dec=dec,
+            lat=lat, longi=lon, alt=alt,
+            pmra=pmra, pmdec=pmdec,
+            px=px, epoch=epoch,
+        )
+
+        return bc_vel[0] * u.m / u.s
+
+
+    # ------------------------------------------------------------------
+    # Algorithm steps
+    # ------------------------------------------------------------------
+
+    def flux_weighted_midpoint(self, interpolate=True, extrapolate=True, fix_bad_exposures=None):
+        """
+        Compute the flux-weighted midpoint observation time from EXPMETER_SCI.
+
+        Parameters
+        ----------
+        interpolate : bool, optional
+            If True, estimate flux during gaps between expmeter readings.
+        extrapolate : bool, optional
+            If True, estimate flux during gaps before the first or after the
+            last expmeter reading, using DATE-BEG / DATE-END from the header.
+        fix_bad_exposures : bool, optional
+            If True, detect and replace outlier expmeter readings before
+            computing the flux-weighted midpoint. Defaults to config value.
+
+        Returns
+        -------
+        t_fwm : Time, shape (nwave,)
+            Flux-weighted midpoint time for each wavelength channel.
+
+        Notes
+        -----
+        Returns one midpoint time per wavelength channel because the flux
+        distribution (and therefore the flux-weighted time) varies across
+        the exposure meter bandpass.
+        """
+        if fix_bad_exposures is None:
+            fix_bad_exposures = self.fix_bad_exposures
+
+        t_beg, t_mid, t_end = self._get_timestamps()
+        f = self._get_normalized_flux()
+
+        if np.any(f < 0):
+            raise ValueError("negative exposure meter flux values detected")
+
+        if fix_bad_exposures:
+            f = self._fix_bad_exposures(f)
+
+        t = t_mid.copy()
+
+        if interpolate:
+            t_gap, f_gap = self._interpolate(t_beg, t_end, f)
+            t = Time(np.concatenate([t.jd, t_gap.jd]), format='jd', scale='utc')
+            f = np.vstack([f, f_gap])
+
+        if extrapolate:
+            hdr = self.kpf2_obj.headers['PRIMARY']
+            obs_beg = Time(hdr['DATE-BEG'], format='isot', scale='utc')
+            obs_end = Time(hdr['DATE-END'], format='isot', scale='utc')
+
+            if obs_beg < t_beg[0]:
+                t_ext, f_ext = self._extrapolate(obs_beg, t_beg[0], t_end[0], f[0])
+                t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
+                f = np.vstack([f, f_ext])
+
+            if obs_end > t_end[-1]:
+                t_ext, f_ext = self._extrapolate(obs_end, t_beg[-1], t_end[-1], f[-1])
+                t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
+                f = np.vstack([f, f_ext])
+
+        t_fwm = Time(
+            np.sum(t.jd[:, None] * f, axis=0) / np.sum(f, axis=0),
+            format='jd', scale='utc'
+        )
+        return t_fwm
+
+
+    def barycentric_correction(self, obs_time):
+        """
+        Compute the barycentric Doppler shift factor for a given observation time.
+
+        Parameters
+        ----------
+        obs_time : Time
+            Observation time (scalar).
+
+        Returns
+        -------
+        z : float
+            Multiplicative Doppler shift factor to apply to wavelength arrays.
+        delta_rv : Quantity
+            Barycentric velocity correction in m/s.
+
+        Notes
+        -----
+        Reads GAIAID from the PRIMARY header to identify the target.
+        Expects the format 'DR3 <numeric_id>' or plain '<numeric_id>'.
+        """
+        gaia_id_raw = self.kpf2_obj.headers['PRIMARY']['GAIAID']
+        gaia_id = re.split(r'\s+', str(gaia_id_raw).strip())[-1]
+
+        location = EarthLocation.of_site('Keck Observatory')
+        skycoord = self._query_gaia(gaia_id)
+        delta_rv = self._compute_barycorr_rv(skycoord, obs_time, location)
+        z = float(compute_doppler_shift(delta_rv))
+
+        return z, delta_rv
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def perform(self, chips=None, fibers=None):
+        """
+        Compute and apply barycentric correction to all wavelength arrays.
+
+        Parameters
+        ----------
+        chips : list of str, optional
+            Chip identifiers, i.e. 'GREEN' or 'RED'.
+        fibers : list of str, optional
+            Fiber identifiers, e.g. 'SCI2'.
+
+        Returns
+        -------
+        kpf2_obj : KPF2
+            Input KPF2 object with wavelength arrays corrected in-place.
+
+        Notes
+        -----
+        Flux-weighted midpoint time is computed per wavelength channel;
+        the mean across channels is used as the scalar observation time
+        passed to barycorrpy.
+        """
+        if chips is None:
+            chips = self.chips
+        if fibers is None:
+            fibers = self.fibers
+
+        t_fwm = self.flux_weighted_midpoint()
+        obs_time = Time(np.mean(t_fwm.jd), format='jd', scale='utc')
+
+        z, delta_rv = self.barycentric_correction(obs_time)
+
+        for chip in chips:
+            for fiber in fibers:
+                wave_ext = f'{chip}_{fiber}_WAVE'
+                if wave_ext in self.kpf2_obj.data:
+                    self.kpf2_obj.data[wave_ext] = self.kpf2_obj.data[wave_ext] * z
+
+        self.kpf2_obj.receipt_add_entry('barycentric_correction', 'PASS')
+
+        self._results = {
+            'obs_time': obs_time,
+            'delta_rv': delta_rv,
+            'z': z,
+        }
+
+        return self.kpf2_obj
+
+
+    def info(self):
+        """Print a summary of the module configuration and correction results."""
+        print("BarycentricCorrection")
+        print(f"  fix_bad_exposures: {self.fix_bad_exposures}")
+
+        if self._results is None:
+            print("  perform() has not been called")
+            return
+
+        delta_rv_ms = round(float(self._results['delta_rv'].to(u.m / u.s).value), 4)
+        obs_time_bjd = round(float(self._results['obs_time'].tdb.jd), 6)
+        z = round(float(self._results['z']), 10)
+
+        print(f"\n  obs_time (BJD):    {obs_time_bjd}")
+        print(f"  delta_rv (m/s):    {delta_rv_ms}")
+        print(f"  z:                 {z}")

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -378,6 +378,10 @@ class BarycentricCorrection:
         if fix_expmeter_outliers:
             f = self._fix_expmeter_outliers(f)
 
+        # Cache boundary readings; f[0] and f[-1] get clobbered by later vstacks.
+        f_first_reading = f[0].copy()
+        f_last_reading  = f[-1].copy()
+
         t = t_mid.copy()
 
         if interpolate:
@@ -391,12 +395,12 @@ class BarycentricCorrection:
             obs_end = Time(hdr['DATE-END'], format='isot', scale='utc')
 
             if obs_beg < t_beg[0]:
-                t_ext, f_ext = self._extrapolate(obs_beg, t_beg[0], t_end[0], f[0])
+                t_ext, f_ext = self._extrapolate(obs_beg, t_beg[0], t_end[0], f_first_reading)
                 t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
                 f = np.vstack([f, f_ext])
 
             if obs_end > t_end[-1]:
-                t_ext, f_ext = self._extrapolate(obs_end, t_beg[-1], t_end[-1], f[-1])
+                t_ext, f_ext = self._extrapolate(obs_end, t_beg[-1], t_end[-1], f_last_reading)
                 t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
                 f = np.vstack([f, f_ext])
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -300,8 +300,12 @@ class BarycentricCorrection:
                 t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
                 f = np.vstack([f, f_ext])
 
+        flux_sum = np.sum(f, axis=0)
+        if np.any(flux_sum <= 0):
+            raise ValueError("exposure meter channel with non-positive total flux; "
+                             "cannot compute flux-weighted midpoint")
         t_em = Time(
-            np.sum(t.jd[:, None] * f, axis=0) / np.sum(f, axis=0),
+            np.sum(t.jd[:, None] * f, axis=0) / flux_sum,
             format='jd', scale='utc',
         )
         return w_em, t_em
@@ -479,6 +483,9 @@ class BarycentricCorrection:
 
         green = slice(0, NORDER_GREEN)
         red   = slice(NORDER_GREEN, NORDER)
+        if weights[green].sum() <= 0 or weights[red].sum() <= 0:
+            raise ValueError("all SCI2 order weights are zero for a CCD; "
+                             "cannot compute per-CCD midpoint")
         w_ccds = np.array([
             np.average(w_orders[green], weights=weights[green]),
             np.average(w_orders[red],   weights=weights[red]),

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -39,7 +39,7 @@ from scipy.interpolate import griddata
 from scipy.ndimage import gaussian_filter, median_filter
 from scipy.special import erfcinv
 
-from kpfpipe import DEFAULTS, DETECTOR
+from kpfpipe import DETECTOR
 from kpfpipe.utils.astro import compute_doppler_shift
 from kpfpipe.utils.config import ConfigHandler
 
@@ -76,22 +76,13 @@ class BarycentricCorrection:
     """
 
     def __init__(self, kpf2_obj, config=None):
-        self.kpf2_obj = kpf2_obj
-
-        if config is None:
-            params = {}
-        elif isinstance(config, dict):
-            params = config
-        elif isinstance(config, ConfigHandler):
-            params = config.get_params(
-                ["DATA_DIRS", "KPFPIPE", "MODULE_BARYCENTRIC_CORRECTION"]
-            )
-        else:
+        # `config` is accepted (None | dict | ConfigHandler) to match sibling
+        # modules and the recipe pattern, but BarycentricCorrection has no
+        # per-module knobs today; all behavior toggles live on perform().
+        if config is not None and not isinstance(config, (dict, ConfigHandler)):
             raise TypeError("config must be None, dict, or ConfigHandler")
 
-        for k, v in DEFAULTS.items():
-            setattr(self, k, params.get(k, v))
-
+        self.kpf2_obj = kpf2_obj
         self._results = None  # populated by perform()
 
     # ------------------------------------------------------------------
@@ -267,6 +258,11 @@ class BarycentricCorrection:
         Returns a SkyCoord with proper motion and distance (from parallax)
         attached, at the Gaia ref_epoch.
         """
+        gaia_id = str(gaia_id)
+        if not gaia_id.isdigit():
+            raise ValueError(
+                f"Gaia source_id must be all digits; got {gaia_id!r}"
+            )
         query = f"""
         SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
         FROM gaiadr3.gaia_source
@@ -287,9 +283,12 @@ class BarycentricCorrection:
         return skycoord
 
     @staticmethod
-    def _compute_barycorr(skycoord, obs_times, location):
+    def _compute_barycorr(skycoord, obs_times, location, rv_mps=0.0):
         """
         Compute barycentric velocity (m/s) and BJD_TDB for an array of obs_times.
+
+        `rv_mps` is the target's systemic RV (m/s), passed to barycorrpy so
+        the light-travel correction in BJD_TDB accounts for stellar motion.
 
         Returns (bc_vel_mps, bjd_tdb), each shape (n,).
         """
@@ -313,6 +312,7 @@ class BarycentricCorrection:
             lat=lat, longi=lon, alt=alt,
             pmra=pmra, pmdec=pmdec,
             px=px, epoch=epoch,
+            rv=rv_mps,
         )
         bjd_tdb, *_ = utc_tdb.JDUTC_to_BJDTDB(
             JDUTC=JDUTC,
@@ -320,6 +320,7 @@ class BarycentricCorrection:
             lat=lat, longi=lon, alt=alt,
             pmra=pmra, pmdec=pmdec,
             px=px, epoch=epoch,
+            rv=rv_mps,
         )
         return np.asarray(bc_vel), np.asarray(bjd_tdb)
 
@@ -459,17 +460,20 @@ class BarycentricCorrection:
             fix_expmeter_outliers=fix_expmeter_outliers,
         )
 
-        # Astrometric solution + per-order barycorr
-        # GAIAID is preserved from L1 PRIMARY by KPF1.to_kpf2() into L2 INSTRUMENT_HEADER.
-        gaia_id_raw = self.kpf2_obj.headers['INSTRUMENT_HEADER']['GAIAID']
+        # Astrometric solution + per-order barycorr. GAIAID and TARGRADV
+        # are preserved from L1 PRIMARY by KPF1.to_kpf2() into INSTRUMENT_HEADER.
+        inst = self.kpf2_obj.headers['INSTRUMENT_HEADER']
+        gaia_id_raw = inst['GAIAID']
         gaia_id = re.split(r'\s+', str(gaia_id_raw).strip())[-1]
         skycoord = self._query_gaia(gaia_id)
 
-        bc_vel_mps, bjd_tdb = self._compute_barycorr(skycoord, t_per_order, KECK_LOCATION)
+        # TARGRADV is in km/s; barycorrpy expects rv in m/s. Missing → 0.
+        rv_mps = float(inst.get('TARGRADV', 0.0) or 0.0) * 1000.0
+        bc_vel_mps, bjd_tdb = self._compute_barycorr(
+            skycoord, t_per_order, KECK_LOCATION, rv_mps=rv_mps,
+        )
         bary_kms = bc_vel_mps / 1000.0
-        bary_z = np.array([
-            float(compute_doppler_shift(v * u.m / u.s)) for v in bc_vel_mps
-        ])
+        bary_z = np.asarray(compute_doppler_shift(bc_vel_mps * u.m / u.s))
 
         # Write rvdata standard extensions (per-order arrays). The WAVE
         # arrays are left untouched; downstream RV computation consumes

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -1,5 +1,31 @@
 """
 KPF Barycentric Correction module.
+
+Computes per-order barycentric corrections from the EXPMETER_SCI flux-weighted
+midpoint times. Populates the rvdata-standard L2 extensions and applies the
+per-order redshift to all WAVE arrays in place.
+
+Outputs (rvdata-standard ImageHDUs, shape (NORDER,)):
+  - BJD_TDB       photon-weighted midpoint in BJD_TDB per spectral order
+  - BARYCORR_KMS  barycentric velocity per spectral order [km/s]
+  - BARYCORR_Z    barycentric redshift per spectral order
+
+Per-CCD scalar summaries (mean across that chip's orders) written to PRIMARY:
+  - CCD1BJD       GREEN photon-weighted mid-time (BJD_TDB)
+  - CCD1BKMS      GREEN mean barycentric velocity [km/s]
+  - CCD1BZ        GREEN mean barycentric redshift
+  - CCD2BJD       RED   photon-weighted mid-time (BJD_TDB)
+  - CCD2BKMS      RED   mean barycentric velocity [km/s]
+  - CCD2BZ        RED   mean barycentric redshift
+
+CCD1BJD/CCD2BJD match the legacy keyword names and semantics; the *BVEL/*BZ
+companions follow the same CCD{n} naming pattern.
+
+Notes
+-----
+Follows the barycentric correction approach described in:
+- Wright & Eastman (2014) — velocity calculation (barycorrpy)
+- Butler et al. (1996)    — flux-weighted midpoint time
 """
 import re
 
@@ -9,30 +35,42 @@ from astropy.stats import mad_std
 from astropy.time import Time
 import astropy.units as u
 from astroquery.gaia import Gaia
-from barycorrpy import get_BC_vel
+from barycorrpy import get_BC_vel, utc_tdb
 from scipy.interpolate import griddata
 from scipy.ndimage import gaussian_filter, median_filter
 from scipy.special import erfcinv
 
-from kpfpipe import DEFAULTS
+from kpfpipe import DEFAULTS, DETECTOR
 from kpfpipe.utils.astro import compute_doppler_shift
 from kpfpipe.utils.config import ConfigHandler
+
+DEFAULTS.update({
+    'fix_bad_exposures': True,
+})
+
+NORDER_GREEN = DETECTOR['norder']['GREEN']
+NORDER_RED   = DETECTOR['norder']['RED']
+NORDER       = NORDER_GREEN + NORDER_RED
 
 
 class BarycentricCorrection:
     """
-    Compute and apply barycentric correction to KPF2 wavelength arrays.
+    Compute and apply per-order barycentric correction to KPF2 wavelength arrays.
 
-    Reads EXPMETER_SCI from the input KPF2 object to compute a
-    flux-weighted midpoint observation time, queries Gaia DR3 for
-    the target's astrometric solution, and applies a Doppler wavelength
-    shift to all fiber wavelength arrays in-place.
+    Reads EXPMETER_SCI to derive the flux-weighted midpoint time per expmeter
+    wavelength channel, interpolates onto each spectral order's central
+    wavelength (using SCI2_WAVE as the reference), queries Gaia DR3 for the
+    target's astrometric solution, and runs barycorrpy per order to populate
+    the rvdata-standard BJD_TDB, BARYCORR_KMS, and BARYCORR_Z extensions.
 
-    Notes
-    -----
-    Follows the barycentric correction approach described in:
-    - Wright & Eastman (2014) for the velocity calculation (barycorrpy)
-    - Flux-weighted midpoint time following Butler et al. (1996)
+    Parameters
+    ----------
+    kpf2_obj : KPF2
+        Extracted L2 frame. Must have EXPMETER_SCI populated and SCI2_WAVE
+        populated by WavelengthCalibration. INSTRUMENT_HEADER (the preserved
+        L1 PRIMARY) must contain GAIAID and DATE-BEG/DATE-END.
+    config : None | dict | ConfigHandler
+        Module configuration. Recognized keys: chips, fibers, fix_bad_exposures.
     """
 
     def __init__(self, kpf2_obj, config=None):
@@ -55,7 +93,7 @@ class BarycentricCorrection:
         self._results = None  # populated by perform()
 
     # ------------------------------------------------------------------
-    # Private helpers
+    # Private helpers — exposure-meter handling
     # ------------------------------------------------------------------
 
     def _get_timestamps(self):
@@ -67,7 +105,7 @@ class BarycentricCorrection:
         t_beg : Time
             Array of exposure start times.
         t_mid : Time
-            Array of exposure midpoint times.
+            Array of exposure midpoint times (unweighted).
         t_end : Time
             Array of exposure end times.
 
@@ -93,20 +131,22 @@ class BarycentricCorrection:
         t_mid = Time((t_beg.jd + t_end.jd) / 2, format='jd', scale='utc')
         return t_beg, t_mid, t_end
 
-
     def _get_normalized_flux(self):
         """
         Read EXPMETER_SCI flux and normalize by gain and wavelength dispersion.
 
         Returns
         -------
+        w : ndarray, shape (nwave,)
+            Wavelength of each expmeter channel (label units; typically
+            Angstroms for KPF).
         f : ndarray, shape (ntime, nwave)
-            Flux in units of photons per Angstrom, normalized by dispersion.
+            Flux in units of photons per (Å|nm), normalized by dispersion.
 
         Notes
         -----
-        Columns with numeric names are treated as wavelength channels.
-        Non-numeric columns (e.g., timestamps) are skipped.
+        Columns with numeric names are treated as wavelength channels;
+        non-numeric columns (e.g., timestamps) are skipped.
         """
         expmeter = self.kpf2_obj.data['EXPMETER_SCI']
 
@@ -124,14 +164,12 @@ class BarycentricCorrection:
         dispersion = np.abs(np.gradient(w))
         f = f * 1.48424 / dispersion  # 1.48424 e-/ADU: exposure meter detector gain
 
-        return f
-
+        return w, f
 
     @staticmethod
     def _strictly_increasing(t):
         """Return True if Time array is strictly increasing."""
         return bool(np.all(t[:-1].jd < t[1:].jd))
-
 
     @staticmethod
     def _fix_bad_exposures(f, kernel_size=5):
@@ -183,20 +221,10 @@ class BarycentricCorrection:
 
         return f_fixed
 
-
     @staticmethod
     def _interpolate(t_beg, t_end, f):
         """
         Estimate flux during gaps between consecutive exposure meter readings.
-
-        Parameters
-        ----------
-        t_beg : Time, shape (ntime,)
-            Exposure start times.
-        t_end : Time, shape (ntime,)
-            Exposure end times.
-        f : ndarray, shape (ntime, nwave)
-            Flux during each exposure.
 
         Returns
         -------
@@ -214,29 +242,17 @@ class BarycentricCorrection:
         dt_gap = (t_beg[1:] - t_end[:-1]).jd     # (ngap,)
 
         rate = f / dt_exp                         # flux per day
-        rate_gap = 0.5 * (rate[1:] + rate[:-1])  # (ngap, nwave)
+        rate_gap = 0.5 * (rate[1:] + rate[:-1])   # (ngap, nwave)
 
         t_gap = Time(t_end[:-1].jd + dt_gap / 2, format='jd', scale='utc')
         f_gap = rate_gap * dt_gap[:, None]
 
         return t_gap, f_gap
 
-
     @staticmethod
     def _extrapolate(t0, t_beg, t_end, f):
         """
         Estimate flux for a gap before the first or after the last expmeter reading.
-
-        Parameters
-        ----------
-        t0 : Time
-            True start or end of the exposure (shutter open / close).
-        t_beg : Time
-            Start of the first or last exposure meter reading.
-        t_end : Time
-            End of the first or last exposure meter reading.
-        f : ndarray, shape (nwave,)
-            Flux during the reference exposure meter reading.
 
         Returns
         -------
@@ -260,6 +276,9 @@ class BarycentricCorrection:
         f_ext = rate * dt_gap
         return t_ext, f_ext
 
+    # ------------------------------------------------------------------
+    # Private helpers — barycorr handoffs
+    # ------------------------------------------------------------------
 
     @staticmethod
     def _query_gaia(gaia_id):
@@ -295,25 +314,26 @@ class BarycentricCorrection:
         )
         return skycoord
 
-
     @staticmethod
-    def _compute_barycorr_rv(skycoord, obs_time, location):
+    def _compute_barycorr(skycoord, obs_times, location):
         """
-        Compute barycentric radial velocity correction using barycorrpy.
+        Compute barycentric velocity and BJD_TDB for an array of obs_times.
 
         Parameters
         ----------
         skycoord : SkyCoord
             Target coordinates with proper motion and distance.
-        obs_time : Time
-            Observation time (scalar).
+        obs_times : Time
+            Observation times (array).
         location : EarthLocation
             Observatory location.
 
         Returns
         -------
-        delta_rv : Quantity
-            Barycentric velocity correction (m/s).
+        bc_vel_mps : ndarray, shape (n,)
+            Barycentric velocity correction per time [m/s].
+        bjd_tdb : ndarray, shape (n,)
+            Barycentric Julian date in TDB per time.
         """
         icrs = skycoord.icrs
         ra  = icrs.ra.to(u.deg).value
@@ -327,24 +347,32 @@ class BarycentricCorrection:
         lon = location.lon.to(u.deg).value
         alt = location.height.to(u.m).value
 
+        JDUTC = np.atleast_1d(obs_times.utc.jd)
+
         bc_vel, *_ = get_BC_vel(
-            JDUTC=obs_time.utc.jd,
+            JDUTC=JDUTC,
             ra=ra, dec=dec,
             lat=lat, longi=lon, alt=alt,
             pmra=pmra, pmdec=pmdec,
             px=px, epoch=epoch,
         )
-
-        return bc_vel[0] * u.m / u.s
-
+        bjd_tdb, *_ = utc_tdb.JDUTC_to_BJDTDB(
+            JDUTC=JDUTC,
+            ra=ra, dec=dec,
+            lat=lat, longi=lon, alt=alt,
+            pmra=pmra, pmdec=pmdec,
+            px=px, epoch=epoch,
+        )
+        return np.asarray(bc_vel), np.asarray(bjd_tdb)
 
     # ------------------------------------------------------------------
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def flux_weighted_midpoint(self, interpolate=True, extrapolate=True, fix_bad_exposures=True):
+    def flux_weighted_midpoint(self, interpolate=True, extrapolate=True,
+                                fix_bad_exposures=None):
         """
-        Compute the flux-weighted midpoint observation time from EXPMETER_SCI.
+        Compute the flux-weighted midpoint observation time per wavelength channel.
 
         Parameters
         ----------
@@ -354,22 +382,21 @@ class BarycentricCorrection:
             If True, estimate flux during gaps before the first or after the
             last expmeter reading, using DATE-BEG / DATE-END from the header.
         fix_bad_exposures : bool, optional
-            If True, detect and replace outlier expmeter readings before
-            computing the flux-weighted midpoint. Defaults to config value.
+            If True, detect and replace outlier expmeter readings. Defaults
+            to the config value.
 
         Returns
         -------
+        w : ndarray, shape (nwave,)
+            Wavelength of each expmeter channel (label units; typically Å).
         t_fwm : Time, shape (nwave,)
-            Flux-weighted midpoint time for each wavelength channel.
-
-        Notes
-        -----
-        Returns one midpoint time per wavelength channel because the flux
-        distribution (and therefore the flux-weighted time) varies across
-        the exposure meter bandpass.
+            Flux-weighted midpoint time (JD-UTC) for each wavelength channel.
         """
+        if fix_bad_exposures is None:
+            fix_bad_exposures = self.fix_bad_exposures
+
         t_beg, t_mid, t_end = self._get_timestamps()
-        f = self._get_normalized_flux()
+        w, f = self._get_normalized_flux()
 
         if np.any(f < 0):
             raise ValueError("negative exposure meter flux values detected")
@@ -385,7 +412,7 @@ class BarycentricCorrection:
             f = np.vstack([f, f_gap])
 
         if extrapolate:
-            hdr = self.kpf2_obj.headers['PRIMARY']
+            hdr = self.kpf2_obj.headers['INSTRUMENT_HEADER']
             obs_beg = Time(hdr['DATE-BEG'], format='isot', scale='utc')
             obs_end = Time(hdr['DATE-END'], format='isot', scale='utc')
 
@@ -403,106 +430,148 @@ class BarycentricCorrection:
             np.sum(t.jd[:, None] * f, axis=0) / np.sum(f, axis=0),
             format='jd', scale='utc'
         )
-        return t_fwm
+        return w, t_fwm
 
-
-    def barycentric_correction(self, obs_time):
+    def map_to_orders(self, w_em, t_fwm):
         """
-        Compute the barycentric Doppler shift factor for a given observation time.
+        Interpolate per-channel PHOTON_JD onto each spectral order's wavelength.
+
+        Uses SCI2_WAVE (TRACE3_WAVE) as the reference wavelength solution.
+        Per-order central wavelength is the median across columns. Orders
+        outside the expmeter range get the nearest endpoint value (np.interp
+        default behavior).
 
         Parameters
         ----------
-        obs_time : Time
-            Observation time (scalar).
+        w_em : ndarray, shape (nwave,)
+            Expmeter channel wavelengths (label units).
+        t_fwm : Time, shape (nwave,)
+            Per-channel flux-weighted midpoint times.
 
         Returns
         -------
-        z : float
-            Multiplicative Doppler shift factor to apply to wavelength arrays.
-        delta_rv : Quantity
-            Barycentric velocity correction in m/s.
-
-        Notes
-        -----
-        Reads GAIAID from the PRIMARY header to identify the target.
-        Expects the format 'DR3 <numeric_id>' or plain '<numeric_id>'.
+        t_per_order : Time, shape (NORDER,)
+            Per-order flux-weighted midpoint time (JD-UTC).
         """
-        gaia_id_raw = self.kpf2_obj.headers['PRIMARY']['GAIAID']
-        gaia_id = re.split(r'\s+', str(gaia_id_raw).strip())[-1]
+        wave = self.kpf2_obj.data['SCI2_WAVE']
+        if wave is None or np.size(wave) == 0:
+            raise KeyError(
+                "SCI2_WAVE missing or empty; run WavelengthCalibration first"
+            )
+        order_centers = np.median(np.asarray(wave), axis=1)  # (NORDER,)
 
-        location = EarthLocation.of_site('Keck Observatory')
-        skycoord = self._query_gaia(gaia_id)
-        delta_rv = self._compute_barycorr_rv(skycoord, obs_time, location)
-        z = float(compute_doppler_shift(delta_rv))
-
-        return z, delta_rv
+        sort_idx = np.argsort(w_em)
+        jd_per_order = np.interp(order_centers, w_em[sort_idx], t_fwm.jd[sort_idx])
+        return Time(jd_per_order, format='jd', scale='utc')
 
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, chips=None, fibers=None):
+    def perform(self, chips=None, fibers=None, interpolate=True, extrapolate=True,
+                fix_bad_exposures=None):
         """
-        Compute and apply barycentric correction to all wavelength arrays.
+        Compute per-order barycentric correction and apply it to wavelength arrays.
 
         Parameters
         ----------
         chips : list of str, optional
-            Chip identifiers, i.e. 'GREEN' or 'RED'.
+            Chip identifiers, e.g. ['GREEN', 'RED']. Defaults to self.chips.
         fibers : list of str, optional
-            Fiber identifiers, e.g. 'SCI2'.
+            Fiber identifiers, e.g. ['SCI1', 'SCI2', ...]. Defaults to self.fibers.
+        interpolate, extrapolate, fix_bad_exposures : bool, optional
+            Forwarded to flux_weighted_midpoint(). See that method for semantics.
 
         Returns
         -------
         kpf2_obj : KPF2
-            Input KPF2 object with wavelength arrays corrected in-place.
-
-        Notes
-        -----
-        Flux-weighted midpoint time is computed per wavelength channel;
-        the mean across channels is used as the scalar observation time
-        passed to barycorrpy.
+            Input KPF2 with BJD_TDB, BARYCORR_KMS, BARYCORR_Z populated;
+            WAVE arrays scaled in-place by per-order redshift; PRIMARY
+            BJDTDB/BARYKMS/BARYZ summaries written; 'barycentric_correction'
+            receipt entry added.
         """
         if chips is None:
             chips = self.chips
         if fibers is None:
             fibers = self.fibers
 
-        t_fwm = self.flux_weighted_midpoint()
-        obs_time = Time(np.mean(t_fwm.jd), format='jd', scale='utc')
+        # Per-channel flux-weighted midpoint times → per-order via interpolation
+        w_em, t_fwm = self.flux_weighted_midpoint(
+            interpolate=interpolate, extrapolate=extrapolate,
+            fix_bad_exposures=fix_bad_exposures,
+        )
+        t_per_order = self.map_to_orders(w_em, t_fwm)
 
-        z, delta_rv = self.barycentric_correction(obs_time)
+        # Astrometric solution + per-order barycorr
+        # GAIAID is preserved from L1 PRIMARY by KPF1.to_kpf2() into L2 INSTRUMENT_HEADER.
+        gaia_id_raw = self.kpf2_obj.headers['INSTRUMENT_HEADER']['GAIAID']
+        gaia_id = re.split(r'\s+', str(gaia_id_raw).strip())[-1]
+        location = EarthLocation.of_site('Keck Observatory')
+        skycoord = self._query_gaia(gaia_id)
 
-        for chip in chips:
-            for fiber in fibers:
+        bc_vel_mps, bjd_tdb = self._compute_barycorr(skycoord, t_per_order, location)
+        bary_kms = bc_vel_mps / 1000.0
+        bary_z = np.array([
+            float(compute_doppler_shift(v * u.m / u.s)) for v in bc_vel_mps
+        ])
+
+        # Write rvdata standard extensions (per-order arrays)
+        self.kpf2_obj.set_data('BJD_TDB',      np.asarray(bjd_tdb,  dtype=np.float64))
+        self.kpf2_obj.set_data('BARYCORR_KMS', np.asarray(bary_kms, dtype=np.float64))
+        self.kpf2_obj.set_data('BARYCORR_Z',   np.asarray(bary_z,   dtype=np.float64))
+
+        # Apply per-order redshift to all WAVE arrays (in-place, per-order multiply)
+        for fiber in fibers:
+            for chip in chips:
                 wave_ext = f'{chip}_{fiber}_WAVE'
-                if wave_ext in self.kpf2_obj.data:
-                    self.kpf2_obj.data[wave_ext] = self.kpf2_obj.data[wave_ext] * z
+                if wave_ext not in self.kpf2_obj.data:
+                    continue
+                arr = self.kpf2_obj.data[wave_ext]
+                if arr is None or np.size(arr) == 0:
+                    continue
+                z = bary_z[:NORDER_GREEN] if chip.upper() == 'GREEN' else bary_z[NORDER_GREEN:]
+                self.kpf2_obj.data[wave_ext] = (arr * z[:, None]).astype(arr.dtype)
+
+        # Per-CCD scalar summaries on PRIMARY.
+        # CCD1 = GREEN (orders [:NORDER_GREEN]), CCD2 = RED (orders [NORDER_GREEN:]).
+        primary = self.kpf2_obj.headers['PRIMARY']
+        green = slice(0, NORDER_GREEN)
+        red   = slice(NORDER_GREEN, NORDER)
+        primary['CCD1BJD']  = (float(np.mean(bjd_tdb[green])),  'GREEN photon-weighted mid-time (BJD_TDB)')
+        primary['CCD1BKMS'] = (float(np.mean(bary_kms[green])), 'GREEN mean barycentric velocity [km/s]')
+        primary['CCD1BZ']   = (float(np.mean(bary_z[green])),   'GREEN mean barycentric redshift')
+        primary['CCD2BJD']  = (float(np.mean(bjd_tdb[red])),    'RED photon-weighted mid-time (BJD_TDB)')
+        primary['CCD2BKMS'] = (float(np.mean(bary_kms[red])),   'RED mean barycentric velocity [km/s]')
+        primary['CCD2BZ']   = (float(np.mean(bary_z[red])),     'RED mean barycentric redshift')
 
         self.kpf2_obj.receipt_add_entry('barycentric_correction', 'PASS')
 
         self._results = {
-            'obs_time': obs_time,
-            'delta_rv': delta_rv,
-            'z': z,
+            'bjd_tdb':  np.asarray(bjd_tdb),
+            'bary_kms': np.asarray(bary_kms),
+            'bary_z':   np.asarray(bary_z),
         }
-
         return self.kpf2_obj
-
 
     def info(self):
         """Print a summary of the module configuration and correction results."""
         print("BarycentricCorrection")
+        print(f"  obs_id:            {self.kpf2_obj.obs_id}")
         print(f"  fix_bad_exposures: {self.fix_bad_exposures}")
 
         if self._results is None:
             print("  perform() has not been called")
             return
 
-        delta_rv_ms = round(float(self._results['delta_rv'].to(u.m / u.s).value), 4)
-        obs_time_bjd = round(float(self._results['obs_time'].tdb.jd), 6)
-        z = round(float(self._results['z']), 10)
+        bjd = self._results['bjd_tdb']
+        kms = self._results['bary_kms']
+        z   = self._results['bary_z']
+        green = slice(0, NORDER_GREEN)
+        red   = slice(NORDER_GREEN, NORDER)
 
-        print(f"\n  obs_time (BJD):    {obs_time_bjd}")
-        print(f"  delta_rv (m/s):    {delta_rv_ms}")
-        print(f"  z:                 {z}")
+        print(f"\n  {'':<8s}{'BJD_TDB':>18s}{'BARYCORR_KMS':>18s}{'BARYCORR_Z':>18s}")
+        print("  " + "-" * 62)
+        print(f"  {'GREEN':<8s}{np.mean(bjd[green]):>18.6f}{np.mean(kms[green]):>+18.4f}{np.mean(z[green]):>18.10f}")
+        print(f"  {'RED':<8s}{np.mean(bjd[red]):>18.6f}{np.mean(kms[red]):>+18.4f}{np.mean(z[red]):>18.10f}")
+        print(f"\n  per-order spread:   BJD {np.ptp(bjd) * 86400:.3f} sec,"
+              f" BARY {np.ptp(kms) * 1000:.3f} m/s")

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -9,13 +9,14 @@ Outputs (rvdata-standard ImageHDUs, shape (NORDER,)):
   - BARYCORR_KMS  barycentric velocity per spectral order [km/s]
   - BARYCORR_Z    barycentric redshift per spectral order
 
-Per-CCD scalar summaries (mean across that chip's orders) written to INSTRUMENT_HEADER:
+Per-CCD scalar summaries (at each chip's flux-weighted photon-midpoint time)
+written to INSTRUMENT_HEADER:
   - CCD1BJD       GREEN photon-weighted mid-time (BJD_TDB)
-  - CCD1BKMS      GREEN mean barycentric velocity [km/s]
-  - CCD1BZ        GREEN mean barycentric redshift
+  - CCD1BKMS      GREEN barycentric velocity [km/s]
+  - CCD1BZ        GREEN barycentric redshift
   - CCD2BJD       RED   photon-weighted mid-time (BJD_TDB)
-  - CCD2BKMS      RED   mean barycentric velocity [km/s]
-  - CCD2BZ        RED   mean barycentric redshift
+  - CCD2BKMS      RED   barycentric velocity [km/s]
+  - CCD2BZ        RED   barycentric redshift
 
 CCD1BJD/CCD2BJD match the legacy keyword names and semantics; the *BKMS/*BZ
 companions follow the same CCD{n} naming pattern.
@@ -59,31 +60,29 @@ class BarycentricCorrection:
     """
     Compute and store per-order barycentric correction on a KPF2.
 
-    Derives the flux-weighted midpoint per expmeter channel (EXPMETER_SCI),
-    interpolates onto each spectral order's central wavelength (SCI2_WAVE),
-    queries Gaia DR3 for the target's astrometry, and calls barycorrpy to
-    populate BJD_TDB / BARYCORR_KMS / BARYCORR_Z. WAVE arrays are not
-    modified.
+    Derives the flux-weighted midpoint time per expmeter channel (EXPMETER_SCI),
+    averages it over the channels within each spectral order's wavelength range
+    (SCI2_WAVE), queries Gaia DR3 for the target's astrometry, and calls
+    barycorrpy to populate BJD_TDB / BARYCORR_KMS / BARYCORR_Z. WAVE arrays are
+    not modified.
 
     Parameters
     ----------
     kpf2_obj : KPF2
         Extracted L2 frame. Must have EXPMETER_SCI populated and SCI2_WAVE
         populated by WavelengthCalibration. INSTRUMENT_HEADER (the preserved
-        L1 PRIMARY) must contain GAIAID and DATE-BEG/DATE-END.
+        L1 PRIMARY) must contain GAIAID, and DATE-BEG/DATE-END when extrapolating.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: chips, fibers.
+        Accepted for interface consistency with sibling modules; unused (all
+        behavior toggles live on perform()).
     """
 
     def __init__(self, kpf2_obj, config=None):
-        # `config` is accepted (None | dict | ConfigHandler) to match sibling
-        # modules and the recipe pattern, but BarycentricCorrection has no
-        # per-module knobs today; all behavior toggles live on perform().
         if config is not None and not isinstance(config, (dict, ConfigHandler)):
             raise TypeError("config must be None, dict, or ConfigHandler")
 
         self.kpf2_obj = kpf2_obj
-        self._results = None   # populated by perform()
+        self._results = None
         self._em_cache = None  # (toggle_key, w_em, t_em) from the last integration
         self._skycoord = None  # cached Gaia DR3 SkyCoord
 
@@ -214,11 +213,11 @@ class BarycentricCorrection:
         the gap duration. Returns (t_gap, f_gap), shapes (ngap,) and
         (ngap, nwave).
         """
-        dt_exp = (t_end - t_beg).jd[:, None]     # (ntime, 1)
-        dt_gap = (t_beg[1:] - t_end[:-1]).jd     # (ngap,)
+        dt_exp = (t_end - t_beg).jd[:, None]
+        dt_gap = (t_beg[1:] - t_end[:-1]).jd
 
-        rate = f / dt_exp                         # flux per day
-        rate_gap = 0.5 * (rate[1:] + rate[:-1])   # (ngap, nwave)
+        rate = f / dt_exp
+        rate_gap = 0.5 * (rate[1:] + rate[:-1])
 
         t_gap = Time(t_end[:-1].jd + dt_gap / 2, format='jd', scale='utc')
         f_gap = rate_gap * dt_gap[:, None]
@@ -397,20 +396,19 @@ class BarycentricCorrection:
         """
         Compute the flux-weighted midpoint observation time.
 
-        Always derives the per-expmeter-channel midpoint internally;
-        `output` controls how those values are projected. When called
-        from perform(), 'orders' (default) will be used.
+        The per-channel midpoint is always derived internally; `output`
+        controls how it is projected.
 
         Parameters
         ----------
         output : {'expmeter', 'orders', 'ccds'}
-            'expmeter' — raw per-channel result, shape (nwave,).
-            'orders'   — linearly interpolated onto each spectral order's
-                         central wavelength (median of SCI2_WAVE), shape (NORDER,).
-                         Orders outside the expmeter range clamp to the
-                         nearest endpoint (np.interp default).
-            'ccds'     — mean of the per-order values within each chip,
-                         shape (2,); [GREEN, RED].
+            'expmeter' — per-channel times, shape (nwave,).
+            'orders'   — per spectral order: mean of the per-channel times for
+                         the expmeter channels within the order's wavelength
+                         range, shape (NORDER,). Orders outside expmeter
+                         coverage fall back to the nearest channel.
+            'ccds'     — per chip: the SCI2-flux-weighted mean of the per-order
+                         values, shape (2,); [GREEN, RED].
         interpolate : bool, optional
             If True, estimate flux during gaps between expmeter readings.
         extrapolate : bool, optional
@@ -433,9 +431,8 @@ class BarycentricCorrection:
                 f"got {output!r}"
             )
 
-        # Cache the per-channel integration keyed on the toggles, so a second
-        # call with the same toggles (e.g. perform() asking for 'orders' then
-        # 'ccds') reuses it instead of re-running the expensive integration.
+        # Reuse the cached integration when the toggles match (perform() asks
+        # for 'orders' then 'ccds').
         key = (interpolate, extrapolate, fix_expmeter_outliers)
         if self._em_cache is None or self._em_cache[0] != key:
             w_em, t_em = self._compute_per_chanel_flux_weighted_midpoint_time(
@@ -448,7 +445,6 @@ class BarycentricCorrection:
         if output == 'expmeter':
             return w_em, t_em
 
-        # Project per-channel times onto each spectral order via SCI2_WAVE.
         wave = self.kpf2_obj.data['SCI2_WAVE']
         if wave is None or np.size(wave) == 0:
             raise KeyError(
@@ -457,8 +453,7 @@ class BarycentricCorrection:
         wave = np.asarray(wave)
         wave_min = wave.min(axis=1)
         wave_max = wave.max(axis=1)
-
-        w_orders = 0.5 * (wave_min + wave_max)  # (NORDER,)
+        w_orders = 0.5 * (wave_min + wave_max)
 
         t_em_jd = t_em.jd
         jd_per_order = np.empty(len(w_orders))
@@ -473,10 +468,8 @@ class BarycentricCorrection:
         if output == 'orders':
             return w_orders, t_orders
 
-        # 'ccds': flux-weighted mean within each chip's order slice, weighted by
-        # each order's SCI2 brightness (90th percentile, robust to cosmics) so
-        # faint/edge orders contribute less. NaN orders (failed extraction) get
-        # zero weight; uniform weights if SCI2_FLUX is absent.
+        # Weight each order by its SCI2 brightness (90th percentile, robust to
+        # cosmics); NaN/failed orders get zero weight, uniform if SCI2_FLUX absent.
         flux = self.kpf2_obj.data['SCI2_FLUX']
         if flux is None or np.size(flux) == 0:
             weights = np.ones(NORDER)
@@ -562,8 +555,6 @@ class BarycentricCorrection:
             per-CCD CCD{1,2}BJD/BKMS/BZ summaries written to
             INSTRUMENT_HEADER, and a 'barycentric_correction' receipt entry.
         """
-        # Per-order and per-CCD barycorr. The 'ccds' call reuses the cached
-        # integration and Gaia query from the 'orders' call.
         kwargs = dict(interpolate=interpolate, extrapolate=extrapolate,
                       fix_expmeter_outliers=fix_expmeter_outliers)
         bjd_tdb, bary_kms, bary_z = self.compute_barycentric_correction(output='orders', **kwargs)
@@ -571,17 +562,12 @@ class BarycentricCorrection:
 
         inst = self.kpf2_obj.headers['INSTRUMENT_HEADER']
 
-        # Write rvdata standard extensions (per-order arrays). The WAVE
-        # arrays are left untouched; downstream RV computation consumes
-        # BARYCORR_Z directly.
+        # Per-order extensions; WAVE arrays are left untouched
         self.kpf2_obj.set_data('BJD_TDB',      np.asarray(bjd_tdb,  dtype=np.float64))
         self.kpf2_obj.set_data('BARYCORR_KMS', np.asarray(bary_kms, dtype=np.float64))
         self.kpf2_obj.set_data('BARYCORR_Z',   np.asarray(bary_z,   dtype=np.float64))
 
-        # Per-CCD scalar summaries on INSTRUMENT_HEADER (KPF-native keywords).
-        # CCD1 = GREEN, CCD2 = RED. INSTRUMENT_HEADER serializes as a no-data
-        # ImageHDU and only accepts scalar values (no (value, comment) tuples)
-        # — see KPF1.to_kpf2.
+        # Per-CCD instrument header keyword (CCD1=GREEN, CCD2=RED)
         inst['CCD1BJD']  = float(ccd_bjd[0])
         inst['CCD1BKMS'] = float(ccd_kms[0])
         inst['CCD1BZ']   = float(ccd_z[0])
@@ -595,11 +581,14 @@ class BarycentricCorrection:
             'bjd_tdb':  np.asarray(bjd_tdb),
             'bary_kms': np.asarray(bary_kms),
             'bary_z':   np.asarray(bary_z),
+            'ccd_bjd':  np.asarray(ccd_bjd),
+            'ccd_kms':  np.asarray(ccd_kms),
+            'ccd_z':    np.asarray(ccd_z),
         }
         return self.kpf2_obj
 
     def info(self):
-        """Print a summary of the module configuration and correction results."""
+        """Print a summary of the barycentric correction results."""
         print("BarycentricCorrection")
         print(f"  obs_id:  {self.kpf2_obj.obs_id}")
 
@@ -607,15 +596,15 @@ class BarycentricCorrection:
             print("  perform() has not been called")
             return
 
-        bjd = self._results['bjd_tdb']
-        kms = self._results['bary_kms']
-        z   = self._results['bary_z']
-        green = slice(0, NORDER_GREEN)
-        red   = slice(NORDER_GREEN, NORDER)
+        r = self._results
+        ccd_bjd, ccd_kms, ccd_z = r['ccd_bjd'], r['ccd_kms'], r['ccd_z']
 
+        # Per-CCD summaries (match CCD1*/CCD2* in INSTRUMENT_HEADER).
         print(f"\n  {'':<8s}{'BJD_TDB':>18s}{'BARYCORR_KMS':>18s}{'BARYCORR_Z':>18s}")
         print("  " + "-" * 62)
-        print(f"  {'GREEN':<8s}{np.mean(bjd[green]):>18.6f}{np.mean(kms[green]):>+18.4f}{np.mean(z[green]):>18.10f}")
-        print(f"  {'RED':<8s}{np.mean(bjd[red]):>18.6f}{np.mean(kms[red]):>+18.4f}{np.mean(z[red]):>18.10f}")
+        print(f"  {'GREEN':<8s}{ccd_bjd[0]:>18.6f}{ccd_kms[0]:>+18.4f}{ccd_z[0]:>18.10f}")
+        print(f"  {'RED':<8s}{ccd_bjd[1]:>18.6f}{ccd_kms[1]:>+18.4f}{ccd_z[1]:>18.10f}")
+
+        bjd, kms = r['bjd_tdb'], r['bary_kms']
         print(f"\n  per-order spread:   BJD {np.ptp(bjd) * 86400:.3f} sec,"
               f" BARY {np.ptp(kms) * 1000:.3f} m/s")

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -48,6 +48,13 @@ NORDER_GREEN = DETECTOR['norder']['GREEN']
 NORDER_RED   = DETECTOR['norder']['RED']
 NORDER       = NORDER_GREEN + NORDER_RED
 
+# WMKO site coordinates
+KECK_LOCATION = EarthLocation(
+    lat=19.8260 * u.deg,
+    lon=-155.474719 * u.deg,
+    height=4145.0 * u.m,
+)
+
 
 class BarycentricCorrection:
     """
@@ -465,10 +472,9 @@ class BarycentricCorrection:
         # GAIAID is preserved from L1 PRIMARY by KPF1.to_kpf2() into L2 INSTRUMENT_HEADER.
         gaia_id_raw = self.kpf2_obj.headers['INSTRUMENT_HEADER']['GAIAID']
         gaia_id = re.split(r'\s+', str(gaia_id_raw).strip())[-1]
-        location = EarthLocation.of_site('Keck Observatory')
         skycoord = self._query_gaia(gaia_id)
 
-        bc_vel_mps, bjd_tdb = self._compute_barycorr(skycoord, t_per_order, location)
+        bc_vel_mps, bjd_tdb = self._compute_barycorr(skycoord, t_per_order, KECK_LOCATION)
         bary_kms = bc_vel_mps / 1000.0
         bary_z = np.array([
             float(compute_doppler_shift(v * u.m / u.s)) for v in bc_vel_mps

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -10,7 +10,7 @@ Outputs (rvdata-standard ImageHDUs, shape (NORDER,)):
   - BARYCORR_KMS  barycentric velocity per spectral order [km/s]
   - BARYCORR_Z    barycentric redshift per spectral order
 
-Per-CCD scalar summaries (mean across that chip's orders) written to PRIMARY:
+Per-CCD scalar summaries (mean across that chip's orders) written to INSTRUMENT_HEADER:
   - CCD1BJD       GREEN photon-weighted mid-time (BJD_TDB)
   - CCD1BKMS      GREEN mean barycentric velocity [km/s]
   - CCD1BZ        GREEN mean barycentric redshift
@@ -18,7 +18,7 @@ Per-CCD scalar summaries (mean across that chip's orders) written to PRIMARY:
   - CCD2BKMS      RED   mean barycentric velocity [km/s]
   - CCD2BZ        RED   mean barycentric redshift
 
-CCD1BJD/CCD2BJD match the legacy keyword names and semantics; the *BVEL/*BZ
+CCD1BJD/CCD2BJD match the legacy keyword names and semantics; the *BKMS/*BZ
 companions follow the same CCD{n} naming pattern.
 
 Notes
@@ -44,10 +44,6 @@ from kpfpipe import DEFAULTS, DETECTOR
 from kpfpipe.utils.astro import compute_doppler_shift
 from kpfpipe.utils.config import ConfigHandler
 
-DEFAULTS.update({
-    'fix_bad_exposures': True,
-})
-
 NORDER_GREEN = DETECTOR['norder']['GREEN']
 NORDER_RED   = DETECTOR['norder']['RED']
 NORDER       = NORDER_GREEN + NORDER_RED
@@ -57,11 +53,12 @@ class BarycentricCorrection:
     """
     Compute and apply per-order barycentric correction to KPF2 wavelength arrays.
 
-    Reads EXPMETER_SCI to derive the flux-weighted midpoint time per expmeter
-    wavelength channel, interpolates onto each spectral order's central
-    wavelength (using SCI2_WAVE as the reference), queries Gaia DR3 for the
-    target's astrometric solution, and runs barycorrpy per order to populate
-    the rvdata-standard BJD_TDB, BARYCORR_KMS, and BARYCORR_Z extensions.
+    Derives the flux-weighted midpoint per expmeter wavelength channel
+    (EXPMETER_SCI), interpolates onto each spectral order's central
+    wavelength (SCI2_WAVE), queries Gaia DR3 for the target's astrometry,
+    and calls barycorrpy to populate the rvdata-standard BJD_TDB /
+    BARYCORR_KMS / BARYCORR_Z extensions. Per-order BARYCORR_Z is then
+    applied to every WAVE array in place.
 
     Parameters
     ----------
@@ -70,7 +67,7 @@ class BarycentricCorrection:
         populated by WavelengthCalibration. INSTRUMENT_HEADER (the preserved
         L1 PRIMARY) must contain GAIAID and DATE-BEG/DATE-END.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: chips, fibers, fix_bad_exposures.
+        Module configuration. Recognized keys: chips, fibers.
     """
 
     def __init__(self, kpf2_obj, config=None):
@@ -135,18 +132,15 @@ class BarycentricCorrection:
         """
         Read EXPMETER_SCI flux and normalize by gain and wavelength dispersion.
 
+        Columns with numeric names are wavelength channels; non-numeric
+        columns (e.g. timestamps) are skipped.
+
         Returns
         -------
         w : ndarray, shape (nwave,)
-            Wavelength of each expmeter channel (label units; typically
-            Angstroms for KPF).
+            Wavelength of each expmeter channel (label units, e.g. Å).
         f : ndarray, shape (ntime, nwave)
-            Flux in units of photons per (Å|nm), normalized by dispersion.
-
-        Notes
-        -----
-        Columns with numeric names are treated as wavelength channels;
-        non-numeric columns (e.g., timestamps) are skipped.
+            Dispersion-normalized flux [e- per wavelength unit].
         """
         expmeter = self.kpf2_obj.data['EXPMETER_SCI']
 
@@ -172,26 +166,15 @@ class BarycentricCorrection:
         return bool(np.all(t[:-1].jd < t[1:].jd))
 
     @staticmethod
-    def _fix_bad_exposures(f, kernel_size=5):
+    def _fix_expmeter_outliers(f, kernel_size=5):
         """
-        Detect and interpolate outlier pixels in the exposure meter array.
+        Detect and interpolate outlier pixels in an expmeter flux array.
 
-        Parameters
-        ----------
-        f : ndarray, shape (ntime, nwave)
-            Exposure meter flux array.
-        kernel_size : int
-            Kernel size for median and Gaussian smoothing filters.
+        Outlier threshold is adaptive (Chauvenet-like criterion based on
+        array size). Replacement uses scipy.griddata linear interpolation,
+        falling back to nearest for any remaining NaNs.
 
-        Returns
-        -------
-        f_fixed : ndarray, shape (ntime, nwave)
-            Flux array with outliers replaced by interpolated values.
-
-        Notes
-        -----
-        Outlier threshold is set adaptively using the expected maximum
-        deviation for the array size (Chauvenet-like criterion).
+        Returns a copy of f with outliers replaced; shape unchanged.
         """
         f_smooth = gaussian_filter(median_filter(f, size=kernel_size), sigma=kernel_size)
 
@@ -226,17 +209,9 @@ class BarycentricCorrection:
         """
         Estimate flux during gaps between consecutive exposure meter readings.
 
-        Returns
-        -------
-        t_gap : Time, shape (ngap,)
-            Midpoint time of each inter-exposure gap.
-        f_gap : ndarray, shape (ngap, nwave)
-            Estimated flux during each gap.
-
-        Notes
-        -----
-        Gap flux is estimated as the average count rate of adjacent
-        exposures multiplied by the gap duration.
+        Gap flux is the average count rate of adjacent exposures times
+        the gap duration. Returns (t_gap, f_gap), shapes (ngap,) and
+        (ngap, nwave).
         """
         dt_exp = (t_end - t_beg).jd[:, None]     # (ntime, 1)
         dt_gap = (t_beg[1:] - t_end[:-1]).jd     # (ngap,)
@@ -252,14 +227,10 @@ class BarycentricCorrection:
     @staticmethod
     def _extrapolate(t0, t_beg, t_end, f):
         """
-        Estimate flux for a gap before the first or after the last expmeter reading.
+        Estimate flux for a gap before the first or after the last reading.
 
-        Returns
-        -------
-        t_ext : Time
-            Midpoint of the extrapolated gap.
-        f_ext : ndarray, shape (nwave,)
-            Estimated flux during the gap.
+        Same rate-based model as `_interpolate`. Returns (t_ext, f_ext)
+        for the single gap defined by t0 vs t_beg/t_end.
         """
         dt_exp = (t_end - t_beg).jd
         rate = f / dt_exp
@@ -283,17 +254,10 @@ class BarycentricCorrection:
     @staticmethod
     def _query_gaia(gaia_id):
         """
-        Query Gaia DR3 for the astrometric solution of a target.
+        Query Gaia DR3 for a target's ICRS astrometry.
 
-        Parameters
-        ----------
-        gaia_id : int or str
-            Gaia DR3 source ID (numeric).
-
-        Returns
-        -------
-        skycoord : SkyCoord
-            Target coordinates including proper motion and distance.
+        Returns a SkyCoord with proper motion and distance (from parallax)
+        attached, at the Gaia ref_epoch.
         """
         query = f"""
         SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
@@ -317,23 +281,9 @@ class BarycentricCorrection:
     @staticmethod
     def _compute_barycorr(skycoord, obs_times, location):
         """
-        Compute barycentric velocity and BJD_TDB for an array of obs_times.
+        Compute barycentric velocity (m/s) and BJD_TDB for an array of obs_times.
 
-        Parameters
-        ----------
-        skycoord : SkyCoord
-            Target coordinates with proper motion and distance.
-        obs_times : Time
-            Observation times (array).
-        location : EarthLocation
-            Observatory location.
-
-        Returns
-        -------
-        bc_vel_mps : ndarray, shape (n,)
-            Barycentric velocity correction per time [m/s].
-        bjd_tdb : ndarray, shape (n,)
-            Barycentric Julian date in TDB per time.
+        Returns (bc_vel_mps, bjd_tdb), each shape (n,).
         """
         icrs = skycoord.icrs
         ra  = icrs.ra.to(u.deg).value
@@ -370,7 +320,7 @@ class BarycentricCorrection:
     # ------------------------------------------------------------------
 
     def flux_weighted_midpoint(self, interpolate=True, extrapolate=True,
-                                fix_bad_exposures=None):
+                                fix_expmeter_outliers=True):
         """
         Compute the flux-weighted midpoint observation time per wavelength channel.
 
@@ -380,10 +330,10 @@ class BarycentricCorrection:
             If True, estimate flux during gaps between expmeter readings.
         extrapolate : bool, optional
             If True, estimate flux during gaps before the first or after the
-            last expmeter reading, using DATE-BEG / DATE-END from the header.
-        fix_bad_exposures : bool, optional
-            If True, detect and replace outlier expmeter readings. Defaults
-            to the config value.
+            last expmeter reading, using DATE-BEG / DATE-END from
+            INSTRUMENT_HEADER.
+        fix_expmeter_outliers : bool, optional
+            If True (default), detect and replace outlier expmeter readings.
 
         Returns
         -------
@@ -392,17 +342,14 @@ class BarycentricCorrection:
         t_fwm : Time, shape (nwave,)
             Flux-weighted midpoint time (JD-UTC) for each wavelength channel.
         """
-        if fix_bad_exposures is None:
-            fix_bad_exposures = self.fix_bad_exposures
-
         t_beg, t_mid, t_end = self._get_timestamps()
         w, f = self._get_normalized_flux()
 
         if np.any(f < 0):
             raise ValueError("negative exposure meter flux values detected")
 
-        if fix_bad_exposures:
-            f = self._fix_bad_exposures(f)
+        if fix_expmeter_outliers:
+            f = self._fix_expmeter_outliers(f)
 
         t = t_mid.copy()
 
@@ -434,17 +381,16 @@ class BarycentricCorrection:
 
     def map_to_orders(self, w_em, t_fwm):
         """
-        Interpolate per-channel PHOTON_JD onto each spectral order's wavelength.
+        Interpolate per-channel midpoint times onto each spectral order.
 
-        Uses SCI2_WAVE (TRACE3_WAVE) as the reference wavelength solution.
-        Per-order central wavelength is the median across columns. Orders
-        outside the expmeter range get the nearest endpoint value (np.interp
-        default behavior).
+        Order central wavelength = median of SCI2_WAVE across columns.
+        Orders outside the expmeter range clamp to the nearest endpoint
+        (np.interp default).
 
         Parameters
         ----------
         w_em : ndarray, shape (nwave,)
-            Expmeter channel wavelengths (label units).
+            Expmeter channel wavelengths (label units; same as SCI2_WAVE).
         t_fwm : Time, shape (nwave,)
             Per-channel flux-weighted midpoint times.
 
@@ -469,7 +415,7 @@ class BarycentricCorrection:
     # ------------------------------------------------------------------
 
     def perform(self, chips=None, fibers=None, interpolate=True, extrapolate=True,
-                fix_bad_exposures=None):
+                fix_expmeter_outliers=True):
         """
         Compute per-order barycentric correction and apply it to wavelength arrays.
 
@@ -479,16 +425,16 @@ class BarycentricCorrection:
             Chip identifiers, e.g. ['GREEN', 'RED']. Defaults to self.chips.
         fibers : list of str, optional
             Fiber identifiers, e.g. ['SCI1', 'SCI2', ...]. Defaults to self.fibers.
-        interpolate, extrapolate, fix_bad_exposures : bool, optional
+        interpolate, extrapolate, fix_expmeter_outliers : bool, optional
             Forwarded to flux_weighted_midpoint(). See that method for semantics.
 
         Returns
         -------
         kpf2_obj : KPF2
-            Input KPF2 with BJD_TDB, BARYCORR_KMS, BARYCORR_Z populated;
-            WAVE arrays scaled in-place by per-order redshift; PRIMARY
-            BJDTDB/BARYKMS/BARYZ summaries written; 'barycentric_correction'
-            receipt entry added.
+            Input KPF2 with BJD_TDB / BARYCORR_KMS / BARYCORR_Z populated,
+            WAVE arrays scaled in-place by per-order redshift, per-CCD
+            CCD{1,2}BJD/BKMS/BZ summaries written to INSTRUMENT_HEADER,
+            and a 'barycentric_correction' receipt entry.
         """
         if chips is None:
             chips = self.chips
@@ -498,7 +444,7 @@ class BarycentricCorrection:
         # Per-channel flux-weighted midpoint times → per-order via interpolation
         w_em, t_fwm = self.flux_weighted_midpoint(
             interpolate=interpolate, extrapolate=extrapolate,
-            fix_bad_exposures=fix_bad_exposures,
+            fix_expmeter_outliers=fix_expmeter_outliers,
         )
         t_per_order = self.map_to_orders(w_em, t_fwm)
 
@@ -532,17 +478,19 @@ class BarycentricCorrection:
                 z = bary_z[:NORDER_GREEN] if chip.upper() == 'GREEN' else bary_z[NORDER_GREEN:]
                 self.kpf2_obj.data[wave_ext] = (arr * z[:, None]).astype(arr.dtype)
 
-        # Per-CCD scalar summaries on PRIMARY.
+        # Per-CCD scalar summaries on INSTRUMENT_HEADER (KPF-native keywords).
         # CCD1 = GREEN (orders [:NORDER_GREEN]), CCD2 = RED (orders [NORDER_GREEN:]).
-        primary = self.kpf2_obj.headers['PRIMARY']
+        # INSTRUMENT_HEADER serializes as a no-data ImageHDU and only accepts
+        # scalar values (no (value, comment) tuples) — see KPF1.to_kpf2.
+        inst = self.kpf2_obj.headers['INSTRUMENT_HEADER']
         green = slice(0, NORDER_GREEN)
         red   = slice(NORDER_GREEN, NORDER)
-        primary['CCD1BJD']  = (float(np.mean(bjd_tdb[green])),  'GREEN photon-weighted mid-time (BJD_TDB)')
-        primary['CCD1BKMS'] = (float(np.mean(bary_kms[green])), 'GREEN mean barycentric velocity [km/s]')
-        primary['CCD1BZ']   = (float(np.mean(bary_z[green])),   'GREEN mean barycentric redshift')
-        primary['CCD2BJD']  = (float(np.mean(bjd_tdb[red])),    'RED photon-weighted mid-time (BJD_TDB)')
-        primary['CCD2BKMS'] = (float(np.mean(bary_kms[red])),   'RED mean barycentric velocity [km/s]')
-        primary['CCD2BZ']   = (float(np.mean(bary_z[red])),     'RED mean barycentric redshift')
+        inst['CCD1BJD']  = float(np.mean(bjd_tdb[green]))
+        inst['CCD1BKMS'] = float(np.mean(bary_kms[green]))
+        inst['CCD1BZ']   = float(np.mean(bary_z[green]))
+        inst['CCD2BJD']  = float(np.mean(bjd_tdb[red]))
+        inst['CCD2BKMS'] = float(np.mean(bary_kms[red]))
+        inst['CCD2BZ']   = float(np.mean(bary_z[red]))
 
         self.kpf2_obj.receipt_add_entry('barycentric_correction', 'PASS')
 
@@ -556,8 +504,7 @@ class BarycentricCorrection:
     def info(self):
         """Print a summary of the module configuration and correction results."""
         print("BarycentricCorrection")
-        print(f"  obs_id:            {self.kpf2_obj.obs_id}")
-        print(f"  fix_bad_exposures: {self.fix_bad_exposures}")
+        print(f"  obs_id:  {self.kpf2_obj.obs_id}")
 
         if self._results is None:
             print("  perform() has not been called")

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -83,7 +83,9 @@ class BarycentricCorrection:
             raise TypeError("config must be None, dict, or ConfigHandler")
 
         self.kpf2_obj = kpf2_obj
-        self._results = None  # populated by perform()
+        self._results = None   # populated by perform()
+        self._em_cache = None  # (toggle_key, w_em, t_em) from the last integration
+        self._skycoord = None  # cached Gaia DR3 SkyCoord
 
     # ------------------------------------------------------------------
     # Private helpers — exposure-meter handling
@@ -246,41 +248,103 @@ class BarycentricCorrection:
         f_ext = rate * dt_gap
         return t_ext, f_ext
 
+    def _compute_per_chanel_flux_weighted_midpoint_time(self, interpolate=True, extrapolate=True,
+                                  fix_expmeter_outliers=True):
+        """
+        Compute the flux-weighted midpoint time for each expmeter channel.
+
+        Reads EXPMETER_SCI, optionally fills gaps between readings
+        (`interpolate`), gaps before/after the shutter window (`extrapolate`,
+        using DATE-BEG/DATE-END), and replaces outlier readings
+        (`fix_expmeter_outliers`), then collapses the time axis to a single
+        flux-weighted mean time per channel.
+
+        Returns
+        -------
+        w_em : ndarray, shape (nwave,)
+            Wavelength of each expmeter channel [Å].
+        t_em : Time, shape (nwave,)
+            Flux-weighted midpoint time (JD-UTC) per channel.
+        """
+        t_beg, t_mid, t_end = self._get_timestamps()
+        w_em, f = self._get_normalized_flux()
+
+        if np.any(f < 0):
+            raise ValueError("negative exposure meter flux values detected")
+
+        if fix_expmeter_outliers:
+            f = self._fix_expmeter_outliers(f)
+
+        # Cache boundary readings; f[0] and f[-1] get clobbered by later vstacks.
+        f_first_reading = f[0].copy()
+        f_last_reading  = f[-1].copy()
+
+        t = t_mid.copy()
+
+        if interpolate:
+            t_gap, f_gap = self._interpolate(t_beg, t_end, f)
+            t = Time(np.concatenate([t.jd, t_gap.jd]), format='jd', scale='utc')
+            f = np.vstack([f, f_gap])
+
+        if extrapolate:
+            hdr = self.kpf2_obj.headers['INSTRUMENT_HEADER']
+            obs_beg = Time(hdr['DATE-BEG'], format='isot', scale='utc')
+            obs_end = Time(hdr['DATE-END'], format='isot', scale='utc')
+
+            if obs_beg < t_beg[0]:
+                t_ext, f_ext = self._extrapolate(obs_beg, t_beg[0], t_end[0], f_first_reading)
+                t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
+                f = np.vstack([f, f_ext])
+
+            if obs_end > t_end[-1]:
+                t_ext, f_ext = self._extrapolate(obs_end, t_beg[-1], t_end[-1], f_last_reading)
+                t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
+                f = np.vstack([f, f_ext])
+
+        t_em = Time(
+            np.sum(t.jd[:, None] * f, axis=0) / np.sum(f, axis=0),
+            format='jd', scale='utc',
+        )
+        return w_em, t_em
+
     # ------------------------------------------------------------------
     # Private helpers — barycorr handoffs
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _query_gaia(gaia_id):
+    def _query_gaia(self):
         """
-        Query Gaia DR3 for a target's ICRS astrometry.
+        Query Gaia DR3 for the target's ICRS astrometry (cached).
 
-        Returns a SkyCoord with proper motion and distance (from parallax)
-        attached, at the Gaia ref_epoch.
+        The source_id is read from GAIAID in INSTRUMENT_HEADER (preserved from
+        L1 PRIMARY by KPF1.to_kpf2()). Returns a SkyCoord with proper motion
+        and distance (from parallax) attached, at the Gaia ref_epoch. The
+        network query runs once and is reused across calls (one target/frame).
         """
-        gaia_id = str(gaia_id)
-        if not gaia_id.isdigit():
-            raise ValueError(
-                f"Gaia source_id must be all digits; got {gaia_id!r}"
+        if self._skycoord is None:
+            gaia_id_raw = self.kpf2_obj.headers['INSTRUMENT_HEADER']['GAIAID']
+            gaia_id = re.split(r'\s+', str(gaia_id_raw).strip())[-1]
+            if not gaia_id.isdigit():
+                raise ValueError(
+                    f"Gaia source_id must be all digits; got {gaia_id!r}"
+                )
+            query = f"""
+            SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
+            FROM gaiadr3.gaia_source
+            WHERE source_id = {gaia_id}
+            """
+            job = Gaia.launch_job(query)
+            result = job.get_results()[0]
+
+            self._skycoord = SkyCoord(
+                ra=result['ra'] * u.deg,
+                dec=result['dec'] * u.deg,
+                pm_ra_cosdec=result['pmra'] * u.mas / u.yr,
+                pm_dec=result['pmdec'] * u.mas / u.yr,
+                distance=(1e3 / result['parallax']) * u.pc,
+                obstime=Time(result['ref_epoch'], format='jyear'),
+                frame='icrs',
             )
-        query = f"""
-        SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
-        FROM gaiadr3.gaia_source
-        WHERE source_id = {gaia_id}
-        """
-        job = Gaia.launch_job(query)
-        result = job.get_results()[0]
-
-        skycoord = SkyCoord(
-            ra=result['ra'] * u.deg,
-            dec=result['dec'] * u.deg,
-            pm_ra_cosdec=result['pmra'] * u.mas / u.yr,
-            pm_dec=result['pmdec'] * u.mas / u.yr,
-            distance=(1e3 / result['parallax']) * u.pc,
-            obstime=Time(result['ref_epoch'], format='jyear'),
-            frame='icrs',
-        )
-        return skycoord
+        return self._skycoord
 
     @staticmethod
     def _compute_barycorr(skycoord, obs_times, location, rv_mps=0.0):
@@ -298,7 +362,7 @@ class BarycentricCorrection:
         pmra  = icrs.pm_ra_cosdec.to(u.mas / u.yr).value if icrs.pm_ra_cosdec is not None else 0.0
         pmdec = icrs.pm_dec.to(u.mas / u.yr).value if icrs.pm_dec is not None else 0.0
         px    = (1 / icrs.distance.to(u.pc).value * 1e3) if icrs.distance is not None else 0.0
-        epoch = icrs.obstime.jyear
+        epoch = icrs.obstime.jd
 
         lat = location.lat.to(u.deg).value
         lon = location.lon.to(u.deg).value
@@ -369,45 +433,17 @@ class BarycentricCorrection:
                 f"got {output!r}"
             )
 
-        t_beg, t_mid, t_end = self._get_timestamps()
-        w_em, f = self._get_normalized_flux()
-
-        if np.any(f < 0):
-            raise ValueError("negative exposure meter flux values detected")
-
-        if fix_expmeter_outliers:
-            f = self._fix_expmeter_outliers(f)
-
-        # Cache boundary readings; f[0] and f[-1] get clobbered by later vstacks.
-        f_first_reading = f[0].copy()
-        f_last_reading  = f[-1].copy()
-
-        t = t_mid.copy()
-
-        if interpolate:
-            t_gap, f_gap = self._interpolate(t_beg, t_end, f)
-            t = Time(np.concatenate([t.jd, t_gap.jd]), format='jd', scale='utc')
-            f = np.vstack([f, f_gap])
-
-        if extrapolate:
-            hdr = self.kpf2_obj.headers['INSTRUMENT_HEADER']
-            obs_beg = Time(hdr['DATE-BEG'], format='isot', scale='utc')
-            obs_end = Time(hdr['DATE-END'], format='isot', scale='utc')
-
-            if obs_beg < t_beg[0]:
-                t_ext, f_ext = self._extrapolate(obs_beg, t_beg[0], t_end[0], f_first_reading)
-                t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
-                f = np.vstack([f, f_ext])
-
-            if obs_end > t_end[-1]:
-                t_ext, f_ext = self._extrapolate(obs_end, t_beg[-1], t_end[-1], f_last_reading)
-                t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
-                f = np.vstack([f, f_ext])
-
-        t_em = Time(
-            np.sum(t.jd[:, None] * f, axis=0) / np.sum(f, axis=0),
-            format='jd', scale='utc',
-        )
+        # Cache the per-channel integration keyed on the toggles, so a second
+        # call with the same toggles (e.g. perform() asking for 'orders' then
+        # 'ccds') reuses it instead of re-running the expensive integration.
+        key = (interpolate, extrapolate, fix_expmeter_outliers)
+        if self._em_cache is None or self._em_cache[0] != key:
+            w_em, t_em = self._compute_per_chanel_flux_weighted_midpoint_time(
+                interpolate=interpolate, extrapolate=extrapolate,
+                fix_expmeter_outliers=fix_expmeter_outliers,
+            )
+            self._em_cache = (key, w_em, t_em)
+        _, w_em, t_em = self._em_cache
 
         if output == 'expmeter':
             return w_em, t_em
@@ -418,23 +454,92 @@ class BarycentricCorrection:
             raise KeyError(
                 "SCI2_WAVE missing or empty; run WavelengthCalibration first"
             )
-        order_centers = np.median(np.asarray(wave), axis=1)  # (NORDER,)
-        sort_idx = np.argsort(w_em)
-        jd_per_order = np.interp(order_centers, w_em[sort_idx], t_em.jd[sort_idx])
+        wave = np.asarray(wave)
+        wave_min = wave.min(axis=1)
+        wave_max = wave.max(axis=1)
+
+        w_orders = 0.5 * (wave_min + wave_max)  # (NORDER,)
+
+        t_em_jd = t_em.jd
+        jd_per_order = np.empty(len(w_orders))
+        for i in range(len(w_orders)):
+            in_order = (w_em >= wave_min[i]) & (w_em <= wave_max[i])
+            if np.any(in_order):
+                jd_per_order[i] = np.mean(t_em_jd[in_order])
+            else:
+                jd_per_order[i] = t_em_jd[np.argmin(np.abs(w_em - w_orders[i]))]
         t_orders = Time(jd_per_order, format='jd', scale='utc')
 
         if output == 'orders':
-            return order_centers, t_orders
+            return w_orders, t_orders
 
-        # 'ccds': mean within each chip's order slice.
+        # 'ccds': flux-weighted mean within each chip's order slice, weighted by
+        # each order's SCI2 brightness (90th percentile, robust to cosmics) so
+        # faint/edge orders contribute less. NaN orders (failed extraction) get
+        # zero weight; uniform weights if SCI2_FLUX is absent.
+        flux = self.kpf2_obj.data['SCI2_FLUX']
+        if flux is None or np.size(flux) == 0:
+            weights = np.ones(NORDER)
+        else:
+            weights = np.nanpercentile(np.asarray(flux, dtype=float), 90, axis=1)
+        weights = np.nan_to_num(weights, nan=0.0)
+
         green = slice(0, NORDER_GREEN)
         red   = slice(NORDER_GREEN, NORDER)
-        w_ccds = np.array([order_centers[green].mean(), order_centers[red].mean()])
+        w_ccds = np.array([
+            np.average(w_orders[green], weights=weights[green]),
+            np.average(w_orders[red],   weights=weights[red]),
+        ])
         t_ccds = Time(
-            [jd_per_order[green].mean(), jd_per_order[red].mean()],
+            [np.average(jd_per_order[green], weights=weights[green]),
+             np.average(jd_per_order[red],   weights=weights[red])],
             format='jd', scale='utc',
         )
         return w_ccds, t_ccds
+
+    def compute_barycentric_correction(self, output='orders', interpolate=True,
+                                extrapolate=True, fix_expmeter_outliers=True):
+        """
+        Compute the barycentric correction at the flux-weighted photon-midpoint
+        time for each output bin.
+
+        Mirrors compute_flux_weighted_midpoint_times: `output` selects the
+        binning. The per-channel integration and the Gaia astrometry are both
+        cached, so calling this for 'orders' then 'ccds' does the heavy work
+        once.
+
+        Parameters
+        ----------
+        output : {'expmeter', 'orders', 'ccds'}
+            Binning level; forwarded to compute_flux_weighted_midpoint_times().
+        interpolate, extrapolate, fix_expmeter_outliers : bool, optional
+            Forwarded to compute_flux_weighted_midpoint_times().
+
+        Returns
+        -------
+        bjd_tdb : ndarray
+            Photon-weighted midpoint in BJD_TDB per output bin.
+        bary_kms : ndarray
+            Barycentric velocity per output bin [km/s].
+        bary_z : ndarray
+            Barycentric redshift per output bin.
+        """
+        _, t_fwm = self.compute_flux_weighted_midpoint_times(
+            output=output, interpolate=interpolate, extrapolate=extrapolate,
+            fix_expmeter_outliers=fix_expmeter_outliers,
+        )
+        skycoord = self._query_gaia()
+
+        # TARGRADV is in km/s; barycorrpy expects rv in m/s. Missing → 0.
+        inst = self.kpf2_obj.headers['INSTRUMENT_HEADER']
+        rv_mps = float(inst.get('TARGRADV', 0.0) or 0.0) * 1000.0
+
+        bc_vel_mps, bjd_tdb = self._compute_barycorr(
+            skycoord, t_fwm, KECK_LOCATION, rv_mps=rv_mps,
+        )
+        bary_kms = bc_vel_mps / 1000.0
+        bary_z = np.asarray(compute_doppler_shift(bc_vel_mps * u.m / u.s))
+        return bjd_tdb, bary_kms, bary_z
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -457,27 +562,14 @@ class BarycentricCorrection:
             per-CCD CCD{1,2}BJD/BKMS/BZ summaries written to
             INSTRUMENT_HEADER, and a 'barycentric_correction' receipt entry.
         """
-        # Per-order flux-weighted midpoint times (interpolated from per-channel)
-        _, t_per_order = self.compute_flux_weighted_midpoint_times(
-            output='orders',
-            interpolate=interpolate, extrapolate=extrapolate,
-            fix_expmeter_outliers=fix_expmeter_outliers,
-        )
+        # Per-order and per-CCD barycorr. The 'ccds' call reuses the cached
+        # integration and Gaia query from the 'orders' call.
+        kwargs = dict(interpolate=interpolate, extrapolate=extrapolate,
+                      fix_expmeter_outliers=fix_expmeter_outliers)
+        bjd_tdb, bary_kms, bary_z = self.compute_barycentric_correction(output='orders', **kwargs)
+        ccd_bjd, ccd_kms, ccd_z   = self.compute_barycentric_correction(output='ccds', **kwargs)
 
-        # Astrometric solution + per-order barycorr. GAIAID and TARGRADV
-        # are preserved from L1 PRIMARY by KPF1.to_kpf2() into INSTRUMENT_HEADER.
         inst = self.kpf2_obj.headers['INSTRUMENT_HEADER']
-        gaia_id_raw = inst['GAIAID']
-        gaia_id = re.split(r'\s+', str(gaia_id_raw).strip())[-1]
-        skycoord = self._query_gaia(gaia_id)
-
-        # TARGRADV is in km/s; barycorrpy expects rv in m/s. Missing → 0.
-        rv_mps = float(inst.get('TARGRADV', 0.0) or 0.0) * 1000.0
-        bc_vel_mps, bjd_tdb = self._compute_barycorr(
-            skycoord, t_per_order, KECK_LOCATION, rv_mps=rv_mps,
-        )
-        bary_kms = bc_vel_mps / 1000.0
-        bary_z = np.asarray(compute_doppler_shift(bc_vel_mps * u.m / u.s))
 
         # Write rvdata standard extensions (per-order arrays). The WAVE
         # arrays are left untouched; downstream RV computation consumes
@@ -487,18 +579,15 @@ class BarycentricCorrection:
         self.kpf2_obj.set_data('BARYCORR_Z',   np.asarray(bary_z,   dtype=np.float64))
 
         # Per-CCD scalar summaries on INSTRUMENT_HEADER (KPF-native keywords).
-        # CCD1 = GREEN (orders [:NORDER_GREEN]), CCD2 = RED (orders [NORDER_GREEN:]).
-        # INSTRUMENT_HEADER serializes as a no-data ImageHDU and only accepts
-        # scalar values (no (value, comment) tuples) — see KPF1.to_kpf2.
-        inst = self.kpf2_obj.headers['INSTRUMENT_HEADER']
-        green = slice(0, NORDER_GREEN)
-        red   = slice(NORDER_GREEN, NORDER)
-        inst['CCD1BJD']  = float(np.mean(bjd_tdb[green]))
-        inst['CCD1BKMS'] = float(np.mean(bary_kms[green]))
-        inst['CCD1BZ']   = float(np.mean(bary_z[green]))
-        inst['CCD2BJD']  = float(np.mean(bjd_tdb[red]))
-        inst['CCD2BKMS'] = float(np.mean(bary_kms[red]))
-        inst['CCD2BZ']   = float(np.mean(bary_z[red]))
+        # CCD1 = GREEN, CCD2 = RED. INSTRUMENT_HEADER serializes as a no-data
+        # ImageHDU and only accepts scalar values (no (value, comment) tuples)
+        # — see KPF1.to_kpf2.
+        inst['CCD1BJD']  = float(ccd_bjd[0])
+        inst['CCD1BKMS'] = float(ccd_kms[0])
+        inst['CCD1BZ']   = float(ccd_z[0])
+        inst['CCD2BJD']  = float(ccd_bjd[1])
+        inst['CCD2BKMS'] = float(ccd_kms[1])
+        inst['CCD2BZ']   = float(ccd_z[1])
 
         self.kpf2_obj.receipt_add_entry('barycentric_correction', 'PASS')
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -142,12 +142,15 @@ class BarycentricCorrection:
         Columns with numeric names are wavelength channels; non-numeric
         columns (e.g. timestamps) are skipped.
 
+        EXPMETER_SCI column labels are in Å on L1+ data (converted from the
+        native L0 nm by ImageAssembly), so `w` is returned in Å.
+
         Returns
         -------
         w : ndarray, shape (nwave,)
-            Wavelength of each expmeter channel (label units, e.g. Å).
+            Wavelength of each expmeter channel [Å].
         f : ndarray, shape (ntime, nwave)
-            Dispersion-normalized flux [e- per wavelength unit].
+            Dispersion-normalized flux [e- / Å].
         """
         expmeter = self.kpf2_obj.data['EXPMETER_SCI']
 
@@ -357,7 +360,7 @@ class BarycentricCorrection:
         Returns
         -------
         w : ndarray
-            Wavelengths corresponding to each output bin (label units).
+            Wavelengths corresponding to each output bin [Å].
         t_fwm : Time
             Flux-weighted midpoint time (JD-UTC) per output bin.
         """

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -319,13 +319,25 @@ class BarycentricCorrection:
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def flux_weighted_midpoint(self, interpolate=True, extrapolate=True,
-                                fix_expmeter_outliers=True):
+    def compute_flux_weighted_midpoint_times(self, output='orders', interpolate=True,
+                                extrapolate=True, fix_expmeter_outliers=True):
         """
-        Compute the flux-weighted midpoint observation time per wavelength channel.
+        Compute the flux-weighted midpoint observation time.
+
+        Always derives the per-expmeter-channel midpoint internally;
+        `output` controls how those values are projected. When called
+        from perform(), 'orders' (default) will be used.
 
         Parameters
         ----------
+        output : {'expmeter', 'orders', 'ccds'}
+            'expmeter' — raw per-channel result, shape (nwave,).
+            'orders'   — linearly interpolated onto each spectral order's
+                         central wavelength (median of SCI2_WAVE), shape (NORDER,).
+                         Orders outside the expmeter range clamp to the
+                         nearest endpoint (np.interp default).
+            'ccds'     — mean of the per-order values within each chip,
+                         shape (2,); [GREEN, RED].
         interpolate : bool, optional
             If True, estimate flux during gaps between expmeter readings.
         extrapolate : bool, optional
@@ -337,13 +349,19 @@ class BarycentricCorrection:
 
         Returns
         -------
-        w : ndarray, shape (nwave,)
-            Wavelength of each expmeter channel (label units; typically Å).
-        t_fwm : Time, shape (nwave,)
-            Flux-weighted midpoint time (JD-UTC) for each wavelength channel.
+        w : ndarray
+            Wavelengths corresponding to each output bin (label units).
+        t_fwm : Time
+            Flux-weighted midpoint time (JD-UTC) per output bin.
         """
+        if output not in ('expmeter', 'orders', 'ccds'):
+            raise ValueError(
+                f"output must be 'expmeter', 'orders', or 'ccds'; "
+                f"got {output!r}"
+            )
+
         t_beg, t_mid, t_end = self._get_timestamps()
-        w, f = self._get_normalized_flux()
+        w_em, f = self._get_normalized_flux()
 
         if np.any(f < 0):
             raise ValueError("negative exposure meter flux values detected")
@@ -373,42 +391,37 @@ class BarycentricCorrection:
                 t = Time(np.concatenate([t.jd, [t_ext.jd]]), format='jd', scale='utc')
                 f = np.vstack([f, f_ext])
 
-        t_fwm = Time(
+        t_em = Time(
             np.sum(t.jd[:, None] * f, axis=0) / np.sum(f, axis=0),
-            format='jd', scale='utc'
+            format='jd', scale='utc',
         )
-        return w, t_fwm
 
-    def map_to_orders(self, w_em, t_fwm):
-        """
-        Interpolate per-channel midpoint times onto each spectral order.
+        if output == 'expmeter':
+            return w_em, t_em
 
-        Order central wavelength = median of SCI2_WAVE across columns.
-        Orders outside the expmeter range clamp to the nearest endpoint
-        (np.interp default).
-
-        Parameters
-        ----------
-        w_em : ndarray, shape (nwave,)
-            Expmeter channel wavelengths (label units; same as SCI2_WAVE).
-        t_fwm : Time, shape (nwave,)
-            Per-channel flux-weighted midpoint times.
-
-        Returns
-        -------
-        t_per_order : Time, shape (NORDER,)
-            Per-order flux-weighted midpoint time (JD-UTC).
-        """
+        # Project per-channel times onto each spectral order via SCI2_WAVE.
         wave = self.kpf2_obj.data['SCI2_WAVE']
         if wave is None or np.size(wave) == 0:
             raise KeyError(
                 "SCI2_WAVE missing or empty; run WavelengthCalibration first"
             )
         order_centers = np.median(np.asarray(wave), axis=1)  # (NORDER,)
-
         sort_idx = np.argsort(w_em)
-        jd_per_order = np.interp(order_centers, w_em[sort_idx], t_fwm.jd[sort_idx])
-        return Time(jd_per_order, format='jd', scale='utc')
+        jd_per_order = np.interp(order_centers, w_em[sort_idx], t_em.jd[sort_idx])
+        t_orders = Time(jd_per_order, format='jd', scale='utc')
+
+        if output == 'orders':
+            return order_centers, t_orders
+
+        # 'ccds': mean within each chip's order slice.
+        green = slice(0, NORDER_GREEN)
+        red   = slice(NORDER_GREEN, NORDER)
+        w_ccds = np.array([order_centers[green].mean(), order_centers[red].mean()])
+        t_ccds = Time(
+            [jd_per_order[green].mean(), jd_per_order[red].mean()],
+            format='jd', scale='utc',
+        )
+        return w_ccds, t_ccds
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -426,7 +439,7 @@ class BarycentricCorrection:
         fibers : list of str, optional
             Fiber identifiers, e.g. ['SCI1', 'SCI2', ...]. Defaults to self.fibers.
         interpolate, extrapolate, fix_expmeter_outliers : bool, optional
-            Forwarded to flux_weighted_midpoint(). See that method for semantics.
+            Forwarded to compute_flux_weighted_midpoint_times(). See that method for semantics.
 
         Returns
         -------
@@ -441,12 +454,12 @@ class BarycentricCorrection:
         if fibers is None:
             fibers = self.fibers
 
-        # Per-channel flux-weighted midpoint times → per-order via interpolation
-        w_em, t_fwm = self.flux_weighted_midpoint(
+        # Per-order flux-weighted midpoint times (interpolated from per-channel)
+        _, t_per_order = self.compute_flux_weighted_midpoint_times(
+            output='orders',
             interpolate=interpolate, extrapolate=extrapolate,
             fix_expmeter_outliers=fix_expmeter_outliers,
         )
-        t_per_order = self.map_to_orders(w_em, t_fwm)
 
         # Astrometric solution + per-order barycorr
         # GAIAID is preserved from L1 PRIMARY by KPF1.to_kpf2() into L2 INSTRUMENT_HEADER.

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -2,8 +2,7 @@
 KPF Barycentric Correction module.
 
 Computes per-order barycentric corrections from the EXPMETER_SCI flux-weighted
-midpoint times. Populates the rvdata-standard L2 extensions and applies the
-per-order redshift to all WAVE arrays in place.
+midpoint times and stores them on the L2. WAVE arrays are not modified.
 
 Outputs (rvdata-standard ImageHDUs, shape (NORDER,)):
   - BJD_TDB       photon-weighted midpoint in BJD_TDB per spectral order
@@ -58,14 +57,13 @@ KECK_LOCATION = EarthLocation(
 
 class BarycentricCorrection:
     """
-    Compute and apply per-order barycentric correction to KPF2 wavelength arrays.
+    Compute and store per-order barycentric correction on a KPF2.
 
-    Derives the flux-weighted midpoint per expmeter wavelength channel
-    (EXPMETER_SCI), interpolates onto each spectral order's central
-    wavelength (SCI2_WAVE), queries Gaia DR3 for the target's astrometry,
-    and calls barycorrpy to populate the rvdata-standard BJD_TDB /
-    BARYCORR_KMS / BARYCORR_Z extensions. Per-order BARYCORR_Z is then
-    applied to every WAVE array in place.
+    Derives the flux-weighted midpoint per expmeter channel (EXPMETER_SCI),
+    interpolates onto each spectral order's central wavelength (SCI2_WAVE),
+    queries Gaia DR3 for the target's astrometry, and calls barycorrpy to
+    populate BJD_TDB / BARYCORR_KMS / BARYCORR_Z. WAVE arrays are not
+    modified.
 
     Parameters
     ----------
@@ -437,33 +435,23 @@ class BarycentricCorrection:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, chips=None, fibers=None, interpolate=True, extrapolate=True,
-                fix_expmeter_outliers=True):
+    def perform(self, interpolate=True, extrapolate=True, fix_expmeter_outliers=True):
         """
-        Compute per-order barycentric correction and apply it to wavelength arrays.
+        Compute per-order barycentric correction and store it on the KPF2.
 
         Parameters
         ----------
-        chips : list of str, optional
-            Chip identifiers, e.g. ['GREEN', 'RED']. Defaults to self.chips.
-        fibers : list of str, optional
-            Fiber identifiers, e.g. ['SCI1', 'SCI2', ...]. Defaults to self.fibers.
         interpolate, extrapolate, fix_expmeter_outliers : bool, optional
-            Forwarded to compute_flux_weighted_midpoint_times(). See that method for semantics.
+            Forwarded to compute_flux_weighted_midpoint_times(). See that
+            method for semantics.
 
         Returns
         -------
         kpf2_obj : KPF2
             Input KPF2 with BJD_TDB / BARYCORR_KMS / BARYCORR_Z populated,
-            WAVE arrays scaled in-place by per-order redshift, per-CCD
-            CCD{1,2}BJD/BKMS/BZ summaries written to INSTRUMENT_HEADER,
-            and a 'barycentric_correction' receipt entry.
+            per-CCD CCD{1,2}BJD/BKMS/BZ summaries written to
+            INSTRUMENT_HEADER, and a 'barycentric_correction' receipt entry.
         """
-        if chips is None:
-            chips = self.chips
-        if fibers is None:
-            fibers = self.fibers
-
         # Per-order flux-weighted midpoint times (interpolated from per-channel)
         _, t_per_order = self.compute_flux_weighted_midpoint_times(
             output='orders',
@@ -483,22 +471,12 @@ class BarycentricCorrection:
             float(compute_doppler_shift(v * u.m / u.s)) for v in bc_vel_mps
         ])
 
-        # Write rvdata standard extensions (per-order arrays)
+        # Write rvdata standard extensions (per-order arrays). The WAVE
+        # arrays are left untouched; downstream RV computation consumes
+        # BARYCORR_Z directly.
         self.kpf2_obj.set_data('BJD_TDB',      np.asarray(bjd_tdb,  dtype=np.float64))
         self.kpf2_obj.set_data('BARYCORR_KMS', np.asarray(bary_kms, dtype=np.float64))
         self.kpf2_obj.set_data('BARYCORR_Z',   np.asarray(bary_z,   dtype=np.float64))
-
-        # Apply per-order redshift to all WAVE arrays (in-place, per-order multiply)
-        for fiber in fibers:
-            for chip in chips:
-                wave_ext = f'{chip}_{fiber}_WAVE'
-                if wave_ext not in self.kpf2_obj.data:
-                    continue
-                arr = self.kpf2_obj.data[wave_ext]
-                if arr is None or np.size(arr) == 0:
-                    continue
-                z = bary_z[:NORDER_GREEN] if chip.upper() == 'GREEN' else bary_z[NORDER_GREEN:]
-                self.kpf2_obj.data[wave_ext] = (arr * z[:, None]).astype(arr.dtype)
 
         # Per-CCD scalar summaries on INSTRUMENT_HEADER (KPF-native keywords).
         # CCD1 = GREEN (orders [:NORDER_GREEN]), CCD2 = RED (orders [NORDER_GREEN:]).

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -36,6 +36,7 @@ class ImageAssembly:
       - measuring read noise
       - subtracting overscan bias
       - assembling full-frame images (FFI)
+      - converting EXPMETER_SCI/SKY wavelengths from nm to Angstroms
     """
     def __init__(self, l0_obj, config=None):
         self.l0_obj = l0_obj
@@ -208,6 +209,35 @@ class ImageAssembly:
         l1_obj.headers['PRIMARY']['OSCANMET'] = (
             self.overscan_method, 'Overscan subtraction method'
         )
+
+    @staticmethod
+    def _convert_expmeter_wavelengths_to_angstroms(l1_obj):
+        """
+        Rename EXPMETER_SCI/SKY wavelength column labels from nm to Å.
+
+        Raw L0 expmeter tables label per-channel flux columns with the
+        channel central wavelength in nanometers (e.g. '498.12'). The
+        RVData L2 standard and KPF WAVE arrays use Angstroms, so this
+        renames those columns at the L0 → L1 boundary so the entire
+        L1+ pipeline operates in a single wavelength unit.
+
+        Non-numeric columns (e.g. 'Date-Beg', 'Date-End') are skipped.
+        Underlying flux values are unchanged.
+        """
+        for ext_name in ('EXPMETER_SCI', 'EXPMETER_SKY'):
+            if ext_name not in l1_obj.data:
+                continue
+            table = l1_obj.data[ext_name]
+            if table is None or not hasattr(table, 'rename_column'):
+                continue
+            for col in list(table.colnames):
+                try:
+                    wave_nm = float(col)
+                except (ValueError, TypeError):
+                    continue
+                new_name = format(wave_nm * 10, 'g')
+                if new_name != col:
+                    table.rename_column(col, new_name)
 
     # ------------------------------------------------------------------
     # Algorithm steps
@@ -477,6 +507,7 @@ class ImageAssembly:
         5. Subtract overscan bias
         6. Re-orient channels if needed
         7. Stitch channels into a full-frame image
+        8. Convert EXPMETER_SCI/SKY wavelength column labels from nm to Å
         """
         if chips is None:
             chips = self.chips
@@ -504,6 +535,7 @@ class ImageAssembly:
             l1_obj.set_data(f'{chip}_VAR', var_ffi)
 
         self._set_kpf1_headers(l1_obj)
+        self._convert_expmeter_wavelengths_to_angstroms(l1_obj)
         l1_obj.receipt_add_entry('image_assembly', 'PASS')
 
         self._results = {

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -244,6 +244,10 @@ class WLS(BaseMasterModule):
         """
         linelist_array = self._load_linelist(linelist)
 
+        # Fit in float64 (wavelength solutions are float64).
+        flux1d = np.asarray(flux1d, dtype=np.float64)
+        wave1d = np.asarray(wave1d, dtype=np.float64)
+
         if len(flux1d) != len(wave1d):
             raise ValueError("length of flux and wave arrays are mismatched")
         ncol = len(flux1d)

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -147,7 +147,7 @@ class WavelengthCalibration:
                         f"WLS master has no data for {key}; "
                         f"cannot apply wavelength solution"
                     )
-                self.l2_obj.set_data(key, src)
+                self.l2_obj.set_data(key, np.asarray(src, dtype=np.float64))
 
         self.l2_obj.receipt_add_entry('wavelength_calibration', 'PASS')
 

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -8,7 +8,7 @@ from kpfpipe.modules.calibration_association import CalibrationAssociation
 from kpfpipe.modules.image_processing import ImageProcessing
 from kpfpipe.modules.spectral_extraction import SpectralExtraction
 from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
-#from kpfpipe.modules.barycentric_correction import BarycentricCorrection
+from kpfpipe.modules.barycentric_correction import BarycentricCorrection
 
 from kpfpipe.quality_control.diagnostics import DiagL1, DiagL2
 from kpfpipe.quality_control.qc_binaries import QCL1, QCL2
@@ -68,9 +68,9 @@ def main(config, args):
     DiagL2(l2).run()
     QCL2(l2).run()
 
-    # calculate barycentric correction
-    #barycentric_correction = BarycentricCorrection(l2, config)
-    #l2 = barycentric_correction.perform()
+    # apply per-order barycentric correction (writes BJD_TDB, BARYCORR_KMS, BARYCORR_Z)
+    barycentric_correction = BarycentricCorrection(l2, config)
+    l2 = barycentric_correction.perform()
 
     # write L2 data product to disk
     out_path = build_filepath(obs_id, 'L2', data_root=data_root_out)

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -1,0 +1,439 @@
+"""
+Tests for the BarycentricCorrection module (KPF2 → KPF2).
+
+Static-method unit tests require no fixtures. Integration tests use a
+synthetic KPF2 object with a small EXPMETER_SCI table. Tests that would
+require a live Gaia query or barycorrpy call are covered via monkeypatching.
+"""
+
+import numpy as np
+import pytest
+import astropy.units as u
+from astropy.table import Table
+from astropy.time import Time
+
+from kpfpipe import DETECTOR
+from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.modules.barycentric_correction import BarycentricCorrection
+
+NORDER_GREEN = DETECTOR['norder']['GREEN']
+NORDER_RED   = DETECTOR['norder']['RED']
+NCOL         = 50   # reduced column count for speed
+
+
+# ---------------------------------------------------------------------------
+# Synthetic KPF2 fixture
+# ---------------------------------------------------------------------------
+
+# Exposure meter: 3 readings of 60s, with 60s gaps, starting at T0.
+#   Reading 0: 00:00:00 → 00:01:00
+#   Gap:       00:01:00 → 00:02:00
+#   Reading 1: 00:02:00 → 00:03:00
+#   Gap:       00:03:00 → 00:04:00
+#   Reading 2: 00:04:00 → 00:05:00
+# DATE-BEG = 00:00:00, DATE-END = 00:05:00 (shutter open for full range)
+_T0 = '2024-01-01T'
+_WAVE_COLS  = ['5000', '5100', '5200', '5300']   # 100Å spacing → dispersion = 100Å
+_FLUX_VALUE = 100.0                               # uniform ADU per reading
+
+
+def _make_expmeter_table():
+    begs = [f'{_T0}00:00:00.000', f'{_T0}00:02:00.000', f'{_T0}00:04:00.000']
+    ends = [f'{_T0}00:01:00.000', f'{_T0}00:03:00.000', f'{_T0}00:05:00.000']
+    data = {'Date-Beg': begs, 'Date-End': ends}
+    for wc in _WAVE_COLS:
+        data[wc] = np.full(3, _FLUX_VALUE)
+    return Table(data)
+
+
+@pytest.fixture
+def synthetic_kpf2():
+    """KPF2 with synthetic EXPMETER_SCI and wavelength arrays."""
+    kpf2 = KPF2()
+
+    kpf2.headers['PRIMARY']['DATE-BEG'] = f'{_T0}00:00:00.000'
+    kpf2.headers['PRIMARY']['DATE-END'] = f'{_T0}00:05:00.000'
+    kpf2.headers['PRIMARY']['GAIAID'] = 'DR3 1234567890123456789'
+
+    kpf2.set_data('EXPMETER_SCI', _make_expmeter_table())
+
+    for chip in ['GREEN', 'RED']:
+        n = NORDER_GREEN if chip == 'GREEN' else NORDER_RED
+        for fiber in ['SKY', 'SCI1', 'SCI2', 'SCI3', 'CAL']:
+            kpf2.set_data(f'{chip}_{fiber}_WAVE',
+                          np.full((n, NCOL), 5000.0, dtype=np.float32))
+
+    return kpf2
+
+
+# ---------------------------------------------------------------------------
+# _strictly_increasing
+# ---------------------------------------------------------------------------
+
+class TestStrictlyIncreasing:
+
+    def _make_time(self, seconds):
+        jd0 = 2460310.5  # arbitrary JD base
+        return Time(jd0 + np.array(seconds) / 86400.0, format='jd', scale='utc')
+
+    def test_increasing(self):
+        t = self._make_time([0, 1, 2, 3])
+        assert BarycentricCorrection._strictly_increasing(t) is True
+
+    def test_constant_fails(self):
+        t = self._make_time([0, 1, 1, 2])
+        assert BarycentricCorrection._strictly_increasing(t) is False
+
+    def test_decreasing_fails(self):
+        t = self._make_time([3, 2, 1, 0])
+        assert BarycentricCorrection._strictly_increasing(t) is False
+
+    def test_single_element(self):
+        t = self._make_time([0])
+        # slice t[:-1] and t[1:] are both empty → np.all of empty → True
+        assert BarycentricCorrection._strictly_increasing(t) is True
+
+
+# ---------------------------------------------------------------------------
+# _interpolate
+# ---------------------------------------------------------------------------
+
+class TestInterpolate:
+
+    def _make_times(self, seconds):
+        jd0 = 2460310.5
+        return Time(jd0 + np.array(seconds, dtype=float) / 86400.0,
+                    format='jd', scale='utc')
+
+    def test_gap_midpoint_time(self):
+        """Gap midpoint should fall halfway between end of reading 0 and start of reading 1."""
+        t_beg = self._make_times([0, 120])    # two 60s readings, 60s gap between
+        t_end = self._make_times([60, 180])
+        f = np.ones((2, 3))
+
+        t_gap, _ = BarycentricCorrection._interpolate(t_beg, t_end, f)
+
+        expected_jd = (t_end[0].jd + t_beg[1].jd) / 2
+        np.testing.assert_allclose(t_gap[0].jd, expected_jd)
+
+    def test_gap_flux_equal_exposure_flux_when_same_duration(self):
+        """If gap duration == exposure duration and flux is uniform, f_gap == f."""
+        t_beg = self._make_times([0, 120])
+        t_end = self._make_times([60, 180])
+        f = np.full((2, 4), _FLUX_VALUE)
+
+        _, f_gap = BarycentricCorrection._interpolate(t_beg, t_end, f)
+
+        np.testing.assert_allclose(f_gap[0], _FLUX_VALUE, rtol=1e-6)
+
+    def test_output_shape(self):
+        """n readings → n-1 gaps."""
+        t_beg = self._make_times([0, 120, 240])
+        t_end = self._make_times([60, 180, 300])
+        f = np.ones((3, 4))
+
+        t_gap, f_gap = BarycentricCorrection._interpolate(t_beg, t_end, f)
+
+        assert len(t_gap) == 2
+        assert f_gap.shape == (2, 4)
+
+    def test_zero_gap_gives_zero_flux(self):
+        """Back-to-back readings (zero gap) should produce zero gap flux."""
+        t_beg = self._make_times([0, 60])    # reading 1 starts exactly when reading 0 ends
+        t_end = self._make_times([60, 120])
+        f = np.ones((2, 3))
+
+        _, f_gap = BarycentricCorrection._interpolate(t_beg, t_end, f)
+
+        np.testing.assert_allclose(f_gap[0], 0.0, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# _extrapolate
+# ---------------------------------------------------------------------------
+
+class TestExtrapolate:
+
+    def _t(self, sec):
+        return Time(2460310.5 + sec / 86400.0, format='jd', scale='utc')
+
+    def test_extrapolate_before_first_reading(self):
+        """Gap before the first reading: midpoint is halfway between t0 and t_beg."""
+        t0   = self._t(0)
+        t_beg = self._t(60)
+        t_end = self._t(120)
+        f = np.full(4, _FLUX_VALUE)
+
+        t_ext, f_ext = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
+
+        expected_jd = (t0.jd + t_beg.jd) / 2
+        np.testing.assert_allclose(t_ext.jd, expected_jd)
+
+    def test_extrapolate_before_flux_proportional(self):
+        """Gap flux equals exposure flux when gap and exposure have equal duration."""
+        t0    = self._t(0)
+        t_beg = self._t(60)   # 60s gap before first reading
+        t_end = self._t(120)  # 60s reading
+        f = np.full(4, _FLUX_VALUE)
+
+        _, f_ext = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
+
+        np.testing.assert_allclose(f_ext, _FLUX_VALUE, rtol=1e-6)
+
+    def test_extrapolate_after_last_reading(self):
+        """Gap after the last reading: midpoint is halfway between t_end and t0."""
+        t_beg = self._t(0)
+        t_end = self._t(60)
+        t0    = self._t(120)
+        f = np.full(4, _FLUX_VALUE)
+
+        t_ext, f_ext = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
+
+        expected_jd = (t_end.jd + t0.jd) / 2
+        np.testing.assert_allclose(t_ext.jd, expected_jd)
+
+    def test_t0_inside_raises(self):
+        """t0 between t_beg and t_end should raise ValueError."""
+        t_beg = self._t(0)
+        t_end = self._t(120)
+        t0    = self._t(60)
+        f = np.ones(4)
+
+        with pytest.raises(ValueError):
+            BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
+
+
+# ---------------------------------------------------------------------------
+# _fix_bad_exposures
+# ---------------------------------------------------------------------------
+
+class TestFixBadExposures:
+
+    def test_clean_array_unchanged(self):
+        rng = np.random.default_rng(0)
+        # Use a realistically-noisy array so mad_std > 0 and no outliers are flagged
+        f = rng.normal(100.0, 2.0, (60, 20))
+        f_fixed = BarycentricCorrection._fix_bad_exposures(f)
+        np.testing.assert_allclose(f_fixed, f, rtol=1e-4)
+
+    def test_outlier_repaired(self):
+        rng = np.random.default_rng(1)
+        f = rng.normal(100.0, 2.0, (60, 20))
+        f[30, 10] = 1e6   # inject a large outlier
+
+        f_fixed = BarycentricCorrection._fix_bad_exposures(f)
+
+        assert abs(f_fixed[30, 10] - 100.0) < 20.0, (
+            f"Outlier not repaired: f_fixed[30,10] = {f_fixed[30, 10]}"
+        )
+
+    def test_output_shape_preserved(self):
+        rng = np.random.default_rng(2)
+        f = rng.normal(50.0, 1.0, (60, 20))
+        f_fixed = BarycentricCorrection._fix_bad_exposures(f)
+        assert f_fixed.shape == f.shape
+
+
+# ---------------------------------------------------------------------------
+# _get_timestamps and _get_normalized_flux
+# ---------------------------------------------------------------------------
+
+class TestGetTimestamps:
+
+    def test_returns_three_time_arrays(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        t_beg, t_mid, t_end = bc._get_timestamps()
+        assert len(t_beg) == 3
+        assert len(t_mid) == 3
+        assert len(t_end) == 3
+
+    def test_mid_is_between_beg_and_end(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        t_beg, t_mid, t_end = bc._get_timestamps()
+        assert np.all(t_mid.jd > t_beg.jd)
+        assert np.all(t_mid.jd < t_end.jd)
+
+    def test_beg_strictly_increasing(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        t_beg, _, _ = bc._get_timestamps()
+        assert BarycentricCorrection._strictly_increasing(t_beg)
+
+    def test_non_monotonic_raises(self, synthetic_kpf2):
+        """Reversed timestamps should raise ValueError."""
+        from astropy.table import Table
+        bad_table = Table({
+            'Date-Beg': ['2024-01-01T00:04:00.000', '2024-01-01T00:02:00.000',
+                         '2024-01-01T00:00:00.000'],
+            'Date-End': ['2024-01-01T00:05:00.000', '2024-01-01T00:03:00.000',
+                         '2024-01-01T00:01:00.000'],
+            '5000': [1.0, 1.0, 1.0],
+        })
+        synthetic_kpf2.set_data('EXPMETER_SCI', bad_table)
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(ValueError, match="strictly increasing"):
+            bc._get_timestamps()
+
+
+class TestGetNormalizedFlux:
+
+    def test_output_shape(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        f = bc._get_normalized_flux()
+        assert f.shape == (3, 4)   # 3 time steps, 4 wavelength channels
+
+    def test_non_numeric_columns_excluded(self, synthetic_kpf2):
+        """Date-Beg and Date-End should not appear in the flux array."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        f = bc._get_normalized_flux()
+        # 4 numeric wave columns in the fixture → ncol = 4
+        assert f.shape[1] == len(_WAVE_COLS)
+
+    def test_gain_and_dispersion_applied(self, synthetic_kpf2):
+        """With 100Å uniform spacing, f_norm = f_raw * 1.48424 / 100."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        f = bc._get_normalized_flux()
+        expected = _FLUX_VALUE * 1.48424 / 100.0
+        np.testing.assert_allclose(f, expected, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# flux_weighted_midpoint
+# ---------------------------------------------------------------------------
+
+class TestFluxWeightedMidpoint:
+
+    def test_uniform_flux_gives_geometric_midpoint(self, synthetic_kpf2):
+        """With uniform flux and symmetric timestamps the FWM should equal
+        the mean of the three reading midpoints (ignoring gaps and edges)."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
+                                           fix_bad_exposures=False)
+        t_beg, t_mid, _ = bc._get_timestamps()
+        expected_jd = np.mean(t_mid.jd)
+        np.testing.assert_allclose(
+            np.mean(t_fwm.jd), expected_jd, atol=1e-6
+        )
+
+    def test_output_shape(self, synthetic_kpf2):
+        """One FWM time per wavelength channel."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
+                                           fix_bad_exposures=False)
+        assert len(t_fwm) == len(_WAVE_COLS)
+
+    def test_negative_flux_raises(self, synthetic_kpf2, monkeypatch):
+        """Negative expmeter values should raise ValueError."""
+        def mock_flux(self):
+            return np.full((3, 4), -1.0)
+        monkeypatch.setattr(BarycentricCorrection, '_get_normalized_flux', mock_flux)
+
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(ValueError, match="negative"):
+            bc.flux_weighted_midpoint()
+
+    def test_interpolate_shifts_midpoint_later_when_front_weighted(self, synthetic_kpf2):
+        """When flux is front-weighted, the interpolated gap between bright
+        reading 0 and dim reading 1 has a large flux sample at T+90s — later
+        than reading 0's midpoint — so FWM shifts later with interpolation."""
+        from astropy.table import Table
+
+        # Front-weighted flux: first reading much brighter than the rest
+        data = {'Date-Beg': ['2024-01-01T00:00:00.000',
+                              '2024-01-01T00:02:00.000',
+                              '2024-01-01T00:04:00.000'],
+                'Date-End': ['2024-01-01T00:01:00.000',
+                              '2024-01-01T00:03:00.000',
+                              '2024-01-01T00:05:00.000'],
+                '5000': [1000.0, 1.0, 1.0],
+                '5100': [1000.0, 1.0, 1.0],
+                }
+        synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
+        bc = BarycentricCorrection(synthetic_kpf2)
+
+        t_no_interp = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
+                                                fix_bad_exposures=False)
+        t_with_interp = bc.flux_weighted_midpoint(interpolate=True, extrapolate=False,
+                                                   fix_bad_exposures=False)
+
+        # Gap sample at T+90s is bright (≈500), pulling FWM later than without it
+        assert np.mean(t_with_interp.jd) >= np.mean(t_no_interp.jd) - 1e-9
+
+
+# ---------------------------------------------------------------------------
+# perform() — Gaia and barycorrpy are monkeypatched
+# ---------------------------------------------------------------------------
+
+class TestPerform:
+
+    Z_TEST = 1.0 - 1e-4   # arbitrary but non-trivial shift factor
+
+    @pytest.fixture
+    def bc_monkeypatched(self, synthetic_kpf2, monkeypatch):
+        """BarycentricCorrection with network calls stubbed out."""
+        def mock_fwm(self, **kwargs):
+            t0 = Time('2024-01-01T00:02:30.000', format='isot', scale='utc')
+            return Time(np.full(len(_WAVE_COLS), t0.jd), format='jd', scale='utc')
+
+        def mock_barycorr(self, obs_time):
+            return TestPerform.Z_TEST, 30000.0 * u.m / u.s
+
+        monkeypatch.setattr(BarycentricCorrection, 'flux_weighted_midpoint', mock_fwm)
+        monkeypatch.setattr(BarycentricCorrection, 'barycentric_correction', mock_barycorr)
+        return BarycentricCorrection(synthetic_kpf2)
+
+    def test_returns_kpf2(self, bc_monkeypatched):
+        result = bc_monkeypatched.perform()
+        assert isinstance(result, KPF2)
+
+    def test_returns_same_object(self, bc_monkeypatched):
+        """perform() should modify the KPF2 in-place and return the same object."""
+        original = bc_monkeypatched.kpf2_obj
+        result = bc_monkeypatched.perform()
+        assert result is original
+
+    def test_wavelength_arrays_scaled(self, bc_monkeypatched):
+        """All WAVE extensions should be multiplied by z."""
+        kpf2 = bc_monkeypatched.kpf2_obj
+        # Record original values before perform
+        orig = {}
+        for chip in ['GREEN', 'RED']:
+            for fiber in ['SKY', 'SCI1', 'SCI2', 'SCI3', 'CAL']:
+                orig[f'{chip}_{fiber}_WAVE'] = kpf2.data[f'{chip}_{fiber}_WAVE'].copy()
+
+        bc_monkeypatched.perform()
+
+        for key, original_wave in orig.items():
+            np.testing.assert_allclose(
+                kpf2.data[key], original_wave * TestPerform.Z_TEST, rtol=1e-5,
+                err_msg=f"{key} not scaled correctly"
+            )
+
+    def test_receipt_entry_added(self, bc_monkeypatched):
+        bc_monkeypatched.perform()
+        modules = bc_monkeypatched.kpf2_obj.receipt['Module_Name'].values
+        assert 'barycentric_correction' in modules
+
+    def test_results_populated(self, bc_monkeypatched):
+        assert bc_monkeypatched._results is None
+        bc_monkeypatched.perform()
+        assert bc_monkeypatched._results is not None
+        assert 'obs_time' in bc_monkeypatched._results
+        assert 'delta_rv' in bc_monkeypatched._results
+        assert 'z' in bc_monkeypatched._results
+
+    def test_z_equals_one_leaves_wavelengths_unchanged(self, synthetic_kpf2, monkeypatch):
+        """A z of exactly 1.0 should leave all wavelength arrays unchanged."""
+        def mock_fwm(self, **kwargs):
+            t0 = Time('2024-01-01T00:02:30.000', format='isot', scale='utc')
+            return Time(np.full(len(_WAVE_COLS), t0.jd), format='jd', scale='utc')
+
+        def mock_barycorr(self, obs_time):
+            return 1.0, 0.0 * u.m / u.s
+
+        monkeypatch.setattr(BarycentricCorrection, 'flux_weighted_midpoint', mock_fwm)
+        monkeypatch.setattr(BarycentricCorrection, 'barycentric_correction', mock_barycorr)
+
+        bc = BarycentricCorrection(synthetic_kpf2)
+        orig = bc.kpf2_obj.data['GREEN_SCI2_WAVE'].copy()
+        bc.perform()
+        np.testing.assert_array_equal(bc.kpf2_obj.data['GREEN_SCI2_WAVE'], orig)

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -397,6 +397,32 @@ class TestFluxWeightedMidpointCcds:
             [t_orders.jd[:NORDER_GREEN].mean(), t_orders.jd[NORDER_GREEN:].mean()],
         )
 
+    def test_green_and_red_resolve_distinct_values(self, synthetic_kpf2):
+        """With GREEN orders at 5000Å and RED orders at 5100Å plus a chromatic
+        flux gradient, 'ccds' should report distinguishable times per chip."""
+        synthetic_kpf2.set_data('GREEN_SCI2_WAVE',
+                                np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float32))
+        synthetic_kpf2.set_data('RED_SCI2_WAVE',
+                                np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float32))
+        # Front-weighted at 5000Å, back-weighted at 5100Å → distinct midpoints
+        data = {'Date-Beg': ['2024-01-01T00:00:00.000',
+                              '2024-01-01T00:02:00.000',
+                              '2024-01-01T00:04:00.000'],
+                'Date-End': ['2024-01-01T00:01:00.000',
+                              '2024-01-01T00:03:00.000',
+                              '2024-01-01T00:05:00.000'],
+                '5000': [1000.0, 1.0, 1.0],
+                '5100': [1.0, 1.0, 1000.0]}
+        synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
+
+        bc = BarycentricCorrection(synthetic_kpf2)
+        w, t = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
+        assert w[0] == 5000.0 and w[1] == 5100.0
+        assert t.jd[0] < t.jd[1], (
+            f"GREEN should be earlier than RED with front-then-back-weighted flux; "
+            f"got GREEN={t.jd[0]}, RED={t.jd[1]}"
+        )
+
 
 class TestFluxWeightedMidpointFormat:
 
@@ -414,6 +440,26 @@ class TestFluxWeightedMidpointFormat:
 
 
 # ---------------------------------------------------------------------------
+# _query_gaia input validation
+# ---------------------------------------------------------------------------
+
+class TestQueryGaiaValidation:
+    """Reject non-numeric source IDs before they hit the ADQL query string."""
+
+    @pytest.mark.parametrize('bad_id', [
+        'foo',                           # not a number at all
+        '12345 OR 1=1',                  # injection attempt
+        '12345; DROP TABLE',
+        '',
+        '12.34',                         # decimal
+        '-12345',                        # negative
+    ])
+    def test_non_numeric_raises(self, bad_id):
+        with pytest.raises(ValueError, match='all digits'):
+            BarycentricCorrection._query_gaia(bad_id)
+
+
+# ---------------------------------------------------------------------------
 # perform() — Gaia and barycorrpy stubbed
 # ---------------------------------------------------------------------------
 
@@ -427,7 +473,7 @@ class TestPerform:
         def mock_query(gaia_id):
             return _fake_skycoord()
 
-        def mock_compute(skycoord, obs_times, location):
+        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
             n = len(np.atleast_1d(obs_times.jd))
             bc_vel = np.full(n, TestPerform.DELTA_RV_MPS, dtype=float)
             # BJD = JD + 500s (light-travel approx); same for every order in this stub
@@ -507,6 +553,43 @@ class TestPerform:
         bc_monkeypatched.perform()
         modules = bc_monkeypatched.kpf2_obj.receipt['Module_Name'].values
         assert 'barycentric_correction' in modules
+
+    def test_targradv_converted_km_to_m_and_passed_through(self, synthetic_kpf2, monkeypatch):
+        """TARGRADV (km/s) should arrive at _compute_barycorr as m/s."""
+        synthetic_kpf2.headers['INSTRUMENT_HEADER']['TARGRADV'] = 81.87  # km/s
+        captured = {}
+
+        def mock_query(gaia_id):
+            return _fake_skycoord()
+
+        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
+            captured['rv_mps'] = rv_mps
+            n = len(np.atleast_1d(obs_times.jd))
+            return np.zeros(n), np.atleast_1d(obs_times.jd)
+
+        def passthrough(f, kernel_size=5):
+            return f.copy()
+
+        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
+        monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
+        monkeypatch.setattr(BarycentricCorrection, '_fix_expmeter_outliers', staticmethod(passthrough))
+
+        BarycentricCorrection(synthetic_kpf2).perform()
+        assert captured['rv_mps'] == pytest.approx(81870.0)
+
+    def test_missing_targradv_defaults_to_zero(self, bc_monkeypatched, monkeypatch):
+        """No TARGRADV in INSTRUMENT_HEADER → rv_mps=0 passed through."""
+        # synthetic_kpf2 fixture does not set TARGRADV
+        captured = {}
+
+        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
+            captured['rv_mps'] = rv_mps
+            n = len(np.atleast_1d(obs_times.jd))
+            return np.full(n, TestPerform.DELTA_RV_MPS), np.atleast_1d(obs_times.jd)
+
+        monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
+        bc_monkeypatched.perform()
+        assert captured['rv_mps'] == 0.0
 
     def test_results_populated(self, bc_monkeypatched):
         assert bc_monkeypatched._results is None

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -421,15 +421,58 @@ class TestFluxWeightedMidpointCcds:
         assert w.shape == (2,)
         assert len(t) == 2
 
-    def test_ccd_values_equal_chip_means(self, synthetic_kpf2):
-        """The ccds output should equal the per-chip means of the orders output."""
+    def test_ccd_values_equal_chip_means_with_uniform_weights(self, synthetic_kpf2):
+        """With no SCI2_FLUX (uniform weights), the ccds output should equal the
+        plain per-chip means of the orders output."""
         bc = BarycentricCorrection(synthetic_kpf2)
         _, t_orders = bc.compute_flux_weighted_midpoint_times(output='orders', **self._KWARGS)
-        w_ccds, t_ccds = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
+        _, t_ccds   = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
         np.testing.assert_allclose(
             t_ccds.jd,
             [t_orders.jd[:NORDER_GREEN].mean(), t_orders.jd[NORDER_GREEN:].mean()],
         )
+
+    def test_flux_weighting_biases_ccd_time_toward_bright_orders(self, synthetic_kpf2):
+        """A bright bluest GREEN order pulls the chip summary toward its
+        (earlier) midpoint relative to the unweighted chip mean."""
+        green_waves = np.linspace(5000.0, 5300.0, NORDER_GREEN, dtype=np.float32)
+        synthetic_kpf2.set_data(
+            'GREEN_SCI2_WAVE', np.repeat(green_waves[:, None], NCOL, axis=1))
+        synthetic_kpf2.set_data(
+            'RED_SCI2_WAVE', np.full((NORDER_RED, NCOL), 5300.0, dtype=np.float32))
+        # Chromatic flux gradient: bluest channel early, reddest channel late.
+        data = {'Date-Beg': ['2024-01-01T00:00:00.000',
+                             '2024-01-01T00:02:00.000',
+                             '2024-01-01T00:04:00.000'],
+                'Date-End': ['2024-01-01T00:01:00.000',
+                             '2024-01-01T00:03:00.000',
+                             '2024-01-01T00:05:00.000'],
+                '5000': [1000.0, 1.0, 1.0],
+                '5300': [1.0, 1.0, 1000.0]}
+        synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
+
+        bc = BarycentricCorrection(synthetic_kpf2)
+        _, t_orders = bc.compute_flux_weighted_midpoint_times(output='orders', **self._KWARGS)
+        unweighted_green = t_orders.jd[:NORDER_GREEN].mean()
+
+        # Make the bluest (earliest) GREEN order dominate the flux weighting.
+        flux = np.ones((NORDER, NCOL), dtype=float)
+        flux[0] = 1000.0
+        synthetic_kpf2.set_data('SCI2_FLUX', flux)
+
+        _, t_ccds = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
+        assert t_ccds.jd[0] < unweighted_green
+
+    def test_nan_flux_order_gets_zero_weight(self, synthetic_kpf2):
+        """A failed-extraction order (all-NaN SCI2 flux) gets zero weight rather
+        than poisoning its chip summary, so the ccds time stays finite."""
+        flux = np.ones((NORDER, NCOL), dtype=float)
+        flux[NORDER_GREEN] = np.nan   # first RED order failed extraction
+        synthetic_kpf2.set_data('SCI2_FLUX', flux)
+
+        bc = BarycentricCorrection(synthetic_kpf2)
+        _, t_ccds = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
+        assert np.all(np.isfinite(t_ccds.jd))
 
     def test_green_and_red_resolve_distinct_values(self, synthetic_kpf2):
         """With GREEN orders at 5000Å and RED orders at 5100Å plus a chromatic
@@ -488,9 +531,11 @@ class TestQueryGaiaValidation:
         '12.34',                         # decimal
         '-12345',                        # negative
     ])
-    def test_non_numeric_raises(self, bad_id):
+    def test_non_numeric_raises(self, synthetic_kpf2, bad_id):
+        synthetic_kpf2.headers['INSTRUMENT_HEADER']['GAIAID'] = bad_id
+        bc = BarycentricCorrection(synthetic_kpf2)
         with pytest.raises(ValueError, match='all digits'):
-            BarycentricCorrection._query_gaia(bad_id)
+            bc._query_gaia()
 
 
 # ---------------------------------------------------------------------------
@@ -504,7 +549,7 @@ class TestPerform:
     @pytest.fixture
     def bc_monkeypatched(self, synthetic_kpf2, monkeypatch):
         """BarycentricCorrection with Gaia + barycorrpy stubbed."""
-        def mock_query(gaia_id):
+        def mock_query(self):
             return _fake_skycoord()
 
         def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
@@ -517,7 +562,7 @@ class TestPerform:
         def passthrough(f, kernel_size=5):
             return f.copy()
 
-        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
+        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', mock_query)
         monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
         # Stub _fix_expmeter_outliers: the 3×4 uniform-flux fixture triggers a
         # degenerate triangulation inside scipy.griddata. Filter itself is
@@ -593,7 +638,7 @@ class TestPerform:
         synthetic_kpf2.headers['INSTRUMENT_HEADER']['TARGRADV'] = 81.87  # km/s
         captured = {}
 
-        def mock_query(gaia_id):
+        def mock_query(self):
             return _fake_skycoord()
 
         def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
@@ -604,7 +649,7 @@ class TestPerform:
         def passthrough(f, kernel_size=5):
             return f.copy()
 
-        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
+        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', mock_query)
         monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
         monkeypatch.setattr(BarycentricCorrection, '_fix_expmeter_outliers', staticmethod(passthrough))
 
@@ -648,14 +693,14 @@ class TestPerform:
         synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
         synthetic_kpf2.headers['INSTRUMENT_HEADER']['DATE-END'] = '2024-01-01T01:00:00.000'
 
-        def mock_query(gaia_id):
+        def mock_query(self):
             return _fake_skycoord()
 
         def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
             n = len(np.atleast_1d(obs_times.jd))
             return np.full(n, 1000.0), np.atleast_1d(obs_times.jd)
 
-        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
+        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', mock_query)
         monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
 
         # No monkeypatch on _fix_expmeter_outliers — real filter runs.

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -307,6 +307,8 @@ class TestFluxWeightedMidpointExpmeter:
             bc.compute_flux_weighted_midpoint_times(output='expmeter')
 
     def test_interpolate_shifts_midpoint_with_front_weighted_flux(self, synthetic_kpf2):
+        """Front-weighted flux: interpolation sees a bright sample at the
+        first gap (~T+90s) that pulls the FWM strictly later."""
         data = {'Date-Beg': ['2024-01-01T00:00:00.000',
                               '2024-01-01T00:02:00.000',
                               '2024-01-01T00:04:00.000'],
@@ -326,7 +328,39 @@ class TestFluxWeightedMidpointExpmeter:
             output='expmeter',
             interpolate=True, extrapolate=False, fix_expmeter_outliers=False,
         )
-        assert np.mean(t_yes.jd) >= np.mean(t_no.jd) - 1e-9
+        # Shift should be sub-minute → tens of microdays, easily > 1e-9 days
+        assert np.mean(t_yes.jd) > np.mean(t_no.jd) + 1e-7
+
+    def test_extrapolate_shifts_midpoint_when_shutter_brackets_expmeter(self, synthetic_kpf2):
+        """DATE-BEG before t_beg[0] and DATE-END after t_end[-1] → extrapolated
+        gap samples on both sides pull the FWM. Bright first reading + faint
+        last → leading extrapolation dominates → midpoint earlier than with
+        extrapolate=False."""
+        data = {'Date-Beg': ['2024-01-01T00:02:00.000',   # readings inset from shutter
+                              '2024-01-01T00:02:30.000',
+                              '2024-01-01T00:03:00.000'],
+                'Date-End': ['2024-01-01T00:02:20.000',
+                              '2024-01-01T00:02:50.000',
+                              '2024-01-01T00:03:20.000'],
+                '5000': [1000.0, 1.0, 1.0],
+                '5100': [1000.0, 1.0, 1.0]}
+        synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
+        # Shutter open 00:00:00 → 00:05:00; readings only 00:02:00–00:03:20
+        synthetic_kpf2.headers['INSTRUMENT_HEADER']['DATE-BEG'] = '2024-01-01T00:00:00.000'
+        synthetic_kpf2.headers['INSTRUMENT_HEADER']['DATE-END'] = '2024-01-01T00:05:00.000'
+
+        bc = BarycentricCorrection(synthetic_kpf2)
+        _, t_no  = bc.compute_flux_weighted_midpoint_times(
+            output='expmeter',
+            interpolate=False, extrapolate=False, fix_expmeter_outliers=False,
+        )
+        _, t_yes = bc.compute_flux_weighted_midpoint_times(
+            output='expmeter',
+            interpolate=False, extrapolate=True, fix_expmeter_outliers=False,
+        )
+        # Bright first reading + 2-minute leading shutter gap → big leading
+        # extrapolation pulls FWM clearly earlier than the no-extrap case.
+        assert np.mean(t_yes.jd) < np.mean(t_no.jd) - 1e-7
 
 
 class TestFluxWeightedMidpointOrders:
@@ -598,4 +632,79 @@ class TestPerform:
         assert set(results.keys()) == {'bjd_tdb', 'bary_kms', 'bary_z'}
         for v in results.values():
             assert len(v) == NORDER
+
+    def test_real_outlier_filter_runs_end_to_end(self, synthetic_kpf2, monkeypatch):
+        """Exercise fix_expmeter_outliers=True through perform() with a
+        noisy expmeter table (3×4 uniform fixture would crash griddata)."""
+        rng = np.random.default_rng(0)
+        ntime, nwave = 60, 20
+        wave_cols = [str(5000.0 + 10 * i) for i in range(nwave)]
+        data = {'Date-Beg': [f'2024-01-01T00:{m:02d}:00.000' for m in range(ntime)],
+                'Date-End': [f'2024-01-01T00:{m:02d}:30.000' for m in range(ntime)]}
+        for wc in wave_cols:
+            data[wc] = rng.normal(100.0, 2.0, ntime).astype(float)
+        # Inject a clear outlier so the filter has work to do
+        data[wave_cols[5]][30] = 1e6
+        synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
+        synthetic_kpf2.headers['INSTRUMENT_HEADER']['DATE-END'] = '2024-01-01T01:00:00.000'
+
+        def mock_query(gaia_id):
+            return _fake_skycoord()
+
+        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
+            n = len(np.atleast_1d(obs_times.jd))
+            return np.full(n, 1000.0), np.atleast_1d(obs_times.jd)
+
+        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
+        monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
+
+        # No monkeypatch on _fix_expmeter_outliers — real filter runs.
+        kpf2 = BarycentricCorrection(synthetic_kpf2).perform(fix_expmeter_outliers=True)
+        assert np.all(np.isfinite(np.asarray(kpf2.data['BJD_TDB'])))
+
+
+# ---------------------------------------------------------------------------
+# Constructor + missing-header error paths
+# ---------------------------------------------------------------------------
+
+class TestConstructor:
+
+    def test_invalid_config_type_raises(self, synthetic_kpf2):
+        with pytest.raises(TypeError, match="None, dict, or ConfigHandler"):
+            BarycentricCorrection(synthetic_kpf2, config="not-a-config")
+
+
+class TestMissingHeader:
+    """perform() should fail loudly when required INSTRUMENT_HEADER keys are absent."""
+
+    def test_missing_gaiaid_raises(self, synthetic_kpf2, monkeypatch):
+        # Stub _fix_expmeter_outliers so we don't hit the griddata degeneracy
+        # before reaching the GAIAID lookup.
+        def passthrough(f, kernel_size=5):
+            return f.copy()
+        monkeypatch.setattr(BarycentricCorrection, '_fix_expmeter_outliers', staticmethod(passthrough))
+
+        del synthetic_kpf2.headers['INSTRUMENT_HEADER']['GAIAID']
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(KeyError, match='GAIAID'):
+            bc.perform()
+
+    def test_missing_date_beg_raises_when_extrapolating(self, synthetic_kpf2):
+        del synthetic_kpf2.headers['INSTRUMENT_HEADER']['DATE-BEG']
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(KeyError, match='DATE-BEG'):
+            bc.compute_flux_weighted_midpoint_times(
+                output='expmeter',
+                interpolate=False, extrapolate=True, fix_expmeter_outliers=False,
+            )
+
+    def test_missing_date_beg_ok_without_extrapolate(self, synthetic_kpf2):
+        """DATE-BEG is only needed when extrapolate=True."""
+        del synthetic_kpf2.headers['INSTRUMENT_HEADER']['DATE-BEG']
+        bc = BarycentricCorrection(synthetic_kpf2)
+        # Should not raise:
+        bc.compute_flux_weighted_midpoint_times(
+            output='expmeter',
+            interpolate=False, extrapolate=False, fix_expmeter_outliers=False,
+        )
 

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -306,6 +306,24 @@ class TestFluxWeightedMidpointExpmeter:
         with pytest.raises(ValueError, match="negative"):
             bc.compute_flux_weighted_midpoint_times(output='expmeter')
 
+    def test_zero_flux_channel_raises(self, synthetic_kpf2):
+        """A channel with zero flux across all readings → 0/0 midpoint; fail loudly."""
+        data = {'Date-Beg': ['2024-01-01T00:00:00.000',
+                             '2024-01-01T00:02:00.000',
+                             '2024-01-01T00:04:00.000'],
+                'Date-End': ['2024-01-01T00:01:00.000',
+                             '2024-01-01T00:03:00.000',
+                             '2024-01-01T00:05:00.000'],
+                '5000': [100.0, 100.0, 100.0],
+                '5100': [0.0, 0.0, 0.0]}
+        synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(ValueError, match="total flux"):
+            bc.compute_flux_weighted_midpoint_times(
+                output='expmeter',
+                interpolate=False, extrapolate=False, fix_expmeter_outliers=False,
+            )
+
     def test_interpolate_shifts_midpoint_with_front_weighted_flux(self, synthetic_kpf2):
         """Front-weighted flux: interpolation sees a bright sample at the
         first gap (~T+90s) that pulls the FWM strictly later."""
@@ -473,6 +491,15 @@ class TestFluxWeightedMidpointCcds:
         bc = BarycentricCorrection(synthetic_kpf2)
         _, t_ccds = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
         assert np.all(np.isfinite(t_ccds.jd))
+
+    def test_all_zero_weight_chip_raises(self, synthetic_kpf2):
+        """A whole chip with zero SCI2 flux → undefined weighted mean; fail loudly."""
+        flux = np.ones((NORDER, NCOL), dtype=float)
+        flux[NORDER_GREEN:] = 0.0   # all RED orders have zero flux
+        synthetic_kpf2.set_data('SCI2_FLUX', flux)
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(ValueError, match="weights are zero"):
+            bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
 
     def test_green_and_red_resolve_distinct_values(self, synthetic_kpf2):
         """With GREEN orders at 5000Å and RED orders at 5100Å plus a chromatic

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -473,7 +473,8 @@ class TestPerform:
         # 30 km/s redshift is < 1: positive RV means moving away
         assert 0.9 < z[0] < 1.0
 
-    def test_wave_arrays_scaled(self, bc_monkeypatched):
+    def test_wave_arrays_untouched(self, bc_monkeypatched):
+        """BarycentricCorrection should track but not apply: WAVE arrays unchanged."""
         kpf2 = bc_monkeypatched.kpf2_obj
         orig = {f'{chip}_{fiber}_WAVE': kpf2.data[f'{chip}_{fiber}_WAVE'].copy()
                 for chip in ['GREEN', 'RED']
@@ -481,13 +482,11 @@ class TestPerform:
 
         bc_monkeypatched.perform()
 
-        z_extension = np.asarray(kpf2.data['BARYCORR_Z'])
         for key, before in orig.items():
-            after = kpf2.data[key]
-            chip = key.split('_')[0]
-            z = z_extension[:NORDER_GREEN] if chip == 'GREEN' else z_extension[NORDER_GREEN:]
-            np.testing.assert_allclose(after, before * z[:, None], rtol=1e-5,
-                                       err_msg=f"{key} not scaled correctly")
+            np.testing.assert_array_equal(
+                kpf2.data[key], before,
+                err_msg=f"{key} should be unmodified",
+            )
 
     def test_per_ccd_instrument_header_keywords(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.perform()
@@ -517,19 +516,3 @@ class TestPerform:
         for v in results.values():
             assert len(v) == NORDER
 
-    def test_zero_rv_leaves_wavelengths_unchanged(self, synthetic_kpf2, monkeypatch):
-        """delta_rv == 0 → z == 1 → WAVE arrays unchanged."""
-        def mock_query(gaia_id):
-            return _fake_skycoord()
-
-        def mock_compute(skycoord, obs_times, location):
-            n = len(np.atleast_1d(obs_times.jd))
-            return np.zeros(n), np.atleast_1d(obs_times.jd)
-
-        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
-        monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
-
-        bc = BarycentricCorrection(synthetic_kpf2)
-        orig = bc.kpf2_obj.data['GREEN_SCI2_WAVE'].copy()
-        bc.perform(fix_expmeter_outliers=False)
-        np.testing.assert_allclose(bc.kpf2_obj.data['GREEN_SCI2_WAVE'], orig, rtol=1e-7)

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -2,23 +2,27 @@
 Tests for the BarycentricCorrection module (KPF2 → KPF2).
 
 Static-method unit tests require no fixtures. Integration tests use a
-synthetic KPF2 object with a small EXPMETER_SCI table. Tests that would
-require a live Gaia query or barycorrpy call are covered via monkeypatching.
+synthetic KPF2 with a small EXPMETER_SCI table and populated SCI2_WAVE.
+Gaia and barycorrpy calls are stubbed via monkeypatching.
 """
 
 import numpy as np
 import pytest
 import astropy.units as u
+from astropy.coordinates import SkyCoord
 from astropy.table import Table
 from astropy.time import Time
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.level2 import KPF2
-from kpfpipe.modules.barycentric_correction import BarycentricCorrection
+from kpfpipe.modules.barycentric_correction import (
+    BarycentricCorrection,
+    NORDER_GREEN,
+    NORDER_RED,
+    NORDER,
+)
 
-NORDER_GREEN = DETECTOR['norder']['GREEN']
-NORDER_RED   = DETECTOR['norder']['RED']
-NCOL         = 50   # reduced column count for speed
+NCOL = 50   # reduced column count for speed
 
 
 # ---------------------------------------------------------------------------
@@ -48,12 +52,19 @@ def _make_expmeter_table():
 
 @pytest.fixture
 def synthetic_kpf2():
-    """KPF2 with synthetic EXPMETER_SCI and wavelength arrays."""
+    """KPF2 with synthetic EXPMETER_SCI and wavelength arrays.
+
+    SCI2_WAVE is filled with 5000.0 — order_center = 5000 for every order,
+    so np.interp returns the per-channel value at 5000Å (i.e. the first
+    PHOTON_JD) for every order. Tests that need per-order variation
+    populate SCI2_WAVE themselves.
+    """
     kpf2 = KPF2()
 
-    kpf2.headers['PRIMARY']['DATE-BEG'] = f'{_T0}00:00:00.000'
-    kpf2.headers['PRIMARY']['DATE-END'] = f'{_T0}00:05:00.000'
-    kpf2.headers['PRIMARY']['GAIAID'] = 'DR3 1234567890123456789'
+    # KPF-native keywords live in INSTRUMENT_HEADER on L2 (preserved L1 PRIMARY).
+    kpf2.headers['INSTRUMENT_HEADER']['DATE-BEG'] = f'{_T0}00:00:00.000'
+    kpf2.headers['INSTRUMENT_HEADER']['DATE-END'] = f'{_T0}00:05:00.000'
+    kpf2.headers['INSTRUMENT_HEADER']['GAIAID']   = 'DR3 1234567890123456789'
 
     kpf2.set_data('EXPMETER_SCI', _make_expmeter_table())
 
@@ -66,37 +77,40 @@ def synthetic_kpf2():
     return kpf2
 
 
+def _fake_skycoord():
+    """Deterministic ICRS SkyCoord with realistic proper motion / parallax."""
+    return SkyCoord(
+        ra=180.0 * u.deg, dec=0.0 * u.deg,
+        pm_ra_cosdec=0.0 * u.mas / u.yr,
+        pm_dec=0.0 * u.mas / u.yr,
+        distance=100.0 * u.pc,
+        obstime=Time(2016.0, format='jyear'),
+        frame='icrs',
+    )
+
+
 # ---------------------------------------------------------------------------
-# _strictly_increasing
+# Static helpers — unchanged behavior across the split
 # ---------------------------------------------------------------------------
 
 class TestStrictlyIncreasing:
 
     def _make_time(self, seconds):
-        jd0 = 2460310.5  # arbitrary JD base
+        jd0 = 2460310.5
         return Time(jd0 + np.array(seconds) / 86400.0, format='jd', scale='utc')
 
     def test_increasing(self):
-        t = self._make_time([0, 1, 2, 3])
-        assert BarycentricCorrection._strictly_increasing(t) is True
+        assert BarycentricCorrection._strictly_increasing(self._make_time([0, 1, 2, 3])) is True
 
     def test_constant_fails(self):
-        t = self._make_time([0, 1, 1, 2])
-        assert BarycentricCorrection._strictly_increasing(t) is False
+        assert BarycentricCorrection._strictly_increasing(self._make_time([0, 1, 1, 2])) is False
 
     def test_decreasing_fails(self):
-        t = self._make_time([3, 2, 1, 0])
-        assert BarycentricCorrection._strictly_increasing(t) is False
+        assert BarycentricCorrection._strictly_increasing(self._make_time([3, 2, 1, 0])) is False
 
     def test_single_element(self):
-        t = self._make_time([0])
-        # slice t[:-1] and t[1:] are both empty → np.all of empty → True
-        assert BarycentricCorrection._strictly_increasing(t) is True
+        assert BarycentricCorrection._strictly_increasing(self._make_time([0])) is True
 
-
-# ---------------------------------------------------------------------------
-# _interpolate
-# ---------------------------------------------------------------------------
 
 class TestInterpolate:
 
@@ -106,51 +120,38 @@ class TestInterpolate:
                     format='jd', scale='utc')
 
     def test_gap_midpoint_time(self):
-        """Gap midpoint should fall halfway between end of reading 0 and start of reading 1."""
-        t_beg = self._make_times([0, 120])    # two 60s readings, 60s gap between
+        t_beg = self._make_times([0, 120])
         t_end = self._make_times([60, 180])
         f = np.ones((2, 3))
 
         t_gap, _ = BarycentricCorrection._interpolate(t_beg, t_end, f)
-
-        expected_jd = (t_end[0].jd + t_beg[1].jd) / 2
-        np.testing.assert_allclose(t_gap[0].jd, expected_jd)
+        np.testing.assert_allclose(t_gap[0].jd, (t_end[0].jd + t_beg[1].jd) / 2)
 
     def test_gap_flux_equal_exposure_flux_when_same_duration(self):
-        """If gap duration == exposure duration and flux is uniform, f_gap == f."""
         t_beg = self._make_times([0, 120])
         t_end = self._make_times([60, 180])
         f = np.full((2, 4), _FLUX_VALUE)
 
         _, f_gap = BarycentricCorrection._interpolate(t_beg, t_end, f)
-
         np.testing.assert_allclose(f_gap[0], _FLUX_VALUE, rtol=1e-6)
 
     def test_output_shape(self):
-        """n readings → n-1 gaps."""
         t_beg = self._make_times([0, 120, 240])
         t_end = self._make_times([60, 180, 300])
         f = np.ones((3, 4))
 
         t_gap, f_gap = BarycentricCorrection._interpolate(t_beg, t_end, f)
-
         assert len(t_gap) == 2
         assert f_gap.shape == (2, 4)
 
     def test_zero_gap_gives_zero_flux(self):
-        """Back-to-back readings (zero gap) should produce zero gap flux."""
-        t_beg = self._make_times([0, 60])    # reading 1 starts exactly when reading 0 ends
+        t_beg = self._make_times([0, 60])
         t_end = self._make_times([60, 120])
         f = np.ones((2, 3))
 
         _, f_gap = BarycentricCorrection._interpolate(t_beg, t_end, f)
-
         np.testing.assert_allclose(f_gap[0], 0.0, atol=1e-10)
 
-
-# ---------------------------------------------------------------------------
-# _extrapolate
-# ---------------------------------------------------------------------------
 
 class TestExtrapolate:
 
@@ -158,42 +159,33 @@ class TestExtrapolate:
         return Time(2460310.5 + sec / 86400.0, format='jd', scale='utc')
 
     def test_extrapolate_before_first_reading(self):
-        """Gap before the first reading: midpoint is halfway between t0 and t_beg."""
-        t0   = self._t(0)
+        t0    = self._t(0)
         t_beg = self._t(60)
         t_end = self._t(120)
         f = np.full(4, _FLUX_VALUE)
 
-        t_ext, f_ext = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
-
-        expected_jd = (t0.jd + t_beg.jd) / 2
-        np.testing.assert_allclose(t_ext.jd, expected_jd)
+        t_ext, _ = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
+        np.testing.assert_allclose(t_ext.jd, (t0.jd + t_beg.jd) / 2)
 
     def test_extrapolate_before_flux_proportional(self):
-        """Gap flux equals exposure flux when gap and exposure have equal duration."""
         t0    = self._t(0)
-        t_beg = self._t(60)   # 60s gap before first reading
-        t_end = self._t(120)  # 60s reading
+        t_beg = self._t(60)
+        t_end = self._t(120)
         f = np.full(4, _FLUX_VALUE)
 
         _, f_ext = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
-
         np.testing.assert_allclose(f_ext, _FLUX_VALUE, rtol=1e-6)
 
     def test_extrapolate_after_last_reading(self):
-        """Gap after the last reading: midpoint is halfway between t_end and t0."""
         t_beg = self._t(0)
         t_end = self._t(60)
         t0    = self._t(120)
         f = np.full(4, _FLUX_VALUE)
 
-        t_ext, f_ext = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
-
-        expected_jd = (t_end.jd + t0.jd) / 2
-        np.testing.assert_allclose(t_ext.jd, expected_jd)
+        t_ext, _ = BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
+        np.testing.assert_allclose(t_ext.jd, (t_end.jd + t0.jd) / 2)
 
     def test_t0_inside_raises(self):
-        """t0 between t_beg and t_end should raise ValueError."""
         t_beg = self._t(0)
         t_end = self._t(120)
         t0    = self._t(60)
@@ -203,15 +195,10 @@ class TestExtrapolate:
             BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
 
 
-# ---------------------------------------------------------------------------
-# _fix_bad_exposures
-# ---------------------------------------------------------------------------
-
 class TestFixBadExposures:
 
     def test_clean_array_unchanged(self):
         rng = np.random.default_rng(0)
-        # Use a realistically-noisy array so mad_std > 0 and no outliers are flagged
         f = rng.normal(100.0, 2.0, (60, 20))
         f_fixed = BarycentricCorrection._fix_bad_exposures(f)
         np.testing.assert_allclose(f_fixed, f, rtol=1e-4)
@@ -219,23 +206,19 @@ class TestFixBadExposures:
     def test_outlier_repaired(self):
         rng = np.random.default_rng(1)
         f = rng.normal(100.0, 2.0, (60, 20))
-        f[30, 10] = 1e6   # inject a large outlier
+        f[30, 10] = 1e6
 
         f_fixed = BarycentricCorrection._fix_bad_exposures(f)
-
-        assert abs(f_fixed[30, 10] - 100.0) < 20.0, (
-            f"Outlier not repaired: f_fixed[30,10] = {f_fixed[30, 10]}"
-        )
+        assert abs(f_fixed[30, 10] - 100.0) < 20.0
 
     def test_output_shape_preserved(self):
         rng = np.random.default_rng(2)
         f = rng.normal(50.0, 1.0, (60, 20))
-        f_fixed = BarycentricCorrection._fix_bad_exposures(f)
-        assert f_fixed.shape == f.shape
+        assert BarycentricCorrection._fix_bad_exposures(f).shape == f.shape
 
 
 # ---------------------------------------------------------------------------
-# _get_timestamps and _get_normalized_flux
+# _get_timestamps / _get_normalized_flux
 # ---------------------------------------------------------------------------
 
 class TestGetTimestamps:
@@ -243,9 +226,7 @@ class TestGetTimestamps:
     def test_returns_three_time_arrays(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
         t_beg, t_mid, t_end = bc._get_timestamps()
-        assert len(t_beg) == 3
-        assert len(t_mid) == 3
-        assert len(t_end) == 3
+        assert len(t_beg) == 3 and len(t_mid) == 3 and len(t_end) == 3
 
     def test_mid_is_between_beg_and_end(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
@@ -253,14 +234,7 @@ class TestGetTimestamps:
         assert np.all(t_mid.jd > t_beg.jd)
         assert np.all(t_mid.jd < t_end.jd)
 
-    def test_beg_strictly_increasing(self, synthetic_kpf2):
-        bc = BarycentricCorrection(synthetic_kpf2)
-        t_beg, _, _ = bc._get_timestamps()
-        assert BarycentricCorrection._strictly_increasing(t_beg)
-
     def test_non_monotonic_raises(self, synthetic_kpf2):
-        """Reversed timestamps should raise ValueError."""
-        from astropy.table import Table
         bad_table = Table({
             'Date-Beg': ['2024-01-01T00:04:00.000', '2024-01-01T00:02:00.000',
                          '2024-01-01T00:00:00.000'],
@@ -276,68 +250,59 @@ class TestGetTimestamps:
 
 class TestGetNormalizedFlux:
 
-    def test_output_shape(self, synthetic_kpf2):
+    def test_returns_wavelengths_and_flux(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
-        f = bc._get_normalized_flux()
-        assert f.shape == (3, 4)   # 3 time steps, 4 wavelength channels
+        w, f = bc._get_normalized_flux()
+        assert w.shape == (len(_WAVE_COLS),)
+        assert f.shape == (3, len(_WAVE_COLS))
+
+    def test_wavelengths_match_column_labels(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        w, _ = bc._get_normalized_flux()
+        np.testing.assert_array_equal(w, [float(c) for c in _WAVE_COLS])
 
     def test_non_numeric_columns_excluded(self, synthetic_kpf2):
-        """Date-Beg and Date-End should not appear in the flux array."""
         bc = BarycentricCorrection(synthetic_kpf2)
-        f = bc._get_normalized_flux()
-        # 4 numeric wave columns in the fixture → ncol = 4
+        _, f = bc._get_normalized_flux()
         assert f.shape[1] == len(_WAVE_COLS)
 
     def test_gain_and_dispersion_applied(self, synthetic_kpf2):
-        """With 100Å uniform spacing, f_norm = f_raw * 1.48424 / 100."""
         bc = BarycentricCorrection(synthetic_kpf2)
-        f = bc._get_normalized_flux()
-        expected = _FLUX_VALUE * 1.48424 / 100.0
-        np.testing.assert_allclose(f, expected, rtol=1e-5)
+        _, f = bc._get_normalized_flux()
+        np.testing.assert_allclose(f, _FLUX_VALUE * 1.48424 / 100.0, rtol=1e-5)
 
 
 # ---------------------------------------------------------------------------
-# flux_weighted_midpoint
+# flux_weighted_midpoint (now returns (w, t_fwm))
 # ---------------------------------------------------------------------------
 
 class TestFluxWeightedMidpoint:
 
     def test_uniform_flux_gives_geometric_midpoint(self, synthetic_kpf2):
-        """With uniform flux and symmetric timestamps the FWM should equal
-        the mean of the three reading midpoints (ignoring gaps and edges)."""
         bc = BarycentricCorrection(synthetic_kpf2)
-        t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                           fix_bad_exposures=False)
-        t_beg, t_mid, _ = bc._get_timestamps()
-        expected_jd = np.mean(t_mid.jd)
-        np.testing.assert_allclose(
-            np.mean(t_fwm.jd), expected_jd, atol=1e-6
-        )
+        w, t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
+                                              fix_bad_exposures=False)
+        _, t_mid, _ = bc._get_timestamps()
+        np.testing.assert_allclose(np.mean(t_fwm.jd), np.mean(t_mid.jd), atol=1e-6)
 
-    def test_output_shape(self, synthetic_kpf2):
-        """One FWM time per wavelength channel."""
+    def test_output_shapes(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
-        t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                           fix_bad_exposures=False)
+        w, t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
+                                              fix_bad_exposures=False)
+        assert w.shape == (len(_WAVE_COLS),)
         assert len(t_fwm) == len(_WAVE_COLS)
 
     def test_negative_flux_raises(self, synthetic_kpf2, monkeypatch):
-        """Negative expmeter values should raise ValueError."""
         def mock_flux(self):
-            return np.full((3, 4), -1.0)
+            w = np.array([float(c) for c in _WAVE_COLS])
+            return w, np.full((3, len(_WAVE_COLS)), -1.0)
         monkeypatch.setattr(BarycentricCorrection, '_get_normalized_flux', mock_flux)
 
         bc = BarycentricCorrection(synthetic_kpf2)
         with pytest.raises(ValueError, match="negative"):
             bc.flux_weighted_midpoint()
 
-    def test_interpolate_shifts_midpoint_later_when_front_weighted(self, synthetic_kpf2):
-        """When flux is front-weighted, the interpolated gap between bright
-        reading 0 and dim reading 1 has a large flux sample at T+90s — later
-        than reading 0's midpoint — so FWM shifts later with interpolation."""
-        from astropy.table import Table
-
-        # Front-weighted flux: first reading much brighter than the rest
+    def test_interpolate_shifts_midpoint_with_front_weighted_flux(self, synthetic_kpf2):
         data = {'Date-Beg': ['2024-01-01T00:00:00.000',
                               '2024-01-01T00:02:00.000',
                               '2024-01-01T00:04:00.000'],
@@ -345,68 +310,154 @@ class TestFluxWeightedMidpoint:
                               '2024-01-01T00:03:00.000',
                               '2024-01-01T00:05:00.000'],
                 '5000': [1000.0, 1.0, 1.0],
-                '5100': [1000.0, 1.0, 1.0],
-                }
+                '5100': [1000.0, 1.0, 1.0]}
         synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
         bc = BarycentricCorrection(synthetic_kpf2)
 
-        t_no_interp = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                                fix_bad_exposures=False)
-        t_with_interp = bc.flux_weighted_midpoint(interpolate=True, extrapolate=False,
-                                                   fix_bad_exposures=False)
-
-        # Gap sample at T+90s is bright (≈500), pulling FWM later than without it
-        assert np.mean(t_with_interp.jd) >= np.mean(t_no_interp.jd) - 1e-9
+        _, t_no = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
+                                             fix_bad_exposures=False)
+        _, t_yes = bc.flux_weighted_midpoint(interpolate=True, extrapolate=False,
+                                              fix_bad_exposures=False)
+        assert np.mean(t_yes.jd) >= np.mean(t_no.jd) - 1e-9
 
 
 # ---------------------------------------------------------------------------
-# perform() — Gaia and barycorrpy are monkeypatched
+# map_to_orders
+# ---------------------------------------------------------------------------
+
+class TestMapToOrders:
+
+    def test_output_shape(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        w_em = np.array([5000.0, 5100.0, 5200.0, 5300.0])
+        t_fwm = Time(np.linspace(2460310.5, 2460310.6, 4), format='jd', scale='utc')
+        t_per_order = bc.map_to_orders(w_em, t_fwm)
+        assert len(t_per_order) == NORDER
+
+    def test_constant_wave_gives_constant_time(self, synthetic_kpf2):
+        """SCI2_WAVE filled with 5000.0 → every order interpolates at 5000Å
+        and gets the first per-channel t_fwm."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        w_em = np.array([5000.0, 5100.0, 5200.0, 5300.0])
+        jds = np.array([10.0, 20.0, 30.0, 40.0])
+        t_fwm = Time(2460310.5 + jds / 86400.0, format='jd', scale='utc')
+        t_per_order = bc.map_to_orders(w_em, t_fwm)
+        np.testing.assert_allclose(t_per_order.jd, t_fwm.jd[0])
+
+    def test_orders_get_distinct_times_when_waves_vary(self, synthetic_kpf2):
+        """Set SCI2_WAVE so GREEN orders straddle 5000Å and RED orders 5300Å."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        green = np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float32)
+        red   = np.full((NORDER_RED, NCOL),   5300.0, dtype=np.float32)
+        synthetic_kpf2.set_data('GREEN_SCI2_WAVE', green)
+        synthetic_kpf2.set_data('RED_SCI2_WAVE',   red)
+
+        w_em = np.array([5000.0, 5100.0, 5200.0, 5300.0])
+        jds  = np.array([10.0, 20.0, 30.0, 40.0])
+        t_fwm = Time(2460310.5 + jds / 86400.0, format='jd', scale='utc')
+
+        t_per_order = bc.map_to_orders(w_em, t_fwm)
+        # GREEN orders → t_fwm[0] (=10s), RED orders → t_fwm[-1] (=40s)
+        np.testing.assert_allclose(t_per_order.jd[:NORDER_GREEN], t_fwm.jd[0])
+        np.testing.assert_allclose(t_per_order.jd[NORDER_GREEN:], t_fwm.jd[-1])
+
+    def test_empty_sci2_wave_raises(self, synthetic_kpf2, monkeypatch):
+        """If SCI2_WAVE is empty, map_to_orders should fail loudly."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        # Force the underlying TRACE3_WAVE to empty by replacing the alias target
+        synthetic_kpf2.data['TRACE3_WAVE'] = np.array([])
+        w_em = np.array([5000.0, 5100.0])
+        t_fwm = Time([2460310.5, 2460310.6], format='jd', scale='utc')
+        with pytest.raises(KeyError, match="SCI2_WAVE"):
+            bc.map_to_orders(w_em, t_fwm)
+
+
+# ---------------------------------------------------------------------------
+# perform() — Gaia and barycorrpy stubbed
 # ---------------------------------------------------------------------------
 
 class TestPerform:
 
-    Z_TEST = 1.0 - 1e-4   # arbitrary but non-trivial shift factor
+    DELTA_RV_MPS = 30000.0   # constant 30 km/s shift across all orders
 
     @pytest.fixture
     def bc_monkeypatched(self, synthetic_kpf2, monkeypatch):
-        """BarycentricCorrection with network calls stubbed out."""
-        def mock_fwm(self, **kwargs):
-            t0 = Time('2024-01-01T00:02:30.000', format='isot', scale='utc')
-            return Time(np.full(len(_WAVE_COLS), t0.jd), format='jd', scale='utc')
+        """BarycentricCorrection with Gaia + barycorrpy stubbed."""
+        def mock_query(gaia_id):
+            return _fake_skycoord()
 
-        def mock_barycorr(self, obs_time):
-            return TestPerform.Z_TEST, 30000.0 * u.m / u.s
+        def mock_compute(skycoord, obs_times, location):
+            n = len(np.atleast_1d(obs_times.jd))
+            bc_vel = np.full(n, TestPerform.DELTA_RV_MPS, dtype=float)
+            # BJD = JD + 500s (light-travel approx); same for every order in this stub
+            bjd_tdb = np.atleast_1d(obs_times.jd) + 500.0 / 86400.0
+            return bc_vel, bjd_tdb
 
-        monkeypatch.setattr(BarycentricCorrection, 'flux_weighted_midpoint', mock_fwm)
-        monkeypatch.setattr(BarycentricCorrection, 'barycentric_correction', mock_barycorr)
-        return BarycentricCorrection(synthetic_kpf2)
+        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
+        monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
+        # Disable fix_bad_exposures: the 3×4 uniform-flux fixture triggers a
+        # degenerate triangulation inside scipy.griddata. Filter itself is
+        # exercised by TestFixBadExposures with a noisy 60×20 array.
+        return BarycentricCorrection(synthetic_kpf2, config={'fix_bad_exposures': False})
 
     def test_returns_kpf2(self, bc_monkeypatched):
-        result = bc_monkeypatched.perform()
-        assert isinstance(result, KPF2)
+        assert isinstance(bc_monkeypatched.perform(), KPF2)
 
     def test_returns_same_object(self, bc_monkeypatched):
-        """perform() should modify the KPF2 in-place and return the same object."""
         original = bc_monkeypatched.kpf2_obj
-        result = bc_monkeypatched.perform()
-        assert result is original
+        assert bc_monkeypatched.perform() is original
 
-    def test_wavelength_arrays_scaled(self, bc_monkeypatched):
-        """All WAVE extensions should be multiplied by z."""
+    def test_bjd_tdb_extension_populated(self, bc_monkeypatched):
+        kpf2 = bc_monkeypatched.perform()
+        bjd = np.asarray(kpf2.data['BJD_TDB'])
+        assert bjd.shape == (NORDER,)
+        assert np.all(np.isfinite(bjd))
+
+    def test_barycorr_kms_extension_populated(self, bc_monkeypatched):
+        kpf2 = bc_monkeypatched.perform()
+        kms = np.asarray(kpf2.data['BARYCORR_KMS'])
+        assert kms.shape == (NORDER,)
+        np.testing.assert_allclose(kms, TestPerform.DELTA_RV_MPS / 1000.0)
+
+    def test_barycorr_z_extension_populated(self, bc_monkeypatched):
+        kpf2 = bc_monkeypatched.perform()
+        z = np.asarray(kpf2.data['BARYCORR_Z'])
+        assert z.shape == (NORDER,)
+        # All orders share the same delta_rv → all z values identical
+        assert np.std(z) < 1e-12
+        # 30 km/s redshift is < 1: positive RV means moving away
+        assert 0.9 < z[0] < 1.0
+
+    def test_wave_arrays_scaled(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.kpf2_obj
-        # Record original values before perform
-        orig = {}
-        for chip in ['GREEN', 'RED']:
-            for fiber in ['SKY', 'SCI1', 'SCI2', 'SCI3', 'CAL']:
-                orig[f'{chip}_{fiber}_WAVE'] = kpf2.data[f'{chip}_{fiber}_WAVE'].copy()
+        orig = {f'{chip}_{fiber}_WAVE': kpf2.data[f'{chip}_{fiber}_WAVE'].copy()
+                for chip in ['GREEN', 'RED']
+                for fiber in ['SKY', 'SCI1', 'SCI2', 'SCI3', 'CAL']}
 
         bc_monkeypatched.perform()
 
-        for key, original_wave in orig.items():
-            np.testing.assert_allclose(
-                kpf2.data[key], original_wave * TestPerform.Z_TEST, rtol=1e-5,
-                err_msg=f"{key} not scaled correctly"
-            )
+        z_extension = np.asarray(kpf2.data['BARYCORR_Z'])
+        for key, before in orig.items():
+            after = kpf2.data[key]
+            chip = key.split('_')[0]
+            z = z_extension[:NORDER_GREEN] if chip == 'GREEN' else z_extension[NORDER_GREEN:]
+            np.testing.assert_allclose(after, before * z[:, None], rtol=1e-5,
+                                       err_msg=f"{key} not scaled correctly")
+
+    def test_per_ccd_primary_keywords(self, bc_monkeypatched):
+        kpf2 = bc_monkeypatched.perform()
+        primary = kpf2.headers['PRIMARY']
+        for key in ['CCD1BJD', 'CCD1BKMS', 'CCD1BZ',
+                    'CCD2BJD', 'CCD2BKMS', 'CCD2BZ']:
+            assert key in primary, f"{key} missing from PRIMARY"
+
+        def _v(k):
+            x = primary[k]
+            return x[0] if isinstance(x, tuple) else x
+
+        # All orders had the same delta_rv → green and red means are equal
+        np.testing.assert_allclose(_v('CCD1BKMS'), _v('CCD2BKMS'))
+        np.testing.assert_allclose(_v('CCD1BZ'),   _v('CCD2BZ'))
 
     def test_receipt_entry_added(self, bc_monkeypatched):
         bc_monkeypatched.perform()
@@ -416,24 +467,24 @@ class TestPerform:
     def test_results_populated(self, bc_monkeypatched):
         assert bc_monkeypatched._results is None
         bc_monkeypatched.perform()
-        assert bc_monkeypatched._results is not None
-        assert 'obs_time' in bc_monkeypatched._results
-        assert 'delta_rv' in bc_monkeypatched._results
-        assert 'z' in bc_monkeypatched._results
+        results = bc_monkeypatched._results
+        assert set(results.keys()) == {'bjd_tdb', 'bary_kms', 'bary_z'}
+        for v in results.values():
+            assert len(v) == NORDER
 
-    def test_z_equals_one_leaves_wavelengths_unchanged(self, synthetic_kpf2, monkeypatch):
-        """A z of exactly 1.0 should leave all wavelength arrays unchanged."""
-        def mock_fwm(self, **kwargs):
-            t0 = Time('2024-01-01T00:02:30.000', format='isot', scale='utc')
-            return Time(np.full(len(_WAVE_COLS), t0.jd), format='jd', scale='utc')
+    def test_zero_rv_leaves_wavelengths_unchanged(self, synthetic_kpf2, monkeypatch):
+        """delta_rv == 0 → z == 1 → WAVE arrays unchanged."""
+        def mock_query(gaia_id):
+            return _fake_skycoord()
 
-        def mock_barycorr(self, obs_time):
-            return 1.0, 0.0 * u.m / u.s
+        def mock_compute(skycoord, obs_times, location):
+            n = len(np.atleast_1d(obs_times.jd))
+            return np.zeros(n), np.atleast_1d(obs_times.jd)
 
-        monkeypatch.setattr(BarycentricCorrection, 'flux_weighted_midpoint', mock_fwm)
-        monkeypatch.setattr(BarycentricCorrection, 'barycentric_correction', mock_barycorr)
+        monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
+        monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
 
-        bc = BarycentricCorrection(synthetic_kpf2)
+        bc = BarycentricCorrection(synthetic_kpf2, config={'fix_bad_exposures': False})
         orig = bc.kpf2_obj.data['GREEN_SCI2_WAVE'].copy()
         bc.perform()
-        np.testing.assert_array_equal(bc.kpf2_obj.data['GREEN_SCI2_WAVE'], orig)
+        np.testing.assert_allclose(bc.kpf2_obj.data['GREEN_SCI2_WAVE'], orig, rtol=1e-7)

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -273,22 +273,26 @@ class TestGetNormalizedFlux:
 
 
 # ---------------------------------------------------------------------------
-# flux_weighted_midpoint (now returns (w, t_fwm))
+# compute_flux_weighted_midpoint_times (output = 'expmeter' | 'orders' | 'ccds')
 # ---------------------------------------------------------------------------
 
-class TestFluxWeightedMidpoint:
+class TestFluxWeightedMidpointExpmeter:
 
     def test_uniform_flux_gives_geometric_midpoint(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
-        w, t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                              fix_expmeter_outliers=False)
+        _, t_fwm = bc.compute_flux_weighted_midpoint_times(
+            output='expmeter',
+            interpolate=False, extrapolate=False, fix_expmeter_outliers=False,
+        )
         _, t_mid, _ = bc._get_timestamps()
         np.testing.assert_allclose(np.mean(t_fwm.jd), np.mean(t_mid.jd), atol=1e-6)
 
     def test_output_shapes(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
-        w, t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                              fix_expmeter_outliers=False)
+        w, t_fwm = bc.compute_flux_weighted_midpoint_times(
+            output='expmeter',
+            interpolate=False, extrapolate=False, fix_expmeter_outliers=False,
+        )
         assert w.shape == (len(_WAVE_COLS),)
         assert len(t_fwm) == len(_WAVE_COLS)
 
@@ -300,7 +304,7 @@ class TestFluxWeightedMidpoint:
 
         bc = BarycentricCorrection(synthetic_kpf2)
         with pytest.raises(ValueError, match="negative"):
-            bc.flux_weighted_midpoint()
+            bc.compute_flux_weighted_midpoint_times(output='expmeter')
 
     def test_interpolate_shifts_midpoint_with_front_weighted_flux(self, synthetic_kpf2):
         data = {'Date-Beg': ['2024-01-01T00:00:00.000',
@@ -314,62 +318,99 @@ class TestFluxWeightedMidpoint:
         synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
         bc = BarycentricCorrection(synthetic_kpf2)
 
-        _, t_no = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                             fix_expmeter_outliers=False)
-        _, t_yes = bc.flux_weighted_midpoint(interpolate=True, extrapolate=False,
-                                              fix_expmeter_outliers=False)
+        _, t_no = bc.compute_flux_weighted_midpoint_times(
+            output='expmeter',
+            interpolate=False, extrapolate=False, fix_expmeter_outliers=False,
+        )
+        _, t_yes = bc.compute_flux_weighted_midpoint_times(
+            output='expmeter',
+            interpolate=True, extrapolate=False, fix_expmeter_outliers=False,
+        )
         assert np.mean(t_yes.jd) >= np.mean(t_no.jd) - 1e-9
 
 
-# ---------------------------------------------------------------------------
-# map_to_orders
-# ---------------------------------------------------------------------------
+class TestFluxWeightedMidpointOrders:
 
-class TestMapToOrders:
+    _KWARGS = dict(interpolate=False, extrapolate=False, fix_expmeter_outliers=False)
 
     def test_output_shape(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
-        w_em = np.array([5000.0, 5100.0, 5200.0, 5300.0])
-        t_fwm = Time(np.linspace(2460310.5, 2460310.6, 4), format='jd', scale='utc')
-        t_per_order = bc.map_to_orders(w_em, t_fwm)
-        assert len(t_per_order) == NORDER
+        w, t = bc.compute_flux_weighted_midpoint_times(output='orders', **self._KWARGS)
+        assert w.shape == (NORDER,)
+        assert len(t) == NORDER
 
     def test_constant_wave_gives_constant_time(self, synthetic_kpf2):
         """SCI2_WAVE filled with 5000.0 → every order interpolates at 5000Å
-        and gets the first per-channel t_fwm."""
+        and gets the value from the first per-channel t_fwm."""
         bc = BarycentricCorrection(synthetic_kpf2)
-        w_em = np.array([5000.0, 5100.0, 5200.0, 5300.0])
-        jds = np.array([10.0, 20.0, 30.0, 40.0])
-        t_fwm = Time(2460310.5 + jds / 86400.0, format='jd', scale='utc')
-        t_per_order = bc.map_to_orders(w_em, t_fwm)
-        np.testing.assert_allclose(t_per_order.jd, t_fwm.jd[0])
+        _, t = bc.compute_flux_weighted_midpoint_times(output='orders', **self._KWARGS)
+        # All per-channel times are equal (uniform flux), so all per-order
+        # interpolated times equal that shared value.
+        assert np.std(t.jd) < 1e-12
 
     def test_orders_get_distinct_times_when_waves_vary(self, synthetic_kpf2):
-        """Set SCI2_WAVE so GREEN orders straddle 5000Å and RED orders 5300Å."""
+        """Front-weighted flux + GREEN orders at 5000Å vs RED at 5100Å:
+        GREEN orders should get an earlier midpoint than RED."""
+        synthetic_kpf2.set_data('GREEN_SCI2_WAVE',
+                                np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float32))
+        synthetic_kpf2.set_data('RED_SCI2_WAVE',
+                                np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float32))
+        # Front-weighted at 5000Å, back-weighted at 5100Å
+        data = {'Date-Beg': ['2024-01-01T00:00:00.000',
+                              '2024-01-01T00:02:00.000',
+                              '2024-01-01T00:04:00.000'],
+                'Date-End': ['2024-01-01T00:01:00.000',
+                              '2024-01-01T00:03:00.000',
+                              '2024-01-01T00:05:00.000'],
+                '5000': [1000.0, 1.0, 1.0],
+                '5100': [1.0, 1.0, 1000.0]}
+        synthetic_kpf2.set_data('EXPMETER_SCI', Table(data))
+
         bc = BarycentricCorrection(synthetic_kpf2)
-        green = np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float32)
-        red   = np.full((NORDER_RED, NCOL),   5300.0, dtype=np.float32)
-        synthetic_kpf2.set_data('GREEN_SCI2_WAVE', green)
-        synthetic_kpf2.set_data('RED_SCI2_WAVE',   red)
+        _, t = bc.compute_flux_weighted_midpoint_times(output='orders', **self._KWARGS)
+        assert t.jd[:NORDER_GREEN].mean() < t.jd[NORDER_GREEN:].mean()
 
-        w_em = np.array([5000.0, 5100.0, 5200.0, 5300.0])
-        jds  = np.array([10.0, 20.0, 30.0, 40.0])
-        t_fwm = Time(2460310.5 + jds / 86400.0, format='jd', scale='utc')
-
-        t_per_order = bc.map_to_orders(w_em, t_fwm)
-        # GREEN orders → t_fwm[0] (=10s), RED orders → t_fwm[-1] (=40s)
-        np.testing.assert_allclose(t_per_order.jd[:NORDER_GREEN], t_fwm.jd[0])
-        np.testing.assert_allclose(t_per_order.jd[NORDER_GREEN:], t_fwm.jd[-1])
-
-    def test_empty_sci2_wave_raises(self, synthetic_kpf2, monkeypatch):
-        """If SCI2_WAVE is empty, map_to_orders should fail loudly."""
+    def test_empty_sci2_wave_raises(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
-        # Force the underlying TRACE3_WAVE to empty by replacing the alias target
         synthetic_kpf2.data['TRACE3_WAVE'] = np.array([])
-        w_em = np.array([5000.0, 5100.0])
-        t_fwm = Time([2460310.5, 2460310.6], format='jd', scale='utc')
         with pytest.raises(KeyError, match="SCI2_WAVE"):
-            bc.map_to_orders(w_em, t_fwm)
+            bc.compute_flux_weighted_midpoint_times(output='orders', **self._KWARGS)
+
+
+class TestFluxWeightedMidpointCcds:
+
+    _KWARGS = dict(interpolate=False, extrapolate=False, fix_expmeter_outliers=False)
+
+    def test_output_shape(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        w, t = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
+        assert w.shape == (2,)
+        assert len(t) == 2
+
+    def test_ccd_values_equal_chip_means(self, synthetic_kpf2):
+        """The ccds output should equal the per-chip means of the orders output."""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        _, t_orders = bc.compute_flux_weighted_midpoint_times(output='orders', **self._KWARGS)
+        w_ccds, t_ccds = bc.compute_flux_weighted_midpoint_times(output='ccds', **self._KWARGS)
+        np.testing.assert_allclose(
+            t_ccds.jd,
+            [t_orders.jd[:NORDER_GREEN].mean(), t_orders.jd[NORDER_GREEN:].mean()],
+        )
+
+
+class TestFluxWeightedMidpointFormat:
+
+    def test_invalid_format_raises(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(ValueError, match="output"):
+            bc.compute_flux_weighted_midpoint_times(output='bogus')
+
+    def test_default_is_orders(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        w, t = bc.compute_flux_weighted_midpoint_times(
+            interpolate=False, extrapolate=False, fix_expmeter_outliers=False,
+        )
+        assert w.shape == (NORDER,)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -195,12 +195,12 @@ class TestExtrapolate:
             BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
 
 
-class TestFixBadExposures:
+class TestFixExpmeterOutliers:
 
     def test_clean_array_unchanged(self):
         rng = np.random.default_rng(0)
         f = rng.normal(100.0, 2.0, (60, 20))
-        f_fixed = BarycentricCorrection._fix_bad_exposures(f)
+        f_fixed = BarycentricCorrection._fix_expmeter_outliers(f)
         np.testing.assert_allclose(f_fixed, f, rtol=1e-4)
 
     def test_outlier_repaired(self):
@@ -208,13 +208,13 @@ class TestFixBadExposures:
         f = rng.normal(100.0, 2.0, (60, 20))
         f[30, 10] = 1e6
 
-        f_fixed = BarycentricCorrection._fix_bad_exposures(f)
+        f_fixed = BarycentricCorrection._fix_expmeter_outliers(f)
         assert abs(f_fixed[30, 10] - 100.0) < 20.0
 
     def test_output_shape_preserved(self):
         rng = np.random.default_rng(2)
         f = rng.normal(50.0, 1.0, (60, 20))
-        assert BarycentricCorrection._fix_bad_exposures(f).shape == f.shape
+        assert BarycentricCorrection._fix_expmeter_outliers(f).shape == f.shape
 
 
 # ---------------------------------------------------------------------------
@@ -281,14 +281,14 @@ class TestFluxWeightedMidpoint:
     def test_uniform_flux_gives_geometric_midpoint(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
         w, t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                              fix_bad_exposures=False)
+                                              fix_expmeter_outliers=False)
         _, t_mid, _ = bc._get_timestamps()
         np.testing.assert_allclose(np.mean(t_fwm.jd), np.mean(t_mid.jd), atol=1e-6)
 
     def test_output_shapes(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
         w, t_fwm = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                              fix_bad_exposures=False)
+                                              fix_expmeter_outliers=False)
         assert w.shape == (len(_WAVE_COLS),)
         assert len(t_fwm) == len(_WAVE_COLS)
 
@@ -315,9 +315,9 @@ class TestFluxWeightedMidpoint:
         bc = BarycentricCorrection(synthetic_kpf2)
 
         _, t_no = bc.flux_weighted_midpoint(interpolate=False, extrapolate=False,
-                                             fix_bad_exposures=False)
+                                             fix_expmeter_outliers=False)
         _, t_yes = bc.flux_weighted_midpoint(interpolate=True, extrapolate=False,
-                                              fix_bad_exposures=False)
+                                              fix_expmeter_outliers=False)
         assert np.mean(t_yes.jd) >= np.mean(t_no.jd) - 1e-9
 
 
@@ -393,12 +393,16 @@ class TestPerform:
             bjd_tdb = np.atleast_1d(obs_times.jd) + 500.0 / 86400.0
             return bc_vel, bjd_tdb
 
+        def passthrough(f, kernel_size=5):
+            return f.copy()
+
         monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
         monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
-        # Disable fix_bad_exposures: the 3×4 uniform-flux fixture triggers a
+        # Stub _fix_expmeter_outliers: the 3×4 uniform-flux fixture triggers a
         # degenerate triangulation inside scipy.griddata. Filter itself is
-        # exercised by TestFixBadExposures with a noisy 60×20 array.
-        return BarycentricCorrection(synthetic_kpf2, config={'fix_bad_exposures': False})
+        # exercised by TestFixExpmeterOutliers with a noisy 60×20 array.
+        monkeypatch.setattr(BarycentricCorrection, '_fix_expmeter_outliers', staticmethod(passthrough))
+        return BarycentricCorrection(synthetic_kpf2)
 
     def test_returns_kpf2(self, bc_monkeypatched):
         assert isinstance(bc_monkeypatched.perform(), KPF2)
@@ -444,15 +448,15 @@ class TestPerform:
             np.testing.assert_allclose(after, before * z[:, None], rtol=1e-5,
                                        err_msg=f"{key} not scaled correctly")
 
-    def test_per_ccd_primary_keywords(self, bc_monkeypatched):
+    def test_per_ccd_instrument_header_keywords(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.perform()
-        primary = kpf2.headers['PRIMARY']
+        inst = kpf2.headers['INSTRUMENT_HEADER']
         for key in ['CCD1BJD', 'CCD1BKMS', 'CCD1BZ',
                     'CCD2BJD', 'CCD2BKMS', 'CCD2BZ']:
-            assert key in primary, f"{key} missing from PRIMARY"
+            assert key in inst, f"{key} missing from INSTRUMENT_HEADER"
 
         def _v(k):
-            x = primary[k]
+            x = inst[k]
             return x[0] if isinstance(x, tuple) else x
 
         # All orders had the same delta_rv → green and red means are equal
@@ -484,7 +488,7 @@ class TestPerform:
         monkeypatch.setattr(BarycentricCorrection, '_query_gaia', staticmethod(mock_query))
         monkeypatch.setattr(BarycentricCorrection, '_compute_barycorr', staticmethod(mock_compute))
 
-        bc = BarycentricCorrection(synthetic_kpf2, config={'fix_bad_exposures': False})
+        bc = BarycentricCorrection(synthetic_kpf2)
         orig = bc.kpf2_obj.data['GREEN_SCI2_WAVE'].copy()
-        bc.perform()
+        bc.perform(fix_expmeter_outliers=False)
         np.testing.assert_allclose(bc.kpf2_obj.data['GREEN_SCI2_WAVE'], orig, rtol=1e-7)

--- a/tests/test_barycentric_correction.py
+++ b/tests/test_barycentric_correction.py
@@ -674,9 +674,12 @@ class TestPerform:
         assert bc_monkeypatched._results is None
         bc_monkeypatched.perform()
         results = bc_monkeypatched._results
-        assert set(results.keys()) == {'bjd_tdb', 'bary_kms', 'bary_z'}
-        for v in results.values():
-            assert len(v) == NORDER
+        assert set(results.keys()) == {
+            'bjd_tdb', 'bary_kms', 'bary_z', 'ccd_bjd', 'ccd_kms', 'ccd_z'}
+        for key in ('bjd_tdb', 'bary_kms', 'bary_z'):
+            assert len(results[key]) == NORDER
+        for key in ('ccd_bjd', 'ccd_kms', 'ccd_z'):
+            assert len(results[key]) == 2
 
     def test_real_outlier_filter_runs_end_to_end(self, synthetic_kpf2, monkeypatch):
         """Exercise fix_expmeter_outliers=True through perform() with a

--- a/tests/test_image_assembly.py
+++ b/tests/test_image_assembly.py
@@ -237,6 +237,100 @@ class TestImageAssembly4Amp:
 
 
 # ---------------------------------------------------------------------------
+# Expmeter wavelength unit conversion (nm → Å at L0 → L1)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def synthetic_4amp_l0_with_expmeter(tmp_path):
+    """Synthetic 4-amp L0 with EXPMETER_SCI/SKY tables labeled in nm.
+
+    The wavelength column labels mirror real KPF expmeter native units
+    (e.g. '498.12' nm). The detector amp data is the same minimal 4-amp
+    scaffold used by `synthetic_4amp_l0`.
+    """
+    fn = str(tmp_path / "KP.20240101.00002.00.fits")
+    rng = np.random.default_rng(7)
+
+    nrow, ncol = 2070, 2094
+    bias_level = 1000.0
+
+    primary = fits.PrimaryHDU()
+    primary.header["INSTRUME"] = "KPF"
+    primary.header["OBJECT"]   = "synthetic-expmeter"
+    primary.header["IMTYPE"]   = "Bias"
+    primary.header["DATE-OBS"] = "2024-01-01T00:00:01"
+
+    hdus = [primary]
+    for chip in ["GREEN", "RED"]:
+        for amp in range(1, 5):
+            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+
+    # EXPMETER tables: Date-Beg/Date-End + a handful of channels in nm
+    wave_nm_labels = ['498.12', '604.38', '710.62', '816.88']
+    nrows = 3
+    for ext_name in ['EXPMETER_SCI', 'EXPMETER_SKY']:
+        cols = [
+            fits.Column(name='Date-Beg', format='25A',
+                        array=['2024-01-01T00:00:00.000'] * nrows),
+            fits.Column(name='Date-End', format='25A',
+                        array=['2024-01-01T00:00:01.000'] * nrows),
+        ]
+        for w in wave_nm_labels:
+            cols.append(fits.Column(name=w, format='E',
+                                     array=np.full(nrows, 100.0, dtype=np.float32)))
+        hdus.append(fits.BinTableHDU.from_columns(cols, name=ext_name))
+
+    fits.HDUList(hdus).writeto(fn, overwrite=True)
+    return fn
+
+
+class TestExpmeterWavelengthConversion:
+    """L0 → L1 should relabel EXPMETER_SCI/SKY wavelength columns from nm to Å."""
+
+    @pytest.fixture
+    def l1(self, synthetic_4amp_l0_with_expmeter):
+        l0 = KPF0.from_fits(synthetic_4amp_l0_with_expmeter)
+        return ImageAssembly(l0).perform()
+
+    def test_sci_columns_converted_to_angstroms(self, l1):
+        cols = l1.data['EXPMETER_SCI'].colnames
+        # nm labels (498.12, 604.38, 710.62, 816.88) → Å (4981.2, 6043.8, 7106.2, 8168.8)
+        for expected in ('4981.2', '6043.8', '7106.2', '8168.8'):
+            assert expected in cols, f"missing Å column {expected!r}; got {cols}"
+
+    def test_sky_columns_converted_to_angstroms(self, l1):
+        cols = l1.data['EXPMETER_SKY'].colnames
+        for expected in ('4981.2', '6043.8', '7106.2', '8168.8'):
+            assert expected in cols
+
+    def test_nm_labels_removed(self, l1):
+        cols = l1.data['EXPMETER_SCI'].colnames
+        for nm_label in ('498.12', '604.38', '710.62', '816.88'):
+            assert nm_label not in cols, f"nm label {nm_label!r} should be gone"
+
+    def test_non_numeric_columns_preserved(self, l1):
+        cols = l1.data['EXPMETER_SCI'].colnames
+        assert 'Date-Beg' in cols
+        assert 'Date-End' in cols
+
+    def test_values_preserved(self, l1):
+        # Underlying flux values shouldn't be touched by the rename.
+        np.testing.assert_array_equal(
+            np.asarray(l1.data['EXPMETER_SCI']['4981.2']),
+            np.full(3, 100.0, dtype=np.float32),
+        )
+
+    def test_no_error_when_expmeter_absent(self, synthetic_4amp_l0):
+        """Frames without an EXPMETER extension (e.g. biases) shouldn't error."""
+        l0 = KPF0.from_fits(synthetic_4amp_l0)
+        l1 = ImageAssembly(l0).perform()
+        # EXPMETER_SCI exists in the extension registry but is empty/None
+        em = l1.data.get('EXPMETER_SCI')
+        assert em is None or not hasattr(em, 'colnames') or len(em.colnames) == 0
+
+
+# ---------------------------------------------------------------------------
 # FITS round-trip tests (real data)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -579,6 +579,20 @@ class TestFitLinePositions:
         for key in ['wav', 'pix', 'std', 'amp', 'rms', 'bad']:
             assert len(result[key]) == 0
 
+    def test_fit_returns_float64_from_float32_inputs(self):
+        """float32 flux/wave inputs must not drag the line fit into float32."""
+        wls = WLS(FILE_LIST)
+        ncol = 100
+        x = np.arange(ncol)
+        wave = np.linspace(5000.0, 5100.0, ncol).astype(np.float32)
+        flux = (1.0 + 50.0 * np.exp(-0.5 * ((x - 50) / 2.0) ** 2)).astype(np.float32)
+        wls._linelist_array = np.array([wave[50]], dtype=float)
+
+        result = wls.fit_line_positions_1d(flux, wave, lineprofile='gaussian')
+        assert len(result['wav']) == 1
+        for key in ['wav', 'pix', 'std', 'amp', 'rms']:
+            assert result[key].dtype == np.float64
+
     def test_all_nan_fiber_emits_fiber_level_warning(self):
         """A fiber whose every order is NaN should emit a fiber-level warning."""
         wls = WLS(FILE_LIST)

--- a/tests/test_science_recipe.py
+++ b/tests/test_science_recipe.py
@@ -125,6 +125,7 @@ class TestScienceRecipe:
             arr = np.asarray(l2.data[ext])
             assert arr.shape == (norder,), f"{ext} shape {arr.shape} != ({norder},)"
             assert np.all(np.isfinite(arr)), f"{ext} has non-finite values"
+            assert np.issubdtype(arr.dtype, np.float64), f"{ext} is {arr.dtype}, expected float64"
         # Sanity: barycentric Z should be very close to 1 (|v| << c).
         z = np.asarray(l2.data['BARYCORR_Z'])
         assert np.all(np.abs(z - 1.0) < 1e-3)
@@ -160,6 +161,9 @@ class TestScienceRecipe:
         assert l2.data['RED_SCI2_WAVE'].shape   == (NORDER_RED,   NCOL)
         assert np.any(l2.data['GREEN_SCI2_WAVE'] != 0)
         assert np.any(l2.data['RED_SCI2_WAVE']   != 0)
+        # Wavelength solutions are stored in float64.
+        assert np.issubdtype(l2.data['GREEN_SCI2_WAVE'].dtype, np.float64)
+        assert np.issubdtype(l2.data['RED_SCI2_WAVE'].dtype,   np.float64)
 
     def test_qlp_l0_pngs_exist(self, recipe_output):
         qlp_dir = Path(recipe_output).parents[2] / 'QLP' / '20240405' / OBS_ID / 'L0'

--- a/tests/test_science_recipe.py
+++ b/tests/test_science_recipe.py
@@ -114,6 +114,29 @@ class TestScienceRecipe:
         assert 'calibration_association' in modules
         assert 'spectral_extraction' in modules
         assert 'wavelength_calibration' in modules
+        assert 'barycentric_correction' in modules
+
+    def test_barycorr_extensions_populated(self, recipe_output):
+        """BarycentricCorrection should populate the rvdata-standard extensions
+        per-order, with finite values."""
+        l2 = KPF2.from_fits(recipe_output)
+        norder = NORDER_GREEN + NORDER_RED
+        for ext in ('BJD_TDB', 'BARYCORR_KMS', 'BARYCORR_Z'):
+            arr = np.asarray(l2.data[ext])
+            assert arr.shape == (norder,), f"{ext} shape {arr.shape} != ({norder},)"
+            assert np.all(np.isfinite(arr)), f"{ext} has non-finite values"
+        # Sanity: barycentric Z should be very close to 1 (|v| << c).
+        z = np.asarray(l2.data['BARYCORR_Z'])
+        assert np.all(np.abs(z - 1.0) < 1e-3)
+
+    def test_per_ccd_barycorr_keywords(self, recipe_output):
+        """Per-CCD scalar summaries should land on INSTRUMENT_HEADER."""
+        l2 = KPF2.from_fits(recipe_output)
+        inst = l2.headers['INSTRUMENT_HEADER']
+        for key in ('CCD1BJD', 'CCD1BKMS', 'CCD1BZ',
+                    'CCD2BJD', 'CCD2BKMS', 'CCD2BZ'):
+            assert key in inst, f"{key} missing from INSTRUMENT_HEADER"
+            assert np.isfinite(float(inst[key])), f"{key} not finite"
 
     def test_calibration_headers_set(self, recipe_output):
         """CalibrationAssociation's L1 PRIMARY writes survive into L2 INSTRUMENT_HEADER."""

--- a/tests/test_wavelength_calibration.py
+++ b/tests/test_wavelength_calibration.py
@@ -173,6 +173,16 @@ class TestPerform:
                 key = f'{chip}_{fiber}_WAVE'
                 np.testing.assert_array_equal(l2.data[key], master.data[key])
 
+    def test_wave_arrays_are_float64(self, master_wls_path):
+        # The fixture master is float32 (4-byte); the science WAVE must be float64.
+        master = KPFMasterL2.from_fits(master_wls_path)
+        assert master.data['GREEN_SCI2_WAVE'].dtype.itemsize == 4
+        l2 = _make_science_l2(wls_path=master_wls_path)
+        WavelengthCalibration(l2).perform()
+        for chip in _CHIPS:
+            for fiber in _FIBERS:
+                assert l2.data[f'{chip}_{fiber}_WAVE'].dtype == np.float64
+
     def test_explicit_path_bypasses_header(self, master_wls_path):
         # WLSFILE header is bogus, but wls_path override is valid → perform() succeeds.
         l2 = _make_science_l2(wls_path='/tmp/bogus.fits')


### PR DESCRIPTION
## Summary

  Implements per-order barycentric correction for KPF L2 data and
  wires it into the science recipe. Populates the rvdata-standard
  `BJD_TDB`, `BARYCORR_KMS`, and `BARYCORR_Z` extensions per
  spectral order, plus per-CCD scalar summaries
  (`CCD1BJD`/`CCD1BKMS`/`CCD1BZ`, `CCD2*`) on `INSTRUMENT_HEADER`.
   WAVE arrays are tracked but not modified — downstream RV
  computation consumes `BARYCORR_Z` directly.

  ## Key changes

  - **New `BarycentricCorrection` module**. Reads the EXPMETER_SCI
   flux time series, computes the per-order flux-weighted midpoint
   time via interpolation onto `SCI2_WAVE`, queries Gaia DR3 for
  astrometry, and calls barycorrpy (with `TARGRADV` threaded
  through as the systemic RV).
  - **EXPMETER unit conversion in `ImageAssembly`**. Renames
  `EXPMETER_SCI`/`SKY` wavelength columns from nm (L0 native) to Å
   (L1+ convention) so the whole post-L0 pipeline operates in a
  single wavelength unit, consistent with WAVE arrays.
  - **Recipe wiring**. `kpf_drp_science` runs
  `BarycentricCorrection` after `WavelengthCalibration`.

  ## Test plan

  - [x] New unit tests for `BarycentricCorrection` (algorithm,
  error paths, header propagation, output shapes)
  - [x] New unit tests for `ImageAssembly` covering the nm→Å
  conversion
  - [x] Extended `test_science_recipe` to assert the new
  extensions, per-CCD keywords, and receipt entry
  - [x] Full test suite passes
  - [ ] Run on real data to check for correctness