### PR TITLE
Split data roots into INPUT / MASTERS_OUTPUT / SCIENCE_OUTPUT

### DIFF
--- a/configs/kpf_drp_masters.toml
+++ b/configs/kpf_drp_masters.toml
@@ -1,6 +1,7 @@
 [DATA_DIRS]
 KPF_DATA_INPUT = "/data/kpf/"
-KPF_DATA_OUTPUT = "/data/kpf-next/"
+KPF_MASTERS_OUTPUT = "/data/kpf-next/masters-root/"
+KPF_SCIENCE_OUTPUT = "/data/kpf-next/science-root/"
 
 [KPFPIPE]
 chips = ["GREEN", "RED"]

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -1,6 +1,7 @@
 [DATA_DIRS]
 KPF_DATA_INPUT = "/data/kpf/"
-KPF_DATA_OUTPUT = "/data/kpf-next/"
+KPF_MASTERS_OUTPUT = "/data/kpf-next/masters-root/"
+KPF_SCIENCE_OUTPUT = "/data/kpf-next/science-root/"
 
 [KPFPIPE]
 chips = ["GREEN", "RED"]

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -51,6 +51,10 @@ class CalibrationAssociation:
         observation timestamp is read from its PRIMARY header (DATE-OBS).
     config : None | dict | ConfigHandler
         Module configuration. Recognised keys:
+            KPF_MASTERS_OUTPUT : str
+                Root directory under which master calibration files live
+                (searched as {root}/masters/{datecode}/). This is where the
+                masters recipe writes its products.
             masters_search_window_days : [int, int]
                 Search window as [days_before, days_after] relative to the
                 science frame's observation date. Negative values are in the
@@ -73,7 +77,7 @@ class CalibrationAssociation:
         for k, v in _DEFAULTS.items():
             setattr(self, k, params.get(k, v))
 
-        self._data_root = params.get('KPF_DATA_INPUT')
+        self._masters_root = params.get('KPF_MASTERS_OUTPUT')
         self._results = None  # populated by perform()
 
     # ------------------------------------------------------------------
@@ -123,7 +127,7 @@ class CalibrationAssociation:
             search_date = obs_date + timedelta(days=delta)
             datecode = search_date.strftime('%Y%m%d')
             pattern = os.path.join(
-                self._data_root, 'masters', datecode,
+                self._masters_root, 'masters', datecode,
                 f'*_master_{cal_type}_{level}.fits'
             )
             for filepath in sorted(glob.glob(pattern)):
@@ -237,7 +241,7 @@ class CalibrationAssociation:
         """Print a summary of the module configuration and association results."""
         print("CalibrationAssociation")
         print(f"  obs_id:        {self.l1_obj.obs_id}")
-        print(f"  data root:     {self._data_root}")
+        print(f"  masters root:  {self._masters_root}")
         print(f"  search window: {self.masters_search_window_days} days [before, after]")
 
         if self._results is None:

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -37,7 +37,7 @@ class WLS(BaseMasterModule):
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: linelist, lineprofile,
         polyorder_x, polyorder_m, polyorder_f, chips, fibers,
-        KPF_DATA_INPUT.
+        KPF_MASTERS_OUTPUT.
     """
 
     _DEFAULTS = {**BaseMasterModule._DEFAULTS,
@@ -58,7 +58,11 @@ class WLS(BaseMasterModule):
         else:
             raise TypeError("config must be None, dict, or ConfigHandler")
         super().__init__(l0_file_list, params)
-        self._data_root = params.get('KPF_DATA_INPUT')
+        # WLS extraction associates a master bias for each ThAr frame. Masters
+        # (including the bias the masters recipe just built) live under
+        # KPF_MASTERS_OUTPUT, which is also where CalibrationAssociation reads
+        # them, so there is no input/output mismatch.
+        self._masters_root = params.get('KPF_MASTERS_OUTPUT')
         self.rough_wls_file = _ROUGH_WLS_FILE
 
         self._load_rough_wls()
@@ -129,7 +133,7 @@ class WLS(BaseMasterModule):
     
 
     def _extract_frame(self, l1_obj, verbose=True):
-        calibration_association = CalibrationAssociation(l1_obj, {'KPF_DATA_INPUT': self._data_root})
+        calibration_association = CalibrationAssociation(l1_obj, {'KPF_MASTERS_OUTPUT': self._masters_root})
         l1_obj = calibration_association.perform(['bias'])
 
         image_processing = ImageProcessing(l1_obj)

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -18,8 +18,8 @@ def main(config, args):
     datecode = args.datecode
 
     data_dirs = config.get_params(['DATA_DIRS'])
-    data_root_in  = data_dirs['KPF_DATA_INPUT']
-    data_root_out = data_dirs['KPF_DATA_OUTPUT']
+    data_root_in      = data_dirs['KPF_DATA_INPUT']
+    data_root_masters = data_dirs['KPF_MASTERS_OUTPUT']
 
     l0_dir = os.path.join(data_root_in, 'L0', datecode)
     if not os.path.isdir(l0_dir):
@@ -28,25 +28,25 @@ def main(config, args):
 
     # master bias
     for files in build_l0_file_lists('bias', mini_db=mini_db):
-        bias_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='bias')
+        bias_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_masters, master='bias')
         bias_handler = Bias(files, config)
         bias_handler.make_master_l1(filepath=bias_path)
 
     # master dark (not yet implemented)
     #for files in build_l0_file_lists('dark', mini_db=mini_db):
-    #    dark_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='dark')
+    #    dark_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_masters, master='dark')
     #    dark_handler = Dark(files, config)
     #    dark_handler.make_master_l1(filepath=dark_path)
 
     # master flat (not yet implemented)
     #for files in build_l0_file_lists('flat', mini_db=mini_db):
-    #    flat_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_out, master='flat')
+    #    flat_path = build_filepath(get_obs_id(files[0]), 'L1', data_root=data_root_masters, master='flat')
     #    flat_handler = Flat(files, config)
     #    flat_handler.make_master_l1(filepath=flat_path)
 
     # master wavelength solution (ThAr)
     for files in build_l0_file_lists('thar', mini_db=mini_db):
-        wls_master_path      = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_out, master='thar')
+        wls_master_path      = build_filepath(get_obs_id(files[0]), 'L2', data_root=data_root_masters, master='thar')
         wls_diagnostics_path = wls_master_path[:-len('_L2.fits')] + '_diagnostics.h5'
 
         wls_handler = WLS(files, config)

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -28,12 +28,12 @@ def main(config, args):
     obs_id = args.obs_id
 
     data_dirs = config.get_params(['DATA_DIRS'])
-    data_root_in  = data_dirs['KPF_DATA_INPUT']
-    data_root_out = data_dirs['KPF_DATA_OUTPUT']
+    data_root_in      = data_dirs['KPF_DATA_INPUT']
+    data_root_science = data_dirs['KPF_SCIENCE_OUTPUT']
 
     l0 = KPF0.from_fits(build_filepath(obs_id, 'L0', data_root=data_root_in))
 
-    l0_qlp_dir = build_qlp_dir(obs_id, 'L0', data_root=data_root_out)
+    l0_qlp_dir = build_qlp_dir(obs_id, 'L0', data_root=data_root_science)
     PlotL0(l0, output_dir=l0_qlp_dir).run('all')
 
     # read raw L0 file and assemble into L1 full frame image (FFI)
@@ -42,7 +42,7 @@ def main(config, args):
 
     # L1 QLP is computed on the assembled (pre-bias-subtraction) image because
     # ImageProcessing mutates GREEN_CCD/RED_CCD in place during bias subtraction.
-    l1_qlp_dir = build_qlp_dir(obs_id, 'L1', data_root=data_root_out)
+    l1_qlp_dir = build_qlp_dir(obs_id, 'L1', data_root=data_root_science)
     PlotL1(l1, output_dir=l1_qlp_dir).run('all')
 
     # assign calibration masters (bias, dark, flat, wls) to this frame
@@ -74,7 +74,7 @@ def main(config, args):
     l2 = barycentric_correction.perform()
 
     # write L2 data product to disk
-    l2_out_path = build_filepath(obs_id, 'L2', data_root=data_root_out)
+    l2_out_path = build_filepath(obs_id, 'L2', data_root=data_root_science)
     os.makedirs(os.path.dirname(l2_out_path), exist_ok=True)
     l2.to_fits(l2_out_path)
 
@@ -83,7 +83,7 @@ def main(config, args):
     l4 = radial_velocity.perform()
 
     # write L4 data product to disk
-    l4_out_path = build_filepath(obs_id, 'L4', data_root=data_root_out)
+    l4_out_path = build_filepath(obs_id, 'L4', data_root=data_root_science)
     os.makedirs(os.path.dirname(l4_out_path), exist_ok=True)
     l4.to_fits(l4_out_path)
 

--- a/tests/test_calibration_association.py
+++ b/tests/test_calibration_association.py
@@ -24,7 +24,7 @@ class MockL1:
 
 def _make_module(tmp_path, date_obs='2024-04-05T11:08:33'):
     l1 = MockL1(date_obs)
-    return CalibrationAssociation(l1, config={'KPF_DATA_INPUT': str(tmp_path)})
+    return CalibrationAssociation(l1, config={'KPF_MASTERS_OUTPUT': str(tmp_path)})
 
 
 _LEVEL_BY_CAL_TYPE = {

--- a/tests/test_master_wls.py
+++ b/tests/test_master_wls.py
@@ -73,13 +73,21 @@ def mock_pipeline(monkeypatch):
 
 class TestInit:
 
-    def test_none_config_sets_data_input_none(self):
+    def test_none_config_sets_masters_root_none(self):
         wls = WLS(FILE_LIST)
-        assert wls._data_root is None
+        assert wls._masters_root is None
 
-    def test_dict_config_sets_data_input(self):
-        wls = WLS(FILE_LIST, config={'KPF_DATA_INPUT': '/data/kpf'})
-        assert wls._data_root == '/data/kpf'
+    def test_reads_masters_root_from_config(self):
+        # WLS associates the master bias from KPF_MASTERS_OUTPUT -- where the
+        # masters recipe writes it and where CalibrationAssociation reads it.
+        wls = WLS(FILE_LIST, config={'KPF_MASTERS_OUTPUT': '/masters'})
+        assert wls._masters_root == '/masters'
+
+    def test_ignores_data_input_for_masters_root(self):
+        # The raw input root is not where masters live; only KPF_MASTERS_OUTPUT
+        # drives the masters search.
+        wls = WLS(FILE_LIST, config={'KPF_DATA_INPUT': '/in'})
+        assert wls._masters_root is None
 
     def test_invalid_config_raises(self):
         with pytest.raises(TypeError):
@@ -97,7 +105,8 @@ class TestExtractFrame:
         result = wls._extract_frame(MockL1())
         assert result is mock_pipeline
 
-    def test_passes_data_input_to_calibration_association(self, monkeypatch):
+    def test_passes_masters_root_to_calibration_association(self, monkeypatch):
+        # _extract_frame must associate the bias from KPF_MASTERS_OUTPUT.
         mock_ca = MagicMock()
         mock_ca.return_value.perform.return_value = MockL1()
         mock_ip = MagicMock()
@@ -109,11 +118,11 @@ class TestExtractFrame:
         monkeypatch.setattr(wls_module, 'ImageProcessing', mock_ip)
         monkeypatch.setattr(wls_module, 'SpectralExtraction', mock_se)
 
-        wls = WLS(FILE_LIST, config={'KPF_DATA_INPUT': '/data/kpf'})
+        wls = WLS(FILE_LIST, config={'KPF_MASTERS_OUTPUT': '/masters'})
         wls._extract_frame(MockL1())
 
         call_args = mock_ca.call_args[0]
-        assert call_args[1].get('KPF_DATA_INPUT') == '/data/kpf'
+        assert call_args[1].get('KPF_MASTERS_OUTPUT') == '/masters'
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_masters_recipe.py
+++ b/tests/test_masters_recipe.py
@@ -455,14 +455,14 @@ class TestMastersRecipe:
 
 class TestMastersRecipeErrors:
 
-    def _make_config(self, data_input, data_output):
+    def _make_config(self, data_input, data_masters):
         import argparse
         return ConfigHandler(
             str(MASTERS_CONFIG_PATH),
             overrides={
                 'DATA_DIRS': {
-                    'KPF_DATA_INPUT':  str(data_input),
-                    'KPF_DATA_OUTPUT': str(data_output),
+                    'KPF_DATA_INPUT':     str(data_input),
+                    'KPF_MASTERS_OUTPUT': str(data_masters),
                 }
             },
         )

--- a/tests/test_science_recipe.py
+++ b/tests/test_science_recipe.py
@@ -61,8 +61,9 @@ class TestScienceRecipe:
             str(CONFIG_PATH),
             overrides={
                 'DATA_DIRS': {
-                    'KPF_DATA_INPUT':  str(TESTDATA_DIR),
-                    'KPF_DATA_OUTPUT': str(tmp_path),
+                    'KPF_DATA_INPUT':     str(TESTDATA_DIR),
+                    'KPF_MASTERS_OUTPUT': str(TESTDATA_DIR),
+                    'KPF_SCIENCE_OUTPUT': str(tmp_path),
                 }
             },
         )
@@ -189,8 +190,9 @@ class TestScienceRecipeErrors:
             str(CONFIG_PATH),
             overrides={
                 'DATA_DIRS': {
-                    'KPF_DATA_INPUT':  str(tmp_path),
-                    'KPF_DATA_OUTPUT': str(tmp_path),
+                    'KPF_DATA_INPUT':     str(tmp_path),
+                    'KPF_MASTERS_OUTPUT': str(tmp_path),
+                    'KPF_SCIENCE_OUTPUT': str(tmp_path),
                 }
             },
         )
@@ -204,8 +206,9 @@ class TestScienceRecipeErrors:
             str(CONFIG_PATH),
             overrides={
                 'DATA_DIRS': {
-                    'KPF_DATA_INPUT':  str(tmp_path),
-                    'KPF_DATA_OUTPUT': str(tmp_path),
+                    'KPF_DATA_INPUT':     str(tmp_path),
+                    'KPF_MASTERS_OUTPUT': str(tmp_path),
+                    'KPF_SCIENCE_OUTPUT': str(tmp_path),
                 }
             },
         )

--- a/tests/test_wavelength_calibration.py
+++ b/tests/test_wavelength_calibration.py
@@ -323,7 +323,7 @@ class TestSpectrumOrientation:
         from kpfpipe.utils.pipeline import build_filepath
 
         config = {
-            'KPF_DATA_INPUT': str(TESTDATA_DIR),
+            'KPF_MASTERS_OUTPUT': str(TESTDATA_DIR),
             'chips':  _CHIPS,
             'fibers': _SCI_FIBERS,
         }

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -47,8 +47,9 @@ def main():
     target = parser.add_mutually_exclusive_group()
     target.add_argument('-d', '--datecode', default=None, help='datecode, e.g. 20240405 (masters recipe only; mutually exclusive with -o)')
     target.add_argument('-o', '--obs_id',   default=None, help='obs_id, e.g. KP.20240405.40113.57 (science recipe only; mutually exclusive with -d)')
-    parser.add_argument('--data_input',  default=None, help='override KPF_DATA_INPUT directory')
-    parser.add_argument('--data_output', default=None, help='override KPF_DATA_OUTPUT directory')
+    parser.add_argument('--data_input',   default=None, help='override KPF_DATA_INPUT directory')
+    parser.add_argument('--data_masters', default=None, help='override KPF_MASTERS_OUTPUT directory')
+    parser.add_argument('--data_science', default=None, help='override KPF_SCIENCE_OUTPUT directory')
     parser.add_argument('--test', action='store_true',
                         help='shorthand to use tests/testdata/ for input and output')
     args = parser.parse_args()
@@ -72,16 +73,19 @@ def main():
         parser.error("science recipe takes -o/--obs_id, not -d/--datecode")
 
     if args.test:
-        args.data_input  = args.data_input  or _TESTDATA_DIR
-        args.data_output = args.data_output or _TESTDATA_DIR
+        args.data_input   = args.data_input   or _TESTDATA_DIR
+        args.data_masters = args.data_masters or _TESTDATA_DIR
+        args.data_science = args.data_science or _TESTDATA_DIR
 
     overrides = {}
-    if args.data_input or args.data_output:
+    if args.data_input or args.data_masters or args.data_science:
         overrides['DATA_DIRS'] = {}
         if args.data_input:
             overrides['DATA_DIRS']['KPF_DATA_INPUT'] = args.data_input
-        if args.data_output:
-            overrides['DATA_DIRS']['KPF_DATA_OUTPUT'] = args.data_output
+        if args.data_masters:
+            overrides['DATA_DIRS']['KPF_MASTERS_OUTPUT'] = args.data_masters
+        if args.data_science:
+            overrides['DATA_DIRS']['KPF_SCIENCE_OUTPUT'] = args.data_science
 
     config = ConfigHandler(args.config, overrides=overrides or None)
 


### PR DESCRIPTION
## What

Replace the ambiguous two-key data-root scheme (`KPF_DATA_INPUT`, `KPF_DATA_OUTPUT`) with three explicit roots:

- **`KPF_DATA_INPUT`** — raw L0 input files (read only)
- **`KPF_MASTERS_OUTPUT`** — master calibration files (bias/dark/flat/WLS): written by the masters recipe, **read** by `CalibrationAssociation` for both recipes
- **`KPF_SCIENCE_OUTPUT`** — science products (L2/L4) and all QLP PNGs

## Why

A single `KPF_DATA_OUTPUT` conflated master calibration products with science products, and master lookup was split across two code paths (`CalibrationAssociation` searched `KPF_DATA_INPUT/masters/`; `WLS` overrode it to `KPF_DATA_OUTPUT`). That split is what caused the original bias-lookup failure during the masters recipe (WLS couldn't see the bias it had just written when input != output).

With masters now written to **and** read from `KPF_MASTERS_OUTPUT`, `CalibrationAssociation` is the single master-lookup chokepoint and the WLS special-case is gone — the mismatch can no longer occur. This **dissolves** the bug the prior one-line `KPF_DATA_OUTPUT or KPF_DATA_INPUT` fallback was patching.

## Scope

Clean break — `KPF_DATA_OUTPUT` is removed entirely (no fallback chain); recipes fail loudly (`KeyError`) if a required root is absent, per the charter's "no hidden state / fail loudly". Touches both recipes, both TOML configs, the CLI (`--data_masters` / `--data_science` replace `--data_output`; `--test` points all three roots at `tests/testdata`), and the affected tests (`test_master_wls`, `test_calibration_association`, `test_masters_recipe`, `test_science_recipe`, `test_wavelength_calibration`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
