### PR TITLE
Add DiagL2 SNR and orderlet-flux-ratio diagnostics

### DIFF
--- a/kpfpipe/quality_control/diagnostics/level2.py
+++ b/kpfpipe/quality_control/diagnostics/level2.py
@@ -7,6 +7,9 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 _FIBERS = ('SCI1', 'SCI2', 'SCI3', 'SKY', 'CAL')
 _CHIPS = ('GREEN', 'RED')
+_SCI_FIBERS = ('SCI1', 'SCI2', 'SCI3')
+_SNR_PERCENTILE = 95
+_CHIP_PREFIX = {'GREEN': 'G', 'RED': 'R'}
 
 _NAN_KEYS = {
     'SCI1': ('NANSCI1', 'NaN pixel count, SCI1 (green+red)'),
@@ -58,3 +61,74 @@ class DiagL2(Diagnostics):
         frac = round(float(total_zero / total_pix), 6)
         return {'ZEROFRAC': (frac, 'Fraction of L2 flux pixels equal to zero')}
     zero_flux_fraction._diag_name = 'zero_flux_fraction'
+
+    def _arr(self, chip, fiber, kind):
+        """Return the (norder, ncol) FLUX or VAR array for a fiber, or None."""
+        arr = self.kpf.data.get(f'{chip}_{fiber}_{kind}')
+        if arr is None:
+            return None
+        arr = np.asarray(arr)
+        return arr if (arr.ndim == 2 and arr.size > 0) else None
+
+    @staticmethod
+    def _median_snr(flux, var):
+        """Median over orders of the per-order 95th-percentile SNR.
+
+        SNR = flux / sqrt(|var|); non-finite values are treated as 0 so a
+        single bad pixel does not poison the percentile.
+        """
+        with np.errstate(divide='ignore', invalid='ignore'):
+            snr = flux / np.sqrt(np.abs(var))
+        snr = np.where(np.isfinite(snr), snr, 0.0)
+        per_order = np.nanpercentile(snr, _SNR_PERCENTILE, axis=1)
+        return round(float(np.nanmedian(per_order)), 2)
+
+    def snr(self):
+        """Representative SNR per chip for the summed-SCI, SKY, and CAL fibers.
+
+        A compact RV-stability indicator: per order take the 95th-percentile
+        of flux/sqrt(|var|), then the median across orders. Summed SCI uses
+        SCI1+SCI2+SCI3 flux and variance. Skipped per (chip, fiber) when that
+        data is absent.
+        """
+        out = {}
+        for chip, p in _CHIP_PREFIX.items():
+            sci_f = [self._arr(chip, f, 'FLUX') for f in _SCI_FIBERS]
+            sci_v = [self._arr(chip, f, 'VAR') for f in _SCI_FIBERS]
+            if all(a is not None for a in sci_f + sci_v):
+                out[f'{p}SNRSCI'] = (self._median_snr(sum(sci_f), sum(sci_v)),
+                                     f'Median 95th-pctile SNR, summed SCI ({chip})')
+            for fiber in ('SKY', 'CAL'):
+                f = self._arr(chip, fiber, 'FLUX')
+                v = self._arr(chip, fiber, 'VAR')
+                if f is not None and v is not None:
+                    out[f'{p}SNR{fiber}'] = (self._median_snr(f, v),
+                                             f'Median 95th-pctile SNR, {fiber} ({chip})')
+        return out
+    snr._diag_name = 'snr'
+
+    def orderlet_flux_ratios(self):
+        """Median inter-fiber flux ratios per chip (fiber-throughput stability).
+
+        Ratio is the per-order median flux of fiber A over fiber B, then the
+        median across orders. All fibers share the order/pixel grid, so no
+        wavelength resampling is needed.
+        """
+        pairs = [('SCI1', 'SCI2', 'FR12'), ('SCI3', 'SCI2', 'FR32'),
+                 ('SKY', 'SCI2', 'FRS2'), ('CAL', 'SCI2', 'FRC2')]
+        out = {}
+        for chip, p in _CHIP_PREFIX.items():
+            for a, b, tag in pairs:
+                fa = self._arr(chip, a, 'FLUX')
+                fb = self._arr(chip, b, 'FLUX')
+                if fa is None or fb is None:
+                    continue
+                with np.errstate(divide='ignore', invalid='ignore'):
+                    ratio = np.nanmedian(fa, axis=1) / np.nanmedian(fb, axis=1)
+                ratio = ratio[np.isfinite(ratio)]
+                if ratio.size == 0:
+                    continue
+                out[f'{p}{tag}'] = (round(float(np.nanmedian(ratio)), 4),
+                                    f'Median flux ratio {a}/{b} ({chip})')
+        return out
+    orderlet_flux_ratios._diag_name = 'orderlet_flux_ratios'

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -275,3 +275,88 @@ class TestDiagL2ZeroFlux:
         kpf2 = l1.to_kpf2()
         DiagL2(kpf2).run()
         assert 'ZEROFRAC' not in kpf2.headers['PRIMARY']
+
+
+def _set_fiber_arrays(kpf2, suffix, value, chips=('GREEN', 'RED'), fibers=_FIBERS):
+    """Populate {chip}_{fiber}_{suffix} with a constant for the given fibers."""
+    norder = {'GREEN': NORDER_GREEN, 'RED': NORDER_RED}
+    for chip in chips:
+        for fiber in fibers:
+            kpf2.set_data(f'{chip}_{fiber}_{suffix}',
+                          np.full((norder[chip], NCOL), value, dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# DiagL2 — per-fiber SNR
+# ---------------------------------------------------------------------------
+
+class TestDiagL2Snr:
+
+    _SNR_KEYS = ('GSNRSCI', 'GSNRSKY', 'GSNRCAL', 'RSNRSCI', 'RSNRSKY', 'RSNRCAL')
+
+    def test_keys_written_when_flux_and_var_present(self):
+        kpf2 = _make_kpf2_with_flux()  # all FLUX ones
+        _set_fiber_arrays(kpf2, 'VAR', 0.25)
+        DiagL2(kpf2).run()
+        for key in self._SNR_KEYS:
+            assert key in kpf2.headers['PRIMARY'], f"missing {key}"
+            assert _hval(kpf2.headers['PRIMARY'][key]) > 0
+
+    def test_single_fiber_snr_value(self):
+        # SKY flux=2, var=0.04 -> SNR = 2/sqrt(0.04) = 10.0 in every pixel.
+        kpf2 = _make_kpf2_with_flux()
+        _set_fiber_arrays(kpf2, 'FLUX', 2.0, fibers=('SKY',))
+        _set_fiber_arrays(kpf2, 'VAR', 0.04, fibers=('SKY',))
+        DiagL2(kpf2).run()
+        assert _hval(kpf2.headers['PRIMARY']['GSNRSKY']) == pytest.approx(10.0, abs=0.01)
+        assert _hval(kpf2.headers['PRIMARY']['RSNRSKY']) == pytest.approx(10.0, abs=0.01)
+
+    def test_summed_sci_snr_value(self):
+        # Each SCI fiber flux=2, var=0.04 -> summed flux=6, var=0.12;
+        # SNR = 6/sqrt(0.12) ~= 17.32.
+        kpf2 = _make_kpf2_with_flux()
+        _set_fiber_arrays(kpf2, 'FLUX', 2.0, fibers=('SCI1', 'SCI2', 'SCI3'))
+        _set_fiber_arrays(kpf2, 'VAR', 0.04, fibers=('SCI1', 'SCI2', 'SCI3'))
+        DiagL2(kpf2).run()
+        assert _hval(kpf2.headers['PRIMARY']['GSNRSCI']) == pytest.approx(17.32, abs=0.05)
+
+    def test_summed_sci_skipped_when_a_sci_var_missing(self):
+        # VAR for SCI1/SCI2 only (SCI3 var stays empty) -> summed-SCI skipped,
+        # but SKY (var present) is still computed.
+        kpf2 = _make_kpf2_with_flux()
+        _set_fiber_arrays(kpf2, 'VAR', 0.25, fibers=('SCI1', 'SCI2', 'SKY', 'CAL'))
+        DiagL2(kpf2).run()
+        assert 'GSNRSCI' not in kpf2.headers['PRIMARY']
+        assert 'GSNRSKY' in kpf2.headers['PRIMARY']
+
+    def test_skipped_without_var(self):
+        # Default fixture leaves VAR empty -> no SNR keys at all.
+        kpf2 = _make_kpf2_with_flux()
+        DiagL2(kpf2).run()
+        for key in self._SNR_KEYS:
+            assert key not in kpf2.headers['PRIMARY']
+
+
+# ---------------------------------------------------------------------------
+# DiagL2 — orderlet flux ratios
+# ---------------------------------------------------------------------------
+
+class TestDiagL2OrderletFluxRatios:
+
+    _RATIO_KEYS = ('GFR12', 'GFR32', 'GFRS2', 'GFRC2',
+                   'RFR12', 'RFR32', 'RFRS2', 'RFRC2')
+
+    def test_keys_written_and_unity_when_uniform(self):
+        # All fibers flux=1 (default) -> every inter-fiber ratio == 1.0.
+        kpf2 = _make_kpf2_with_flux()
+        DiagL2(kpf2).run()
+        for key in self._RATIO_KEYS:
+            assert key in kpf2.headers['PRIMARY'], f"missing {key}"
+            assert _hval(kpf2.headers['PRIMARY'][key]) == pytest.approx(1.0)
+
+    def test_ratio_value(self):
+        # GREEN SCI1 flux=2 over SCI2 flux=1 -> GFR12 == 2.0.
+        kpf2 = _make_kpf2_with_flux()
+        _set_fiber_arrays(kpf2, 'FLUX', 2.0, chips=('GREEN',), fibers=('SCI1',))
+        DiagL2(kpf2).run()
+        assert _hval(kpf2.headers['PRIMARY']['GFR12']) == pytest.approx(2.0)


### PR DESCRIPTION
**Stacked on #1462** (base: `kpf-next-wls-bias-root`). First of the L2 series: **Diagnostics → QC → QLP**. When #1462 merges, GitHub retargets this to `kpf-next`.

## What

Two new L2 diagnostics in `kpfpipe/quality_control/diagnostics/level2.py`, complementing the existing `nan_counts` / `zero_flux_fraction`. Both write to the PRIMARY header via the standard `_diag_name` mechanism.

- **`snr`** → `GSNRSCI`, `GSNRSKY`, `GSNRCAL`, `RSNRSCI`, `RSNRSKY`, `RSNRCAL`. Per order, the 95th-percentile of `flux/sqrt(|var|)`, then the median across orders. Summed-SCI uses `SCI1+SCI2+SCI3` flux and variance. A compact RV-stability indicator; skipped per (chip, fiber) when flux/var is absent.
- **`orderlet_flux_ratios`** → `GFR12`, `GFR32`, `GFRS2`, `GFRC2` (+ RED). Per-order median flux of fiber A over fiber B (SCI1/SCI2, SCI3/SCI2, SKY/SCI2, CAL/SCI2), then median across orders — a fiber-throughput stability check.

## Tests

`tests/test_diagnostics.py`: keyword emission, exact values (single-fiber SNR=10.0, summed-SCI≈17.32, ratio=2.0), the summed-SCI skip when a SCI variance is missing, and the no-variance skip path. Full file passes (22 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
