### PR TITLE
Add QCL2 variance-positive and science-SNR checks

### DIFF
--- a/kpfpipe/quality_control/qc_booleans/level2.py
+++ b/kpfpipe/quality_control/qc_booleans/level2.py
@@ -9,6 +9,9 @@ _FIBERS = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 
 _NAN_KEYS = ["NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL"]
 
+# Minimum plausible science SNR; a fully failed extraction yields ~0.
+_MIN_SCI_SNR = 1.0
+
 
 def _hdr_float(hdr, key):
     """Return float value for a header key, or None if absent."""
@@ -69,3 +72,46 @@ class QCL2(QC):
 
     nonzero_flux._qc_key = "L2FLXOK"
     nonzero_flux._qc_comment = "QC: L2 zero-flux fraction < 0.5"
+
+    def variance_positive(self):
+        """No strictly-negative variance where the flux is finite.
+
+        A negative extracted variance is unphysical (box/optimal variance is a
+        sum of non-negative terms) and would corrupt downstream RV weighting.
+        Zero variance at off-detector / fully-masked columns is tolerated.
+        """
+        saw_data = False
+        for chip in _CHIPS:
+            for fiber in _FIBERS:
+                flux = self.kpf.data.get(f"{chip}_{fiber}_FLUX")
+                var = self.kpf.data.get(f"{chip}_{fiber}_VAR")
+                if flux is None or var is None:
+                    continue
+                flux = np.asarray(flux)
+                var = np.asarray(var)
+                if flux.size == 0 or var.shape != flux.shape:
+                    continue
+                saw_data = True
+                if np.any(np.isfinite(flux) & np.isfinite(var) & (var < 0)):
+                    return False
+        return saw_data
+
+    variance_positive._qc_key = "L2VARPOS"
+    variance_positive._qc_comment = "QC: no negative L2 variance where flux finite"
+
+    def science_snr(self):
+        """Science SNR is finite and above a minimum floor.
+
+        Reads the GSNRSCI/RSNRSCI metrics written by DiagL2.snr (run DiagL2
+        before QCL2, mirroring the flux_finite_fraction -> nan_counts
+        dependency). Guards against a silently failed extraction.
+        """
+        hdr = self.kpf.headers["PRIMARY"]
+        values = [_hdr_float(hdr, k) for k in ("GSNRSCI", "RSNRSCI")]
+        values = [v for v in values if v is not None]
+        if not values:
+            return False
+        return all(np.isfinite(v) and v > _MIN_SCI_SNR for v in values)
+
+    science_snr._qc_key = "L2SNROK"
+    science_snr._qc_comment = "QC: science SNR finite and above floor"

--- a/tests/test_qc_booleans.py
+++ b/tests/test_qc_booleans.py
@@ -128,6 +128,15 @@ def _make_kpf2_with_flux(*, nan_frac=0.0, zero_frac=0.1, missing_ext=None):
     return kpf2
 
 
+def _set_kpf2_var(kpf2, fill=1.0):
+    """Populate all {CHIP}_{FIBER}_VAR extensions with a constant fill."""
+    for chip in ["GREEN", "RED"]:
+        nrows = _NORDER[chip]
+        for fiber in ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]:
+            kpf2.set_data(f"{chip}_{fiber}_VAR",
+                          np.full((nrows, _NCOLS), fill, dtype=np.float32))
+
+
 # ---------------------------------------------------------------------------
 # Task 2: QC base class runner
 # ---------------------------------------------------------------------------
@@ -583,11 +592,55 @@ class TestQCL2:
         kpf2 = _make_kpf2_with_flux(zero_frac=0.5)
         assert QCL2(kpf2).nonzero_flux() is False
 
+    # --- variance_positive (L2VARPOS) ---
+
+    def test_variance_positive_pass(self):
+        kpf2 = _make_kpf2_with_flux()
+        _set_kpf2_var(kpf2, 1.0)
+        assert QCL2(kpf2).variance_positive() is True
+
+    def test_variance_positive_tolerates_zero(self):
+        kpf2 = _make_kpf2_with_flux()
+        _set_kpf2_var(kpf2, 0.0)  # zero variance is allowed
+        assert QCL2(kpf2).variance_positive() is True
+
+    def test_variance_positive_fail_negative(self):
+        kpf2 = _make_kpf2_with_flux()
+        _set_kpf2_var(kpf2, 1.0)
+        var = np.full((_NORDER["GREEN"], _NCOLS), 1.0, dtype=np.float32)
+        var[0, 0] = -1.0  # negative variance where flux is finite
+        kpf2.set_data("GREEN_SCI1_VAR", var)
+        assert QCL2(kpf2).variance_positive() is False
+
+    def test_variance_positive_fail_no_var(self):
+        kpf2 = _make_kpf2_with_flux()  # no VAR populated
+        assert QCL2(kpf2).variance_positive() is False
+
+    # --- science_snr (L2SNROK) ---
+
+    def test_science_snr_pass(self):
+        kpf2 = _make_kpf2_with_flux()
+        kpf2.headers["PRIMARY"]["GSNRSCI"] = (20.0, "g snr")
+        kpf2.headers["PRIMARY"]["RSNRSCI"] = (18.0, "r snr")
+        assert QCL2(kpf2).science_snr() is True
+
+    def test_science_snr_fail_missing(self):
+        kpf2 = _make_kpf2_with_flux()  # no GSNRSCI/RSNRSCI headers
+        assert QCL2(kpf2).science_snr() is False
+
+    def test_science_snr_fail_below_floor(self):
+        kpf2 = _make_kpf2_with_flux()
+        kpf2.headers["PRIMARY"]["GSNRSCI"] = (0.5, "g snr")  # below floor
+        kpf2.headers["PRIMARY"]["RSNRSCI"] = (18.0, "r snr")
+        assert QCL2(kpf2).science_snr() is False
+
     def test_qc_keys_correct(self):
         expected = {
             "extraction_present":    "DATAPRL2",
             "flux_finite_fraction":  "L2NANOK",
             "nonzero_flux":          "L2FLXOK",
+            "variance_positive":     "L2VARPOS",
+            "science_snr":           "L2SNROK",
         }
         for method_name, key in expected.items():
             fn = QCL2.__dict__[method_name]


### PR DESCRIPTION
**Stacked on #1463** (base: `kpf-next-diag-l2`). Second of the L2 series: Diagnostics → **QC** → QLP. `science_snr` reads the `GSNRSCI`/`RSNRSCI` headers added in #1463, so it builds on that branch. When the parents merge, GitHub retargets this down the chain.

## What

Two new checks in `kpfpipe/quality_control/qc_binaries/level2.py` (write 0/1 to PRIMARY, folded into `ISGOOD`):

- **`variance_positive`** (`L2VARPOS`) — fail if any extracted variance is strictly negative where the flux is finite (unphysical; would corrupt downstream RV weighting). Zero variance (off-detector / masked columns) is tolerated; fails if no flux/var data is present at all.
- **`science_snr`** (`L2SNROK`) — fail if `GSNRSCI`/`RSNRSCI` (from `DiagL2.snr`, #1463) are absent or not above a 1.0 floor, guarding against a silently failed extraction. Run DiagL2 before QCL2 (mirrors the existing `flux_finite_fraction` → `nan_counts` header dependency).

## Tests

`tests/test_qc_binaries.py`: variance_positive (pass, zero-tolerance, negative-variance fail, no-variance fail); science_snr (pass, missing-header fail, below-floor fail); `test_qc_keys_correct` extended. Full file passes (68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
