### PR TITLE
Consistency sweep: parameter tiers, filename conventions, and nomenclature docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,12 @@ L1.to_kpf2() → KPF2 (extracted spectra, EPRV-compliant)
 
 Extension definitions, trace mappings, and aliases are CSV-driven (`data_models/config/`). Detector parameters (CCD dimensions, order counts) live in `data_models/config/detector.toml` and are exposed via `kpfpipe.constants`.
 
+### Filename conventions
+
+Science: `L0 = {obs_id}.fits` (KPF-native `KP.*`); `L1 = kpf_L1_{YYYYMMDD}T{HHmmss}.fits` — note **no EPRV "S"**, because the EPRV standard defines no L1 (its filename regex only accepts `SL2`/`SL3`/`SL4`); `L2/L4 = kpf_SL{N}_…` (EPRV-standard). Masters (WMKO DRP-RUN-05): `{KOAID-of-first-input}_master_{type}_L{N}.fits`.
+
+Two authorities encode this rule and **must agree per level**: `build_filepath(obs_id, level, …)` (`utils/io.py`) is the pipeline's path builder (directory + filename, from an obs_id string) and is what recipes use to write; `<model>.generate_standard_filename()` builds only the basename from a populated object's headers and is the `to_fits(fn=None)` fallback — **rvdata-owned for the standard levels L2/L4** (do not override), **KPF-overridden for the non-standard L0/L1**. `TestFilenameConsistency` (in `tests/regression/test_masters_recipe.py`) enforces that the two never drift.
+
 ### Masters Pipeline
 
 `kpfpipe/modules/masters/` — stacks multiple observations to create bias, dark, flat, and wavelength solution (WLS) calibration products. Uses sigma-clipped statistics with a single-pass streaming accumulation (per-pixel counts and exposure time) for large stacks; the master image is the exposure-weighted rate `counts_sum / exptime_sum`.

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -255,10 +255,12 @@ class StageName:
     the configured `self.<attr>` (the "`None` means use config" tunables); then the
     *semi-hidden* parameters — rarely-tuned knobs left exposed for developer experimentation,
     carrying a real literal default (e.g. `min_npts=9`, `verbose=True`) and intentionally
-    **absent** from both `_DEFAULTS` and config. (A semi-hidden param needing a mutable
-    default still uses the `None`-sentinel form with an in-body literal fallback, e.g.
-    `clip_edge_pixels=None → [500, 500]`; it is grouped and documented as semi-hidden, not
-    configurable.) Within each group, keep a sensible domain order.
+    **absent** from both `_DEFAULTS` and config. The invariant is that a tunable's tier is
+    legible from the signature alone: **`=None` ⇒ configurable** (resolves to `self.<attr>`),
+    **literal default ⇒ semi-hidden**. So a semi-hidden param needing a sequence default uses
+    an *immutable literal* (a tuple, safe as a default argument), e.g.
+    `clip_edge_pixels=(500, 500)`, never the `None`-sentinel + in-body list fallback. Within
+    each group, keep a sensible domain order.
 - **The `make_master_*` entry points follow the same shape** (§10), with `l0_file_list`
   as the sole positional in place of `chips`/`fibers`.
 - **Parameter ordering applies to *every* method**, not just the public entry points:

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -203,8 +203,11 @@ class StageName:
   Tunable params become instance attributes via the `_DEFAULTS` setattr loop.
 - **`_DEFAULTS` merges the global defaults**: `_DEFAULTS = {**DEFAULTS, "key": ...}`
   (use the `{**DEFAULTS, ...}` spread form, not `dict(DEFAULTS)`).
-- **Defaults live in the module, not the config file.** Config (TOML) values are
-  *overrides* applied on top of `_DEFAULTS` via `params.get(k, v)`.
+- **Defaults live in the module, not the config file.** Resolution is a three-tier
+  override chain, lowest precedence first: `_DEFAULTS` (the in-module default) → config
+  (TOML values applied on top via `params.get(k, v)` in the loop above) → a direct keyword
+  argument on a method call (overrides both). Config is the production override path;
+  direct kwargs are the developer/interactive path (e.g. notebooks), not used in production.
 - **Declare every lazily-populated attribute in `__init__`, set to `None`/`{}`, with a
   trailing comment naming the method that fills it** — this is a defining house style:
   ```python
@@ -247,10 +250,15 @@ class StageName:
     positional in the same slot (e.g. `CalibrationAssociation.perform(self, cal_types, *, ...)`).
   - **Everything else is keyword-only** — place a bare `*` after the positionals so all
     tunables must be passed by name.
-  - **Order the keyword-only args in two groups**: first the *configurable* parameters that
-    default to `None` (the "`None` means use config" tunables), then the *semi-hidden*
-    parameters that carry a real default value (e.g. `min_npts=9`, `verbose=True`). Within
-    each group, keep a sensible domain order.
+  - **Order the keyword-only args in two groups**: first the *configurable* parameters —
+    backed by a `_DEFAULTS` key and a config entry, defaulting to `None` and resolving to
+    the configured `self.<attr>` (the "`None` means use config" tunables); then the
+    *semi-hidden* parameters — rarely-tuned knobs left exposed for developer experimentation,
+    carrying a real literal default (e.g. `min_npts=9`, `verbose=True`) and intentionally
+    **absent** from both `_DEFAULTS` and config. (A semi-hidden param needing a mutable
+    default still uses the `None`-sentinel form with an in-body literal fallback, e.g.
+    `clip_edge_pixels=None → [500, 500]`; it is grouped and documented as semi-hidden, not
+    configurable.) Within each group, keep a sensible domain order.
 - **The `make_master_*` entry points follow the same shape** (§10), with `l0_file_list`
   as the sole positional in place of `chips`/`fibers`.
 - **Parameter ordering applies to *every* method**, not just the public entry points:

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -366,6 +366,13 @@ class StageName:
   kwarg of `np.sum` et al. for masked reductions.
 - **Views vs copies are deliberate**: slicing yields views on purpose (consistent with
   the data-model "view not copy" philosophy); `.copy()` when you must mutate.
+- **Row/col nomenclature is numpy, not KPF.** All image/spectrum arrays use the numpy axis
+  convention throughout: **axis 0** (`row`/`nrow`) = **cross-dispersion** (across orders, flux
+  varies rapidly); **axis 1** (`col`/`ncol`) = **dispersion** (along an order, flux varies
+  slowly). This is the *transpose* of the KPF/observatory physical convention (where a "row"
+  runs along dispersion), so a reader expecting KPF physical directions will misread the code's
+  `row`/`col` — but the code is uniform and self-consistent.
+  `# Axis convention: axis 0 = cross-dispersion (KPF col); axis 1 = dispersion (KPF row).`
 - **Delegate shared numerics to `kpfpipe/utils/`** (`flag_outliers`, `optimize_lsq`,
   `interpolate_bad_pixels`, `compute_redshift`, `strictly_increasing`). `scipy` is the
   numerical backend (`least_squares` with an analytic Jacobian, `ndimage`,

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -266,7 +266,7 @@ class StageName:
   def _box_extraction(D, V, *, S=None, M=None, W=None): ...
   ```
   Required positionals first; everything tunable after the `*`.
-- **String-enum mode parameters** (e.g. `method`, `response`, `imtype`) are validated
+- **String-enum mode parameters** (e.g. `method`, `response`, `cal_type`) are validated
   against an explicit allowed set, raising `ValueError` that names the valid options.
 - **Return patterns**:
   - A transform's `perform()` returns the next-level data object after mutating
@@ -481,10 +481,17 @@ documented, intentional ways — follow *its* conventions when adding masters co
   - Transform modules → `.perform()`; QC/Diag/Quicklook → `.run()` (or `.run("all")`);
     masters → `.make_master_l1/l2()`. The constructor takes the **whole `ConfigHandler`**,
     not pre-extracted params — each module pulls its own section internally.
-- **All path construction goes through utils helpers** (`build_filepath`, `build_qlp_dir`,
-  `build_l0_file_lists`, `get_obs_id`), never string concatenation. Level passed as a
-  literal `"L0"/"L1"/"L2"/"L4"`. `os.makedirs(os.path.dirname(path), exist_ok=True)`
-  before every `.to_fits()`.
+- **Product paths go through the `utils/io.py` helpers** (`build_filepath`, `glob_masters`,
+  `build_qlp_dir`, `build_l0_file_lists`, `get_obs_id`) — never re-derived by string
+  concatenation in modules/recipes. These helpers are the single definition of the on-disk
+  layout and filename conventions, built inline within each (no shared layout/filename
+  constant or directory helper — that abstraction was deliberately removed as more confusing
+  than the duplication). Where a convention is necessarily encoded twice — the masters
+  *writer* (`build_filepath`) and *reader* (`glob_masters`) build their paths independently —
+  keep them in lock-step with a **drift test** (`test_glob_masters_matches_build_filepath`),
+  not a shared helper. Plain `os.path.join` is fine for incidental input-directory assembly
+  (e.g. an L0 scan dir). Level passed as a literal `"L0"/"L1"/"L2"/"L4"`;
+  `os.makedirs(os.path.dirname(path), exist_ok=True)` before every `.to_fits()`.
 - **Arg validation**: guard at the top, `raise SystemExit("Error: --obs_id is required …")`
   with an example.
 - **Recipe comments** are terse, lowercase, imperative, and explain the *why* (science

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -110,6 +110,8 @@ class KPF0(KPFDataModel):
                     df = df.reindex(columns=all_cols).fillna("")
                 self.receipt = df
             elif fits_type == "ImageHDU":
+                # np.array (not asarray) materializes the memmapped HDU into RAM
+                # before from_fits closes the file; a view would dangle afterward.
                 self.set_data(ext_name, np.array(hdu.data))
             elif fits_type == "BinTableHDU":
                 self.set_data(ext_name, Table.read(hdu))

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -119,6 +119,8 @@ class KPF1(KPFDataModel):
                     df = df.reindex(columns=all_cols).fillna("")
                 self.receipt = df
             elif fits_type == "ImageHDU":
+                # np.array (not asarray) materializes the memmapped HDU into RAM
+                # before from_fits closes the file; a view would dangle afterward.
                 self.set_data(ext_name, np.array(hdu.data))
             elif fits_type == "BinTableHDU":
                 self.set_data(ext_name, Table.read(hdu))

--- a/kpfpipe/data_models/masters/base.py
+++ b/kpfpipe/data_models/masters/base.py
@@ -16,13 +16,17 @@ avoid confusion: units and normalization conventions differ by
 calibration type (bias, dark, flat) and are not the same as raw
 science counts (e.g., GREEN_CCD).
 
-Filename convention: masters products follow WMKO filename format
-(KP.YYYYMMDD.NNNNN.NN.fits), not the EPRV per-level convention.
+Filename convention (WMKO DRP-RUN-05): masters are written as
+``{KOAID-of-first-input}_master_{type}_L{level}.fits`` (e.g.
+``KP.20240405.49597.71_master_bias_L1.fits``), built by
+``generate_standard_filename()``.
 """
 
 import pandas as pd
 
 from kpfpipe.data_models.base import KPFDataModel
+from kpfpipe.utils.io import build_filepath
+from kpfpipe.utils.kpf import get_obs_id
 
 
 class KPFMasterModel(KPFDataModel):
@@ -38,6 +42,41 @@ class KPFMasterModel(KPFDataModel):
     def __init__(self):
         KPFDataModel.__init__(self)
 
-    def set_input_files(self, file_list):
-        """Record the input L0 file list in the INPUT_FILES extension."""
+    def set_input_files(self, file_list, master_type):
+        """
+        Record the stacked input L0 files and the master calibration type.
+
+        `master_type` is the WMKO filename token ('bias', 'dark', 'flat', or
+        'thar'); it is stored in the PRIMARY ``MASTYPE`` header so that
+        `generate_standard_filename()` can always build a DRP-RUN-05-compliant
+        name, including after a `from_fits()` round-trip.
+        """
         self.set_data("INPUT_FILES", pd.DataFrame({"FILENAME": file_list}))
+        # Plain string (not a value/comment tuple): the in-memory PRIMARY header
+        # is a dict, so a tuple would be returned verbatim by .get() and break
+        # generate_standard_filename() before the FITS round-trip.
+        self.headers["PRIMARY"]["MASTYPE"] = master_type
+
+    def generate_standard_filename(self):
+        """
+        Return the WMKO DRP-RUN-05 master filename for this product:
+        ``{KOAID-of-first-input}_master_{type}_L{level}.fits``.
+
+        The KOAID is read from the first recorded input file and the type from
+        the PRIMARY ``MASTYPE`` header (both set by `set_input_files()`). Raises
+        if either is missing, so a non-compliant master name can never be
+        produced; `build_filepath` validates the type token and level.
+        """
+        master_type = self.headers["PRIMARY"].get("MASTYPE")
+        if not master_type:
+            raise ValueError(
+                "MASTYPE header is unset; call set_input_files() before "
+                "generating a master filename"
+            )
+        input_files = self.data.get("INPUT_FILES")
+        if input_files is None or len(input_files) == 0:
+            raise ValueError(
+                "INPUT_FILES is empty; cannot determine the first-input KOAID"
+            )
+        koaid = get_obs_id(str(input_files["FILENAME"][0]))
+        return build_filepath(koaid, f"L{self.level}", master=master_type)

--- a/kpfpipe/data_models/masters/level1.py
+++ b/kpfpipe/data_models/masters/level1.py
@@ -12,8 +12,10 @@ differ from science L1 to reflect masters-specific normalization:
     GREEN_MASK -- boolean bad pixel mask (1=good, 0=bad)
     RED_IMG, RED_SNR, RED_MASK -- same for red chip
 
-Filename convention: masters products follow WMKO filename format
-(KP.YYYYMMDD.NNNNN.NN.fits), not the EPRV per-level convention.
+Filename convention (WMKO DRP-RUN-05): masters are written as
+{KOAID-of-first-input}_master_{type}_L1.fits (e.g.
+KP.20240405.49597.71_master_bias_L1.fits), built by
+KPFMasterModel.generate_standard_filename().
 """
 
 import importlib.resources
@@ -46,7 +48,6 @@ class KPFMasterL1(KPFMasterModel, KPF1):
     """
 
     _DATALVL = "ML1"
-    _FILENAME_PREFIX = "kpf_ML1"
     _known_extensions = set(_MASTERS_L1_EXTENSIONS["Name"])
 
     def __init__(self):

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -117,6 +117,8 @@ class KPFMasterL2(KPFMasterModel, KPF2):
                     df = df.reindex(columns=all_cols).fillna("")
                 self.receipt = df
             elif fits_type == "ImageHDU":
+                # np.array (not asarray) materializes the memmapped HDU into RAM
+                # before from_fits closes the file; a view would dangle afterward.
                 self.set_data(ext_name, np.array(hdu.data))
             elif fits_type == "BinTableHDU":
                 self.set_data(ext_name, Table.read(hdu))

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -11,8 +11,10 @@ SCI2_WAVE and the standard names like TRACE3_WAVE). Only masters-
 specific additions (INPUT_FILES) are declared in
 Masters-L2-extensions.csv.
 
-Filename convention: masters products follow WMKO filename format
-(KP.YYYYMMDD.NNNNN.NN.fits), not the EPRV per-level convention.
+Filename convention (WMKO DRP-RUN-05): masters are written as
+{KOAID-of-first-input}_master_{type}_L2.fits (e.g.
+KP.20240405.49597.71_master_thar_L2.fits), built by
+KPFMasterModel.generate_standard_filename().
 """
 
 import importlib.resources
@@ -44,7 +46,6 @@ class KPFMasterL2(KPFMasterModel, KPF2):
     """
 
     _DATALVL = "ML2"
-    _FILENAME_PREFIX = "kpf_ML2"
     _known_extensions = set(_MASTERS_L2_EXTENSIONS["Name"]) | set(
         KPF2().extensions.keys()
     )

--- a/kpfpipe/data_models/masters/level4.py
+++ b/kpfpipe/data_models/masters/level4.py
@@ -3,8 +3,9 @@ KPF Masters Level 4 data model.
 
 Masters RV/CCF calibration products. Not yet implemented.
 
-Filename convention: masters products follow WMKO filename format
-(KP.YYYYMMDD.NNNNN.NN.fits), not the EPRV per-level convention.
+Filename convention (WMKO DRP-RUN-05): masters are written as
+{KOAID-of-first-input}_master_{type}_L4.fits, built by
+KPFMasterModel.generate_standard_filename().
 """
 
 from kpfpipe.data_models.level4 import KPF4
@@ -19,7 +20,6 @@ class KPFMasterL4(KPFMasterModel, KPF4):
     """
 
     _DATALVL = "ML4"
-    _FILENAME_PREFIX = "kpf_ML4"
 
     def __init__(self):
         raise NotImplementedError("KPFMasterL4 is not yet implemented")

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -197,13 +197,14 @@ class BarycentricCorrection:
         return w, f
 
     @staticmethod
-    def _fix_expmeter_outliers(f, kernel_size=5):
+    def _fix_expmeter_outliers(f, kernel_size=5, k=3.0):
         """
         Detect and interpolate outlier pixels in an expmeter flux array.
 
-        Outlier threshold is adaptive (Chauvenet-like criterion based on
-        array size). Replacement uses scipy.griddata linear interpolation,
-        falling back to nearest for any remaining NaNs.
+        Outlier threshold is adaptive (Chauvenet-like criterion based on array
+        size), scaled by the coefficient `k` (larger rejects fewer points).
+        Replacement uses scipy.griddata linear interpolation, falling back to
+        nearest for any remaining NaNs.
 
         Returns a copy of f with outliers replaced; shape unchanged.
         """
@@ -211,7 +212,7 @@ class BarycentricCorrection:
             median_filter(f, size=kernel_size), sigma=kernel_size
         )
 
-        eta = 3 * np.sqrt(2) * erfcinv(1 / np.min(np.shape(f)))
+        eta = k * np.sqrt(2) * erfcinv(1 / np.min(np.shape(f)))
         bad = np.abs(f - f_smooth) / mad_std(f - f_smooth) > eta
 
         if np.sum(bad) == 0:
@@ -516,6 +517,7 @@ class BarycentricCorrection:
         interpolate=True,
         extrapolate=True,
         fix_expmeter_outliers=True,
+        weight_percentile=90,
     ):
         """
         Compute the flux-weighted midpoint observation time.
@@ -541,6 +543,9 @@ class BarycentricCorrection:
             INSTRUMENT_HEADER.
         fix_expmeter_outliers : bool, optional
             If True (default), detect and replace outlier expmeter readings.
+        weight_percentile : float, optional
+            Per-order SCI2 brightness percentile used to weight orders for the
+            'ccds' output (robust to cosmics). Defaults to 90.
 
         Returns
         -------
@@ -592,15 +597,18 @@ class BarycentricCorrection:
         if output == "orders":
             return w_orders, t_orders
 
-        # Weight each order by its SCI2 brightness (90th percentile, robust to
-        # cosmics); NaN/failed orders get zero weight, uniform if SCI2_FLUX absent.
+        # Weight each order by its SCI2 brightness (`weight_percentile`, robust
+        # to cosmics); NaN/failed orders get zero weight, uniform if SCI2_FLUX
+        # absent.
         norder_green = self.norder["GREEN"]
         norder = norder_green + self.norder["RED"]
         flux = self.l2_obj.data["SCI2_FLUX"]
         if flux is None or np.size(flux) == 0:
             weights = np.ones(norder)
         else:
-            weights = np.nanpercentile(np.asarray(flux, dtype=float), 90, axis=1)
+            weights = np.nanpercentile(
+                np.asarray(flux, dtype=float), weight_percentile, axis=1
+            )
         weights = np.nan_to_num(weights, nan=0.0)
 
         green = slice(0, norder_green)

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta
 
 from kpfpipe import DEFAULTS
 from kpfpipe.utils.config import ConfigHandler
+from kpfpipe.utils.io import glob_masters
 from kpfpipe.utils.kpf import get_datecode, get_timestamp, kpf_timestamp_to_datetime
 
 _DEFAULTS = {
@@ -137,12 +138,7 @@ class CalibrationAssociation:
         for delta in range(days_before, days_after + 1):
             search_date = obs_date + timedelta(days=delta)
             datecode = search_date.strftime("%Y%m%d")
-            pattern = os.path.join(
-                self._masters_root,
-                "masters",
-                datecode,
-                f"*_master_{cal_type}_{level}.fits",
-            )
+            pattern = glob_masters(self._masters_root, cal_type, level, datecode)
             for filepath in sorted(glob.glob(pattern)):
                 try:
                     ts = get_timestamp(filepath)

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -97,7 +97,7 @@ class ImageAssembly:
             self.orientation.update(dict(zip(df["ext_name"], df["flip"], strict=False)))
             self.gain.update(dict(zip(df["ext_name"], df["gain"], strict=False)))
 
-    def _get_overscan_pixels(self, chip, amp_no, buffer=None):
+    def _get_overscan_pixels(self, chip, amp_no, buffer=(0, 0)):
         """
         Extract overscan pixels for a given amplifier.
 
@@ -107,8 +107,8 @@ class ImageAssembly:
             CCD identifier, e.g., 'GREEN' or 'RED'.
         amp_no : int
             Amplifier number (1-4).
-        buffer : list of int, optional
-            Number of pixels to ignore at edges [start, end].
+        buffer : tuple of int, optional
+            Number of pixels to ignore at edges (start, end). Defaults to (0, 0).
 
         Returns
         -------
@@ -121,8 +121,6 @@ class ImageAssembly:
         -----
         Assumes image orientation has been standardized.
         """
-        if buffer is None:
-            buffer = [0, 0]
         chip = chip.upper()
         full_amplifier = self.l0_obj.data[f"{chip}_AMP{amp_no}"]
 
@@ -371,7 +369,7 @@ class ImageAssembly:
             channel_ext = f"{chip}_AMP{i + 1}"
             self.l0_obj.data[channel_ext] *= self.gain[channel_ext] / (2**16)
 
-    def measure_read_noise(self, chip, sigma=None, buffer=None):
+    def measure_read_noise(self, chip, sigma=None, buffer=(5, 5)):
         """
         Estimate read noise for each amplifier from overscan pixels.
 
@@ -381,8 +379,8 @@ class ImageAssembly:
             CCD identifier, e.g., 'GREEN' or 'RED'.
         sigma : float, optional
             Threshold for sigma clipping overscan pixels.
-        buffer : list of int, optional
-            Number of pixels to ignore at the edges [start, end].
+        buffer : tuple of int, optional
+            Number of pixels to ignore at the edges (start, end). Defaults to (5, 5).
 
         Returns
         -------
@@ -394,8 +392,6 @@ class ImageAssembly:
         - `self.readnoise[channel_ext]` : standard deviation of cleaned overscan.
         - `self.rn_nongauss[channel_ext]` : non-Gaussian factor computed as std/mad.
         """
-        if buffer is None:
-            buffer = [5, 5]
         if sigma is None:
             sigma = self.readnoise_sigma
 
@@ -413,7 +409,7 @@ class ImageAssembly:
             self.readnoise[channel_ext] = std
             self.rn_nongauss[channel_ext] = np.sqrt(2 / np.pi) * std / mad
 
-    def subtract_overscan(self, chip, method=None, buffer=None):
+    def subtract_overscan(self, chip, method=None, buffer=(0, 0)):
         """
         Subtract overscan bias from imaging pixels for each amplifier. Also
         removes overscan region from amplifier channel, leaving only active
@@ -425,15 +421,13 @@ class ImageAssembly:
             CCD identifier, e.g., 'GREEN' or 'RED'.
         method : str
             Overscan subtraction method ('zero', 'median', 'rowmedian').
-        buffer : list of int, optional
-            Number of pixels to ignore at edges.
+        buffer : tuple of int, optional
+            Number of pixels to ignore at edges. Defaults to (0, 0).
 
         Returns
         -------
         None
         """
-        if buffer is None:
-            buffer = [0, 0]
         if method is None:
             method = self.overscan_method
 

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -514,10 +514,7 @@ class ImageAssembly:
     @staticmethod
     def orient_ffi(image, chip):
         """
-        Flip an assembled image into the standard FFI orientation: dispersion
-        columns blue -> red (left -> right), and rows flipped for GREEN (whose
-        raw image is inverted relative to RED). Single source of truth for FFI
-        orientation, shared by stitch_ffi and the L0 quicklook.
+        Flip an assembled image into the standard FFI orientation.
         """
         image = np.flip(image, axis=1)
         if chip.upper() == "GREEN":

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -358,8 +358,44 @@ class BaseMasterModule:
     # Private helpers for frame stacking.
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _check_load_failures(failure, n_total, max_fail_fraction, max_fail_number):
+        """
+        Raise if cumulative frame-load failures exceed either limit.
+
+        Parameters
+        ----------
+        failure : int
+            Number of frames that have failed to load so far.
+        n_total : int
+            Total number of frames in the stack.
+        max_fail_fraction : float
+            Maximum allowed fraction of failed frames.
+        max_fail_number : int
+            Maximum allowed absolute number of failed frames.
+
+        Raises
+        ------
+        ValueError
+            If either limit is exceeded.
+        """
+        if failure / n_total > max_fail_fraction or failure > max_fail_number:
+            raise ValueError(
+                f"too many frames failed to load "
+                f"({failure} of {n_total}); limits are "
+                f"max_fail_fraction={max_fail_fraction:.0%}, "
+                f"max_fail_number={max_fail_number}"
+            )
+
     def _compute_stats_from_datacube(
-        self, l0_file_list=None, *, sigma=None, verbose=True, cache=False
+        self,
+        l0_file_list=None,
+        *,
+        sigma=None,
+        verbose=True,
+        cache=False,
+        max_fail_fraction=0.2,
+        max_fail_number=2,
     ):
         """
         Compute stacked statistics using an in-memory data cube.
@@ -379,6 +415,13 @@ class BaseMasterModule:
             If True, cache each loaded frame so a later pass (the streaming
             exact pass) can reuse it without re-reading from disk. Defaults to
             False, since the standalone datacube path reads each frame once.
+        max_fail_fraction : float, optional
+            Maximum fraction of frames allowed to fail loading before raising.
+            Defaults to 0.2.
+        max_fail_number : int, optional
+            Maximum absolute number of frames allowed to fail loading before
+            raising. Defaults to 2. Stacking raises when either limit is
+            exceeded.
 
         Returns
         -------
@@ -403,7 +446,7 @@ class BaseMasterModule:
         Outlier rejection is performed jointly on CCD and VAR extensions, in
         rate space, so frames of differing exposure are comparable. Exposure
         times must be either all zero or all strictly positive. Raises an error
-        if more than 20% of frames fail to load.
+        if more than `max_fail_fraction` of frames fail to load.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -433,8 +476,9 @@ class BaseMasterModule:
 
             if not success:
                 failure += 1
-                if failure / len(l0_file_list) > 0.2:
-                    raise ValueError("more than 20% of frames in stack failed to load")
+                self._check_load_failures(
+                    failure, len(l0_file_list), max_fail_fraction, max_fail_number
+                )
                 continue
 
             l1_obj = self._process_frame(l1_obj)
@@ -515,7 +559,14 @@ class BaseMasterModule:
         return stats, zero_exptime
 
     def _compute_stats_from_stream(
-        self, l0_file_list=None, *, nstream, sigma=None, verbose=True
+        self,
+        l0_file_list=None,
+        *,
+        nstream,
+        sigma=None,
+        verbose=True,
+        max_fail_fraction=0.2,
+        max_fail_number=2,
     ):
         """
         Compute stacked statistics with a single streaming pass over the frames.
@@ -532,6 +583,13 @@ class BaseMasterModule:
         verbose : bool, optional
             If True (default), emit per-frame progress prints and load
             failure warnings from `_load_frame`.
+        max_fail_fraction : float, optional
+            Maximum fraction of frames allowed to fail loading before raising.
+            Defaults to 0.2.
+        max_fail_number : int, optional
+            Maximum absolute number of frames allowed to fail loading before
+            raising. Defaults to 2. Stacking raises when either limit is
+            exceeded.
 
         Returns
         -------
@@ -554,8 +612,8 @@ class BaseMasterModule:
         the per-pixel clipping bounds for the streaming pass.
 
         Optimized to reduce memory usage at the expense of compute speed.
-        Raises an error if more than 20% of frames fail to load or if exposure
-        times are inconsistent.
+        Raises an error if frame load failures exceed `max_fail_fraction` or
+        `max_fail_number`, or if exposure times are inconsistent.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -572,6 +630,8 @@ class BaseMasterModule:
             sigma=sigma,
             verbose=verbose,
             cache=True,
+            max_fail_fraction=max_fail_fraction,
+            max_fail_number=max_fail_number,
         )
 
         if len(l0_file_list) <= ndirect:
@@ -616,8 +676,9 @@ class BaseMasterModule:
 
             if not success:
                 failure += 1
-                if failure / len(l0_file_list) > 0.2:
-                    raise ValueError("more than 20% of frames in stack failed to load")
+                self._check_load_failures(
+                    failure, len(l0_file_list), max_fail_fraction, max_fail_number
+                )
                 continue
 
             l1_obj = self._process_frame(l1_obj)
@@ -783,7 +844,14 @@ class BaseMasterModule:
     # ------------------------------------------------------------------
 
     def stack_frames(
-        self, l0_file_list=None, nstream=6, sigma=None, verbose=True, cal_type=None
+        self,
+        l0_file_list=None,
+        nstream=6,
+        sigma=None,
+        verbose=True,
+        cal_type=None,
+        max_fail_fraction=0.2,
+        max_fail_number=2,
     ):
         """
         Stack full-frame images to produce masters L1.
@@ -805,6 +873,13 @@ class BaseMasterModule:
             Calibration type, forwarded to `_clean_l1_arrays` to select the
             final outlier-flagging mode. Defaults to the conservative
             global-median mode.
+        max_fail_fraction : float, optional
+            Maximum fraction of frames allowed to fail loading before raising.
+            Defaults to 0.2.
+        max_fail_number : int, optional
+            Maximum absolute number of frames allowed to fail loading before
+            raising. Defaults to 2. Stacking raises when either limit is
+            exceeded.
 
         Returns
         -------
@@ -837,11 +912,20 @@ class BaseMasterModule:
 
         if nframe < nstream:
             stats, _ = self._compute_stats_from_datacube(
-                l0_file_list, sigma=sigma, verbose=verbose
+                l0_file_list,
+                sigma=sigma,
+                verbose=verbose,
+                max_fail_fraction=max_fail_fraction,
+                max_fail_number=max_fail_number,
             )
         else:
             stats, _ = self._compute_stats_from_stream(
-                l0_file_list, nstream=nstream, sigma=sigma, verbose=verbose
+                l0_file_list,
+                nstream=nstream,
+                sigma=sigma,
+                verbose=verbose,
+                max_fail_fraction=max_fail_fraction,
+                max_fail_number=max_fail_number,
             )
 
         for chip in self.chips:

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -45,7 +45,6 @@ class BaseMasterModule:
     # image_processing._DEFAULTS.
     _DEFAULTS = {
         **DEFAULTS,
-        "nframe_stream": 6,
         "stack_sigma": 5.0,
         "bias": True,
         "dark": True,
@@ -183,7 +182,7 @@ class BaseMasterModule:
             self._master_paths[cal_type] = path
         return self._master_ml1[cal_type]
 
-    def _load_frame(self, fn, ncache=None, exptime_tolerance=0.1, verbose=True):
+    def _load_frame(self, fn, cache, exptime_tolerance=0.1, verbose=True):
         """
         Load an L0 file and perform image assembly to produce an L1 object.
 
@@ -191,8 +190,11 @@ class BaseMasterModule:
         ----------
         fn : str
             Path to L0 FITS file.
-        ncache : int, optional
-            Maximum number of L1 objects to retain in internal cache.
+        cache : bool
+            If True, retain the assembled L1 in the internal cache for reuse.
+            The caller decides which frames are worth caching (see the streaming
+            stats path). A frame already cached is returned from the cache
+            regardless of this flag.
         exptime_tolerance : float
             Maximum allowed excess of elapsed time over requested exposure time,
             in seconds (default = 0.1).
@@ -211,15 +213,12 @@ class BaseMasterModule:
 
         Notes
         -----
-        Successfully processed frames may be cached to reduce redundant I/O and
-        recomputation. Cache size is limited by `ncache`, which defaults to
-        `nframe_stream - 1`.
+        When `cache=True`, the successfully processed frame is retained to
+        reduce redundant I/O and recomputation. The streaming stats path caches
+        its approximation-pass frames so the exact pass reuses them.
         """
         if verbose:
             print(f"loading {fn}")
-
-        if ncache is None:
-            ncache = self.nframe_stream - 1
 
         success = True
         failure = False
@@ -232,7 +231,7 @@ class BaseMasterModule:
                 l0_obj = KPF0.from_fits(fn)
                 l1_obj = ImageAssembly(l0_obj).perform()
 
-                if len(self._l1_obj_cache) < ncache:
+                if cache:
                     self._l1_obj_cache[fn] = l1_obj
 
             except (FileNotFoundError, OSError) as e:
@@ -360,7 +359,7 @@ class BaseMasterModule:
     # ------------------------------------------------------------------
 
     def _compute_stats_from_datacube(
-        self, l0_file_list=None, nframe=None, sigma=None, verbose=True
+        self, l0_file_list=None, *, sigma=None, verbose=True, cache=False
     ):
         """
         Compute stacked statistics using an in-memory data cube.
@@ -368,14 +367,18 @@ class BaseMasterModule:
         Parameters
         ----------
         l0_file_list : list of str, optional
-            List of L0 FITS filenames to process.
-        nframe : int, optional
-            Maximum number of successfully loaded frames to include.
+            List of L0 FITS filenames to process. The full list is stacked;
+            the caller is responsible for passing the desired subset (e.g. the
+            streaming path passes only its approximation-pass frames).
         sigma : float, optional
             Sigma threshold for outlier rejection across frames.
         verbose : bool, optional
             If True (default), emit per-frame progress prints and load
             failure warnings from `_load_frame`.
+        cache : bool, optional
+            If True, cache each loaded frame so a later pass (the streaming
+            exact pass) can reuse it without re-reading from disk. Defaults to
+            False, since the standalone datacube path reads each frame once.
 
         Returns
         -------
@@ -404,12 +407,10 @@ class BaseMasterModule:
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
-        if nframe is None:
-            nframe = self.nframe_stream - 1
         if sigma is None:
             sigma = self.stack_sigma
 
-        nframe = np.min([nframe, len(l0_file_list)])
+        nframe = len(l0_file_list)
 
         if nframe < 2:
             raise ValueError(f"Stacking requires at least two frames, got {nframe}")
@@ -428,10 +429,7 @@ class BaseMasterModule:
         failure = 0
 
         for fn in l0_file_list:
-            if i >= nframe:
-                break
-
-            l1_obj, success = self._load_frame(fn, verbose=verbose)
+            l1_obj, success = self._load_frame(fn, cache=cache, verbose=verbose)
 
             if not success:
                 failure += 1
@@ -517,7 +515,7 @@ class BaseMasterModule:
         return stats, zero_exptime
 
     def _compute_stats_from_stream(
-        self, l0_file_list=None, ndirect=None, sigma=None, verbose=True
+        self, l0_file_list=None, *, nstream, sigma=None, verbose=True
     ):
         """
         Compute stacked statistics with a single streaming pass over the frames.
@@ -526,9 +524,9 @@ class BaseMasterModule:
         ----------
         l0_file_list : list of str, optional
             List of L0 FITS filenames to process.
-        ndirect : int, optional
-            Number of initial frames used to estimate approximate statistics
-            for defining clipping thresholds.
+        nstream : int
+            Streaming threshold; the first `nstream - 1` frames form the
+            approximation pass that estimates the per-pixel clipping bounds.
         sigma : float, optional
             Sigma threshold for outlier rejection.
         verbose : bool, optional
@@ -561,16 +559,19 @@ class BaseMasterModule:
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
-        if ndirect is None:
-            ndirect = self.nframe_stream - 1
         if sigma is None:
             sigma = self.stack_sigma
 
+        ndirect = nstream - 1
+
+        # The approximation pass stacks only the first `ndirect` frames; cache
+        # them so the streaming exact pass below reuses them instead of
+        # re-reading those files from disk.
         approx_stats, zero_exptime = self._compute_stats_from_datacube(
-            l0_file_list=l0_file_list,
-            nframe=ndirect,
+            l0_file_list=l0_file_list[:ndirect],
             sigma=sigma,
             verbose=verbose,
+            cache=True,
         )
 
         if len(l0_file_list) <= ndirect:
@@ -609,7 +610,9 @@ class BaseMasterModule:
         clipping_mask = np.ones((nrow, ncol), dtype=bool)
 
         for fn in l0_file_list:
-            l1_obj, success = self._load_frame(fn, verbose=verbose)
+            # The first `ndirect` frames are cache hits from the approximation
+            # pass above; the rest are read once here and not worth caching.
+            l1_obj, success = self._load_frame(fn, cache=False, verbose=verbose)
 
             if not success:
                 failure += 1
@@ -780,7 +783,7 @@ class BaseMasterModule:
     # ------------------------------------------------------------------
 
     def stack_frames(
-        self, l0_file_list=None, nstream=None, sigma=None, verbose=True, cal_type=None
+        self, l0_file_list=None, nstream=6, sigma=None, verbose=True, cal_type=None
     ):
         """
         Stack full-frame images to produce masters L1.
@@ -790,7 +793,9 @@ class BaseMasterModule:
         l0_file_list : list of str, optional
             List of L0 FITS filenames to stack.
         nstream : int, optional
-            Threshold number of frames above which streaming statistics are used.
+            Threshold number of frames at or above which the memory-light
+            streaming path is used instead of the in-memory data cube.
+            Defaults to 6.
         sigma : float, optional
             Sigma threshold for frame-to-frame outlier rejection.
         verbose : bool, optional
@@ -822,8 +827,6 @@ class BaseMasterModule:
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
-        if nstream is None:
-            nstream = self.nframe_stream
         if sigma is None:
             sigma = self.stack_sigma
 
@@ -834,11 +837,11 @@ class BaseMasterModule:
 
         if nframe < nstream:
             stats, _ = self._compute_stats_from_datacube(
-                l0_file_list, nstream - 1, sigma, verbose=verbose
+                l0_file_list, sigma=sigma, verbose=verbose
             )
         else:
             stats, _ = self._compute_stats_from_stream(
-                l0_file_list, nstream - 1, sigma, verbose=verbose
+                l0_file_list, nstream=nstream, sigma=sigma, verbose=verbose
             )
 
         for chip in self.chips:

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -716,7 +716,9 @@ class BaseMasterModule:
     # Private helpers for building outputs and tracking results.
     # ------------------------------------------------------------------
 
-    def _build_ml1_obj(self, l1_arrays, l0_file_list, *, receipt_key, bunit=None):
+    def _build_ml1_obj(
+        self, l1_arrays, l0_file_list, *, master_type, receipt_key, bunit=None
+    ):
         """
         Assemble a KPFMasterL1 from finalized per-chip arrays.
 
@@ -726,6 +728,9 @@ class BaseMasterModule:
             Finalized '{chip}_IMG/_SNR/_MASK' arrays.
         l0_file_list : list of str
             L0 files that went into the stack; recorded via set_input_files.
+        master_type : str
+            WMKO filename token for the product ('bias', 'dark', 'flat'),
+            recorded via set_input_files for the compliant output filename.
         receipt_key : str
             Receipt entry name (e.g. 'master_bias', 'master_dark').
         bunit : str, optional
@@ -746,7 +751,7 @@ class BaseMasterModule:
             if bunit is not None:
                 ml1_obj.headers[f"{chip}_IMG"]["BUNIT"] = bunit
 
-        ml1_obj.set_input_files(l0_file_list)
+        ml1_obj.set_input_files(l0_file_list, master_type)
         ml1_obj.receipt_add_entry(receipt_key, "PASS")
 
         return ml1_obj
@@ -923,5 +928,5 @@ class BaseMasterModule:
                 f"{path} already exists; pass overwrite=True to replace it"
             )
 
-        os.makedirs(os.path.dirname(path), exist_ok=True)
+        # obj.to_fits creates the parent directory as needed.
         obj.to_fits(path)

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -94,7 +94,7 @@ class Bias(BaseMasterModule):
         )
 
         self.ml1_obj = self._build_ml1_obj(
-            l1_arrays, l0_file_list, receipt_key="master_bias"
+            l1_arrays, l0_file_list, master_type="bias", receipt_key="master_bias"
         )
         self._results = self._populate_results(l1_arrays)
 

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -22,7 +22,7 @@ class Bias(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: nframe_stream, stack_sigma,
+        Module configuration. Recognized keys: stack_sigma,
         exptime_tolerance, chips.
     """
 
@@ -49,7 +49,7 @@ class Bias(BaseMasterModule):
         self,
         l0_file_list=None,
         *,
-        nstream=None,
+        nstream=6,
         sigma=None,
         filepath=None,
         verbose=True,
@@ -80,8 +80,6 @@ class Bias(BaseMasterModule):
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
-        if nstream is None:
-            nstream = self.nframe_stream
         if sigma is None:
             sigma = self.stack_sigma
 

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -110,7 +110,11 @@ class Dark(BaseMasterModule):
         # Dark current is a rate: stack_frames normalizes each frame by its
         # exposure time, so the master dark IMG is in electrons/sec.
         self.ml1_obj = self._build_ml1_obj(
-            l1_arrays, l0_file_list, receipt_key="master_dark", bunit="electrons/sec"
+            l1_arrays,
+            l0_file_list,
+            master_type="dark",
+            receipt_key="master_dark",
+            bunit="electrons/sec",
         )
         self._results = self._populate_results(l1_arrays)
 

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -22,7 +22,7 @@ class Dark(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: nframe_stream, stack_sigma,
+        Module configuration. Recognized keys: stack_sigma,
         exptime_tolerance, chips.
     """
 
@@ -57,7 +57,7 @@ class Dark(BaseMasterModule):
         self,
         l0_file_list=None,
         *,
-        nstream=None,
+        nstream=6,
         sigma=None,
         bias=None,
         filepath=None,
@@ -92,8 +92,6 @@ class Dark(BaseMasterModule):
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
-        if nstream is None:
-            nstream = self.nframe_stream
         if sigma is None:
             sigma = self.stack_sigma
 

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -16,7 +16,7 @@ class Flat(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: nframe_stream, stack_sigma,
+        Module configuration. Recognized keys: stack_sigma,
         exptime_tolerance, chips.
     """
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -200,7 +200,7 @@ class WLS(BaseMasterModule):
         failure = 0
 
         for fn in l0_file_list:
-            l1_obj, success = self._load_frame(fn, ncache=0, verbose=verbose)
+            l1_obj, success = self._load_frame(fn, cache=False, verbose=verbose)
 
             if not success:
                 failure += 1

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -147,19 +147,21 @@ class WLS(BaseMasterModule):
 
         return self.rough_wls
 
-    def _line_fit_qc(self, lines, lineprofile, window, loc):
+    def _line_fit_qc(self, lines, lineprofile, window, loc, amp_max=1.5e6, std_min=0.5):
         """
         Quality-control the per-line fits and return a boolean flag array
         (True = line failed QC), aligned with the per-line arrays in `lines`.
 
         `loc` is the per-line window-center pixel; a centroid more than
-        `window` pixels from it is flagged as a runaway fit.
+        `window` pixels from it is flagged as a runaway fit. Fitted amplitudes
+        outside [0, `amp_max`] (default 1.5e6, ~10x single-pixel saturation)
+        and Gaussian sigmas outside [`std_min`, `window`] px are also flagged.
         """
         if lineprofile != "gaussian":
             raise ValueError(f"Unsupported lineprofile: {lineprofile}")
 
-        bad = (lines["amp"] < 0) | (lines["amp"] > 1.5e6)  # 10x single-pixel saturation
-        bad |= (lines["std"] < 0.5) | (lines["std"] >= window)
+        bad = (lines["amp"] < 0) | (lines["amp"] > amp_max)
+        bad |= (lines["std"] < std_min) | (lines["std"] >= window)
         bad |= np.abs(lines["pix"] - loc) > window
 
         return bad
@@ -168,7 +170,13 @@ class WLS(BaseMasterModule):
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def _process_stack_l0_to_l2(self, l0_file_list=None, verbose=True):
+    def _process_stack_l0_to_l2(
+        self,
+        l0_file_list=None,
+        verbose=True,
+        max_fail_fraction=0.2,
+        max_fail_number=2,
+    ):
         """
         Run each L0 frame in the stack through the L0→L2 pipeline.
 
@@ -179,6 +187,12 @@ class WLS(BaseMasterModule):
         verbose : bool, optional
             If True (default), emit progress prints and per-frame warnings
             from the underlying L0 → L1 → L2 calls.
+        max_fail_fraction : float, optional
+            Maximum fraction of frames allowed to fail loading before raising.
+            Defaults to 0.2.
+        max_fail_number : int, optional
+            Maximum absolute number of frames allowed to fail loading before
+            raising. Defaults to 2. Raises when either limit is exceeded.
 
         Returns
         -------
@@ -187,8 +201,8 @@ class WLS(BaseMasterModule):
 
         Notes
         -----
-        Resets self._l2_obj_cache at entry. Raises ValueError if more than
-        20% of frames fail to load.
+        Resets self._l2_obj_cache at entry. Raises ValueError if frame load
+        failures exceed `max_fail_fraction` or `max_fail_number`.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -204,8 +218,9 @@ class WLS(BaseMasterModule):
 
             if not success:
                 failure += 1
-                if failure / len(l0_file_list) > 0.2:
-                    raise ValueError("more than 20% of frames in stack failed to load")
+                self._check_load_failures(
+                    failure, len(l0_file_list), max_fail_fraction, max_fail_number
+                )
                 continue
 
             l1_obj = self._process_frame(l1_obj)

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -914,7 +914,7 @@ class WLS(BaseMasterModule):
             coeffs_hdr["POLYORDM"] = polyorder_m
             coeffs_hdr["POLYORDF"] = polyorder_f
 
-        self.ml2_obj.set_input_files(l0_file_list)
+        self.ml2_obj.set_input_files(l0_file_list, "thar")
 
         primary = self.ml2_obj.headers["PRIMARY"]
         primary["ROUGHWLS"] = (self.rough_wls_file, "Rough WLS reference file")

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -405,15 +405,15 @@ class RadialVelocity:
         return ccf
 
     @staticmethod
-    def _compute_rv_1d(vel, ccf, wave, window, min_npts=9):
+    def _compute_rv_1d(vel, ccf, wave, window, fit_nsigma=3.0, min_npts=9):
         """
         Two-pass Gaussian fit to a CCF dip, with a photon-limited error.
 
         The first pass fits the `window` ([min, max] km/s) about the CCF
         minimum, yielding a mean and sigma. The second pass refits a window of
-        +/-3 sigma about that mean (symmetric about it); those points also set
-        the error estimate (Bouchy et al. 2001). Both windows use at least
-        min_npts grid points.
+        +/-`fit_nsigma` sigma about that mean (symmetric about it); those points
+        also set the error estimate (Bouchy et al. 2001). Both windows use at
+        least min_npts grid points.
 
         Parameters
         ----------
@@ -426,6 +426,9 @@ class RadialVelocity:
             scale used in the error estimate.
         window : list of float
             [min, max] km/s velocity window about the dip for the first pass.
+        fit_nsigma : float
+            Half-width of the second-pass fit window, in units of the
+            first-pass fitted sigma.
         min_npts : int
             Minimum number of grid points to use in each fit window.
 
@@ -457,11 +460,11 @@ class RadialVelocity:
         if not np.isfinite(mu1) or not np.isfinite(sigma1):
             return np.nan, np.nan
 
-        # Second pass: +/-3 sigma about the first-pass mean, symmetric, with at
-        # least min_npts points; these points also set the error estimate.
+        # Second pass: +/-fit_nsigma sigma about the first-pass mean, symmetric,
+        # with at least min_npts points; these points also set the error estimate.
         dv = np.mean(np.diff(vel))
         half_pts = max(
-            int(np.floor(3.0 * sigma1 / dv)), int(np.ceil((min_npts - 1) / 2))
+            int(np.floor(fit_nsigma * sigma1 / dv)), int(np.ceil((min_npts - 1) / 2))
         )
         center = int(np.argmin(np.abs(vel - mu1)))
         idx_lo, idx_hi = center - half_pts, center + half_pts + 1
@@ -710,7 +713,9 @@ class RadialVelocity:
 
         return {"velocity": velocity_grid, "ccf": ccf}
 
-    def compute_order_by_order_rvs(self, chip, fiber, window=None, min_npts=9):
+    def compute_order_by_order_rvs(
+        self, chip, fiber, window=None, fit_nsigma=3.0, min_npts=9
+    ):
         """
         Per-order radial velocities for one chip/fiber, from the cached CCF.
 
@@ -723,6 +728,9 @@ class RadialVelocity:
         window : list of float, optional
             [min, max] km/s window about the dip for the first-pass fit.
             Defaults to the configured value.
+        fit_nsigma : float, optional
+            Half-width of the second-pass fit window in units of the first-pass
+            sigma. Not a configurable parameter; set in code (default 3.0).
         min_npts : int, optional
             Minimum number of grid points to use in each fit window. Not a
             configurable parameter; set in code (default 9).
@@ -760,13 +768,20 @@ class RadialVelocity:
             if not np.any(ccf[o]):
                 continue
             rv[o], rv_err[o] = self._compute_rv_1d(
-                velocity_grid, ccf[o], wave[o], window, min_npts
+                velocity_grid, ccf[o], wave[o], window, fit_nsigma, min_npts
             )
 
         return {"rv": rv, "rv_err": rv_err}
 
     def compute_weighted_rvs(
-        self, chips, fibers, combine_fibers, combine_ccds, window=None, min_npts=9
+        self,
+        chips,
+        fibers,
+        combine_fibers,
+        combine_ccds,
+        window=None,
+        fit_nsigma=3.0,
+        min_npts=9,
     ):
         """
         Weighted-combined RVs from the cached CCFs, collapsing orders (and
@@ -798,6 +813,9 @@ class RadialVelocity:
         window : list of float, optional
             [min, max] km/s window about the dip for the first-pass fit.
             Defaults to the configured value.
+        fit_nsigma : float, optional
+            Half-width of the second-pass fit window in units of the first-pass
+            sigma. Not a configurable parameter; set in code (default 3.0).
         min_npts : int, optional
             Minimum number of grid points to use in each fit window.
 
@@ -841,8 +859,10 @@ class RadialVelocity:
             if not np.any(ccf_w):
                 per_chip[chip] = (np.nan, np.nan)
                 continue
-            rv = self._compute_rv_1d(grid, ccf_w, wave, window, min_npts)[0]
-            rv_err = self._compute_rv_1d(grid, ccf_s, wave, window, min_npts)[1]
+            rv = self._compute_rv_1d(grid, ccf_w, wave, window, fit_nsigma, min_npts)[0]
+            rv_err = self._compute_rv_1d(
+                grid, ccf_s, wave, window, fit_nsigma, min_npts
+            )[1]
             per_chip[chip] = (rv, rv_err)
 
         if not combine_ccds:
@@ -877,6 +897,7 @@ class RadialVelocity:
         ccf_step_size=None,
         ccf_window=None,
         rv_window=None,
+        fit_nsigma=3.0,
         min_npts=9,
         clip_edge_pixels=None,
     ):
@@ -905,6 +926,9 @@ class RadialVelocity:
         rv_window : list of float, optional
             [min, max] km/s window about the dip for the first-pass fit.
             Overrides the configured value.
+        fit_nsigma : float, optional
+            Half-width of the second-pass fit window in units of the first-pass
+            sigma. Not a configurable parameter; set in code (default 3.0).
         min_npts : int, optional
             Minimum number of grid points to use in each fit window. Not a
             configurable parameter; set in code (default 9).
@@ -981,7 +1005,7 @@ class RadialVelocity:
                 )["ccf"]
                 l4_obj.set_data(f"{chip}_{fiber}_CCF", ccf)
                 result = self.compute_order_by_order_rvs(
-                    chip, fiber, rv_window, min_npts
+                    chip, fiber, rv_window, fit_nsigma, min_npts
                 )
                 rows = (
                     slice(0, norder_green)
@@ -998,6 +1022,7 @@ class RadialVelocity:
                 combine_fibers=False,
                 combine_ccds=False,
                 window=rv_window,
+                fit_nsigma=fit_nsigma,
                 min_npts=min_npts,
             )
             ccd_rv = {chip: per_ccd[chip][0] for chip in chips}
@@ -1110,6 +1135,7 @@ class RadialVelocity:
             combine_fibers=True,
             combine_ccds=False,
             window=rv_window,
+            fit_nsigma=fit_nsigma,
             min_npts=min_npts,
         )
         for chip in chips:
@@ -1131,6 +1157,7 @@ class RadialVelocity:
             combine_fibers=True,
             combine_ccds=True,
             window=rv_window,
+            fit_nsigma=fit_nsigma,
             min_npts=min_npts,
         )
         if not np.isfinite(ccfrv):

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -588,7 +588,7 @@ class RadialVelocity:
         width=None,
         step_size=None,
         window=None,
-        clip_edge_pixels=None,
+        clip_edge_pixels=(500, 500),
     ):
         """
         Cross-correlate every order of one chip/fiber against the line mask.
@@ -606,10 +606,10 @@ class RadialVelocity:
         window : list of float, optional
             CCF velocity grid range [km/s] as [min, max] about the grid center.
             Defaults to the configured value.
-        clip_edge_pixels : list of int, optional
-            Number of pixels to drop from the [short_wavelength_end,
-            long_wavelength_end] of each order before correlating, removing the
-            blaze-faint, low-S/N order edges. Defaults to [500, 500].
+        clip_edge_pixels : tuple of int, optional
+            Number of pixels to drop from the (short_wavelength_end,
+            long_wavelength_end) of each order before correlating, removing the
+            blaze-faint, low-S/N order edges. Defaults to (500, 500).
 
         Returns
         -------
@@ -626,8 +626,6 @@ class RadialVelocity:
         NotImplementedError
             If the fiber's illumination source has no CCF path yet (etalon, lfc).
         """
-        if clip_edge_pixels is None:
-            clip_edge_pixels = [500, 500]
         chip = chip.upper()
         fiber = fiber.upper()
         if width is None:
@@ -899,7 +897,7 @@ class RadialVelocity:
         rv_window=None,
         fit_nsigma=3.0,
         min_npts=9,
-        clip_edge_pixels=None,
+        clip_edge_pixels=(500, 500),
     ):
         """
         Compute per-order CCFs and radial velocities and package them in a KPF4.
@@ -932,9 +930,9 @@ class RadialVelocity:
         min_npts : int, optional
             Minimum number of grid points to use in each fit window. Not a
             configurable parameter; set in code (default 9).
-        clip_edge_pixels : list of int, optional
-            Pixels to drop from the [short_wavelength_end, long_wavelength_end]
-            of each order before correlating. Defaults to [500, 500].
+        clip_edge_pixels : tuple of int, optional
+            Pixels to drop from the (short_wavelength_end, long_wavelength_end)
+            of each order before correlating. Defaults to (500, 500).
 
         Returns
         -------
@@ -948,8 +946,6 @@ class RadialVelocity:
             science RV). Unilluminated ('none') fibers are skipped (empty
             extensions).
         """
-        if clip_edge_pixels is None:
-            clip_edge_pixels = [500, 500]
         if chips is None:
             chips = self.chips
         if fibers is None:

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -90,7 +90,7 @@ def build_mini_database(data_dir, write=True):
 
 
 def build_l0_file_lists(
-    imtype, *, data_dir=None, mini_db=None, min_file_count=5, cluster_gap_seconds=7200
+    cal_type, *, data_dir=None, mini_db=None, min_file_count=5, cluster_gap_seconds=7200
 ):
     """
     Return sorted file lists for all calibration clusters of the requested
@@ -106,7 +106,7 @@ def build_l0_file_lists(
 
     Parameters
     ----------
-    imtype : str
+    cal_type : str
         Calibration frame type. One of 'bias', 'dark', 'flat', 'thar'.
     data_dir : str, optional
         Path to directory containing L0 FITS files.
@@ -128,14 +128,14 @@ def build_l0_file_lists(
     Raises
     ------
     ValueError
-        If `imtype` is not a recognized calibration type, if exactly one of
+        If `cal_type` is not a recognized calibration type, if exactly one of
         `data_dir` or `mini_db` is not provided, if no calibration frames of
         the requested type are found, or if any cluster contains fewer than
         `min_file_count` files.
     """
-    if imtype not in _OBJECT_MAP:
+    if cal_type not in _OBJECT_MAP:
         raise ValueError(
-            f"imtype must be one of {list(_OBJECT_MAP.keys())}; got '{imtype}'"
+            f"cal_type must be one of {list(_OBJECT_MAP.keys())}; got '{cal_type}'"
         )
 
     if (data_dir is None) == (mini_db is None):
@@ -173,11 +173,11 @@ def build_l0_file_lists(
         else:
             mini_db = build_mini_database(data_dir)
 
-    cal_df = mini_db[mini_db["OBJECT"].isin(_OBJECT_MAP[imtype])]
+    cal_df = mini_db[mini_db["OBJECT"].isin(_OBJECT_MAP[cal_type])]
 
     if cal_df.empty:
         raise ValueError(
-            f"No '{imtype}' calibration frames found in "
+            f"No '{cal_type}' calibration frames found in "
             f"{data_dir or 'the provided mini_db'}"
         )
 
@@ -202,7 +202,7 @@ def build_l0_file_lists(
     short = [c for c in clusters if len(c) < min_file_count]
     if short:
         raise ValueError(
-            f"'{imtype}' has {len(short)} cluster(s) below "
+            f"'{cal_type}' has {len(short)} cluster(s) below "
             f"min_file_count={min_file_count}; sizes: {[len(c) for c in short]}"
         )
     return clusters
@@ -245,6 +245,15 @@ def build_qlp_dir(obs_id, level, *, data_root):
 def build_filepath(obs_id, level, *, data_root=None, master=None):
     """
     Build a filepath for a KPF data product.
+
+    This is the pipeline's authoritative path builder: it constructs the output
+    path (directory layout + filename) from an obs_id string, before/without a
+    populated data object, and is what every recipe uses to decide where to
+    write. The parallel `<model>.generate_standard_filename()` builds only the
+    basename from a populated object's headers and is the `to_fits(fn=None)`
+    fallback (rvdata-owned for the EPRV-standard levels L2/L4, KPF-overridden for
+    the non-standard levels L0/L1). The two encode the same naming rule and must
+    agree per level; `TestFilenameConsistency` enforces that contract.
 
     Parameters
     ----------
@@ -305,8 +314,9 @@ def build_filepath(obs_id, level, *, data_root=None, master=None):
         return os.path.join(data_root, "masters", datecode, filename)
 
     # Science paths by level:
-    #   L0:       {obs_id}.fits                                       (KPF-native)
-    #   L1/L2/L4: kpf_SL{N}_{YYYYMMDD}T{HHmmss}.fits                (EPRV standard)
+    #   L0:    {obs_id}.fits                            (KPF-native)
+    #   L1:    kpf_L1_{YYYYMMDD}T{HHmmss}.fits          (no EPRV "S": no L1 standard)
+    #   L2/L4: kpf_SL{N}_{YYYYMMDD}T{HHmmss}.fits       (EPRV standard)
     if level not in ("L0", "L1", "L2", "L4"):
         raise ValueError(f"'level' must be 'L0', 'L1', 'L2', or 'L4'; got '{level}'")
 
@@ -314,7 +324,10 @@ def build_filepath(obs_id, level, *, data_root=None, master=None):
         filename = f"{obs_id}.fits"
     else:
         eprv_ts = kpf_timestamp_to_eprv_timestamp(get_timestamp(obs_id))
-        filename = f"kpf_SL{level[1]}_{eprv_ts}.fits"
+        # L1 has no EPRV standard, so it keeps the KPF "kpf_L1" prefix (no "S");
+        # L2/L4 use the EPRV "kpf_SL{N}" prefix.
+        prefix = "kpf_L1" if level == "L1" else f"kpf_SL{level[1]}"
+        filename = f"{prefix}_{eprv_ts}.fits"
 
     if data_root is None:
         return filename
@@ -363,3 +376,18 @@ def build_master_path_from_fits_header(kpf_obj, cal_type):
         )
 
     return os.path.join(master_dir, master_file)
+
+
+def glob_masters(data_root, cal_type, level, datecode):
+    """
+    Glob pattern matching every ``cal_type``/``level`` master written under
+    ``data_root`` for ``datecode`` (the KOAID prefix wildcarded):
+    ``{data_root}/masters/{datecode}/*_master_{cal_type}_{level}.fits``.
+
+    The reader counterpart to a `build_filepath` master path — it builds the same
+    masters directory and filename independently, with the KOAID wildcarded.
+    `test_glob_masters_matches_build_filepath` guards that the two stay in step.
+    """
+    return os.path.join(
+        data_root, "masters", datecode, f"*_master_{cal_type}_{level}.fits"
+    )

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -71,11 +71,14 @@ def main(config, args):
     # Stack the ThAr exposures into a master wavelength solution, since the
     # emission-line spectrum anchors the per-order wavelength calibration.
     for files in build_l0_file_lists("thar", mini_db=mini_db):
+        obs_id = get_obs_id(files[0])
         wls_master_path = build_filepath(
-            get_obs_id(files[0]), "L2", data_root=data_root_masters, master="thar"
+            obs_id, "L2", data_root=data_root_masters, master="thar"
         )
-        wls_diagnostics_path = (
-            wls_master_path.removesuffix("_L2.fits") + "_diagnostics.h5"
+        # The diagnostics HDF5 is a sidecar of the master, in the same directory
+        # and sharing its '{obs_id}_master_thar' stem.
+        wls_diagnostics_path = os.path.join(
+            os.path.dirname(wls_master_path), f"{obs_id}_master_thar_diagnostics.h5"
         )
 
         wls = WLS(files, config)

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -10,8 +10,6 @@ Diagnostics, QC, and quicklook layers run at each level, and the L2 and L4
 data products are written to the output data root.
 """
 
-import os
-
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.modules.barycentric_correction import BarycentricCorrection
 from kpfpipe.modules.calibration_association import CalibrationAssociation
@@ -101,9 +99,9 @@ def main(config, args):
     PlotL2(l2, output_dir=l2_qlp_dir, obs_id=obs_id).run("all")
 
     # Write the L2 data product to disk before the RV step so the calibrated
-    # spectra are preserved even if RV computation fails.
+    # spectra are preserved even if RV computation fails. to_fits creates the
+    # parent directory as needed.
     l2_out_path = build_filepath(obs_id, "L2", data_root=data_root_science)
-    os.makedirs(os.path.dirname(l2_out_path), exist_ok=True)
     l2.to_fits(l2_out_path)
 
     # Compute the radial velocity (RV) from the cross-correlation function
@@ -111,9 +109,9 @@ def main(config, args):
     radial_velocity = RadialVelocity(l2, config)
     l4 = radial_velocity.perform()
 
-    # Write the final L4 data product (RVs and CCFs) to disk.
+    # Write the final L4 data product (RVs and CCFs) to disk; to_fits creates
+    # the parent directory as needed.
     l4_out_path = build_filepath(obs_id, "L4", data_root=data_root_science)
-    os.makedirs(os.path.dirname(l4_out_path), exist_ok=True)
     l4.to_fits(l4_out_path)
 
     print("\n\n=== exiting kpf_drp_science pipeline ===\n\n")

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -26,7 +26,7 @@ from kpfpipe.data_models.masters.base import KPFMasterModel
 def synthetic_masters_l1_file(tmp_path):
     """Create a minimal synthetic Masters L1 FITS file."""
     rng = np.random.default_rng(20240113)
-    fn = str(tmp_path / "kpf_ML1_20240113T102656.fits")
+    fn = str(tmp_path / "KP.20240113.23249.10_master_bias_L1.fits")
 
     primary = fits.PrimaryHDU()
     primary.header["INSTRUME"] = "KPF"
@@ -209,7 +209,6 @@ class TestKPFMasterL1:
 
     def test_class_attributes(self):
         assert KPFMasterL1._DATALVL == "ML1"
-        assert KPFMasterL1._FILENAME_PREFIX == "kpf_ML1"
 
     def test_from_fits(self, synthetic_masters_l1_file):
         m = KPFMasterL1.from_fits(synthetic_masters_l1_file)
@@ -236,11 +235,21 @@ class TestKPFMasterL1:
         with fits.open(out_fn) as hdul:
             assert hdul["PRIMARY"].header["DATALVL"] == "ML1"
 
-    def test_generate_filename(self, synthetic_masters_l1_file):
-        m = KPFMasterL1.from_fits(synthetic_masters_l1_file)
-        fn = m.generate_standard_filename()
-        assert fn.startswith("kpf_ML1_")
-        assert fn.endswith(".fits")
+    def test_generate_filename(self):
+        m = KPFMasterL1()
+        m.set_input_files(
+            ["KP.20240113.23249.10.fits", "KP.20240113.23310.00.fits"], "bias"
+        )
+        assert (
+            m.generate_standard_filename() == "KP.20240113.23249.10_master_bias_L1.fits"
+        )
+
+    def test_generate_filename_requires_inputs(self):
+        # A master can never produce a non-compliant name: with no recorded
+        # inputs / type, generate_standard_filename raises rather than falling
+        # back to a KOAID-less name.
+        with pytest.raises(ValueError):
+            KPFMasterL1().generate_standard_filename()
 
     def test_no_warning_on_known_extensions(self, synthetic_masters_l1_file):
         import warnings
@@ -252,5 +261,6 @@ class TestKPFMasterL1:
     def test_set_input_files(self):
         m = KPFMasterL1()
         files = ["/data/a.fits", "/data/b.fits", "/data/c.fits"]
-        m.set_input_files(files)
+        m.set_input_files(files, "bias")
         assert m.data["INPUT_FILES"]["FILENAME"].tolist() == files
+        assert m.headers["PRIMARY"]["MASTYPE"] == "bias"

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -35,7 +35,7 @@ NORDER = NORDER_GREEN + NORDER_RED
 def synthetic_masters_l2_file(tmp_path):
     """Create a minimal synthetic Masters L2 FITS file."""
     rng = np.random.default_rng(20240113)
-    fn = str(tmp_path / "kpf_ML2_20240113T102656.fits")
+    fn = str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
 
     primary = fits.PrimaryHDU()
     primary.header["INSTRUME"] = "KPF"
@@ -406,7 +406,6 @@ class TestKPFMasterL2:
 
     def test_class_attributes(self):
         assert KPFMasterL2._DATALVL == "ML2"
-        assert KPFMasterL2._FILENAME_PREFIX == "kpf_ML2"
 
     def test_from_fits(self, synthetic_masters_l2_file):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
@@ -444,13 +443,14 @@ class TestKPFMasterL2:
     def test_set_input_files(self):
         m = KPFMasterL2()
         files = ["/data/a.fits", "/data/b.fits", "/data/c.fits"]
-        m.set_input_files(files)
+        m.set_input_files(files, "thar")
         assert m.data["INPUT_FILES"]["FILENAME"].tolist() == files
+        assert m.headers["PRIMARY"]["MASTYPE"] == "thar"
 
     def test_input_files_roundtrip(self, tmp_path):
         m = KPFMasterL2()
         files = ["/data/a.fits", "/data/b.fits", "/data/c.fits"]
-        m.set_input_files(files)
+        m.set_input_files(files, "thar")
         m.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
 
         out_fn = str(tmp_path / "ml2_input_files.fits")

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -765,7 +765,7 @@ class TestStackingValidation:
             patch.object(dark, "_load_frame", lambda fn, **k: (None, False)),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
-            with pytest.raises(ValueError, match="more than 20%"):
+            with pytest.raises(ValueError, match="too many frames failed to load"):
                 dark.stack_frames()
 
     def test_ccd_var_frame_count_mismatch_raises(self):

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -201,7 +201,7 @@ class TestMasterBaseErrors:
         fn = "/nonexistent/KP.20240101.00001.00.fits"
         m = Dark([fn])
         with pytest.warns(UserWarning, match="Failed to load"):
-            l1_obj, success = m._load_frame(fn, verbose=True)
+            l1_obj, success = m._load_frame(fn, cache=False, verbose=True)
         assert l1_obj is None and success is False
 
     def test_load_frame_exptime_failure_warns_and_skips(self, monkeypatch):
@@ -215,7 +215,7 @@ class TestMasterBaseErrors:
 
         monkeypatch.setattr(m, "_check_exptime_vs_elapsed", bad_check)
         with pytest.warns(UserWarning, match="Exptime check failed"):
-            l1_obj, success = m._load_frame(fn, verbose=True)
+            l1_obj, success = m._load_frame(fn, cache=False, verbose=True)
         assert l1_obj is None and success is False
 
 
@@ -496,13 +496,12 @@ class TestRateEstimator:
     rejection is disabled (large sigma) so the arithmetic is exact."""
 
     @staticmethod
-    def _stacked_img(frames, *, nframe_stream=6):
+    def _stacked_img(frames, *, nstream=6):
         file_list = sorted(f"f{i}.fits" for i in range(len(frames)))
         dark = Dark(file_list)
         dark.chips = ["GREEN"]
         dark.ccd = {"nrow": 2, "ncol": 2}
         dark.stack_sigma = 1e6  # effectively no clipping
-        dark.nframe_stream = nframe_stream
         # Keyed by filename: the streaming path re-reads its first frames for
         # the approximate (clip-bound) pass, so a frame may be loaded twice.
         by_fn = dict(zip(file_list, frames, strict=True))
@@ -510,7 +509,7 @@ class TestRateEstimator:
             patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
-            return dark.stack_frames()["GREEN_IMG"]
+            return dark.stack_frames(nstream=nstream)["GREEN_IMG"]
 
     def test_mixed_exptime_is_exposure_weighted(self):
         # rates per frame are 10 and 3.33; an equal-weight mean would give
@@ -530,7 +529,7 @@ class TestRateEstimator:
         np.testing.assert_allclose(self._stacked_img(frames), 120.0, rtol=1e-5)
 
     def test_streaming_path_matches(self):
-        # Force the streaming path (nframe >= nframe_stream) with mixed
+        # Force the streaming path (nframe >= nstream) with mixed
         # exposures: (4*100) / (10+30+10+30) = 5.0 e-/sec.
         frames = [
             _stack_frame(10.0, 100.0, 10.0),
@@ -538,7 +537,7 @@ class TestRateEstimator:
             _stack_frame(10.0, 100.0, 10.0),
             _stack_frame(30.0, 100.0, 10.0),
         ]
-        img = self._stacked_img(frames, nframe_stream=3)
+        img = self._stacked_img(frames, nstream=3)
         np.testing.assert_allclose(img, 5.0, rtol=1e-5)
 
 
@@ -606,14 +605,14 @@ class TestPerPixelRejection:
         dark = Dark(sorted(f"f{i}.fits" for i in range(n)))
         dark.chips = ["GREEN"]
         dark.ccd = {"nrow": 2, "ncol": 2}
-        dark.nframe_stream = 3  # ndirect = 2 -> approx from frames 0, 1
         dark.stack_sigma = 5.0
         by_fn = dict(zip(dark.l0_file_list, frames, strict=True))
         with (
             patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
-            img = dark.stack_frames()["GREEN_IMG"]
+            # nstream = 3 -> ndirect = 2 -> approx from frames 0, 1
+            img = dark.stack_frames(nstream=3)["GREEN_IMG"]
 
         # (95 + 105 + 100) / (3 * 10) = 10 e-/sec; the outlier is excluded from
         # numerator and denominator alike. A mismatch would give 300/40 = 7.5.
@@ -633,7 +632,7 @@ class TestDatacubeClipping:
 
     def test_outlier_frame_is_rejected(self):
         # Five identical frames (100 e- over 10 s -> 10 e-/sec) plus one gross
-        # outlier frame; nframe_stream is set high to stay on the datacube path.
+        # outlier frame; nstream is set high to stay on the datacube path.
         nrow, ncol = 3, 3
         good = [_stack_frame(10.0, 100.0, 100.0, shape=(nrow, ncol)) for _ in range(5)]
         outlier = _stack_frame(10.0, 1e5, 100.0, shape=(nrow, ncol))
@@ -642,14 +641,13 @@ class TestDatacubeClipping:
         dark = Dark(sorted(f"f{i}.fits" for i in range(len(frames))))
         dark.chips = ["GREEN"]
         dark.ccd = {"nrow": nrow, "ncol": ncol}
-        dark.nframe_stream = 10  # > nframe, so the datacube path is used
         dark.stack_sigma = 5.0
         by_fn = dict(zip(dark.l0_file_list, frames, strict=True))
         with (
             patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
-            arrays = dark.stack_frames()
+            arrays = dark.stack_frames(nstream=10)  # > nframe, so datacube path
 
         # Outlier excluded from numerator and denominator: (5*100)/(5*10) = 10.
         # Without rejection it would be (5*100 + 1e5) / (6*10) ~= 1675.

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -151,7 +151,7 @@ class TestProcessIndividualFrames:
     def test_returns_l2_objects_for_all_frames(self, mock_pipeline, monkeypatch):
         wls = WLS(FILE_LIST)
         monkeypatch.setattr(
-            wls, "_load_frame", lambda fn, ncache=0, **kwargs: (MockL1(), True)
+            wls, "_load_frame", lambda fn, cache=False, **kwargs: (MockL1(), True)
         )
         result = wls._process_stack_l0_to_l2()
         assert len(result) == len(FILE_LIST)
@@ -160,7 +160,7 @@ class TestProcessIndividualFrames:
     def test_file_list_override(self, mock_pipeline, monkeypatch):
         wls = WLS(FILE_LIST)
         monkeypatch.setattr(
-            wls, "_load_frame", lambda fn, ncache=0, **kwargs: (MockL1(), True)
+            wls, "_load_frame", lambda fn, cache=False, **kwargs: (MockL1(), True)
         )
         result = wls._process_stack_l0_to_l2(l0_file_list=FILE_LIST[:3])
         assert len(result) == 3
@@ -168,7 +168,7 @@ class TestProcessIndividualFrames:
     def test_raises_when_failures_exceed_threshold(self, monkeypatch):
         wls = WLS(FILE_LIST)
         monkeypatch.setattr(
-            wls, "_load_frame", lambda fn, ncache=0, **kwargs: (None, False)
+            wls, "_load_frame", lambda fn, cache=False, **kwargs: (None, False)
         )
         with pytest.raises(ValueError, match="20%"):
             wls._process_stack_l0_to_l2()
@@ -178,7 +178,7 @@ class TestProcessIndividualFrames:
         calls = iter([(None, False)] + [(MockL1(), True)] * 7)
         wls = WLS(FILE_LIST)
         monkeypatch.setattr(
-            wls, "_load_frame", lambda fn, ncache=0, **kwargs: next(calls)
+            wls, "_load_frame", lambda fn, cache=False, **kwargs: next(calls)
         )
         result = wls._process_stack_l0_to_l2()
         assert len(result) == 7
@@ -197,7 +197,7 @@ def mock_make_master_l2(monkeypatch):
     synthetic W and coefficient arrays with chip-correct shapes.
     """
     monkeypatch.setattr(
-        WLS, "_load_frame", lambda self, fn, ncache=0, **kwargs: (MockL1(), True)
+        WLS, "_load_frame", lambda self, fn, cache=False, **kwargs: (MockL1(), True)
     )
     monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kwargs: l1)
     monkeypatch.setattr(WLS, "_extract_frame", lambda self, l1, **kwargs: MockL2())

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -170,7 +170,7 @@ class TestProcessIndividualFrames:
         monkeypatch.setattr(
             wls, "_load_frame", lambda fn, cache=False, **kwargs: (None, False)
         )
-        with pytest.raises(ValueError, match="20%"):
+        with pytest.raises(ValueError, match="too many frames failed to load"):
             wls._process_stack_l0_to_l2()
 
     def test_tolerates_minority_failure(self, mock_pipeline, monkeypatch):

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -13,6 +13,10 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
+from kpfpipe.data_models.level0 import KPF0
+from kpfpipe.data_models.level1 import KPF1
+from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.data_models.masters.level1 import KPFMasterL1
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import (
@@ -20,6 +24,7 @@ from kpfpipe.utils.io import (
     build_l0_file_lists,
     build_mini_database,
     build_qlp_dir,
+    glob_masters,
 )
 
 # ---------------------------------------------------------------------------
@@ -201,7 +206,7 @@ class TestBuildL0FileLists:
             build_l0_file_lists("dark", data_dir=data_dir)
 
     def test_invalid_imtype_raises(self, data_dir):
-        with pytest.raises(ValueError, match="imtype must be one of"):
+        with pytest.raises(ValueError, match="cal_type must be one of"):
             build_l0_file_lists("bogus", data_dir=data_dir)
 
     def test_thar_returns_two_clusters(self, data_dir):
@@ -322,18 +327,19 @@ class TestBuildFilepath:
         assert path == "/data/L0/20240405/KP.20240405.49597.71.fits"
 
     def test_science_l1(self):
-        # Science L1 uses EPRV naming: KP.20240405.49597.71 → 49597s = 13:46:37
+        # Science L1 keeps the KPF "kpf_L1" prefix (no EPRV "S": no L1 standard).
+        # KP.20240405.49597.71 → 49597s = 13:46:37
         path = build_filepath("KP.20240405.49597.71", "L1", data_root="/data")
-        assert path == "/data/L1/20240405/kpf_SL1_20240405T134637.fits"
+        assert path == "/data/L1/20240405/kpf_L1_20240405T134637.fits"
 
     def test_science_bare_filename_l0(self):
         name = build_filepath("KP.20240405.49597.71", "L0")
         assert name == "KP.20240405.49597.71.fits"
 
     def test_science_bare_filename_l1(self):
-        # 49597s = 13:46:37
+        # 49597s = 13:46:37; L1 keeps the "kpf_L1" prefix (no EPRV "S")
         name = build_filepath("KP.20240405.49597.71", "L1")
-        assert name == "kpf_SL1_20240405T134637.fits"
+        assert name == "kpf_L1_20240405T134637.fits"
 
     def test_invalid_master_type_raises(self):
         with pytest.raises(ValueError, match="'master' must be"):
@@ -387,6 +393,73 @@ class TestBuildFilepath:
             ValueError, match="data_root must be None or a non-empty string"
         ):
             build_filepath("KP.20240405.40113.57", "L2", data_root=12345)
+
+
+# ---------------------------------------------------------------------------
+# glob_masters
+# ---------------------------------------------------------------------------
+
+
+class TestGlobMasters:
+    """`glob_masters` (the masters finder pattern) and `build_filepath` (the
+    masters writer) build the same path independently. These guard that the two
+    inline f-strings can't drift — same directory and `_master_{type}_{level}`
+    filename, with the KOAID wildcarded in the finder."""
+
+    def test_glob_masters(self):
+        assert (
+            glob_masters("/data", "bias", "L1", "20240405")
+            == "/data/masters/20240405/*_master_bias_L1.fits"
+        )
+
+    @pytest.mark.parametrize(
+        "cal_type,level",
+        [("bias", "L1"), ("dark", "L1"), ("flat", "L1"), ("thar", "L2")],
+    )
+    def test_glob_masters_matches_build_filepath(self, cal_type, level):
+        # The finder pattern must equal a written master path with only the
+        # KOAID wildcarded — same directory, same filename convention.
+        obs_id = "KP.20240405.03600.00"
+        written = build_filepath(obs_id, level, data_root="/data", master=cal_type)
+        assert glob_masters("/data", cal_type, level, "20240405") == written.replace(
+            obs_id, "*"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Filename-convention consistency contract
+# ---------------------------------------------------------------------------
+
+
+class TestFilenameConsistency:
+    """`build_filepath` (the pipeline's path builder, from an obs_id) and a data
+    model's `generate_standard_filename` (the to_fits fallback, from headers) are
+    two independent encodings of the same naming rule. This contract asserts they
+    agree on the basename for every level, so the two can never silently drift
+    (the kind of divergence behind the old `kpf_SL1` bug).
+
+    L0/L1 use KPF overrides (no EPRV name for raw/assembled frames); L2/L4 use the
+    EPRV-standard name inherited from rvdata. Both paths are exercised here.
+    """
+
+    OBS_ID = "KP.20240405.49597.71"  # 49597 s of day = 13:46:37 UT
+    DATE_OBS = "2024-04-05T13:46:37"
+
+    def _make(self, level):
+        if level == "L0":
+            obj = KPF0()
+            obj.obs_id = self.OBS_ID
+            return obj
+        obj = {"L1": KPF1, "L2": KPF2, "L4": KPF4}[level]()
+        obj.headers["PRIMARY"]["INSTRUME"] = "KPF"
+        obj.headers["PRIMARY"]["DATE-OBS"] = self.DATE_OBS
+        return obj
+
+    @pytest.mark.parametrize("level", ["L0", "L1", "L2", "L4"])
+    def test_generate_standard_filename_matches_build_filepath(self, level):
+        obj = self._make(level)
+        expected = os.path.basename(build_filepath(self.OBS_ID, level))
+        assert obj.generate_standard_filename() == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -31,7 +31,7 @@ _STEP_KMS = 0.25  # matches the module default
 _NVEL = round((_RANGE_KMS[1] - _RANGE_KMS[0]) / _STEP_KMS) + 1
 _V_INJECT = 1.5  # injected RV [km/s], on the grid
 _MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Å]
-# Wide enough that the default compute_ccfs clip (clip_edge_pixels=[500, 500])
+# Wide enough that the default compute_ccfs clip (clip_edge_pixels=(500, 500))
 # trims the order edges but leaves the 5015-5035 Å mask lines well inside.
 NCOL = 2000
 

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -73,7 +73,7 @@ def _make_science_l2(wls_path=None):
 def master_wls_path(tmp_path):
     """Write a synthetic KPFMasterL2 to disk and return its path."""
     master = _make_master_l2()
-    path = str(tmp_path / "kpf_ML2_20240405T010037.fits")
+    path = str(tmp_path / "KP.20240405.03637.00_master_thar_L2.fits")
     master.to_fits(path)
     return path
 


### PR DESCRIPTION
  ## Consistency sweep: parameter tiers, filename conventions, and nomenclature docs

  A code-review / consistency sweep over `kpf-next`. Each item was scoped, reviewed,
  and committed independently. No scientific-output changes — all edits are
  behavior-preserving refactors, naming/convention enforcement, or documentation.

  ### What changed

  **Filename & path conventions (`0bdae841`)**
  - Enforce the science/master filename rules in one place: `build_filepath()`
    (`utils/io.py`) for pipeline writes, `generate_standard_filename()` for the
    `to_fits` fallback (rvdata-owned for L2/L4, KPF-overridden for L0/L1).
  - Master products follow WMKO **DRP-RUN-05**: `{KOAID-of-first-input}_master_{type}_L{N}.fits`.
  - `TestFilenameConsistency` enforces the two authorities never drift per level.

  **Parameter-tier cleanup (`1bdf5e2b`, `c09ae023`, `761cebc6`)**
  - Unify the masters-stacking knobs and demote `nframe_stream` from an attribute
    to a kwarg, so the stacking engine's tunables live in one place.
  - Promote hard-coded magic numbers to **semi-hidden kwargs** (literal defaults,
    absent from `_DEFAULTS`/config) so they're tunable without config churn.
  - **De-overload the `=None` sentinel.** Previously `=None` meant *both* "fall back
    to `self.<attr>`" (configurable) *and* "fall back to an in-body literal"
    (semi-hidden). Sequence-valued semi-hidden params now use immutable **tuple**
    defaults (`clip_edge_pixels=(500, 500)`, `buffer=(0, 0)`, etc.), so a reader can
    tell a parameter's tier from the signature alone. The in-body
    `if x is None: x = [...]` blocks are removed.

  **Documentation (`e1f70f61`, `eab243f0`)**
  - Document the load-bearing `np.array(hdu.data)` copy in each `_read`: rvdata's
    `from_fits` opens the file under a `with` block and astropy memmaps by default,
    so the copy materializes data into RAM before the file closes — `np.asarray`
    would leave a dangling memmap view.
  - Clarify in the style guide (§7) that the codebase's `row`/`col`/`nrow`/`ncol`
    naming is the **numpy** axis convention, which is the *transpose* of the KPF
    physical convention (KPF "row" = dispersion = numpy axis 1). The code is uniform
    and self-consistent; this is a documentation anchor, not a rename.

  ### Verification
  - `make test-fast` green; full `make test` run for the core/shared-module touches
    (data models, masters stacking, filename conventions).
  - Pre-commit (ruff format + lint) clean.
  - Remaining `TestScienceRecipe` failures are environmental (Gaia astrometry
    network access), not regressions.

  ### Notes
  - Surfaced a CLAUDE.md drift: §Configuration says detector params live at
    `data_models/config/detector.toml`, but the loader reads `reference/detector.toml`
    (`kpfpipe/__init__.py:16`). Flagged for a separate fix.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)