### PR TITLE
Kpf next image assembly refactor 20260624

### DIFF
--- a/kpfpipe/data_models/config/L1-headers.csv
+++ b/kpfpipe/data_models/config/L1-headers.csv
@@ -15,7 +15,7 @@ RNNGRD1,ImageAssembly,Non-Gaussian read noise RED amp 1
 RNNGRD2,ImageAssembly,Non-Gaussian read noise RED amp 2
 RNNGRD3,ImageAssembly,Non-Gaussian read noise RED amp 3
 RNNGRD4,ImageAssembly,Non-Gaussian read noise RED amp 4
-OSCANMET,ImageAssembly,Overscan subtraction method
+OSCANSUB,ImageAssembly,Overscan subtraction applied
 BIASSUB,ImageProcessing,Bias subtraction applied
 DARKSUB,ImageProcessing,Dark subtraction applied
 FLATDIV,ImageProcessing,Flat division applied (reserved)

--- a/kpfpipe/data_models/config/L1-headers.csv
+++ b/kpfpipe/data_models/config/L1-headers.csv
@@ -31,7 +31,6 @@ DRPVERNO,KPF0.to_kpf1,Pipeline version (WMKO DRP-RUN-11; EPRV equivalent is DRPT
 MASTYPE,KPFMaster,Master calibration type (masters products only)
 RNINRNG,QCL1,QC: per-amp RN within range
 RNGAUSS,QCL1,QC: non-Gaussian RN within range
-BIASOK,QCL1,QC: bias subtraction applied
 BIASAGEQ,QCL1,QC: bias master age ok
 DARKAGEQ,QCL1,QC: dark master age ok
 FLATAGEQ,QCL1,QC: flat master age ok

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -184,16 +184,16 @@ class ImageAssembly:
         Calculates single-value median of serial overscan region
         """
         oscan_srl, _ = self._get_overscan_pixels(chip, amp_no, **kwargs)
-        bias = np.nanmedian(oscan_srl)
-        return bias
+        oscan_bias = np.nanmedian(oscan_srl)
+        return oscan_bias
 
     def _oscan_rowmedian(self, chip, amp_no, **kwargs):
         """
         Calculates row-by-row median of serial overscan region
         """
         oscan_srl, _ = self._get_overscan_pixels(chip, amp_no, **kwargs)
-        bias = np.nanmedian(oscan_srl, axis=1)[:, None]
-        return bias
+        oscan_bias = np.nanmedian(oscan_srl, axis=1)[:, None]
+        return oscan_bias
 
     def _set_kpf1_headers(self, l1_obj):
         """
@@ -321,7 +321,11 @@ class ImageAssembly:
 
         Notes
         -----
-        The transformations are flips; calling twice will undo the operation.
+        The transformations are flips, so each is its own inverse — calling
+        twice restores the input. measure_read_noise and subtract_overscan use
+        this to orient to standard, do their work, then restore the original
+        orientation, so a non-standard orientation never propagates between
+        steps; it is also called directly by Quicklook for its L0 display.
         """
         chip = chip.upper()
 
@@ -397,6 +401,9 @@ class ImageAssembly:
 
         chip = chip.upper()
 
+        # Overscan extraction assumes standard orientation; restore the original
+        # afterward so a flipped channel never propagates to the next step.
+        self.orient_channels(chip)
         for i in range(self.namp[chip]):
             channel_ext = f"{chip}_AMP{i + 1}"
 
@@ -408,6 +415,7 @@ class ImageAssembly:
 
             self.readnoise[channel_ext] = std
             self.rn_nongauss[channel_ext] = np.sqrt(2 / np.pi) * std / mad
+        self.orient_channels(chip)
 
     def subtract_overscan(self, chip, method=None, buffer=(0, 0)):
         """
@@ -438,10 +446,14 @@ class ImageAssembly:
                 f"Unsupported overscan subtraction method: '{method}'"
             ) from None
 
+        # Imaging/overscan extraction assumes standard orientation; restore the
+        # original afterward so stitch_ffi consumes channels as it always has.
+        self.orient_channels(chip)
         for i in range(self.namp[chip]):
             image = self._get_imaging_pixels(chip, i + 1)
-            bias = oscan_fxn(chip, i + 1, buffer=buffer)
-            self.l0_obj.data[f"{chip.upper()}_AMP{i + 1}"] = image - bias
+            oscan_bias = oscan_fxn(chip, i + 1, buffer=buffer)
+            self.l0_obj.data[f"{chip.upper()}_AMP{i + 1}"] = image - oscan_bias
+        self.orient_channels(chip)
 
     def stitch_ffi(self, chip):
         """
@@ -549,13 +561,15 @@ class ImageAssembly:
         -----
         Pipeline steps:
         1. Count amplifiers and determine dimensions
-        2. Orient amplifier channels
-        3. Apply gain conversion (ADU --> electrons)
-        4. Measure read noise
-        5. Subtract overscan bias
-        6. Re-orient channels if needed
-        7. Stitch channels into a full-frame image
-        8. Convert EXPMETER_SCI/SKY wavelength column labels from nm to Å
+        2. Apply gain conversion (ADU --> electrons)
+        3. Measure read noise
+        4. Subtract overscan bias
+        5. Stitch channels into a full-frame image
+        6. Convert EXPMETER_SCI/SKY wavelength column labels from nm to Å
+
+        Amplifier-channel orientation is handled on-the-fly inside
+        measure_read_noise and subtract_overscan (each restores the original
+        orientation afterward), not as a separate top-level step.
         """
         if chips is None:
             chips = self.chips
@@ -572,11 +586,9 @@ class ImageAssembly:
 
         for chip in chips:
             self.count_amplifiers(chip)
-            self.orient_channels(chip)
             self.apply_gain_conversion(chip)
             self.measure_read_noise(chip, readnoise_sigma)
             self.subtract_overscan(chip, overscan_method)
-            self.orient_channels(chip)
 
             ccd_ffi, var_ffi = self.stitch_ffi(chip)
             l1_obj.set_data(f"{chip}_CCD", ccd_ffi)

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -215,7 +215,7 @@ class ImageAssembly:
         Header updates:
         1. Read noise per amplifier channel (e.g. RNGRN1)
         2. Non-Gaussian read noise per amplifier channel (e.g. RNNGGR1)
-        3. Overscan subtraction method (OSCANMET)
+        3. Overscan subtraction applied (OSCANSUB)
         """
         for channel_ext, rn in self.readnoise.items():
             key_read, key_rnng = RN_KEYS[channel_ext]
@@ -228,9 +228,10 @@ class ImageAssembly:
                 f"Non-Gaussian read noise {channel_ext}",
             )
 
-        l1_obj.headers["PRIMARY"]["OSCANMET"] = (
-            self.overscan_method,
-            "Overscan subtraction method",
+        # "zero" is the explicit no-op method (strips overscan, subtracts none).
+        l1_obj.headers["PRIMARY"]["OSCANSUB"] = (
+            self.overscan_method != "zero",
+            "Overscan subtraction applied",
         )
 
     @staticmethod
@@ -594,8 +595,8 @@ class ImageAssembly:
             l1_obj.set_data(f"{chip}_CCD", ccd_ffi)
             l1_obj.set_data(f"{chip}_VAR", var_ffi)
 
-        self._set_kpf1_headers(l1_obj)
         self._convert_expmeter_wavelengths_to_angstroms(l1_obj)
+        self._set_kpf1_headers(l1_obj)
         l1_obj.receipt_add_entry("image_assembly", "PASS")
 
         self._results = {

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -26,11 +26,11 @@ _DEFAULTS = {
 }
 
 # PRIMARY-header flag marking a calibration as applied (single source of truth
-# for these keyword names). FLATSUB is reserved for when flat division lands.
+# for these keyword names). FLATDIV is reserved for when flat division lands.
 _CALIBRATION_HEADER_KEYS = {
     "bias": "BIASSUB",
     "dark": "DARKSUB",
-    "flat": "FLATSUB",
+    "flat": "FLATDIV",
 }
 
 

--- a/kpfpipe/quality_control/qc_booleans/level1.py
+++ b/kpfpipe/quality_control/qc_booleans/level1.py
@@ -17,6 +17,14 @@ def _hdr_float(hdr, key):
     return float(val[0] if isinstance(val, tuple) else val)
 
 
+def _hdr_flag(hdr, key):
+    """Return bool value for a header key, or False if absent."""
+    if key not in hdr:
+        return False
+    val = hdr[key]
+    return bool(val[0] if isinstance(val, tuple) else val)
+
+
 class QCL1(QC):
     """QC checks for KPF Level 1 assembled FFI products."""
 
@@ -70,17 +78,18 @@ class QCL1(QC):
     read_noise_nongauss._qc_key = "RNGAUSS"
     read_noise_nongauss._qc_comment = "QC: non-Gaussian RN within 0.8-1.5"
 
+    def overscan_subtracted(self):
+        """OSCANSUB == True."""
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "OSCANSUB")
+
+    overscan_subtracted._qc_key = "OSCANSUB"
+    overscan_subtracted._qc_comment = "QC: overscan subtraction applied"
+
     def bias_subtracted(self):
         """BIASSUB == True."""
-        hdr = self.kpf.headers["PRIMARY"]
-        if "BIASSUB" not in hdr:
-            return False
-        val = hdr["BIASSUB"]
-        if isinstance(val, tuple):
-            val = val[0]
-        return bool(val)
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "BIASSUB")
 
-    bias_subtracted._qc_key = "BIASOK"
+    bias_subtracted._qc_key = "BIASSUB"
     bias_subtracted._qc_comment = "QC: bias subtraction applied"
 
     def bias_age_ok(self):
@@ -91,6 +100,13 @@ class QCL1(QC):
     bias_age_ok._qc_key = "BIASAGEQ"
     bias_age_ok._qc_comment = "QC: bias master age <= 7 days"
 
+    def dark_subtracted(self):
+        """DARKSUB == True."""
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "DARKSUB")
+
+    dark_subtracted._qc_key = "DARKSUB"
+    dark_subtracted._qc_comment = "QC: dark subtraction applied"
+
     def dark_age_ok(self):
         """abs(DARKAGE) <= 14 days."""
         v = _hdr_float(self.kpf.headers["PRIMARY"], "DARKAGE")
@@ -98,6 +114,13 @@ class QCL1(QC):
 
     dark_age_ok._qc_key = "DARKAGEQ"
     dark_age_ok._qc_comment = "QC: dark master age <= 14 days"
+
+    def flat_divided(self):
+        """FLATDIV == True."""
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "FLATDIV")
+
+    flat_divided._qc_key = "FLATDIV"
+    flat_divided._qc_comment = "QC: flat division applied"
 
     def flat_age_ok(self):
         """abs(FLATAGE) <= 30 days."""

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -139,11 +139,11 @@ class TestImageAssemblyBias:
         assert "RNNGGR1" in l1.headers["PRIMARY"]
         assert "RNNGRD1" in l1.headers["PRIMARY"]
 
-    def test_overscan_method_in_header(self, l1_bias):
+    def test_overscan_applied_in_header(self, l1_bias):
         l1, _ = l1_bias
-        oscan = l1.headers["PRIMARY"]["OSCANMET"]
+        oscan = l1.headers["PRIMARY"]["OSCANSUB"]
         val = oscan[0] if isinstance(oscan, tuple) else oscan
-        assert val == "rowmedian"
+        assert val is True
 
     def test_receipt_chain(self, l1_bias):
         l1, _ = l1_bias

--- a/tests/regression/test_qc_booleans.py
+++ b/tests/regression/test_qc_booleans.py
@@ -66,7 +66,10 @@ def _make_kpf1(
     tmp_path,
     *,
     with_rn=True,
+    oscansub=True,
     biassub=True,
+    darksub=True,
+    flatdiv=True,
     agebias=1.0,
     agedark=5.0,
     ageflat=10.0,
@@ -79,7 +82,10 @@ def _make_kpf1(
     primary.header["INSTRUME"] = "KPF"
     primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
     primary.header["EXPTIME"] = 300.0
+    primary.header["OSCANSUB"] = (oscansub, "Overscan subtraction applied")
     primary.header["BIASSUB"] = (biassub, "Bias subtraction applied")
+    primary.header["DARKSUB"] = (darksub, "Dark subtraction applied")
+    primary.header["FLATDIV"] = (flatdiv, "Flat division applied")
     primary.header["BIASAGE"] = (agebias, "Age of bias master [days]")
     primary.header["DARKAGE"] = (agedark, "Age of dark master [days]")
     primary.header["FLATAGE"] = (ageflat, "Age of flat master [days]")
@@ -437,6 +443,19 @@ class TestQCL1:
             del l1.headers["PRIMARY"][f"RNNGRD{i}"]
         assert QCL1(l1).read_noise_nongauss() is True
 
+    def test_overscan_subtracted_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, oscansub=True)
+        assert QCL1(l1).overscan_subtracted() is True
+
+    def test_overscan_subtracted_fail_false(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, oscansub=False)
+        assert QCL1(l1).overscan_subtracted() is False
+
+    def test_overscan_subtracted_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        del l1.headers["PRIMARY"]["OSCANSUB"]
+        assert QCL1(l1).overscan_subtracted() is False
+
     def test_bias_subtracted_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, biassub=True)
         assert QCL1(l1).bias_subtracted() is True
@@ -449,6 +468,32 @@ class TestQCL1:
         l1 = _make_kpf1(tmp_path)
         del l1.headers["PRIMARY"]["BIASSUB"]
         assert QCL1(l1).bias_subtracted() is False
+
+    def test_dark_subtracted_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=True)
+        assert QCL1(l1).dark_subtracted() is True
+
+    def test_dark_subtracted_fail_false(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=False)
+        assert QCL1(l1).dark_subtracted() is False
+
+    def test_dark_subtracted_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        del l1.headers["PRIMARY"]["DARKSUB"]
+        assert QCL1(l1).dark_subtracted() is False
+
+    def test_flat_divided_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=True)
+        assert QCL1(l1).flat_divided() is True
+
+    def test_flat_divided_fail_false(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=False)
+        assert QCL1(l1).flat_divided() is False
+
+    def test_flat_divided_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        del l1.headers["PRIMARY"]["FLATDIV"]
+        assert QCL1(l1).flat_divided() is False
 
     def test_bias_age_ok_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, agebias=3.0)
@@ -507,9 +552,12 @@ class TestQCL1:
         expected = {
             "read_noise_in_range": "RNINRNG",
             "read_noise_nongauss": "RNGAUSS",
-            "bias_subtracted": "BIASOK",
+            "overscan_subtracted": "OSCANSUB",
+            "bias_subtracted": "BIASSUB",
             "bias_age_ok": "BIASAGEQ",
+            "dark_subtracted": "DARKSUB",
             "dark_age_ok": "DARKAGEQ",
+            "flat_divided": "FLATDIV",
             "flat_age_ok": "FLATAGEQ",
             "ffi_finite": "FFIFIN",
         }
@@ -536,9 +584,12 @@ class TestQCL1Run:
         expected_keys = [
             "RNINRNG",
             "RNGAUSS",
-            "BIASOK",
+            "OSCANSUB",
+            "BIASSUB",
             "BIASAGEQ",
+            "DARKSUB",
             "DARKAGEQ",
+            "FLATDIV",
             "FLATAGEQ",
             "FFIFIN",
         ]
@@ -554,8 +605,8 @@ class TestQCL1Run:
         isgood = l1.headers["PRIMARY"]["ISGOOD"]
         assert (isgood[0] if isinstance(isgood, tuple) else isgood) == 0
 
-        biasok = l1.headers["PRIMARY"]["BIASOK"]
-        assert (biasok[0] if isinstance(biasok, tuple) else biasok) == 0
+        biassub = l1.headers["PRIMARY"]["BIASSUB"]
+        assert (biassub[0] if isinstance(biassub, tuple) else biassub) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
 ## Summary

  Refactors `ImageAssembly` so amplifier-channel orientation is handled on-the-fly
  by the steps that need it, and replaces the `OSCANMET` method-string header with a
  boolean `OSCANSUB` flag consistent with the other calibration-applied keywords.
  Output is unchanged: assembled FFI/VAR arrays and all PRIMARY header *values*
  (read noise, calibration flags) are byte-for-byte identical on real frames — only
  the overscan keyword's name and type change.

  ## Changes
  
  ### 1. On-the-fly channel orientation
  - `orient_channels` is no longer a top-level `perform()` step. The two methods that
    read spatially-located regions — `measure_read_noise` and `subtract_overscan` —
    now orient channels to standard on entry and **restore the original orientation on
    exit**, so a non-standard orientation can never propagate between steps.
  - `perform()`'s per-chip loop drops both `orient_channels` calls; it is now
    `count → gain → read noise → overscan → stitch`.
  - `count_amplifiers` and `apply_gain_conversion` are untouched (orientation-independent).
  - `orient_channels` / `orient_ffi` / `stitch_ffi` remain public and behaviorally
    unchanged — Quicklook still imports `orient_channels` for its L0 display.
  - This trades a few extra (cheap) flips per chip for a stronger invariant: each step
    is self-contained w.r.t. orientation.
    
  ### 2. `OSCANMET` → `OSCANSUB`
  - ImageAssembly now writes a boolean `OSCANSUB` flag (whether overscan subtraction was
    applied) instead of the `OSCANMET` method string, mirroring `BIASSUB`/`DARKSUB`/`FLATDIV`.
  - `OSCANSUB` is `False` only for the `"zero"` no-op method (which strips the overscan
    region but subtracts no bias); `True` otherwise.
  - Updated the `L1-headers.csv` registry row and the assertion test to match.

  ## Test plan
  - `test_image_assembly.py`: 41 passed
  - Slow real-frame tests (`test_image_assembly`, `test_science_recipe`,
    `test_masters_recipe`): 51 passed — confirms byte-identical FFI/VAR output and that
    `OSCANSUB` passes EPRV PRIMARY validation through to L2
  - Fast subset (`-m "not slow"`): 878 passed
  - `ruff format` + `ruff check`: clean
  
  ## Notes
  - Base branch is `kpf-next-headers` (this work was cut from it); it should merge after
    the header-refactor PR lands.
  - No changes to scientific arrays or RV metrics (charter §6).