### PR TITLE
refactor: consume calibration-applied flags into QCL1/ISGOOD

### DIFF
--- a/kpfpipe/data_models/config/L1-headers.csv
+++ b/kpfpipe/data_models/config/L1-headers.csv
@@ -31,7 +31,6 @@ DRPVERNO,KPF0.to_kpf1,Pipeline version (WMKO DRP-RUN-11; EPRV equivalent is DRPT
 MASTYPE,KPFMaster,Master calibration type (masters products only)
 RNINRNG,QCL1,QC: per-amp RN within range
 RNGAUSS,QCL1,QC: non-Gaussian RN within range
-BIASOK,QCL1,QC: bias subtraction applied
 BIASAGEQ,QCL1,QC: bias master age ok
 DARKAGEQ,QCL1,QC: dark master age ok
 FLATAGEQ,QCL1,QC: flat master age ok

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -26,11 +26,11 @@ _DEFAULTS = {
 }
 
 # PRIMARY-header flag marking a calibration as applied (single source of truth
-# for these keyword names). FLATSUB is reserved for when flat division lands.
+# for these keyword names). FLATDIV is reserved for when flat division lands.
 _CALIBRATION_HEADER_KEYS = {
     "bias": "BIASSUB",
     "dark": "DARKSUB",
-    "flat": "FLATSUB",
+    "flat": "FLATDIV",
 }
 
 

--- a/kpfpipe/quality_control/qc_booleans/level1.py
+++ b/kpfpipe/quality_control/qc_booleans/level1.py
@@ -17,6 +17,14 @@ def _hdr_float(hdr, key):
     return float(val[0] if isinstance(val, tuple) else val)
 
 
+def _hdr_flag(hdr, key):
+    """Return bool value for a header key, or False if absent."""
+    if key not in hdr:
+        return False
+    val = hdr[key]
+    return bool(val[0] if isinstance(val, tuple) else val)
+
+
 class QCL1(QC):
     """QC checks for KPF Level 1 assembled FFI products."""
 
@@ -70,17 +78,18 @@ class QCL1(QC):
     read_noise_nongauss._qc_key = "RNGAUSS"
     read_noise_nongauss._qc_comment = "QC: non-Gaussian RN within 0.8-1.5"
 
+    def overscan_subtracted(self):
+        """OSCANSUB == True."""
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "OSCANSUB")
+
+    overscan_subtracted._qc_key = "OSCANSUB"
+    overscan_subtracted._qc_comment = "QC: overscan subtraction applied"
+
     def bias_subtracted(self):
         """BIASSUB == True."""
-        hdr = self.kpf.headers["PRIMARY"]
-        if "BIASSUB" not in hdr:
-            return False
-        val = hdr["BIASSUB"]
-        if isinstance(val, tuple):
-            val = val[0]
-        return bool(val)
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "BIASSUB")
 
-    bias_subtracted._qc_key = "BIASOK"
+    bias_subtracted._qc_key = "BIASSUB"
     bias_subtracted._qc_comment = "QC: bias subtraction applied"
 
     def bias_age_ok(self):
@@ -91,6 +100,13 @@ class QCL1(QC):
     bias_age_ok._qc_key = "BIASAGEQ"
     bias_age_ok._qc_comment = "QC: bias master age <= 7 days"
 
+    def dark_subtracted(self):
+        """DARKSUB == True."""
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "DARKSUB")
+
+    dark_subtracted._qc_key = "DARKSUB"
+    dark_subtracted._qc_comment = "QC: dark subtraction applied"
+
     def dark_age_ok(self):
         """abs(DARKAGE) <= 14 days."""
         v = _hdr_float(self.kpf.headers["PRIMARY"], "DARKAGE")
@@ -98,6 +114,13 @@ class QCL1(QC):
 
     dark_age_ok._qc_key = "DARKAGEQ"
     dark_age_ok._qc_comment = "QC: dark master age <= 14 days"
+
+    def flat_divided(self):
+        """FLATDIV == True."""
+        return _hdr_flag(self.kpf.headers["PRIMARY"], "FLATDIV")
+
+    flat_divided._qc_key = "FLATDIV"
+    flat_divided._qc_comment = "QC: flat division applied"
 
     def flat_age_ok(self):
         """abs(FLATAGE) <= 30 days."""

--- a/tests/regression/test_qc_booleans.py
+++ b/tests/regression/test_qc_booleans.py
@@ -66,7 +66,10 @@ def _make_kpf1(
     tmp_path,
     *,
     with_rn=True,
+    oscansub=True,
     biassub=True,
+    darksub=True,
+    flatdiv=True,
     agebias=1.0,
     agedark=5.0,
     ageflat=10.0,
@@ -79,7 +82,10 @@ def _make_kpf1(
     primary.header["INSTRUME"] = "KPF"
     primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
     primary.header["EXPTIME"] = 300.0
+    primary.header["OSCANSUB"] = (oscansub, "Overscan subtraction applied")
     primary.header["BIASSUB"] = (biassub, "Bias subtraction applied")
+    primary.header["DARKSUB"] = (darksub, "Dark subtraction applied")
+    primary.header["FLATDIV"] = (flatdiv, "Flat division applied")
     primary.header["BIASAGE"] = (agebias, "Age of bias master [days]")
     primary.header["DARKAGE"] = (agedark, "Age of dark master [days]")
     primary.header["FLATAGE"] = (ageflat, "Age of flat master [days]")
@@ -437,6 +443,19 @@ class TestQCL1:
             del l1.headers["PRIMARY"][f"RNNGRD{i}"]
         assert QCL1(l1).read_noise_nongauss() is True
 
+    def test_overscan_subtracted_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, oscansub=True)
+        assert QCL1(l1).overscan_subtracted() is True
+
+    def test_overscan_subtracted_fail_false(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, oscansub=False)
+        assert QCL1(l1).overscan_subtracted() is False
+
+    def test_overscan_subtracted_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        del l1.headers["PRIMARY"]["OSCANSUB"]
+        assert QCL1(l1).overscan_subtracted() is False
+
     def test_bias_subtracted_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, biassub=True)
         assert QCL1(l1).bias_subtracted() is True
@@ -449,6 +468,32 @@ class TestQCL1:
         l1 = _make_kpf1(tmp_path)
         del l1.headers["PRIMARY"]["BIASSUB"]
         assert QCL1(l1).bias_subtracted() is False
+
+    def test_dark_subtracted_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=True)
+        assert QCL1(l1).dark_subtracted() is True
+
+    def test_dark_subtracted_fail_false(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=False)
+        assert QCL1(l1).dark_subtracted() is False
+
+    def test_dark_subtracted_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        del l1.headers["PRIMARY"]["DARKSUB"]
+        assert QCL1(l1).dark_subtracted() is False
+
+    def test_flat_divided_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=True)
+        assert QCL1(l1).flat_divided() is True
+
+    def test_flat_divided_fail_false(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=False)
+        assert QCL1(l1).flat_divided() is False
+
+    def test_flat_divided_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        del l1.headers["PRIMARY"]["FLATDIV"]
+        assert QCL1(l1).flat_divided() is False
 
     def test_bias_age_ok_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, agebias=3.0)
@@ -507,9 +552,12 @@ class TestQCL1:
         expected = {
             "read_noise_in_range": "RNINRNG",
             "read_noise_nongauss": "RNGAUSS",
-            "bias_subtracted": "BIASOK",
+            "overscan_subtracted": "OSCANSUB",
+            "bias_subtracted": "BIASSUB",
             "bias_age_ok": "BIASAGEQ",
+            "dark_subtracted": "DARKSUB",
             "dark_age_ok": "DARKAGEQ",
+            "flat_divided": "FLATDIV",
             "flat_age_ok": "FLATAGEQ",
             "ffi_finite": "FFIFIN",
         }
@@ -536,9 +584,12 @@ class TestQCL1Run:
         expected_keys = [
             "RNINRNG",
             "RNGAUSS",
-            "BIASOK",
+            "OSCANSUB",
+            "BIASSUB",
             "BIASAGEQ",
+            "DARKSUB",
             "DARKAGEQ",
+            "FLATDIV",
             "FLATAGEQ",
             "FFIFIN",
         ]
@@ -554,8 +605,8 @@ class TestQCL1Run:
         isgood = l1.headers["PRIMARY"]["ISGOOD"]
         assert (isgood[0] if isinstance(isgood, tuple) else isgood) == 0
 
-        biasok = l1.headers["PRIMARY"]["BIASOK"]
-        assert (biasok[0] if isinstance(biasok, tuple) else biasok) == 0
+        biassub = l1.headers["PRIMARY"]["BIASSUB"]
+        assert (biassub[0] if isinstance(biassub, tuple) else biassub) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  ## Summary

  Consolidates the L1 "calibration applied" QC checks so that the pipeline flags
  written upstream (`OSCANSUB`, `BIASSUB`, `DARKSUB`, `FLATDIV`) are consumed directly
  into `QCL1` and the `ISGOOD` aggregate, instead of mirroring `BIASSUB` into a
  redundant `BIASOK` keyword.

  **Base:** `kpf-next-image-assembly-refactor-20260624` (this branch stacks on the
  ImageAssembly refactor; it depends on the `OSCANSUB` keyword introduced there).

  ## Changes

  ### QCL1: applied-flags feed ISGOOD (`qc_booleans/level1.py`)
  `bias_subtracted` previously wrote a separate `BIASOK` keyword that was a verbatim
  copy of `BIASSUB` (no threshold logic). It now overwrites `BIASSUB` itself,
  re-emitting the flag with a `"QC: …"` comment and folding it into `ISGOOD`. Added
  matching checks for the other calibration-applied flags:

  | Check method | `_qc_key` | source flag |
  | `overscan_subtracted` *(new)* | `OSCANSUB` | ImageAssembly |
  | `bias_subtracted` *(`BIASOK` → `BIASSUB`)* | `BIASSUB` | ImageProcessing |
  | `dark_subtracted` *(new)* | `DARKSUB` | ImageProcessing |
  | `flat_divided` *(new)* | `FLATDIV` | ImageProcessing (stub) |
  
  - All four share a new `_hdr_flag(hdr, key)` helper (parallel to `_hdr_float`),
    replacing `bias_subtracted`'s hand-rolled lookup.
  - Methods reordered to pair each cal type's *applied* check with its *age* check.
  - Removed the now-defunct `BIASOK` row from `L1-headers.csv`;
    `BIASSUB`/`DARKSUB`/`FLATDIV`/`OSCANSUB` are already registered.

  ### Fix latent `FLATSUB`/`FLATDIV` inconsistency (`image_processing.py`)
  `_CALIBRATION_HEADER_KEYS["flat"]` was `FLATSUB`, but the registry — and the
  `"flat division"` semantics — use `FLATDIV`. Had flat division ever landed,
  ImageProcessing would have written an unregistered keyword and failed EPRV
  validation. Now aligned to `FLATDIV`. `FLATSUB` was unreachable (flat is a stub)
  and referenced nowhere else.
  
  ## Test plan
  - `test_qc_booleans.py` + `test_image_processing.py`: 147 passed (incl. 9 new unit
    tests — pass/false/missing for each new check; updated key-map, full-run, and
    `ISGOOD=0` assertions)
  - Slow recipe/masters (`test_science_recipe`, `test_masters_recipe`,
    `test_master_dark`, `test_master_wls`): 37 passed — confirms `QCL1.run()` in the
    science recipe writes the four flags and `FLATDIV` carries L1→L2 through EPRV
    PRIMARY validation
  - Fast subset (`-m "not slow"`): 887 passed
  - `ruff format` + `ruff check`: clean

  ## Notes
  - **`ISGOOD` stays `0` on real science frames** until the flat module is built —
    `flat_divided` and `flat_age_ok` both fail while `FLATDIV`/`FLATAGE` are absent.
    This was already the case via `flat_age_ok`; the new check is consistent with it.
  - **Value type:** `BIASSUB`/`DARKSUB`/`OSCANSUB` flip from `True/False` (bool, as
    written by the pipeline module) to `1/0` (int) once `QCL1.run()` overwrites them.
    ImageProcessing's own tests assert the bool form *before* QC runs and are
    unaffected; `calibration_applied()` uses `bool(...)` and is robust either way.
  - No changes to scientific arrays or RV metrics (charter §6). 