### PR TITLE
Kpf next module caching standardization

### DIFF
--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -134,26 +134,32 @@ class StageName:
     def perform(self, chips=None):
         ...                                    # populate header-source attributes
         self._set_kpf2_headers(self.l2_obj)    # consolidates ALL PRIMARY writes
+        self._track_info(chips)                # populates _info, just before the receipt
         self.l2_obj.receipt_add_entry("stage_name", "PASS")
-        self._info = {...}                     # info() summary only
         return self.l2_obj
 
     def _set_kpf2_headers(self, l2_obj):
         """Sole place this module writes PRIMARY; reads instance attributes."""
         l2_obj.headers["PRIMARY"][KEY] = (self._attr, "comment")
 
+    def _track_info(self, chips=None, fibers=None):
+        """Populate _info from instance attributes (takes only chips/fibers)."""
+        self._info = {...}
+
     def info(self): ...   # human-readable reporter, always last
 ```
 
 - **Method order is fixed and marked with 66-dash banner comments**:
   `__init__` → *Private helpers* → *Algorithm steps* → *Public entry point* (`perform`,
-  then `_set_kpf{level}_headers`) → `info()`.
+  then `_set_kpf{level}_headers`, `_track_info`) → `info()`.
 - **Header consolidation & `_info`.** A module writes PRIMARY in exactly one place — a private
   `_set_kpf{level}_headers(obj)` that sources its values from instance attributes (never recomputes,
   never reads another product), called immediately before `receipt_add_entry`. `{level}` is the
   module's *output* level; modules that write no PRIMARY keep an empty helper for uniformity.
   `_info` (formerly `_results`) is a pruned, human-readable summary consumed **only** by `info()` —
-  never the science/header chain, and never tests (tests assert on the underlying attributes).
+  never the science/header chain, and never tests (tests assert on the underlying attributes). It is
+  populated by a private `_track_info(self[, chips, fibers])` (no other args — it sources from
+  instance attributes), called immediately after `_set_kpf{level}_headers` and before the receipt.
 - The banner is exactly:
   ```python
       # ------------------------------------------------------------------

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -116,7 +116,7 @@ class StageName:
     def __init__(self, l1_obj, config=None):
         self.l1_obj = l1_obj
         # ... canonical config block (see §4) ...
-        self._results = None  # populated by perform()
+        self._info = None  # info() summary only
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -132,16 +132,28 @@ class StageName:
     # Public entry point
     # ------------------------------------------------------------------
     def perform(self, chips=None):
-        ...
+        ...                                    # populate header-source attributes
+        self._set_kpf2_headers(self.l2_obj)    # consolidates ALL PRIMARY writes
         self.l2_obj.receipt_add_entry("stage_name", "PASS")
+        self._info = {...}                     # info() summary only
         return self.l2_obj
+
+    def _set_kpf2_headers(self, l2_obj):
+        """Sole place this module writes PRIMARY; reads instance attributes."""
+        l2_obj.headers["PRIMARY"][KEY] = (self._attr, "comment")
 
     def info(self): ...   # human-readable reporter, always last
 ```
 
 - **Method order is fixed and marked with 66-dash banner comments**:
-  `__init__` → *Private helpers* → *Algorithm steps* → *Public entry point* (`perform`)
-  → `info()`.
+  `__init__` → *Private helpers* → *Algorithm steps* → *Public entry point* (`perform`,
+  then `_set_kpf{level}_headers`) → `info()`.
+- **Header consolidation & `_info`.** A module writes PRIMARY in exactly one place — a private
+  `_set_kpf{level}_headers(obj)` that sources its values from instance attributes (never recomputes,
+  never reads another product), called immediately before `receipt_add_entry`. `{level}` is the
+  module's *output* level; modules that write no PRIMARY keep an empty helper for uniformity.
+  `_info` (formerly `_results`) is a pruned, human-readable summary consumed **only** by `info()` —
+  never the science/header chain, and never tests (tests assert on the underlying attributes).
 - The banner is exactly:
   ```python
       # ------------------------------------------------------------------
@@ -208,12 +220,13 @@ class StageName:
   (TOML values applied on top via `params.get(k, v)` in the loop above) → a direct keyword
   argument on a method call (overrides both). Config is the production override path;
   direct kwargs are the developer/interactive path (e.g. notebooks), not used in production.
-- **Declare every lazily-populated attribute in `__init__`, set to `None`/`{}`, with a
-  trailing comment naming the method that fills it** — this is a defining house style:
+- **Declare every lazily-populated attribute in `__init__`, set to `None`/`{}`.** Add a
+  trailing comment naming the filling method (and its shape) **only where that isn't obvious**;
+  keep comments minimal otherwise. Conventional attributes (`_info`) stay bare:
   ```python
-  self._results = None       # populated by perform()
-  self._line_mask = {}       # line mask, set by _build_line_mask()
-  self.ml1_obj = None        # populated by subclass make_master_l1()
+  self._info = None
+  self._ccd_bary = None  # per-CCD {bjd, kms, z} for _set_kpf2_headers
+  self._line_mask = {}   # set by _build_line_mask()
   ```
 - **Detector geometry comes from `DETECTOR` (sourced from `detector.toml`), consumed on
   the instance** — every module gets `self.norder` (`{GREEN, RED}` dict), `self.ccd`,

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -129,37 +129,40 @@ class StageName:
     def do_step(self, ...): ...
 
     # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+    def _track_info(self, chips=None, fibers=None):
+        """Populate _info from instance attributes (takes only chips/fibers)."""
+        self._info = {...}
+
+    def _set_headers(self, l2_obj):
+        """Sole place this module writes PRIMARY; reads instance attributes."""
+        l2_obj.headers["PRIMARY"][KEY] = (self._attr, "comment")
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
     def perform(self, chips=None):
         ...                                    # populate header-source attributes
-        self._set_kpf2_headers(self.l2_obj)    # consolidates ALL PRIMARY writes
+        self._set_headers(self.l2_obj)         # consolidates ALL PRIMARY writes
         self._track_info(chips)                # populates _info, just before the receipt
         self.l2_obj.receipt_add_entry("stage_name", "PASS")
         return self.l2_obj
-
-    def _set_kpf2_headers(self, l2_obj):
-        """Sole place this module writes PRIMARY; reads instance attributes."""
-        l2_obj.headers["PRIMARY"][KEY] = (self._attr, "comment")
-
-    def _track_info(self, chips=None, fibers=None):
-        """Populate _info from instance attributes (takes only chips/fibers)."""
-        self._info = {...}
 
     def info(self): ...   # human-readable reporter, always last
 ```
 
 - **Method order is fixed and marked with 66-dash banner comments**:
-  `__init__` → *Private helpers* → *Algorithm steps* → *Public entry point* (`perform`,
-  then `_set_kpf{level}_headers`, `_track_info`) → `info()`.
+  `__init__` → *Private helpers* → *Algorithm steps* → *Private helpers - module execution*
+  (`_track_info`, then `_set_headers`) → *Public entry point* (`perform`) → `info()`.
 - **Header consolidation & `_info`.** A module writes PRIMARY in exactly one place — a private
-  `_set_kpf{level}_headers(obj)` that sources its values from instance attributes (never recomputes,
-  never reads another product), called immediately before `receipt_add_entry`. `{level}` is the
-  module's *output* level; modules that write no PRIMARY keep an empty helper for uniformity.
-  `_info` (formerly `_results`) is a pruned, human-readable summary consumed **only** by `info()` —
-  never the science/header chain, and never tests (tests assert on the underlying attributes). It is
-  populated by a private `_track_info(self[, chips, fibers])` (no other args — it sources from
-  instance attributes), called immediately after `_set_kpf{level}_headers` and before the receipt.
+  `_set_headers(obj)` that sources its values from instance attributes (never recomputes,
+  never reads another product), called immediately before `receipt_add_entry`. Modules that write
+  no PRIMARY keep an empty helper for uniformity. `_info` (formerly `_results`) is a pruned,
+  human-readable summary consumed **only** by `info()` — never the science/header chain, and never
+  tests (tests assert on the underlying attributes). It is populated by a private
+  `_track_info(self[, chips, fibers])` (no other args — it sources from instance attributes),
+  called immediately after `_set_headers` and before the receipt.
 - The banner is exactly:
   ```python
       # ------------------------------------------------------------------
@@ -231,7 +234,7 @@ class StageName:
   keep comments minimal otherwise. Conventional attributes (`_info`) stay bare:
   ```python
   self._info = None
-  self._ccd_bary = None  # per-CCD {bjd, kms, z} for _set_kpf2_headers
+  self._ccd_bjd = None   # per-CCD [GREEN, RED] arrays for _set_headers
   self._line_mask = {}   # set by _build_line_mask()
   ```
 - **Detector geometry comes from `DETECTOR` (sourced from `detector.toml`), consumed on
@@ -269,17 +272,13 @@ class StageName:
     positional in the same slot (e.g. `CalibrationAssociation.perform(self, cal_types, *, ...)`).
   - **Everything else is keyword-only** — place a bare `*` after the positionals so all
     tunables must be passed by name.
-  - **Order the keyword-only args in two groups**: first the *configurable* parameters —
-    backed by a `_DEFAULTS` key and a config entry, defaulting to `None` and resolving to
-    the configured `self.<attr>` (the "`None` means use config" tunables); then the
-    *semi-hidden* parameters — rarely-tuned knobs left exposed for developer experimentation,
-    carrying a real literal default (e.g. `min_npts=9`, `verbose=True`) and intentionally
-    **absent** from both `_DEFAULTS` and config. The invariant is that a tunable's tier is
-    legible from the signature alone: **`=None` ⇒ configurable** (resolves to `self.<attr>`),
-    **literal default ⇒ semi-hidden**. So a semi-hidden param needing a sequence default uses
-    an *immutable literal* (a tuple, safe as a default argument), e.g.
-    `clip_edge_pixels=(500, 500)`, never the `None`-sentinel + in-body list fallback. Within
-    each group, keep a sensible domain order.
+  - **Order the keyword-only args in two groups**, each in sensible domain order: first the
+    *configurable* params (backed by `_DEFAULTS` + config, defaulting to `None`, resolving to
+    `self.<attr>`), then the *semi-hidden* knobs (a real literal default like `min_npts=9` or
+    `verbose=True`, absent from both `_DEFAULTS` and config). A tunable's tier must be legible
+    from the signature alone: **`=None` ⇒ configurable**, **literal default ⇒ semi-hidden**. A
+    semi-hidden param needing a sequence default uses an *immutable literal*
+    (`clip_edge_pixels=(500, 500)`), never a `None`-sentinel + in-body list fallback.
 - **The `make_master_*` entry points follow the same shape** (§10), with `l0_file_list`
   as the sole positional in place of `chips`/`fibers`.
 - **Parameter ordering applies to *every* method**, not just the public entry points:
@@ -342,10 +341,8 @@ class StageName:
   value with `!r`**: `raise ValueError(f"data_root must be a non-empty string; got {data_root!r}")`.
 - **Narrow your `except`**, never bare `except:`. Broad `except Exception` is acceptable
   only around external I/O that converts to a warning-and-skip. **Always parenthesize a
-  multi-type clause** — `except (ValueError, TypeError):`, binding or not. PEP 758 makes the
-  bare `except A, B:` valid at runtime on 3.14, but Pylance/Pyright doesn't yet parse it and
-  flags every such clause; the parenthesized form is accepted by every tool. The formatter
-  leaves these parens in place because `target-version` is pinned to `py313` (see §8).
+  multi-type clause** — `except (ValueError, TypeError):`, binding or not: the bare PEP 758
+  form (`except A, B:`) is valid on 3.14 but Pylance/Pyright can't parse it (§8).
 - **Always chain re-raises** (Ruff `B904`): `raise ... from e` to preserve the original
   context, or `raise ... from None` when translating a low-level error (a `KeyError`/
   `AttributeError` from a dict lookup or `getattr` dispatch) into a clearer domain error
@@ -403,12 +400,10 @@ class StageName:
 
 - **Prefer Ruff's normalization for stylistic nits.** When the formatter has an opinion on a
   purely stylistic point (paren placement, line wrapping, quote style, blank lines), follow
-  what `ruff format` produces rather than hand-styling against it — fighting the formatter
-  just churns. Deviate only with a strong, documented reason. (Example of such a reason:
-  Ruff's `target-version` is pinned to `py313`, one below the 3.14.3 runtime, *so that* the
-  formatter keeps the parens on a multi-type `except` instead of emitting PEP 758's bare form
-  — which Pylance/Pyright can't parse. The pin makes the formatter agree with the type
-  checker; see §6.)
+  what `ruff format` produces rather than fighting it. Deviate only with a strong, documented
+  reason — e.g. `target-version` is pinned to `py313` (one below the 3.14.3 runtime) *so that*
+  the formatter keeps the parens on a multi-type `except` rather than emitting PEP 758's bare
+  form, which Pylance/Pyright can't parse (§6).
 - **`ruff` is the unified formatter + linter** (it replaced black/isort/flake8). The
   formatter is black-compatible: **88-char target line length**, double-quote normalization.
   Config lives in `pyproject.toml` under `[tool.ruff]`; `ruff==0.15.17` and

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -101,7 +101,8 @@ class BarycentricCorrection:
         for k, v in _DEFAULTS.items():
             setattr(self, k, params.get(k, v))
 
-        self._results = None
+        self._info = None
+        self._ccd_bary = None  # per-CCD {bjd, kms, z} for _set_kpf2_headers
         self._em_cache = None  # (toggle_key, w_em, t_em) from the last integration
         self._skycoord = None  # cached Gaia DR3 SkyCoord
         self._astrometry_source = (
@@ -739,37 +740,55 @@ class BarycentricCorrection:
             output="ccds", **kwargs
         )
 
-        prim = self.l2_obj.headers["PRIMARY"]
-
         # Per-order extensions; WAVE arrays are left untouched
         self.l2_obj.set_data("BJD_TDB", np.asarray(bjd_tdb, dtype=np.float64))
         self.l2_obj.set_data("BARYCORR_KMS", np.asarray(bary_kms, dtype=np.float64))
         self.l2_obj.set_data("BARYCORR_Z", np.asarray(bary_z, dtype=np.float64))
 
-        # Per-CCD PRIMARY keywords (CCD1=GREEN, CCD2=RED); registered
-        # KPF-pipeline keywords (config/L2-headers.csv).
-        prim["CCD1BJD"] = (float(ccd_bjd[0]), "[BJD_TDB] GREEN mid-time")
-        prim["CCD1BKMS"] = (float(ccd_kms[0]), "[km/s] GREEN barycentric velocity")
-        prim["CCD1BZ"] = (float(ccd_z[0]), "GREEN barycentric redshift z")
-        prim["CCD2BJD"] = (float(ccd_bjd[1]), "[BJD_TDB] RED mid-time")
-        prim["CCD2BKMS"] = (float(ccd_kms[1]), "[km/s] RED barycentric velocity")
-        prim["CCD2BZ"] = (float(ccd_z[1]), "RED barycentric redshift z")
+        # Per-CCD summaries (CCD1=GREEN, CCD2=RED), consumed by _set_kpf2_headers.
+        self._ccd_bary = {
+            1: {
+                "bjd": float(ccd_bjd[0]),
+                "kms": float(ccd_kms[0]),
+                "z": float(ccd_z[0]),
+            },
+            2: {
+                "bjd": float(ccd_bjd[1]),
+                "kms": float(ccd_kms[1]),
+                "z": float(ccd_z[1]),
+            },
+        }
 
-        # Provenance: which astrometry source actually produced the correction
-        prim["ASTRSRC"] = (self._astrometry_source, "Astrometry source")
-
+        self._set_kpf2_headers(self.l2_obj)
         self.l2_obj.receipt_add_entry("barycentric_correction", "PASS")
 
-        self._results = {
+        self._info = {
             "bjd_tdb": np.asarray(bjd_tdb),
             "bary_kms": np.asarray(bary_kms),
-            "bary_z": np.asarray(bary_z),
             "ccd_bjd": np.asarray(ccd_bjd),
             "ccd_kms": np.asarray(ccd_kms),
             "ccd_z": np.asarray(ccd_z),
             "astrometry_source": self._astrometry_source,
         }
         return self.l2_obj
+
+    def _set_kpf2_headers(self, l2_obj):
+        """Write all PRIMARY-header keywords for barycentric correction.
+
+        Reads self._ccd_bary and self._astrometry_source (populated by
+        perform()); the single place this module writes PRIMARY, called just
+        before the receipt entry. Per-CCD keywords are registered KPF-pipeline
+        keywords (config/L2-headers.csv); CCD1=GREEN, CCD2=RED.
+        """
+        prim = l2_obj.headers["PRIMARY"]
+        green, red = self._ccd_bary[1], self._ccd_bary[2]
+        prim["CCD1BJD"] = (green["bjd"], "[BJD_TDB] GREEN mid-time")
+        prim["CCD1BKMS"] = (green["kms"], "[km/s] GREEN barycentric velocity")
+        prim["CCD1BZ"] = (green["z"], "GREEN barycentric redshift z")
+        prim["CCD2BJD"] = (red["bjd"], "[BJD_TDB] RED mid-time")
+        prim["CCD2BKMS"] = (red["kms"], "[km/s] RED barycentric velocity")
+        prim["CCD2BZ"] = (red["z"], "RED barycentric redshift z")
+        prim["ASTRSRC"] = (self._astrometry_source, "Astrometry source")
 
     def info(self):
         """Print a summary of the barycentric correction results."""
@@ -779,11 +798,11 @@ class BarycentricCorrection:
             obs_id = obs_id[0]
         print(f"  obs_id:  {obs_id}")
 
-        if self._results is None:
+        if self._info is None:
             print("  perform() has not been called")
             return
 
-        r = self._results
+        r = self._info
         print(f"  astrometry:  {r['astrometry_source']}")
         ccd_bjd, ccd_kms, ccd_z = r["ccd_bjd"], r["ccd_kms"], r["ccd_z"]
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -102,7 +102,7 @@ class BarycentricCorrection:
             setattr(self, k, params.get(k, v))
 
         self._info = None
-        self._ccd_bjd = None  # Per-CCD [GREEN, RED] arrays for _set_kpf2_headers
+        self._ccd_bjd = None  # Per-CCD [GREEN, RED] arrays for _set_headers
         self._ccd_kms = None
         self._ccd_z = None
         self._exposure_meter = None  # (toggle_key, w_em, t_em)
@@ -694,6 +694,41 @@ class BarycentricCorrection:
         return bjd_tdb, bary_kms, bary_z
 
     # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {
+            "bjd_tdb": np.asarray(self.l2_obj.data["BJD_TDB"]),
+            "bary_kms": np.asarray(self.l2_obj.data["BARYCORR_KMS"]),
+            "ccd_bjd": np.asarray(self._ccd_bjd),
+            "ccd_kms": np.asarray(self._ccd_kms),
+            "ccd_z": np.asarray(self._ccd_z),
+            "astrometry_source": self._astrometry_source,
+        }
+
+    def _set_headers(self, l2_obj):
+        """Write all PRIMARY-header keywords for barycentric correction.
+
+        Reads self._ccd_bjd/_ccd_kms/_ccd_z and self._astrometry_source
+        (populated by perform()); the single place this module writes PRIMARY,
+        called just before the receipt entry. Per-CCD keywords are registered
+        KPF-pipeline keywords (config/L2-headers.csv); CCD1=GREEN, CCD2=RED.
+        """
+        prim = l2_obj.headers["PRIMARY"]
+        prim["CCD1BJD"] = (float(self._ccd_bjd[0]), "[BJD_TDB] GREEN mid-time")
+        prim["CCD1BKMS"] = (
+            float(self._ccd_kms[0]),
+            "[km/s] GREEN barycentric velocity",
+        )
+        prim["CCD1BZ"] = (float(self._ccd_z[0]), "GREEN barycentric redshift z")
+        prim["CCD2BJD"] = (float(self._ccd_bjd[1]), "[BJD_TDB] RED mid-time")
+        prim["CCD2BKMS"] = (float(self._ccd_kms[1]), "[km/s] RED barycentric velocity")
+        prim["CCD2BZ"] = (float(self._ccd_z[1]), "RED barycentric redshift z")
+        prim["ASTRSRC"] = (self._astrometry_source, "Astrometry source")
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -738,7 +773,7 @@ class BarycentricCorrection:
         bjd_tdb, bary_kms, bary_z = self.compute_barycentric_correction(
             output="orders", **kwargs
         )
-        # Per-CCD summaries [GREEN, RED], consumed by _set_kpf2_headers.
+        # Per-CCD summaries [GREEN, RED], consumed by _set_headers.
         self._ccd_bjd, self._ccd_kms, self._ccd_z = self.compute_barycentric_correction(
             output="ccds", **kwargs
         )
@@ -748,42 +783,11 @@ class BarycentricCorrection:
         self.l2_obj.set_data("BARYCORR_KMS", np.asarray(bary_kms, dtype=np.float64))
         self.l2_obj.set_data("BARYCORR_Z", np.asarray(bary_z, dtype=np.float64))
 
-        self._set_kpf2_headers(self.l2_obj)
+        self._set_headers(self.l2_obj)
         self._track_info()
         self.l2_obj.receipt_add_entry("barycentric_correction", "PASS")
 
         return self.l2_obj
-
-    def _track_info(self):
-        """Populate _info (the info() summary) from instance attributes."""
-        self._info = {
-            "bjd_tdb": np.asarray(self.l2_obj.data["BJD_TDB"]),
-            "bary_kms": np.asarray(self.l2_obj.data["BARYCORR_KMS"]),
-            "ccd_bjd": np.asarray(self._ccd_bjd),
-            "ccd_kms": np.asarray(self._ccd_kms),
-            "ccd_z": np.asarray(self._ccd_z),
-            "astrometry_source": self._astrometry_source,
-        }
-
-    def _set_kpf2_headers(self, l2_obj):
-        """Write all PRIMARY-header keywords for barycentric correction.
-
-        Reads self._ccd_bjd/_ccd_kms/_ccd_z and self._astrometry_source
-        (populated by perform()); the single place this module writes PRIMARY,
-        called just before the receipt entry. Per-CCD keywords are registered
-        KPF-pipeline keywords (config/L2-headers.csv); CCD1=GREEN, CCD2=RED.
-        """
-        prim = l2_obj.headers["PRIMARY"]
-        prim["CCD1BJD"] = (float(self._ccd_bjd[0]), "[BJD_TDB] GREEN mid-time")
-        prim["CCD1BKMS"] = (
-            float(self._ccd_kms[0]),
-            "[km/s] GREEN barycentric velocity",
-        )
-        prim["CCD1BZ"] = (float(self._ccd_z[0]), "GREEN barycentric redshift z")
-        prim["CCD2BJD"] = (float(self._ccd_bjd[1]), "[BJD_TDB] RED mid-time")
-        prim["CCD2BKMS"] = (float(self._ccd_kms[1]), "[km/s] RED barycentric velocity")
-        prim["CCD2BZ"] = (float(self._ccd_z[1]), "RED barycentric redshift z")
-        prim["ASTRSRC"] = (self._astrometry_source, "Astrometry source")
 
     def info(self):
         """Print a summary of the barycentric correction results."""

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -760,17 +760,22 @@ class BarycentricCorrection:
         }
 
         self._set_kpf2_headers(self.l2_obj)
+        self._track_info()
         self.l2_obj.receipt_add_entry("barycentric_correction", "PASS")
 
+        return self.l2_obj
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
+        green, red = self._ccd_bary[1], self._ccd_bary[2]
         self._info = {
-            "bjd_tdb": np.asarray(bjd_tdb),
-            "bary_kms": np.asarray(bary_kms),
-            "ccd_bjd": np.asarray(ccd_bjd),
-            "ccd_kms": np.asarray(ccd_kms),
-            "ccd_z": np.asarray(ccd_z),
+            "bjd_tdb": np.asarray(self.l2_obj.data["BJD_TDB"]),
+            "bary_kms": np.asarray(self.l2_obj.data["BARYCORR_KMS"]),
+            "ccd_bjd": np.array([green["bjd"], red["bjd"]]),
+            "ccd_kms": np.array([green["kms"], red["kms"]]),
+            "ccd_z": np.array([green["z"], red["z"]]),
             "astrometry_source": self._astrometry_source,
         }
-        return self.l2_obj
 
     def _set_kpf2_headers(self, l2_obj):
         """Write all PRIMARY-header keywords for barycentric correction.

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -102,8 +102,10 @@ class BarycentricCorrection:
             setattr(self, k, params.get(k, v))
 
         self._info = None
-        self._ccd_bary = None  # per-CCD {bjd, kms, z} for _set_kpf2_headers
-        self._em_cache = None  # (toggle_key, w_em, t_em) from the last integration
+        self._ccd_bjd = None  # Per-CCD [GREEN, RED] arrays for _set_kpf2_headers
+        self._ccd_kms = None
+        self._ccd_z = None
+        self._exposure_meter = None  # (toggle_key, w_em, t_em)
         self._skycoord = None  # cached Gaia DR3 SkyCoord
         self._astrometry_source = (
             None  # 'Gaia DR3' | 'WMKO header', set by _get_skycoord
@@ -565,14 +567,14 @@ class BarycentricCorrection:
         # Reuse the cached integration when the toggles match (perform() asks
         # for 'orders' then 'ccds').
         key = (interpolate, extrapolate, fix_expmeter_outliers)
-        if self._em_cache is None or self._em_cache[0] != key:
+        if self._exposure_meter is None or self._exposure_meter[0] != key:
             w_em, t_em = self._compute_per_chanel_flux_weighted_midpoint_time(
                 interpolate=interpolate,
                 extrapolate=extrapolate,
                 fix_expmeter_outliers=fix_expmeter_outliers,
             )
-            self._em_cache = (key, w_em, t_em)
-        _, w_em, t_em = self._em_cache
+            self._exposure_meter = (key, w_em, t_em)
+        _, w_em, t_em = self._exposure_meter
 
         if output == "expmeter":
             return w_em, t_em
@@ -736,7 +738,8 @@ class BarycentricCorrection:
         bjd_tdb, bary_kms, bary_z = self.compute_barycentric_correction(
             output="orders", **kwargs
         )
-        ccd_bjd, ccd_kms, ccd_z = self.compute_barycentric_correction(
+        # Per-CCD summaries [GREEN, RED], consumed by _set_kpf2_headers.
+        self._ccd_bjd, self._ccd_kms, self._ccd_z = self.compute_barycentric_correction(
             output="ccds", **kwargs
         )
 
@@ -744,20 +747,6 @@ class BarycentricCorrection:
         self.l2_obj.set_data("BJD_TDB", np.asarray(bjd_tdb, dtype=np.float64))
         self.l2_obj.set_data("BARYCORR_KMS", np.asarray(bary_kms, dtype=np.float64))
         self.l2_obj.set_data("BARYCORR_Z", np.asarray(bary_z, dtype=np.float64))
-
-        # Per-CCD summaries (CCD1=GREEN, CCD2=RED), consumed by _set_kpf2_headers.
-        self._ccd_bary = {
-            1: {
-                "bjd": float(ccd_bjd[0]),
-                "kms": float(ccd_kms[0]),
-                "z": float(ccd_z[0]),
-            },
-            2: {
-                "bjd": float(ccd_bjd[1]),
-                "kms": float(ccd_kms[1]),
-                "z": float(ccd_z[1]),
-            },
-        }
 
         self._set_kpf2_headers(self.l2_obj)
         self._track_info()
@@ -767,32 +756,33 @@ class BarycentricCorrection:
 
     def _track_info(self):
         """Populate _info (the info() summary) from instance attributes."""
-        green, red = self._ccd_bary[1], self._ccd_bary[2]
         self._info = {
             "bjd_tdb": np.asarray(self.l2_obj.data["BJD_TDB"]),
             "bary_kms": np.asarray(self.l2_obj.data["BARYCORR_KMS"]),
-            "ccd_bjd": np.array([green["bjd"], red["bjd"]]),
-            "ccd_kms": np.array([green["kms"], red["kms"]]),
-            "ccd_z": np.array([green["z"], red["z"]]),
+            "ccd_bjd": np.asarray(self._ccd_bjd),
+            "ccd_kms": np.asarray(self._ccd_kms),
+            "ccd_z": np.asarray(self._ccd_z),
             "astrometry_source": self._astrometry_source,
         }
 
     def _set_kpf2_headers(self, l2_obj):
         """Write all PRIMARY-header keywords for barycentric correction.
 
-        Reads self._ccd_bary and self._astrometry_source (populated by
-        perform()); the single place this module writes PRIMARY, called just
-        before the receipt entry. Per-CCD keywords are registered KPF-pipeline
-        keywords (config/L2-headers.csv); CCD1=GREEN, CCD2=RED.
+        Reads self._ccd_bjd/_ccd_kms/_ccd_z and self._astrometry_source
+        (populated by perform()); the single place this module writes PRIMARY,
+        called just before the receipt entry. Per-CCD keywords are registered
+        KPF-pipeline keywords (config/L2-headers.csv); CCD1=GREEN, CCD2=RED.
         """
         prim = l2_obj.headers["PRIMARY"]
-        green, red = self._ccd_bary[1], self._ccd_bary[2]
-        prim["CCD1BJD"] = (green["bjd"], "[BJD_TDB] GREEN mid-time")
-        prim["CCD1BKMS"] = (green["kms"], "[km/s] GREEN barycentric velocity")
-        prim["CCD1BZ"] = (green["z"], "GREEN barycentric redshift z")
-        prim["CCD2BJD"] = (red["bjd"], "[BJD_TDB] RED mid-time")
-        prim["CCD2BKMS"] = (red["kms"], "[km/s] RED barycentric velocity")
-        prim["CCD2BZ"] = (red["z"], "RED barycentric redshift z")
+        prim["CCD1BJD"] = (float(self._ccd_bjd[0]), "[BJD_TDB] GREEN mid-time")
+        prim["CCD1BKMS"] = (
+            float(self._ccd_kms[0]),
+            "[km/s] GREEN barycentric velocity",
+        )
+        prim["CCD1BZ"] = (float(self._ccd_z[0]), "GREEN barycentric redshift z")
+        prim["CCD2BJD"] = (float(self._ccd_bjd[1]), "[BJD_TDB] RED mid-time")
+        prim["CCD2BKMS"] = (float(self._ccd_kms[1]), "[km/s] RED barycentric velocity")
+        prim["CCD2BZ"] = (float(self._ccd_z[1]), "RED barycentric redshift z")
         prim["ASTRSRC"] = (self._astrometry_source, "Astrometry source")
 
     def info(self):

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -83,7 +83,7 @@ class CalibrationAssociation:
             setattr(self, k, params.get(k, v))
 
         self._masters_root = params.get("KPF_MASTERS_OUTPUT")
-        self._calibrations = None  # per-cal {filepath, age_days} for _set_kpf1_headers
+        self._calibrations = None  # per-cal {filepath, age_days} for _set_headers
         self._info = None
 
     # ------------------------------------------------------------------
@@ -183,7 +183,17 @@ class CalibrationAssociation:
             ),
         )[0]
 
-    def _set_kpf1_headers(self, l1_obj):
+    # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {
+            cal_type: dict(cal) for cal_type, cal in self._calibrations.items()
+        }
+
+    def _set_headers(self, l1_obj):
         """Write all PRIMARY-header keywords for calibration association.
 
         Reads self._calibrations (populated by perform()); the single place this
@@ -258,17 +268,11 @@ class CalibrationAssociation:
             age_days = (master_dt - obs_dt).total_seconds() / 86400.0
             self._calibrations[cal_type] = {"filepath": filepath, "age_days": age_days}
 
-        self._set_kpf1_headers(self.l1_obj)
+        self._set_headers(self.l1_obj)
         self._track_info()
         self.l1_obj.receipt_add_entry("calibration_association", "PASS")
 
         return self.l1_obj
-
-    def _track_info(self):
-        """Populate _info (the info() summary) from instance attributes."""
-        self._info = {
-            cal_type: dict(cal) for cal_type, cal in self._calibrations.items()
-        }
 
     def info(self):
         """Print a summary of the module configuration and association results."""

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -83,7 +83,8 @@ class CalibrationAssociation:
             setattr(self, k, params.get(k, v))
 
         self._masters_root = params.get("KPF_MASTERS_OUTPUT")
-        self._results = None  # populated by perform()
+        self._calibrations = None  # per-cal {filepath, age_days} for _set_kpf1_headers
+        self._info = None
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -182,6 +183,20 @@ class CalibrationAssociation:
             ),
         )[0]
 
+    def _set_kpf1_headers(self, l1_obj):
+        """Write all PRIMARY-header keywords for calibration association.
+
+        Reads self._calibrations (populated by perform()); the single place this
+        module writes PRIMARY, called just before the receipt entry. Each cal
+        type contributes {PREFIX}FILE (full master path) and {PREFIX}AGE (signed
+        fractional-day age).
+        """
+        primary = l1_obj.headers["PRIMARY"]
+        for cal_type, cal in self._calibrations.items():
+            prefix = _HEADER_PREFIX[cal_type]
+            primary[f"{prefix}FILE"] = cal["filepath"]
+            primary[f"{prefix}AGE"] = cal["age_days"]
+
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
@@ -224,8 +239,8 @@ class CalibrationAssociation:
 
         date_obs = self.l1_obj.headers["INSTRUMENT_HEADER"]["DATE-OBS"]
         obs_dt = datetime.fromisoformat(date_obs)
-        primary = self.l1_obj.headers["PRIMARY"]
 
+        self._calibrations = {}
         for cal_type in cal_types:
             master_files = self._find_master_files(
                 cal_type, date_obs, masters_search_window_days, verbose=verbose
@@ -237,22 +252,18 @@ class CalibrationAssociation:
                     f"within window {masters_search_window_days} days"
                 )
 
-            # Uniform master-association convention for every cal type: the full
-            # path in {PREFIX}FILE (no {PREFIX}DIR), and the master age in
-            # {PREFIX}AGE as a signed fractional-day float from the master and
-            # obs timestamps (sign convention: master - obs, so the age is
-            # negative when the master predates the obs).
-            prefix = _HEADER_PREFIX[cal_type]
+            # Signed fractional-day age (master - obs): negative when the master
+            # predates the obs.
             master_dt = kpf_timestamp_to_datetime(get_timestamp(filepath))
-            primary[f"{prefix}FILE"] = filepath
-            primary[f"{prefix}AGE"] = (master_dt - obs_dt).total_seconds() / 86400.0
+            age_days = (master_dt - obs_dt).total_seconds() / 86400.0
+            self._calibrations[cal_type] = {"filepath": filepath, "age_days": age_days}
 
-        self._results = {
-            cal_type: primary[f"{_HEADER_PREFIX[cal_type]}FILE"]
-            for cal_type in cal_types
-        }
+        self._set_kpf1_headers(self.l1_obj)
         self.l1_obj.receipt_add_entry("calibration_association", "PASS")
 
+        self._info = {
+            cal_type: dict(cal) for cal_type, cal in self._calibrations.items()
+        }
         return self.l1_obj
 
     def info(self):
@@ -264,16 +275,13 @@ class CalibrationAssociation:
             f"  search window: {self.masters_search_window_days} days [before, after]"
         )
 
-        if self._results is None:
+        if self._info is None:
             print("  perform() has not been called")
             return
 
         print(f"\n  {'cal_type':<12s} {'master file'}")
         print("  " + "-" * 60)
-        h = self.l1_obj.headers["PRIMARY"]
-        for cal_type, filename in self._results.items():
-            prefix = _HEADER_PREFIX[cal_type]
-            age = h.get(f"{prefix}AGE", "n/a")
-            print(f"  {cal_type:<12s} {filename}")
-            print(f"  {'':12s} age = {age}d")
+        for cal_type, cal in self._info.items():
+            print(f"  {cal_type:<12s} {cal['filepath']}")
+            print(f"  {'':12s} age = {cal['age_days']}d")
             print()

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -259,12 +259,16 @@ class CalibrationAssociation:
             self._calibrations[cal_type] = {"filepath": filepath, "age_days": age_days}
 
         self._set_kpf1_headers(self.l1_obj)
+        self._track_info()
         self.l1_obj.receipt_add_entry("calibration_association", "PASS")
 
+        return self.l1_obj
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
         self._info = {
             cal_type: dict(cal) for cal_type, cal in self._calibrations.items()
         }
-        return self.l1_obj
 
     def info(self):
         """Print a summary of the module configuration and association results."""

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -70,7 +70,7 @@ class ImageAssembly:
         for k, v in self.ccd.items():
             setattr(self, k, v)
 
-        self._results = None  # populated by perform()
+        self._info = None
         self.orientation = {}  # amp ext -> flip; set by _parse_amplifier_reference()
         self.gain = {}  # amp ext -> gain; set by _parse_amplifier_reference()
         self.namp = {}  # chip -> n amps; set by count_amplifiers()
@@ -599,7 +599,7 @@ class ImageAssembly:
         self._set_kpf1_headers(l1_obj)
         l1_obj.receipt_add_entry("image_assembly", "PASS")
 
-        self._results = {
+        self._info = {
             chip: {
                 ch: (
                     round(float(self.readnoise[ch]), 4),
@@ -620,13 +620,13 @@ class ImageAssembly:
         print(f"  overscan_method:  {self.overscan_method}")
         print(f"  readnoise_sigma:  {self.readnoise_sigma}")
 
-        if self._results is None:
+        if self._info is None:
             print("  perform() has not been called")
             return
 
         print(f"\n  {'channel':<14s} {'read noise [e-]':<18s} {'non-gaussian'}")
         print("  " + "-" * 48)
-        for chip in self._results:
-            for channel, (rn, rnng) in self._results[chip].items():
+        for chip in self._info:
+            for channel, (rn, rnng) in self._info[chip].items():
                 print(f"  {channel:<14s} {rn:<18} {rnng}")
             print()

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -195,45 +195,6 @@ class ImageAssembly:
         oscan_bias = np.nanmedian(oscan_srl, axis=1)[:, None]
         return oscan_bias
 
-    def _set_kpf1_headers(self, l1_obj):
-        """
-        Populate KPF1 header keywords related to read noise measurement
-        and overscan subtraction.
-
-        Parameters
-        ----------
-        l1_obj : KPF1
-            L1 data object whose PRIMARY header will be updated with
-            read noise and overscan metadata.
-
-        Returns
-        -------
-        None
-
-        Notes
-        -----
-        Header updates:
-        1. Read noise per amplifier channel (e.g. RNGRN1)
-        2. Non-Gaussian read noise per amplifier channel (e.g. RNNGGR1)
-        3. Overscan subtraction applied (OSCANSUB)
-        """
-        for channel_ext, rn in self.readnoise.items():
-            key_read, key_rnng = RN_KEYS[channel_ext]
-            l1_obj.headers["PRIMARY"][key_read] = (
-                round(float(rn), 4),
-                f"Read noise {channel_ext} [e-]",
-            )
-            l1_obj.headers["PRIMARY"][key_rnng] = (
-                round(float(self.rn_nongauss[channel_ext]), 4),
-                f"Non-Gaussian read noise {channel_ext}",
-            )
-
-        # "zero" is the explicit no-op method (strips overscan, subtracts none).
-        l1_obj.headers["PRIMARY"]["OSCANSUB"] = (
-            self.overscan_method != "zero",
-            "Overscan subtraction applied",
-        )
-
     @staticmethod
     def _convert_expmeter_wavelengths_to_angstroms(l1_obj):
         """
@@ -535,6 +496,63 @@ class ImageAssembly:
         return image
 
     # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+
+    def _track_info(self, chips):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {
+            chip: {
+                ch: (
+                    round(float(self.readnoise[ch]), 4),
+                    round(float(self.rn_nongauss[ch]), 4),
+                )
+                for ch in self.readnoise
+                if ch.startswith(chip.upper())
+            }
+            for chip in chips
+        }
+
+    def _set_headers(self, l1_obj):
+        """
+        Populate KPF1 header keywords related to read noise measurement
+        and overscan subtraction.
+
+        Parameters
+        ----------
+        l1_obj : KPF1
+            L1 data object whose PRIMARY header will be updated with
+            read noise and overscan metadata.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Header updates:
+        1. Read noise per amplifier channel (e.g. RNGRN1)
+        2. Non-Gaussian read noise per amplifier channel (e.g. RNNGGR1)
+        3. Overscan subtraction applied (OSCANSUB)
+        """
+        for channel_ext, rn in self.readnoise.items():
+            key_read, key_rnng = RN_KEYS[channel_ext]
+            l1_obj.headers["PRIMARY"][key_read] = (
+                round(float(rn), 4),
+                f"Read noise {channel_ext} [e-]",
+            )
+            l1_obj.headers["PRIMARY"][key_rnng] = (
+                round(float(self.rn_nongauss[channel_ext]), 4),
+                f"Non-Gaussian read noise {channel_ext}",
+            )
+
+        # "zero" is the explicit no-op method (strips overscan, subtracts none).
+        l1_obj.headers["PRIMARY"]["OSCANSUB"] = (
+            self.overscan_method != "zero",
+            "Overscan subtraction applied",
+        )
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -596,25 +614,11 @@ class ImageAssembly:
             l1_obj.set_data(f"{chip}_VAR", var_ffi)
 
         self._convert_expmeter_wavelengths_to_angstroms(l1_obj)
-        self._set_kpf1_headers(l1_obj)
+        self._set_headers(l1_obj)
         self._track_info(chips)
         l1_obj.receipt_add_entry("image_assembly", "PASS")
 
         return l1_obj
-
-    def _track_info(self, chips):
-        """Populate _info (the info() summary) from instance attributes."""
-        self._info = {
-            chip: {
-                ch: (
-                    round(float(self.readnoise[ch]), 4),
-                    round(float(self.rn_nongauss[ch]), 4),
-                )
-                for ch in self.readnoise
-                if ch.startswith(chip.upper())
-            }
-            for chip in chips
-        }
 
     def info(self):
         """Print a summary of the module configuration and processing results."""

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -597,8 +597,13 @@ class ImageAssembly:
 
         self._convert_expmeter_wavelengths_to_angstroms(l1_obj)
         self._set_kpf1_headers(l1_obj)
+        self._track_info(chips)
         l1_obj.receipt_add_entry("image_assembly", "PASS")
 
+        return l1_obj
+
+    def _track_info(self, chips):
+        """Populate _info (the info() summary) from instance attributes."""
         self._info = {
             chip: {
                 ch: (
@@ -610,8 +615,6 @@ class ImageAssembly:
             }
             for chip in chips
         }
-
-        return l1_obj
 
     def info(self):
         """Print a summary of the module configuration and processing results."""

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -347,16 +347,13 @@ class ImageProcessing:
         if self.dark and prior_dark:
             raise RuntimeError("dark already subtracted from this frame (DARKSUB=True)")
 
-        self._info = {}
         if self.bias:
             for chip in self.chips:
                 self.subtract_bias(chip)
-            self._info["bias"] = self._bias_path
 
         if self.dark:
             for chip in self.chips:
                 self.subtract_dark(chip)
-            self._info["dark"] = self._dark_path
 
         # OR with the prior flag so applying one calibration never clears
         # another already recorded on the frame.
@@ -364,9 +361,18 @@ class ImageProcessing:
         self._darksub = bool(self.dark) or prior_dark
 
         self._set_kpf1_headers(self.l1_obj)
+        self._track_info()
         self.l1_obj.receipt_add_entry("image_processing", "PASS")
 
         return self.l1_obj
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {}
+        if self.bias:
+            self._info["bias"] = self._bias_path
+        if self.dark:
+            self._info["dark"] = self._dark_path
 
     def info(self):
         """Print a summary of the module configuration and processing results."""

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -75,7 +75,7 @@ class ImageProcessing:
         self._dark_ml1 = None
         self._bias_path = None
         self._dark_path = None
-        self._biassub = None  # applied flags for _set_kpf1_headers
+        self._biassub = None  # applied flags for _set_headers
         self._darksub = None
         self._info = None
 
@@ -241,6 +241,33 @@ class ImageProcessing:
         )
 
     # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {}
+        if self.bias:
+            self._info["bias"] = self._bias_path
+        if self.dark:
+            self._info["dark"] = self._dark_path
+
+    def _set_headers(self, l1_obj):
+        """Write all PRIMARY-header keywords for image processing.
+
+        Reads the applied-flag attributes populated by perform(); the single
+        place this module writes PRIMARY, called just before the receipt entry.
+        """
+        l1_obj.headers["PRIMARY"]["BIASSUB"] = (
+            self._biassub,
+            "Bias subtraction applied",
+        )
+        l1_obj.headers["PRIMARY"]["DARKSUB"] = (
+            self._darksub,
+            "Dark subtraction applied",
+        )
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -269,21 +296,6 @@ class ImageProcessing:
         if isinstance(val, tuple):  # Headers store (value, comment) tuples.
             val = val[0]
         return bool(val)
-
-    def _set_kpf1_headers(self, l1_obj):
-        """Write all PRIMARY-header keywords for image processing.
-
-        Reads the applied-flag attributes populated by perform(); the single
-        place this module writes PRIMARY, called just before the receipt entry.
-        """
-        l1_obj.headers["PRIMARY"]["BIASSUB"] = (
-            self._biassub,
-            "Bias subtraction applied",
-        )
-        l1_obj.headers["PRIMARY"]["DARKSUB"] = (
-            self._darksub,
-            "Dark subtraction applied",
-        )
 
     def perform(self, chips=None, *, bias=None, dark=None, flat=None):
         """
@@ -360,19 +372,11 @@ class ImageProcessing:
         self._biassub = bool(self.bias) or prior_bias
         self._darksub = bool(self.dark) or prior_dark
 
-        self._set_kpf1_headers(self.l1_obj)
+        self._set_headers(self.l1_obj)
         self._track_info()
         self.l1_obj.receipt_add_entry("image_processing", "PASS")
 
         return self.l1_obj
-
-    def _track_info(self):
-        """Populate _info (the info() summary) from instance attributes."""
-        self._info = {}
-        if self.bias:
-            self._info["bias"] = self._bias_path
-        if self.dark:
-            self._info["dark"] = self._dark_path
 
     def info(self):
         """Print a summary of the module configuration and processing results."""

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -75,7 +75,9 @@ class ImageProcessing:
         self._dark_ml1 = None
         self._bias_path = None
         self._dark_path = None
-        self._results = None  # populated by perform()
+        self._biassub = None  # applied flags for _set_kpf1_headers
+        self._darksub = None
+        self._info = None
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -268,6 +270,21 @@ class ImageProcessing:
             val = val[0]
         return bool(val)
 
+    def _set_kpf1_headers(self, l1_obj):
+        """Write all PRIMARY-header keywords for image processing.
+
+        Reads the applied-flag attributes populated by perform(); the single
+        place this module writes PRIMARY, called just before the receipt entry.
+        """
+        l1_obj.headers["PRIMARY"]["BIASSUB"] = (
+            self._biassub,
+            "Bias subtraction applied",
+        )
+        l1_obj.headers["PRIMARY"]["DARKSUB"] = (
+            self._darksub,
+            "Dark subtraction applied",
+        )
+
     def perform(self, chips=None, *, bias=None, dark=None, flat=None):
         """
         Run image processing calibrations on the L1 frame.
@@ -330,27 +347,23 @@ class ImageProcessing:
         if self.dark and prior_dark:
             raise RuntimeError("dark already subtracted from this frame (DARKSUB=True)")
 
-        self._results = {}
+        self._info = {}
         if self.bias:
             for chip in self.chips:
                 self.subtract_bias(chip)
-            self._results["bias"] = self._bias_path
+            self._info["bias"] = self._bias_path
 
         if self.dark:
             for chip in self.chips:
                 self.subtract_dark(chip)
-            self._results["dark"] = self._dark_path
+            self._info["dark"] = self._dark_path
 
         # OR with the prior flag so applying one calibration never clears
         # another already recorded on the frame.
-        self.l1_obj.headers["PRIMARY"]["BIASSUB"] = (
-            bool(self.bias) or prior_bias,
-            "Bias subtraction applied",
-        )
-        self.l1_obj.headers["PRIMARY"]["DARKSUB"] = (
-            bool(self.dark) or prior_dark,
-            "Dark subtraction applied",
-        )
+        self._biassub = bool(self.bias) or prior_bias
+        self._darksub = bool(self.dark) or prior_dark
+
+        self._set_kpf1_headers(self.l1_obj)
         self.l1_obj.receipt_add_entry("image_processing", "PASS")
 
         return self.l1_obj
@@ -361,11 +374,11 @@ class ImageProcessing:
         print(f"  obs_id: {self.l1_obj.obs_id}")
         print(f"  chips:  {self.chips}")
 
-        if self._results is None:
+        if self._info is None:
             print("  perform() has not been called")
             return
 
         print(f"\n  {'cal_type':<10s} {'master file'}")
         print("  " + "-" * 60)
-        for cal_type, path in self._results.items():
+        for cal_type, path in self._info.items():
             print(f"  {cal_type:<10s} {path}")

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -50,7 +50,7 @@ class SpectralExtraction:
         for k, v in _DEFAULTS.items():
             setattr(self, k, params.get(k, v))
 
-        self._results = None  # populated by perform()
+        self._info = None
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -505,14 +505,23 @@ class SpectralExtraction:
                 )
                 l2_obj.set_data(f"{chip}_{fiber}_VAR", l2_arrays[f"{chip}_{fiber}_VAR"])
 
+        self._set_kpf2_headers(l2_obj)
         l2_obj.receipt_add_entry("spectral_extraction", "PASS")
 
-        self._results = {
+        self._info = {
             chip: {"fibers": list(fibers), "norder": self.norder[chip.upper()]}
             for chip in chips
         }
 
         return l2_obj
+
+    def _set_kpf2_headers(self, l2_obj):
+        """Write all PRIMARY-header keywords for spectral extraction.
+
+        Reserved: this module writes no PRIMARY metadata yet. Present so every
+        module consolidates header writes in one place, called just before the
+        receipt entry.
+        """
 
     def info(self):
         """Print a summary of the module configuration and extraction results."""
@@ -520,12 +529,12 @@ class SpectralExtraction:
         print(f"  obs_id:            {self.l1_obj.obs_id}")
         print(f"  extraction_method: {self.extraction_method}")
 
-        if self._results is None:
+        if self._info is None:
             print("  perform() has not been called")
             return
 
         print(f"\n  {'CHIP':<8s} {'FIBERS':<30s} {'NORDER'}")
         print("  " + "-" * 46)
-        for chip, info in self._results.items():
+        for chip, info in self._info.items():
             fibers_str = " ".join(info["fibers"])
             print(f"  {chip:<8s} {fibers_str:<30s} {info['norder']}")

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -455,6 +455,25 @@ class SpectralExtraction:
         return l2_arrays
 
     # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+
+    def _track_info(self, chips, fibers):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {
+            chip: {"fibers": list(fibers), "norder": self.norder[chip.upper()]}
+            for chip in chips
+        }
+
+    def _set_headers(self, l2_obj):
+        """Write all PRIMARY-header keywords for spectral extraction.
+
+        Reserved: this module writes no PRIMARY metadata yet. Present so every
+        module consolidates header writes in one place, called just before the
+        receipt entry.
+        """
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -505,26 +524,11 @@ class SpectralExtraction:
                 )
                 l2_obj.set_data(f"{chip}_{fiber}_VAR", l2_arrays[f"{chip}_{fiber}_VAR"])
 
-        self._set_kpf2_headers(l2_obj)
+        self._set_headers(l2_obj)
         self._track_info(chips, fibers)
         l2_obj.receipt_add_entry("spectral_extraction", "PASS")
 
         return l2_obj
-
-    def _set_kpf2_headers(self, l2_obj):
-        """Write all PRIMARY-header keywords for spectral extraction.
-
-        Reserved: this module writes no PRIMARY metadata yet. Present so every
-        module consolidates header writes in one place, called just before the
-        receipt entry.
-        """
-
-    def _track_info(self, chips, fibers):
-        """Populate _info (the info() summary) from instance attributes."""
-        self._info = {
-            chip: {"fibers": list(fibers), "norder": self.norder[chip.upper()]}
-            for chip in chips
-        }
 
     def info(self):
         """Print a summary of the module configuration and extraction results."""

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -506,12 +506,8 @@ class SpectralExtraction:
                 l2_obj.set_data(f"{chip}_{fiber}_VAR", l2_arrays[f"{chip}_{fiber}_VAR"])
 
         self._set_kpf2_headers(l2_obj)
+        self._track_info(chips, fibers)
         l2_obj.receipt_add_entry("spectral_extraction", "PASS")
-
-        self._info = {
-            chip: {"fibers": list(fibers), "norder": self.norder[chip.upper()]}
-            for chip in chips
-        }
 
         return l2_obj
 
@@ -522,6 +518,13 @@ class SpectralExtraction:
         module consolidates header writes in one place, called just before the
         receipt entry.
         """
+
+    def _track_info(self, chips, fibers):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {
+            chip: {"fibers": list(fibers), "norder": self.norder[chip.upper()]}
+            for chip in chips
+        }
 
     def info(self):
         """Print a summary of the module configuration and extraction results."""

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -154,9 +154,8 @@ class WavelengthCalibration:
                 self.l2_obj.set_data(key, np.asarray(src, dtype=np.float64))
 
         self._set_kpf2_headers(self.l2_obj)
+        self._track_info()
         self.l2_obj.receipt_add_entry("wavelength_calibration", "PASS")
-
-        self._info = {"wls_path": self._wls_path}
 
         return self.l2_obj
 
@@ -167,6 +166,10 @@ class WavelengthCalibration:
         module consolidates header writes in one place, called just before the
         receipt entry.
         """
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {"wls_path": self._wls_path}
 
     def info(self):
         """Print a summary of the module configuration and association results."""

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -105,6 +105,22 @@ class WavelengthCalibration:
         return KPFMasterL2.from_fits(wls_path)
 
     # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+
+    def _track_info(self):
+        """Populate _info (the info() summary) from instance attributes."""
+        self._info = {"wls_path": self._wls_path}
+
+    def _set_headers(self, l2_obj):
+        """Write all PRIMARY-header keywords for wavelength calibration.
+
+        Reserved: this module writes no PRIMARY metadata yet. Present so every
+        module consolidates header writes in one place, called just before the
+        receipt entry.
+        """
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -153,23 +169,11 @@ class WavelengthCalibration:
                     )
                 self.l2_obj.set_data(key, np.asarray(src, dtype=np.float64))
 
-        self._set_kpf2_headers(self.l2_obj)
+        self._set_headers(self.l2_obj)
         self._track_info()
         self.l2_obj.receipt_add_entry("wavelength_calibration", "PASS")
 
         return self.l2_obj
-
-    def _set_kpf2_headers(self, l2_obj):
-        """Write all PRIMARY-header keywords for wavelength calibration.
-
-        Reserved: this module writes no PRIMARY metadata yet. Present so every
-        module consolidates header writes in one place, called just before the
-        receipt entry.
-        """
-
-    def _track_info(self):
-        """Populate _info (the info() summary) from instance attributes."""
-        self._info = {"wls_path": self._wls_path}
 
     def info(self):
         """Print a summary of the module configuration and association results."""

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -54,7 +54,7 @@ class WavelengthCalibration:
             setattr(self, k, params.get(k, v))
 
         self._wls_path = None  # set by load_wls()
-        self._results = None  # populated by perform()
+        self._info = None
 
     # ------------------------------------------------------------------
     # Algorithm steps
@@ -153,15 +153,20 @@ class WavelengthCalibration:
                     )
                 self.l2_obj.set_data(key, np.asarray(src, dtype=np.float64))
 
+        self._set_kpf2_headers(self.l2_obj)
         self.l2_obj.receipt_add_entry("wavelength_calibration", "PASS")
 
-        self._results = {
-            "wls_path": self._wls_path,
-            "chips": list(chips),
-            "fibers": list(fibers),
-        }
+        self._info = {"wls_path": self._wls_path}
 
         return self.l2_obj
+
+    def _set_kpf2_headers(self, l2_obj):
+        """Write all PRIMARY-header keywords for wavelength calibration.
+
+        Reserved: this module writes no PRIMARY metadata yet. Present so every
+        module consolidates header writes in one place, called just before the
+        receipt entry.
+        """
 
     def info(self):
         """Print a summary of the module configuration and association results."""
@@ -173,12 +178,12 @@ class WavelengthCalibration:
         print(f"  chips:   {self.chips}")
         print(f"  fibers:  {self.fibers}")
 
-        if self._results is None:
+        if self._info is None:
             print("  perform() has not been called")
             return
 
         inst = self.l2_obj.headers.get("INSTRUMENT_HEADER", {})
         agewls = inst.get("WLSAGE")
-        print(f"  wls_path: {self._results['wls_path']}")
+        print(f"  wls_path: {self._info['wls_path']}")
         if agewls is not None:
             print(f"  WLSAGE:   {agewls:+.4f} d  (master - obs)")

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -889,14 +889,14 @@ class TestPerform:
         assert captured["rv_mps"] == 0.0
 
     def test_state_populated(self, bc_monkeypatched):
-        assert bc_monkeypatched._ccd_bary is None
+        for attr in ("_ccd_bjd", "_ccd_kms", "_ccd_z"):
+            assert getattr(bc_monkeypatched, attr) is None
         kpf2 = bc_monkeypatched.perform()
         assert bc_monkeypatched._astrometry_source == "Gaia DR3"
         for key in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
             assert len(kpf2.data[key]) == NORDER
-        assert set(bc_monkeypatched._ccd_bary) == {1, 2}
-        for ccd in (1, 2):
-            assert set(bc_monkeypatched._ccd_bary[ccd]) == {"bjd", "kms", "z"}
+        for attr in ("_ccd_bjd", "_ccd_kms", "_ccd_z"):
+            assert len(getattr(bc_monkeypatched, attr)) == 2
 
     def test_records_gaia_provenance(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.perform()

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -888,24 +888,15 @@ class TestPerform:
         bc_monkeypatched.perform()
         assert captured["rv_mps"] == 0.0
 
-    def test_results_populated(self, bc_monkeypatched):
-        assert bc_monkeypatched._results is None
-        bc_monkeypatched.perform()
-        results = bc_monkeypatched._results
-        assert set(results.keys()) == {
-            "bjd_tdb",
-            "bary_kms",
-            "bary_z",
-            "ccd_bjd",
-            "ccd_kms",
-            "ccd_z",
-            "astrometry_source",
-        }
-        assert results["astrometry_source"] == "Gaia DR3"
-        for key in ("bjd_tdb", "bary_kms", "bary_z"):
-            assert len(results[key]) == NORDER
-        for key in ("ccd_bjd", "ccd_kms", "ccd_z"):
-            assert len(results[key]) == 2
+    def test_state_populated(self, bc_monkeypatched):
+        assert bc_monkeypatched._ccd_bary is None
+        kpf2 = bc_monkeypatched.perform()
+        assert bc_monkeypatched._astrometry_source == "Gaia DR3"
+        for key in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
+            assert len(kpf2.data[key]) == NORDER
+        assert set(bc_monkeypatched._ccd_bary) == {1, 2}
+        for ccd in (1, 2):
+            assert set(bc_monkeypatched._ccd_bary[ccd]) == {"bjd", "kms", "z"}
 
     def test_records_gaia_provenance(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.perform()
@@ -942,7 +933,7 @@ class TestPerform:
 
         astrsrc = kpf2.headers["PRIMARY"]["ASTRSRC"]
         assert (astrsrc[0] if isinstance(astrsrc, tuple) else astrsrc) == "WMKO header"
-        assert bc._results["astrometry_source"] == "WMKO header"
+        assert bc._astrometry_source == "WMKO header"
 
     def test_real_outlier_filter_runs_end_to_end(self, synthetic_kpf2, monkeypatch):
         """Exercise fix_expmeter_outliers=True through perform() with a

--- a/tests/regression/test_image_processing.py
+++ b/tests/regression/test_image_processing.py
@@ -145,8 +145,10 @@ class TestInit:
         with pytest.raises(TypeError):
             ImageProcessing(MockL1(), config=42)
 
-    def test_results_none_before_perform(self):
-        assert ImageProcessing(MockL1())._results is None
+    def test_paths_none_before_perform(self):
+        mod = ImageProcessing(MockL1())
+        assert mod._bias_path is None
+        assert mod._dark_path is None
 
     def test_bias_path_none_before_perform(self):
         assert ImageProcessing(MockL1())._bias_path is None
@@ -183,7 +185,6 @@ class TestBiasResolution:
         mod = _make_module(bias_file="master_bias.fits", bias_dir=str(tmp_path))
         mod.perform(dark=False)
         assert mod._bias_path == bias_path
-        assert mod._results["bias"] == bias_path
         np.testing.assert_allclose(
             mod.l1_obj.data["GREEN_CCD"], _CCD_VALUE - _BIAS_VALUE
         )
@@ -211,7 +212,7 @@ class TestBiasResolution:
         # No BIAS headers — the object is used directly, no disk lookup.
         mod = _make_module()
         mod.perform(bias=master, dark=False)
-        assert "bias" in mod._results
+        assert mod._bias_path is not None
         np.testing.assert_allclose(
             mod.l1_obj.data["GREEN_CCD"], _CCD_VALUE - _BIAS_VALUE
         )
@@ -308,7 +309,6 @@ class TestDarkResolution:
         mod = _make_module(dark_file="master_dark.fits", dark_dir=str(tmp_path))
         mod.perform(bias=False)
         assert mod._dark_path == dark_path
-        assert mod._results["dark"] == dark_path
         np.testing.assert_allclose(
             mod.l1_obj.data["GREEN_CCD"], _CCD_VALUE - _DARK_VALUE * _EXPTIME
         )
@@ -329,7 +329,7 @@ class TestDarkResolution:
         master = KPFMasterL1.from_fits(dark_path)
         mod = _make_module()
         mod.perform(bias=False, dark=master)
-        assert "dark" in mod._results
+        assert mod._dark_path is not None
         np.testing.assert_allclose(
             mod.l1_obj.data["GREEN_CCD"], _CCD_VALUE - _DARK_VALUE * _EXPTIME
         )
@@ -412,10 +412,9 @@ class TestPerform:
             mod_with_bias.l1_obj.data["RED_CCD"], _CCD_VALUE - _BIAS_VALUE
         )
 
-    def test_results_keyed_by_bias(self, mod_with_bias, tmp_path):
+    def test_bias_path_recorded(self, mod_with_bias, tmp_path):
         mod_with_bias.perform()
-        assert "bias" in mod_with_bias._results
-        assert mod_with_bias._results["bias"] == str(tmp_path / "master_bias.fits")
+        assert mod_with_bias._bias_path == str(tmp_path / "master_bias.fits")
 
     def test_biassub_header_set(self, mod_with_bias):
         mod_with_bias.perform()
@@ -447,7 +446,7 @@ class TestPerform:
         # BIASSUB header reflects the choice
         assert result.headers["PRIMARY"]["BIASSUB"][0] is False
         # No bias path recorded
-        assert "bias" not in mod._results
+        assert mod._bias_path is None
 
     def test_darksub_header_false_when_dark_off(self, mod_with_bias):
         mod_with_bias.perform()
@@ -466,7 +465,7 @@ class TestPerform:
         np.testing.assert_allclose(result.data["GREEN_CCD"], _CCD_VALUE - _BIAS_VALUE)
         np.testing.assert_allclose(result.data["RED_CCD"], _CCD_VALUE - _BIAS_VALUE)
         assert result.headers["PRIMARY"]["BIASSUB"][0] is True
-        assert mod._results["bias"] == bias_path
+        assert mod._bias_path == bias_path
 
     def test_bias_master_l1_object_used_directly(self, tmp_path):
         # supplying a KPFMasterL1 instance should bypass disk I/O entirely
@@ -478,7 +477,7 @@ class TestPerform:
         np.testing.assert_allclose(result.data["GREEN_CCD"], _CCD_VALUE - _BIAS_VALUE)
         assert result.headers["PRIMARY"]["BIASSUB"][0] is True
         # _bias_path should reflect the in-memory object's filename
-        assert mod._results["bias"] == bias_path
+        assert mod._bias_path == bias_path
 
     def test_bias_invalid_type_raises_type_error(self):
         mod = _make_module()
@@ -542,9 +541,9 @@ class TestPerformDark:
         mod_with_bias_dark.perform(bias=True, dark=True)
         assert mod_with_bias_dark.l1_obj.headers["PRIMARY"]["DARKSUB"][0] is True
 
-    def test_results_keyed_by_dark(self, mod_with_bias_dark, tmp_path):
+    def test_dark_path_recorded(self, mod_with_bias_dark, tmp_path):
         mod_with_bias_dark.perform(bias=True, dark=True)
-        assert mod_with_bias_dark._results["dark"] == str(tmp_path / "master_dark.fits")
+        assert mod_with_bias_dark._dark_path == str(tmp_path / "master_dark.fits")
 
     def test_dark_filepath_overrides_headers(self, tmp_path):
         dark_path = str(tmp_path / "explicit_dark.fits")
@@ -554,7 +553,7 @@ class TestPerformDark:
         np.testing.assert_allclose(
             mod.l1_obj.data["GREEN_CCD"], _CCD_VALUE - _DARK_VALUE * _EXPTIME
         )
-        assert mod._results["dark"] == dark_path
+        assert mod._dark_path == dark_path
 
     def test_dark_master_l1_object_used_directly(self, tmp_path):
         dark_path = str(tmp_path / "preloaded_dark.fits")
@@ -565,7 +564,7 @@ class TestPerformDark:
         np.testing.assert_allclose(
             mod.l1_obj.data["GREEN_CCD"], _CCD_VALUE - _DARK_VALUE * _EXPTIME
         )
-        assert mod._results["dark"] == dark_path
+        assert mod._dark_path == dark_path
 
     def test_dark_invalid_type_raises_type_error(self):
         mod = _make_module()

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -107,10 +107,6 @@ class TestConstructor:
         with pytest.raises(TypeError):
             WavelengthCalibration(_make_science_l2(), config="not a dict")
 
-    def test_results_is_none_before_perform(self):
-        mod = WavelengthCalibration(_make_science_l2())
-        assert mod._results is None
-
     def test_wls_path_is_none_before_load(self):
         mod = WavelengthCalibration(_make_science_l2())
         assert mod._wls_path is None
@@ -163,13 +159,13 @@ class TestPerform:
         WavelengthCalibration(l2).perform()
         assert (l2.receipt["Module_Name"] == "wavelength_calibration").any()
 
-    def test_results_populated_after_perform(self, master_wls_path):
+    def test_attributes_populated_after_perform(self, master_wls_path):
         l2 = _make_science_l2(wls_path=master_wls_path)
         mod = WavelengthCalibration(l2)
         mod.perform()
-        assert mod._results["wls_path"] == master_wls_path
-        assert mod._results["chips"] == _CHIPS
-        assert mod._results["fibers"] == _FIBERS
+        assert mod._wls_path == master_wls_path
+        assert mod.chips == _CHIPS
+        assert mod.fibers == _FIBERS
 
     def test_copies_all_wave_arrays(self, master_wls_path):
         # Every (chip, fiber) WAVE array on the science L2 should match the master.


### PR DESCRIPTION
  ## Standardize module info-tracking & PRIMARY-header writes

  Unifies how the six standard science modules manage their two non-scientific
  output streams — PRIMARY-header keywords and the `info()` summary — so every
  module follows one predictable shape. **Output is unchanged:** PRIMARY keyword
  names and values are byte-identical; methods are relocated, renamed, and
  re-sourced, not altered.

  **In scope (6 modules):** `image_assembly`, `image_processing`,
  `calibration_association`, `spectral_extraction`, `wavelength_calibration`,
  `barycentric_correction`.
  **Out of scope (deferred to their own refactors):** `radial_velocity` and the
  `modules/masters/` layer — they intentionally keep the old `_results` pattern
  for now.

  ### What changed

    `headers["PRIMARY"]` writes into a single private `_set_headers(obj)` that
    sources every value from instance attributes (never recomputes, never reads
    another product), called immediately before `receipt_add_entry`. Modules that
    write no PRIMARY keep an empty helper for uniformity.
  - **`_results` → `_info`.** The cached summary dict is renamed to clarify it is
    a human-readable `info()` reporter only — never read by the science/header
    chain or by tests. It is pruned to exactly the fields `info()` prints and is
    populated by a standard private `_track_info(self[, chips, fibers])` (no other
    args), called right after `_set_headers`.
  - **`barycentric_correction`:** dropped the intermediate `_ccd_bary` dict; the
    per-CCD summaries are now tracked directly as `_ccd_bjd/_ccd_kms/_ccd_z`
    `[GREEN, RED]` arrays, which feed both the header write and `_info`.
  - **Layout standardized.** `_track_info` and `_set_headers` live together in a
    dedicated `# Private helpers - module execution` banner section placed just
    before `# Public entry point`, and the helper is uniformly named
    `_set_headers` (was `_set_kpf{1,2}_headers` — the output level is already
    clear from context).
  - **Tests** migrated off `_results`/`_info` onto the underlying instance
    attributes; no test references the internal summary dict anymore.
  
  ### Docs
  
  - `KPF_DRP_VNEXT_STYLE_GUIDE.md` §2 "golden skeleton" documents the new
    `_set_headers` / `_track_info` / module-execution section.
  - Swept the style guide for redundancy/verbosity (e.g. the PEP 758 / `py313`-pin
    `except` rationale was told in full in both §6 and §8 — consolidated into §8).

  ### Verification
  
  - 6 module test files: **254 passed**
  - Fast subset (`make test-fast`): **886 passed**
  - Slow science + masters recipes: **84 passed** (per-CCD barycorr keyword and
    calibration-header assertions confirm PRIMARY output is unchanged)
  - `ruff format` + `ruff check`: clean

  ### Commits
  - `refactor: consolidate module PRIMARY-header writes into _set_kpf*_headers; rename _results to _info`
  - `refactor: extract _info population into a standard _track_info() helper`
  - `refactor: track per-CCD barycentric arrays directly, drop _ccd_bary`
  - `refactor: standardize module-execution helper section; rename _set_headers`