### PR TITLE
Streamline and centralize FITS-header keyword reading

### DIFF
--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -559,11 +559,22 @@ documented, intentional ways — follow *its* conventions when adding masters co
 
 The WMKO-native → EPRV-standard conversion happens **only** in `KPF0.to_kpf1`
 (`data_models/headers.py`); see CLAUDE.md *Header standardization* for the full rule.
+Two classes in `data_models/headers.py` own all header handling: **`HeaderParser`**
+(read/write a keyword) and **`HeaderConverter`** (native↔EPRV conversion + validation).
 What this means when writing code:
 
+- **Reading a header value**: use `HeaderParser.get(header, key, default=None)`. A header value
+  is stored either bare or as a `(value, comment)` tuple (and a read-back `fits.Header` yields the
+  scalar); `get` normalizes all three. **Never hand-roll `value[0] if isinstance(value, tuple)`** —
+  that idiom was duplicated ~20× and is now banned; `get` is the one implementation.
+- **Writing a header value**: use `HeaderParser.set(header, key, value, comment=None)` — with a
+  `comment` it writes a `(value, comment)` card, else the bare value.
+- **Conversion / validation**: call `HeaderConverter.native_to_eprv`,
+  `HeaderConverter.build_instrument_header`, and `HeaderConverter.validate_eprv_primary`; don't
+  re-implement the native→EPRV mapping.
 - **Reading a raw instrument keyword** (`ELAPSED`, `MJD-OBS`, `DATE-OBS`, `GAIAID`, `SCI-OBJ`,
-  `TARGTEFF`, …): read it from `headers["INSTRUMENT_HEADER"]`, never from PRIMARY. No silent
-  fallback — let a missing key raise.
+  `TARGTEFF`, …): read it from `headers["INSTRUMENT_HEADER"]` (via `HeaderParser.get`), never from
+  PRIMARY. No silent fallback — let a missing key raise.
 - **Writing a KPF-pipeline keyword**: write it to `headers["PRIMARY"]` *and* add it to
   the matching `config/L{0,1,2,4}-headers.csv`, or `to_kpf2`/`to_kpf4` validation will reject the
   product. Never write to `INSTRUMENT_HEADER` (it is an immutable raw-instrument snapshot).
@@ -707,8 +718,7 @@ the dominant variant of the file/area you're editing**, and don't churn unrelate
 "fix" style.
 
 1. **Quicklook** — no shared base class + tuple-based registration, unlike Diag/QC; DPI
-   (150 vs 600) and axis-fontsize (14 vs 18) drift between L0 and L1; the
-   `(value, comment)`-unwrap helper duplicated ~4×.
+   (150 vs 600) and axis-fontsize (14 vs 18) drift between L0 and L1.
 2. **Masters** — the config-resolution block is duplicated 5× (could be a base helper); the
    `0.2` load-failure threshold is an unnamed magic number.
 3. **Configs** — the `[DATA_DIRS]` + `[KPFPIPE]` blocks are duplicated verbatim across the

--- a/kpfpipe/__init__.py
+++ b/kpfpipe/__init__.py
@@ -1,7 +1,16 @@
+import importlib.metadata
 import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Installed package version (WMKO DRP-RUN-11); stamped onto PRIMARY as DRPTAG/
+# DRPVERNO. Falls back to "unknown" if the package metadata is unavailable
+# (e.g. running from a source tree that was never installed).
+try:
+    __version__ = importlib.metadata.version("kpfpipe")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
 
 # By default use both CCDs and all five fibers
 DEFAULTS = {

--- a/kpfpipe/data_models/headers.py
+++ b/kpfpipe/data_models/headers.py
@@ -6,16 +6,16 @@ Two classes own all KPF header behaviour:
 - :class:`HeaderParser` — read/write a keyword without worrying about whether a
   value is stored bare or as a ``(value, comment)`` tuple. The single place that
   bridges the two in-memory representations (``fits.Header`` vs. ``OrderedDict``).
-- :class:`HeaderConverter` — the single source of truth for the native→EPRV
+- :class:`HeaderConverter` — the single source of truth for the WMKO→EPRV
   keyword mapping (rvdata's ``header_map.csv``) and for what may legitimately
   appear on a KPF EPRV PRIMARY header:
 
-  - ``KPF0.to_kpf1`` calls :meth:`HeaderConverter.native_to_eprv` to build an
+  - ``KPF0.to_kpf1`` calls :meth:`HeaderConverter.wmko_to_eprv` to build an
     EPRV-standard L1 PRIMARY from the raw WMKO L0 PRIMARY, and
     :meth:`HeaderConverter.build_instrument_header` to preserve the verbatim raw
     L0 PRIMARY in an immutable ``INSTRUMENT_HEADER`` extension.
   - ``KPF1.to_kpf2`` / ``KPF2.to_kpf4`` call
-    :meth:`HeaderConverter.validate_eprv_primary` to fail loudly if a raw native
+    :meth:`HeaderConverter.validate_eprv_primary` to fail loudly if a raw wmko
     keyword leaked onto PRIMARY, an unregistered keyword appears, or a required
     EPRV keyword is missing.
 
@@ -24,16 +24,14 @@ booleans, diagnostics, RV/barycentric cards, …) are catalogued in the packaged
 registry (``config/L{0,1,2,4}-headers.csv``) and allowed by the validator.
 """
 
-import importlib.metadata
 import importlib.resources
 
 import pandas as pd
-from astropy.time import Time
 
-from kpfpipe import DETECTOR
+from kpfpipe import DETECTOR, __version__
 
 # --- Authoritative configs -------------------------------------------------
-# rvdata (installed package): the native↔EPRV map and the EPRV PRIMARY keyword
+# rvdata (installed package): the wmko↔EPRV map and the EPRV PRIMARY keyword
 # definitions. KPF consumes these rather than re-encoding the standard.
 _kpf_cfg = importlib.resources.files("rvdata.instruments.kpf.config")
 _rv_cfg = importlib.resources.files("rvdata.core.models.config")
@@ -117,8 +115,8 @@ HEADERMAP_STANDARD_KEYS = {
 }
 # header_map INSTRUMENT names that differ from their STANDARD target are the raw
 # WMKO names that must NOT remain on a converted PRIMARY (they belong in
-# INSTRUMENT_HEADER). Used for a precise "native leak" diagnostic.
-NATIVE_PRIMARY_KEYS = {
+# INSTRUMENT_HEADER). Used for a precise "wmko leak" diagnostic.
+WMKO_PRIMARY_KEYS = {
     str(r["INSTRUMENT"]).strip()
     for _, r in HEADER_MAP.iterrows()
     if pd.notna(r["INSTRUMENT"])
@@ -205,49 +203,24 @@ class HeaderConverter:
     """Convert and validate KPF PRIMARY headers across the WMKO-native, EPRV,
     and KPF-pipeline conventions.
 
-    Single source of truth for the native→EPRV mapping (rvdata's
+    Single source of truth for the wmko→EPRV mapping (rvdata's
     ``header_map.csv``) and the EPRV PRIMARY allowlist. Stateless: the reference
     data (``HEADER_MAP`` and the derived keyword sets) is module-level, loaded
     once at import.
     """
 
     @staticmethod
-    def _drp_version():
-        """Exact DRP version (WMKO DRP-RUN-11), from installed package metadata."""
-        return importlib.metadata.version("kpfpipe")
-
-    @staticmethod
-    def _full_jd_utc(native_primary):
-        """Full Julian Date of the exposure start (EPRV JD_UTC), or None.
-
-        The rvdata header_map maps JD_UTC <- MJD-OBS but omits the epoch offset,
-        leaving a raw MJD (notes/header_audit.md A1). KPF's canonical exposure
-        time is MJD-OBS — legacy code keys off it, and KPF's native DATE-OBS is
-        date-only (e.g. '2024-04-05'), so it cannot supply the time of day. Hence
-        JD_UTC = MJD-OBS + 2400000.5, which equals the JD of the precise ISO
-        DATE-BEG. Fall back to DATE-BEG, then DATE-OBS, only if MJD-OBS is absent.
-        """
-        mjd = HeaderParser.get(native_primary, "MJD-OBS")
-        if mjd not in (None, "", "UNKNOWN"):
-            return float(mjd) + 2400000.5
-        for key in ("DATE-BEG", "DATE-OBS"):
-            val = HeaderParser.get(native_primary, key)
-            if val not in (None, "", "UNKNOWN"):
-                return float(Time(str(val), format="isot", scale="utc").jd)
-        return None
-
-    @classmethod
-    def native_to_eprv(cls, native_primary):
+    def wmko_to_eprv(wmko_primary):
         """Map a raw WMKO PRIMARY header to an EPRV-standard PRIMARY dict.
 
-        For each header_map row, take the instrument (native) value when present,
+        For each header_map row, take the instrument (wmko) value when present,
         else the row default. Then apply the value corrections the installed
         header_map gets wrong (NUMORDER, JD_UTC) and stamp the DRP version
         (DRPTAG for EPRV, DRPVERNO for WMKO DRP-RUN-11).
 
         Parameters
         ----------
-        native_primary : Mapping
+        wmko_primary : Mapping
             The raw L0 PRIMARY header (astropy ``fits.Header`` or dict).
 
         Returns
@@ -263,27 +236,31 @@ class HeaderConverter:
             )
             default_val = row["DEFAULT"] if pd.notna(row["DEFAULT"]) else None
 
-            if instrument_key and instrument_key in native_primary:
-                out[standard_key] = HeaderParser.get(native_primary, instrument_key)
+            if instrument_key and instrument_key in wmko_primary:
+                out[standard_key] = HeaderParser.get(wmko_primary, instrument_key)
             elif default_val is not None and str(default_val).strip():
                 out[standard_key] = default_val
 
         # --- Value corrections (see notes/header_audit.md A1/A2/A3) ---
         out["NUMORDER"] = (_NUMORDER, "Number of echelle orders (green+red)")
-        jd_utc = cls._full_jd_utc(native_primary)
-        if jd_utc is not None:
-            out["JD_UTC"] = (jd_utc, "[day] Julian date of exposure start")
-        version = cls._drp_version()
-        out["DRPTAG"] = (version, "DRP version")
-        out["DRPVERNO"] = (version, "DRP version (WMKO DRP-RUN-11)")
+        # header_map maps JD_UTC <- MJD-OBS but drops the epoch offset, leaving a
+        # raw MJD (A1); KPF's canonical exposure time is MJD-OBS, so add 2400000.5.
+        mjd = HeaderParser.get(wmko_primary, "MJD-OBS")
+        if mjd not in (None, "", "UNKNOWN"):
+            out["JD_UTC"] = (
+                float(mjd) + 2400000.5,
+                "[day] Julian date of exposure start",
+            )
+        out["DRPTAG"] = (__version__, "DRP version")
+        out["DRPVERNO"] = (__version__, "DRP version (WMKO DRP-RUN-11)")
 
-        # WMKO provenance (DRP-RUN-19): native PROGID/KOAID, or 'UNKNOWN' if absent.
+        # WMKO provenance (DRP-RUN-19): PROGID/KOAID, or 'UNKNOWN' if absent.
         out["PROGID"] = (
-            HeaderParser.get(native_primary, "PROGID") or "UNKNOWN",
+            HeaderParser.get(wmko_primary, "PROGID") or "UNKNOWN",
             "WMKO program ID",
         )
         out["KOAID"] = (
-            HeaderParser.get(native_primary, "KOAID") or "UNKNOWN",
+            HeaderParser.get(wmko_primary, "KOAID") or "UNKNOWN",
             "KOA archive ID",
         )
         # Initial reduction status (DRP-RUN-20); modules overwrite it as they run.
@@ -291,7 +268,7 @@ class HeaderConverter:
         return out
 
     @staticmethod
-    def build_instrument_header(native_primary):
+    def build_instrument_header(wmko_primary):
         """Verbatim scalar copy of the raw WMKO PRIMARY for INSTRUMENT_HEADER.
 
         INSTRUMENT_HEADER is an ImageHDU header (scalar values only) and is an
@@ -300,7 +277,7 @@ class HeaderConverter:
 
         Parameters
         ----------
-        native_primary : Mapping
+        wmko_primary : Mapping
             The raw L0 PRIMARY header.
 
         Returns
@@ -312,9 +289,7 @@ class HeaderConverter:
         # commentary card's scalar string, where header["COMMENT"] would instead
         # return an astropy commentary-card object that fits.Header(dict) cannot
         # re-serialize.
-        return {
-            key: HeaderParser._unwrap(value) for key, value in native_primary.items()
-        }
+        return {key: HeaderParser._unwrap(value) for key, value in wmko_primary.items()}
 
     @staticmethod
     def validate_eprv_primary(header, level):
@@ -322,7 +297,7 @@ class HeaderConverter:
 
         Fail-loud guard (no silent fallback) for the L2/L4 boundary. Three rules:
 
-        1. **Native leak** — a raw WMKO keyword name (header_map INSTRUMENT name
+        1. **WMKO leak** — a raw WMKO keyword name (header_map INSTRUMENT name
            differing from its EPRV target) is present on PRIMARY; it should have
            been converted or left in INSTRUMENT_HEADER.
         2. **Unregistered keyword** — a card that is neither an EPRV-standard
@@ -356,7 +331,7 @@ class HeaderConverter:
                 or key in KPFPIPE_PRIMARY_KEYS
             ):
                 continue
-            if key in NATIVE_PRIMARY_KEYS:
+            if key in WMKO_PRIMARY_KEYS:
                 raise ValueError(
                     f"native WMKO keyword {key!r} found on {level} PRIMARY; it must "
                     "be converted to its EPRV name or kept in INSTRUMENT_HEADER"

--- a/kpfpipe/data_models/headers.py
+++ b/kpfpipe/data_models/headers.py
@@ -1,17 +1,23 @@
 """
-WMKO-native ↔ EPRV-standard FITS PRIMARY header conversion and validation.
+FITS header parsing and WMKO ↔ EPRV ↔ KPF PRIMARY conversion.
 
-Single source of truth for the native→EPRV keyword mapping (rvdata's
-``header_map.csv``) and for what may legitimately appear on a KPF EPRV PRIMARY
-header. The conversion lives here, in exactly one place:
+Two classes own all KPF header behaviour:
 
-- ``KPF0.to_kpf1`` calls :func:`convert_native_to_eprv` to build an
-  EPRV-standard L1 PRIMARY from the raw WMKO L0 PRIMARY, and
-  :func:`build_instrument_header` to preserve the verbatim raw L0 PRIMARY in an
-  immutable ``INSTRUMENT_HEADER`` extension.
-- ``KPF1.to_kpf2`` / ``KPF2.to_kpf4`` call :func:`validate_eprv_primary` to fail
-  loudly if a raw native keyword leaked onto PRIMARY, an unregistered keyword
-  appears, or a required EPRV keyword is missing.
+- :class:`HeaderParser` — read/write a keyword without worrying about whether a
+  value is stored bare or as a ``(value, comment)`` tuple. The single place that
+  bridges the two in-memory representations (``fits.Header`` vs. ``OrderedDict``).
+- :class:`HeaderConverter` — the single source of truth for the native→EPRV
+  keyword mapping (rvdata's ``header_map.csv``) and for what may legitimately
+  appear on a KPF EPRV PRIMARY header:
+
+  - ``KPF0.to_kpf1`` calls :meth:`HeaderConverter.native_to_eprv` to build an
+    EPRV-standard L1 PRIMARY from the raw WMKO L0 PRIMARY, and
+    :meth:`HeaderConverter.build_instrument_header` to preserve the verbatim raw
+    L0 PRIMARY in an immutable ``INSTRUMENT_HEADER`` extension.
+  - ``KPF1.to_kpf2`` / ``KPF2.to_kpf4`` call
+    :meth:`HeaderConverter.validate_eprv_primary` to fail loudly if a raw native
+    keyword leaked onto PRIMARY, an unregistered keyword appears, or a required
+    EPRV keyword is missing.
 
 KPF-pipeline keywords that are written directly to PRIMARY (read noise, QC
 booleans, diagnostics, RV/barycentric cards, …) are catalogued in the packaged
@@ -157,162 +163,211 @@ _NUMORDER = int(DETECTOR["norder"]["GREEN"]) + int(DETECTOR["norder"]["RED"])
 _DRPSTATU_DEFAULT = "File ingested into KPF-DRP"
 
 
-def _scalar(value):
-    """Return a header value, dropping any (value, comment) tuple wrapper."""
-    return value[0] if isinstance(value, tuple) else value
+class HeaderParser:
+    """Read and write FITS header keywords without minding the storage form.
 
-
-def _drp_version():
-    """Exact DRP version (WMKO DRP-RUN-11), from the installed package metadata."""
-    return importlib.metadata.version("kpfpipe")
-
-
-def _full_jd_utc(native_primary):
-    """Full Julian Date of the exposure start (EPRV JD_UTC), or None.
-
-    The rvdata header_map maps JD_UTC <- MJD-OBS but omits the epoch offset,
-    leaving a raw MJD (notes/header_audit.md A1). KPF's canonical exposure time
-    is MJD-OBS — legacy code keys off it, and KPF's native DATE-OBS is
-    date-only (e.g. '2024-04-05'), so it cannot supply the time of day. Hence
-    JD_UTC = MJD-OBS + 2400000.5, which equals the JD of the precise ISO
-    DATE-BEG. Fall back to DATE-BEG, then DATE-OBS, only if MJD-OBS is absent.
+    A KPF extension header is either an astropy ``fits.Header`` (scalar values,
+    comments held separately) or a plain ``OrderedDict`` whose PRIMARY keys may
+    hold ``(value, comment)`` tuples. These static helpers are the single place
+    that bridges the two, so callers never hand-roll a tuple unwrap.
     """
-    mjd = _scalar(native_primary.get("MJD-OBS"))
-    if mjd not in (None, "", "UNKNOWN"):
-        return float(mjd) + 2400000.5
-    for key in ("DATE-BEG", "DATE-OBS"):
-        val = _scalar(native_primary.get(key))
-        if val not in (None, "", "UNKNOWN"):
-            return float(Time(str(val), format="isot", scale="utc").jd)
-    return None
+
+    @staticmethod
+    def _unwrap(value):
+        """Drop a ``(value, comment)`` tuple wrapper, returning the bare value."""
+        return value[0] if isinstance(value, tuple) else value
+
+    @staticmethod
+    def get(header, key, default=None):
+        """Return the scalar value of ``key``, unwrapping a ``(value, comment)``
+        tuple if present (a ``fits.Header`` already yields the scalar).
+
+        ``default`` is returned only when ``key`` is **absent**; a stored ``None``
+        value is returned as ``None``.
+        """
+        if key not in header:
+            return default
+        return HeaderParser._unwrap(header[key])
+
+    @staticmethod
+    def set(header, key, value, comment=None):
+        """Write ``key``: as a ``(value, comment)`` card when ``comment`` is
+        given, else as the bare value. The single documented write path.
+
+        A commented write round-trips on PRIMARY and on any ``fits.Header``
+        extension; on a plain-dict **non-PRIMARY** extension rvdata's serializer
+        rejects tuples, so comments there must go through a real ``fits.Header``.
+        """
+        header[key] = (value, comment) if comment is not None else value
 
 
-def convert_native_to_eprv(native_primary):
-    """Map a raw WMKO PRIMARY header to an EPRV-standard PRIMARY dict.
+class HeaderConverter:
+    """Convert and validate KPF PRIMARY headers across the WMKO-native, EPRV,
+    and KPF-pipeline conventions.
 
-    For each header_map row, take the instrument (native) value when present,
-    else the row default. Then apply the value corrections the installed
-    header_map gets wrong (NUMORDER, JD_UTC) and stamp the DRP version
-    (DRPTAG for EPRV, DRPVERNO for WMKO DRP-RUN-11).
-
-    Parameters
-    ----------
-    native_primary : Mapping
-        The raw L0 PRIMARY header (astropy ``fits.Header`` or dict).
-
-    Returns
-    -------
-    dict
-        EPRV-standard PRIMARY keyword → value (a few as ``(value, comment)``).
+    Single source of truth for the native→EPRV mapping (rvdata's
+    ``header_map.csv``) and the EPRV PRIMARY allowlist. Stateless: the reference
+    data (``HEADER_MAP`` and the derived keyword sets) is module-level, loaded
+    once at import.
     """
-    out = {}
-    for _, row in HEADER_MAP.iterrows():
-        standard_key = str(row["STANDARD"]).strip()
-        instrument_key = (
-            str(row["INSTRUMENT"]).strip() if pd.notna(row["INSTRUMENT"]) else ""
-        )
-        default_val = row["DEFAULT"] if pd.notna(row["DEFAULT"]) else None
 
-        if instrument_key and instrument_key in native_primary:
-            out[standard_key] = _scalar(native_primary[instrument_key])
-        elif default_val is not None and str(default_val).strip():
-            out[standard_key] = default_val
+    @staticmethod
+    def _drp_version():
+        """Exact DRP version (WMKO DRP-RUN-11), from installed package metadata."""
+        return importlib.metadata.version("kpfpipe")
 
-    # --- Value corrections (see notes/header_audit.md A1/A2/A3) ---
-    out["NUMORDER"] = (_NUMORDER, "Number of echelle orders (green+red)")
-    jd_utc = _full_jd_utc(native_primary)
-    if jd_utc is not None:
-        out["JD_UTC"] = (jd_utc, "[day] Julian date of exposure start")
-    version = _drp_version()
-    out["DRPTAG"] = (version, "DRP version")
-    out["DRPVERNO"] = (version, "DRP version (WMKO DRP-RUN-11)")
+    @staticmethod
+    def _full_jd_utc(native_primary):
+        """Full Julian Date of the exposure start (EPRV JD_UTC), or None.
 
-    # WMKO provenance (DRP-RUN-19): native PROGID/KOAID, or 'UNKNOWN' if absent.
-    out["PROGID"] = (
-        _scalar(native_primary.get("PROGID")) or "UNKNOWN",
-        "WMKO program ID",
-    )
-    out["KOAID"] = (_scalar(native_primary.get("KOAID")) or "UNKNOWN", "KOA archive ID")
-    # Initial reduction status (DRP-RUN-20); modules overwrite it as they run.
-    out["DRPSTATU"] = (_DRPSTATU_DEFAULT, "DRP reduction status")
-    return out
+        The rvdata header_map maps JD_UTC <- MJD-OBS but omits the epoch offset,
+        leaving a raw MJD (notes/header_audit.md A1). KPF's canonical exposure
+        time is MJD-OBS — legacy code keys off it, and KPF's native DATE-OBS is
+        date-only (e.g. '2024-04-05'), so it cannot supply the time of day. Hence
+        JD_UTC = MJD-OBS + 2400000.5, which equals the JD of the precise ISO
+        DATE-BEG. Fall back to DATE-BEG, then DATE-OBS, only if MJD-OBS is absent.
+        """
+        mjd = HeaderParser.get(native_primary, "MJD-OBS")
+        if mjd not in (None, "", "UNKNOWN"):
+            return float(mjd) + 2400000.5
+        for key in ("DATE-BEG", "DATE-OBS"):
+            val = HeaderParser.get(native_primary, key)
+            if val not in (None, "", "UNKNOWN"):
+                return float(Time(str(val), format="isot", scale="utc").jd)
+        return None
 
+    @classmethod
+    def native_to_eprv(cls, native_primary):
+        """Map a raw WMKO PRIMARY header to an EPRV-standard PRIMARY dict.
 
-def build_instrument_header(native_primary):
-    """Verbatim scalar copy of the raw WMKO PRIMARY for INSTRUMENT_HEADER.
+        For each header_map row, take the instrument (native) value when present,
+        else the row default. Then apply the value corrections the installed
+        header_map gets wrong (NUMORDER, JD_UTC) and stamp the DRP version
+        (DRPTAG for EPRV, DRPVERNO for WMKO DRP-RUN-11).
 
-    INSTRUMENT_HEADER is an ImageHDU header (scalar values only) and is an
-    immutable, pure pass-through of the raw instrument PRIMARY — nothing writes
-    to it after ``to_kpf1``.
+        Parameters
+        ----------
+        native_primary : Mapping
+            The raw L0 PRIMARY header (astropy ``fits.Header`` or dict).
 
-    Parameters
-    ----------
-    native_primary : Mapping
-        The raw L0 PRIMARY header.
-
-    Returns
-    -------
-    dict
-        keyword → scalar value.
-    """
-    return {key: _scalar(value) for key, value in native_primary.items()}
-
-
-def _is_registered_kpfpipe(key):
-    return key in KPFPIPE_PRIMARY_KEYS
-
-
-def validate_eprv_primary(header, level):
-    """Validate a converted EPRV PRIMARY header, raising on any inconsistency.
-
-    Fail-loud guard (no silent fallback) for the L2/L4 boundary. Three rules:
-
-    1. **Native leak** — a raw WMKO keyword name (header_map INSTRUMENT name
-       differing from its EPRV target) is present on PRIMARY; it should have
-       been converted or left in INSTRUMENT_HEADER.
-    2. **Unregistered keyword** — a card that is neither an EPRV-standard
-       keyword, a header_map STANDARD target, a registered KPF-pipeline keyword
-       (``config/L{0,1,2,4}-headers.csv``), nor a structural card.
-    3. **Missing required** — a Required EPRV PRIMARY keyword is absent.
-
-    Parameters
-    ----------
-    header : Mapping
-        The PRIMARY header to validate.
-    level : str
-        ``"L2"`` or ``"L4"`` (selects the EPRV keyword set).
-
-    Raises
-    ------
-    ValueError
-        On the first inconsistency found.
-    """
-    level = str(level).upper()
-    eprv_keys = EPRV_L4_KEYS if level == "L4" else EPRV_L2_KEYS
-    required_keys = REQUIRED_L4_KEYS if level == "L4" else REQUIRED_L2_KEYS
-
-    for raw_key in list(header):
-        key = str(raw_key).strip()
-        if key in _STRUCTURAL_KEYS or key.startswith("NAXIS"):
-            continue
-        if (
-            key in eprv_keys
-            or key in HEADERMAP_STANDARD_KEYS
-            or _is_registered_kpfpipe(key)
-        ):
-            continue
-        if key in NATIVE_PRIMARY_KEYS:
-            raise ValueError(
-                f"native WMKO keyword {key!r} found on {level} PRIMARY; it must be "
-                "converted to its EPRV name or kept in INSTRUMENT_HEADER"
+        Returns
+        -------
+        dict
+            EPRV-standard PRIMARY keyword → value (a few as ``(value, comment)``).
+        """
+        out = {}
+        for _, row in HEADER_MAP.iterrows():
+            standard_key = str(row["STANDARD"]).strip()
+            instrument_key = (
+                str(row["INSTRUMENT"]).strip() if pd.notna(row["INSTRUMENT"]) else ""
             )
-        raise ValueError(
-            f"unregistered keyword {key!r} on {level} PRIMARY; add it to "
-            "config/L{0,1,2,4}-headers.csv or fix the writer"
-        )
+            default_val = row["DEFAULT"] if pd.notna(row["DEFAULT"]) else None
 
-    missing = sorted(k for k in required_keys if k not in header)
-    if missing:
-        raise ValueError(
-            f"missing required EPRV PRIMARY keyword(s) on {level}: {missing}"
+            if instrument_key and instrument_key in native_primary:
+                out[standard_key] = HeaderParser.get(native_primary, instrument_key)
+            elif default_val is not None and str(default_val).strip():
+                out[standard_key] = default_val
+
+        # --- Value corrections (see notes/header_audit.md A1/A2/A3) ---
+        out["NUMORDER"] = (_NUMORDER, "Number of echelle orders (green+red)")
+        jd_utc = cls._full_jd_utc(native_primary)
+        if jd_utc is not None:
+            out["JD_UTC"] = (jd_utc, "[day] Julian date of exposure start")
+        version = cls._drp_version()
+        out["DRPTAG"] = (version, "DRP version")
+        out["DRPVERNO"] = (version, "DRP version (WMKO DRP-RUN-11)")
+
+        # WMKO provenance (DRP-RUN-19): native PROGID/KOAID, or 'UNKNOWN' if absent.
+        out["PROGID"] = (
+            HeaderParser.get(native_primary, "PROGID") or "UNKNOWN",
+            "WMKO program ID",
         )
+        out["KOAID"] = (
+            HeaderParser.get(native_primary, "KOAID") or "UNKNOWN",
+            "KOA archive ID",
+        )
+        # Initial reduction status (DRP-RUN-20); modules overwrite it as they run.
+        out["DRPSTATU"] = (_DRPSTATU_DEFAULT, "DRP reduction status")
+        return out
+
+    @staticmethod
+    def build_instrument_header(native_primary):
+        """Verbatim scalar copy of the raw WMKO PRIMARY for INSTRUMENT_HEADER.
+
+        INSTRUMENT_HEADER is an ImageHDU header (scalar values only) and is an
+        immutable, pure pass-through of the raw instrument PRIMARY — nothing
+        writes to it after ``to_kpf1``.
+
+        Parameters
+        ----------
+        native_primary : Mapping
+            The raw L0 PRIMARY header.
+
+        Returns
+        -------
+        dict
+            keyword → scalar value.
+        """
+        # Iterate .items() (not keyed get): for a fits.Header this yields each
+        # commentary card's scalar string, where header["COMMENT"] would instead
+        # return an astropy commentary-card object that fits.Header(dict) cannot
+        # re-serialize.
+        return {
+            key: HeaderParser._unwrap(value) for key, value in native_primary.items()
+        }
+
+    @staticmethod
+    def validate_eprv_primary(header, level):
+        """Validate a converted EPRV PRIMARY header, raising on any inconsistency.
+
+        Fail-loud guard (no silent fallback) for the L2/L4 boundary. Three rules:
+
+        1. **Native leak** — a raw WMKO keyword name (header_map INSTRUMENT name
+           differing from its EPRV target) is present on PRIMARY; it should have
+           been converted or left in INSTRUMENT_HEADER.
+        2. **Unregistered keyword** — a card that is neither an EPRV-standard
+           keyword, a header_map STANDARD target, a registered KPF-pipeline
+           keyword (``config/L{0,1,2,4}-headers.csv``), nor a structural card.
+        3. **Missing required** — a Required EPRV PRIMARY keyword is absent.
+
+        Parameters
+        ----------
+        header : Mapping
+            The PRIMARY header to validate.
+        level : str
+            ``"L2"`` or ``"L4"`` (selects the EPRV keyword set).
+
+        Raises
+        ------
+        ValueError
+            On the first inconsistency found.
+        """
+        level = str(level).upper()
+        eprv_keys = EPRV_L4_KEYS if level == "L4" else EPRV_L2_KEYS
+        required_keys = REQUIRED_L4_KEYS if level == "L4" else REQUIRED_L2_KEYS
+
+        for raw_key in list(header):
+            key = str(raw_key).strip()
+            if key in _STRUCTURAL_KEYS or key.startswith("NAXIS"):
+                continue
+            if (
+                key in eprv_keys
+                or key in HEADERMAP_STANDARD_KEYS
+                or key in KPFPIPE_PRIMARY_KEYS
+            ):
+                continue
+            if key in NATIVE_PRIMARY_KEYS:
+                raise ValueError(
+                    f"native WMKO keyword {key!r} found on {level} PRIMARY; it must "
+                    "be converted to its EPRV name or kept in INSTRUMENT_HEADER"
+                )
+            raise ValueError(
+                f"unregistered keyword {key!r} on {level} PRIMARY; add it to "
+                "config/L{0,1,2,4}-headers.csv or fix the writer"
+            )
+
+        missing = sorted(k for k in required_keys if k not in header)
+        if missing:
+            raise ValueError(
+                f"missing required EPRV PRIMARY keyword(s) on {level}: {missing}"
+            )

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -183,15 +183,15 @@ class KPF0(KPFDataModel):
         # preserve the verbatim raw L0 PRIMARY in INSTRUMENT_HEADER (immutable
         # pure pass-through — nothing else ever writes to it).
         if "PRIMARY" in self.headers:
-            native_primary = self.headers["PRIMARY"]
-            for key, value in HeaderConverter.native_to_eprv(native_primary).items():
+            wmko_primary = self.headers["PRIMARY"]
+            for key, value in HeaderConverter.wmko_to_eprv(wmko_primary).items():
                 l1.headers["PRIMARY"][key] = value
 
             if "INSTRUMENT_HEADER" not in l1.extensions:
                 l1.create_extension("INSTRUMENT_HEADER", "ImageHDU")
             instrument_header = l1.headers["INSTRUMENT_HEADER"]
             for key, value in HeaderConverter.build_instrument_header(
-                native_primary
+                wmko_primary
             ).items():
                 instrument_header[key] = value
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -174,10 +174,7 @@ class KPF0(KPFDataModel):
         obs_id copied over. GREEN_CCD, GREEN_VAR, RED_CCD, RED_VAR are created
         but empty — the caller (image assembly) fills those in.
         """
-        from kpfpipe.data_models.headers import (
-            build_instrument_header,
-            convert_native_to_eprv,
-        )
+        from kpfpipe.data_models.headers import HeaderConverter
         from kpfpipe.data_models.level1 import KPF1  # deferred: avoids circular import
 
         l1 = KPF1()
@@ -187,13 +184,15 @@ class KPF0(KPFDataModel):
         # pure pass-through — nothing else ever writes to it).
         if "PRIMARY" in self.headers:
             native_primary = self.headers["PRIMARY"]
-            for key, value in convert_native_to_eprv(native_primary).items():
+            for key, value in HeaderConverter.native_to_eprv(native_primary).items():
                 l1.headers["PRIMARY"][key] = value
 
             if "INSTRUMENT_HEADER" not in l1.extensions:
                 l1.create_extension("INSTRUMENT_HEADER", "ImageHDU")
             instrument_header = l1.headers["INSTRUMENT_HEADER"]
-            for key, value in build_instrument_header(native_primary).items():
+            for key, value in HeaderConverter.build_instrument_header(
+                native_primary
+            ).items():
                 instrument_header[key] = value
 
         # Copy pass-through extensions (data + header)

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -131,10 +131,10 @@ class KPF1(KPFDataModel):
         Uses DATE-OBS from the PRIMARY header.
         """
         if "PRIMARY" in self.headers:
-            date_obs = self.headers["PRIMARY"].get("DATE-OBS")
+            from kpfpipe.data_models.headers import HeaderParser
+
+            date_obs = HeaderParser.get(self.headers["PRIMARY"], "DATE-OBS")
             if date_obs is not None:
-                if isinstance(date_obs, tuple):
-                    date_obs = date_obs[0]
                 date_str = str(date_obs).split(".")[0]
                 try:
                     dt = datetime.datetime.fromisoformat(date_str)
@@ -192,7 +192,7 @@ class KPF1(KPFDataModel):
         arrays are created but empty — the caller (spectral extraction) fills
         those in.
         """
-        from kpfpipe.data_models.headers import validate_eprv_primary
+        from kpfpipe.data_models.headers import HeaderConverter
         from kpfpipe.data_models.level2 import KPF2  # deferred: avoids circular import
 
         kpf2 = KPF2()
@@ -232,7 +232,7 @@ class KPF1(KPFDataModel):
             )
 
         kpf2.headers["PRIMARY"]["DATALVL"] = ("L2", "Data product level")
-        validate_eprv_primary(kpf2.headers["PRIMARY"], "L2")
+        HeaderConverter.validate_eprv_primary(kpf2.headers["PRIMARY"], "L2")
         kpf2.receipt_add_entry("to_kpf2", "PASS")
         return kpf2
 

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -270,7 +270,7 @@ class KPF2(RV2):
         and the receipt chain preserved. RV and CCF data extensions are
         created but empty — the caller (RV computation) fills those in.
         """
-        from kpfpipe.data_models.headers import validate_eprv_primary
+        from kpfpipe.data_models.headers import HeaderConverter
         from kpfpipe.data_models.level4 import KPF4  # deferred: avoids circular import
 
         kpf4 = KPF4()
@@ -290,7 +290,7 @@ class KPF2(RV2):
             kpf4.receipt = self.receipt.copy()
 
         kpf4.headers["PRIMARY"]["DATALVL"] = ("L4", "Data product level")
-        validate_eprv_primary(kpf4.headers["PRIMARY"], "L4")
+        HeaderConverter.validate_eprv_primary(kpf4.headers["PRIMARY"], "L4")
         kpf4.receipt_add_entry("to_kpf4", "PASS")
         return kpf4
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -45,6 +45,7 @@ from scipy.ndimage import gaussian_filter, median_filter
 from scipy.special import erfcinv
 
 from kpfpipe import DEFAULTS
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.utils.astro import compute_redshift
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.validation import strictly_increasing
@@ -719,7 +720,7 @@ class BarycentricCorrection:
         l2_obj : KPF2
             Input KPF2 with BJD_TDB / BARYCORR_KMS / BARYCORR_Z populated,
             per-CCD CCD{1,2}BJD/BKMS/BZ summaries and the astrometry source
-            (ASTRSRC) written to INSTRUMENT_HEADER, and a
+            (ASTRSRC) written to PRIMARY, and a
             'barycentric_correction' receipt entry.
         """
         if use_gaia_astrometry is not None:
@@ -774,9 +775,9 @@ class BarycentricCorrection:
     def info(self):
         """Print a summary of the barycentric correction results."""
         print("BarycentricCorrection")
-        obs_id = self.l2_obj.headers.get("PRIMARY", {}).get("ORIGID", "unknown")
-        if isinstance(obs_id, tuple):
-            obs_id = obs_id[0]
+        obs_id = HeaderParser.get(
+            self.l2_obj.headers.get("PRIMARY", {}), "ORIGID", "unknown"
+        )
         print(f"  obs_id:  {obs_id}")
 
         if self._results is None:
@@ -787,7 +788,7 @@ class BarycentricCorrection:
         print(f"  astrometry:  {r['astrometry_source']}")
         ccd_bjd, ccd_kms, ccd_z = r["ccd_bjd"], r["ccd_kms"], r["ccd_z"]
 
-        # Per-CCD summaries (match CCD1*/CCD2* in INSTRUMENT_HEADER).
+        # Per-CCD summaries (match CCD1*/CCD2* on PRIMARY).
         print(f"\n  {'':<8s}{'BJD_TDB':>18s}{'BARYCORR_KMS':>18s}{'BARYCORR_Z':>18s}")
         print("  " + "-" * 62)
         print(

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -11,6 +11,7 @@ import warnings
 from datetime import datetime, timedelta
 
 from kpfpipe import DEFAULTS
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import glob_masters
 from kpfpipe.utils.kpf import get_timestamp, kpf_timestamp_to_datetime
@@ -244,11 +245,16 @@ class CalibrationAssociation:
             # negative when the master predates the obs).
             prefix = _HEADER_PREFIX[cal_type]
             master_dt = kpf_timestamp_to_datetime(get_timestamp(filepath))
-            primary[f"{prefix}FILE"] = filepath
-            primary[f"{prefix}AGE"] = (master_dt - obs_dt).total_seconds() / 86400.0
+            age = (master_dt - obs_dt).total_seconds() / 86400.0
+            HeaderParser.set(
+                primary, f"{prefix}FILE", filepath, f"{prefix} master path"
+            )
+            HeaderParser.set(
+                primary, f"{prefix}AGE", age, f"[day] {prefix} master age (master-obs)"
+            )
 
         self._results = {
-            cal_type: primary[f"{_HEADER_PREFIX[cal_type]}FILE"]
+            cal_type: HeaderParser.get(primary, f"{_HEADER_PREFIX[cal_type]}FILE")
             for cal_type in cal_types
         }
         self.l1_obj.receipt_add_entry("calibration_association", "PASS")
@@ -273,7 +279,7 @@ class CalibrationAssociation:
         h = self.l1_obj.headers["PRIMARY"]
         for cal_type, filename in self._results.items():
             prefix = _HEADER_PREFIX[cal_type]
-            age = h.get(f"{prefix}AGE", "n/a")
+            age = HeaderParser.get(h, f"{prefix}AGE", "n/a")
             print(f"  {cal_type:<12s} {filename}")
             print(f"  {'':12s} age = {age}d")
             print()

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -14,6 +14,7 @@ import os
 import numpy as np
 
 from kpfpipe import DEFAULTS
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.masters.level1 import KPFMasterL1
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import build_master_path_from_fits_header
@@ -263,9 +264,9 @@ class ImageProcessing:
         bool
             True if the calibration's header flag is present and truthy.
         """
-        val = l1_obj.headers["PRIMARY"].get(_CALIBRATION_HEADER_KEYS[cal_type])
-        if isinstance(val, tuple):  # Headers store (value, comment) tuples.
-            val = val[0]
+        val = HeaderParser.get(
+            l1_obj.headers["PRIMARY"], _CALIBRATION_HEADER_KEYS[cal_type]
+        )
         return bool(val)
 
     def perform(self, chips=None, *, bias=None, dark=None, flat=None):

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -31,6 +31,7 @@ from astropy.io import fits
 from astropy.stats import mad_std
 
 from kpfpipe import DEFAULTS, REPO_ROOT
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.utils.astro import compute_redshift
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.stats import optimize_lsq
@@ -130,9 +131,8 @@ class RadialVelocity:
         # Map the raw keyword value straight to the source object and its CCF
         # settings: mask, whether to barycentric-correct, and the velocity-grid
         # center (systemic RV for a star, 0 for sky/calibration).
-        raw = inst[keyword]
-        v = raw[0] if isinstance(raw, tuple) else raw
-        v = str(v).strip().lower()
+        raw = HeaderParser.get(inst, keyword)
+        v = str(raw).strip().lower()
         if v == "target":
             source = {
                 "object": "target",
@@ -1109,8 +1109,12 @@ class RadialVelocity:
             for chip in ccd_rv:
                 n = 1 if chip == "GREEN" else 2
                 v, e = ccd_rv[chip], ccd_rv_err[chip]
-                prim[f"CCD{n}RV{sfx}"] = float(v) if np.isfinite(v) else None
-                prim[f"CCD{n}ERV{sfx}"] = float(e) if np.isfinite(e) else None
+                HeaderParser.set(
+                    prim, f"CCD{n}RV{sfx}", float(v) if np.isfinite(v) else None
+                )
+                HeaderParser.set(
+                    prim, f"CCD{n}ERV{sfx}", float(e) if np.isfinite(e) else None
+                )
 
         # PRIMARY (EPRV L4): always record the RV method.
         prim = l4_obj.headers["PRIMARY"]
@@ -1162,8 +1166,8 @@ class RadialVelocity:
                     f"  combined RV: {chip} science fit non-finite; excluded from CCFRV"
                 )
             n = 1 if chip == "GREEN" else 2
-            prim[f"CCD{n}RV"] = float(v) if np.isfinite(v) else None
-            prim[f"CCD{n}ERV"] = float(e) if np.isfinite(e) else None
+            HeaderParser.set(prim, f"CCD{n}RV", float(v) if np.isfinite(v) else None)
+            HeaderParser.set(prim, f"CCD{n}ERV", float(e) if np.isfinite(e) else None)
 
         # Cross-chip weighted RV (CCFRV) and inverse-variance error (CCFERV): the
         # per-CCD science RVs combined at the RV level by their summed order
@@ -1183,8 +1187,8 @@ class RadialVelocity:
                 "CCFRV/PRIMARY RV UNDEFINED"
             )
 
-        prim["CCFRV"] = float(ccfrv) if np.isfinite(ccfrv) else None
-        prim["CCFERV"] = float(ccferv) if np.isfinite(ccferv) else None
+        HeaderParser.set(prim, "CCFRV", float(ccfrv) if np.isfinite(ccfrv) else None)
+        HeaderParser.set(prim, "CCFERV", float(ccferv) if np.isfinite(ccferv) else None)
 
         # PRIMARY BERV/BJDTDB: chip-weighted mean of the per-CCD photon-weighted
         # bary summaries (CCD<n>BKMS/CCD<n>BJD from BarycentricCorrection), using
@@ -1194,11 +1198,8 @@ class RadialVelocity:
         for chip in chips:
             n = 1 if chip == "GREEN" else 2
             w = float(np.nansum(self._get_order_weights(chip, rep)))
-            bkms, bjd = prim.get(f"CCD{n}BKMS"), prim.get(f"CCD{n}BJD")
-            if isinstance(bkms, tuple):  # PRIMARY stores (value, comment)
-                bkms = bkms[0]
-            if isinstance(bjd, tuple):
-                bjd = bjd[0]
+            bkms = HeaderParser.get(prim, f"CCD{n}BKMS")
+            bjd = HeaderParser.get(prim, f"CCD{n}BJD")
             if (
                 w > 0
                 and bkms is not None
@@ -1242,9 +1243,9 @@ class RadialVelocity:
     def info(self):
         """Print a summary of the module configuration and RV results."""
         print("RadialVelocity")
-        obs_id = self.l2_obj.headers.get("PRIMARY", {}).get("ORIGID", "unknown")
-        if isinstance(obs_id, tuple):
-            obs_id = obs_id[0]
+        obs_id = HeaderParser.get(
+            self.l2_obj.headers.get("PRIMARY", {}), "ORIGID", "unknown"
+        )
         print(f"  obs_id:         {obs_id}")
         print(f"  ccf_mask_width: {self.ccf_mask_width} km/s")
         print(f"  ccf_step_size:  {self.ccf_step_size} km/s")

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -13,6 +13,7 @@ import os
 import numpy as np
 
 from kpfpipe import DEFAULTS
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.masters.level2 import KPFMasterL2
 from kpfpipe.utils.config import ConfigHandler
 
@@ -94,9 +95,7 @@ class WavelengthCalibration:
                     "WLSFILE missing from L2 PRIMARY; "
                     "run CalibrationAssociation with 'thar' on the L1 first"
                 )
-            wls_path = primary["WLSFILE"]
-            if isinstance(wls_path, tuple):  # PRIMARY stores (value, comment)
-                wls_path = wls_path[0]
+            wls_path = HeaderParser.get(primary, "WLSFILE")
 
         if not os.path.isfile(wls_path):
             raise FileNotFoundError(f"Master WLS file not found: {wls_path}")
@@ -126,14 +125,14 @@ class WavelengthCalibration:
             Defaults to self.fibers.
         wls_path : str, optional
             Direct path to the master WLS L2 file. If omitted, the path is
-            read from WLSFILE on the L2 INSTRUMENT_HEADER extension.
+            read from WLSFILE on the L2 PRIMARY header.
 
         Returns
         -------
         l2_obj : KPF2
             The input L2 with per-fiber _WAVE extensions populated and a
-            'wavelength_calibration' receipt entry. WLSFILE on
-            INSTRUMENT_HEADER is left untouched.
+            'wavelength_calibration' receipt entry. WLSFILE on PRIMARY is
+            left untouched.
         """
         if chips is None:
             chips = self.chips
@@ -166,9 +165,8 @@ class WavelengthCalibration:
     def info(self):
         """Print a summary of the module configuration and association results."""
         print("WavelengthCalibration")
-        obs_id = self.l2_obj.headers.get("PRIMARY", {}).get("ORIGID", "unknown")
-        if isinstance(obs_id, tuple):
-            obs_id = obs_id[0]
+        primary = self.l2_obj.headers.get("PRIMARY", {})
+        obs_id = HeaderParser.get(primary, "ORIGID", "unknown")
         print(f"  obs_id:  {obs_id}")
         print(f"  chips:   {self.chips}")
         print(f"  fibers:  {self.fibers}")
@@ -177,8 +175,8 @@ class WavelengthCalibration:
             print("  perform() has not been called")
             return
 
-        inst = self.l2_obj.headers.get("INSTRUMENT_HEADER", {})
-        agewls = inst.get("WLSAGE")
+        # WLSAGE is written to PRIMARY by CalibrationAssociation (alongside WLSFILE).
+        agewls = HeaderParser.get(primary, "WLSAGE")
         print(f"  wls_path: {self._results['wls_path']}")
         if agewls is not None:
             print(f"  WLSAGE:   {agewls:+.4f} d  (master - obs)")

--- a/kpfpipe/quality_control/qc_booleans/level0.py
+++ b/kpfpipe/quality_control/qc_booleans/level0.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from kpfpipe import REPO_ROOT
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.quality_control.qc_booleans.base import QC
 
 _JUNK_CSV = REPO_ROOT / "reference" / "junk_observations.csv"
@@ -61,11 +62,8 @@ class QCL0(QC):
         hdr = self.kpf.headers["PRIMARY"]
         if "EXPTIME" not in hdr:
             return False
-        val = hdr["EXPTIME"]
-        if isinstance(val, tuple):
-            val = val[0]
         try:
-            f = float(val)
+            f = float(HeaderParser.get(hdr, "EXPTIME"))
         except (TypeError, ValueError):
             return False
         return np.isfinite(f) and f >= 0

--- a/kpfpipe/quality_control/qc_booleans/level1.py
+++ b/kpfpipe/quality_control/qc_booleans/level1.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.modules.image_assembly import RN_KEYS
 from kpfpipe.quality_control.qc_booleans.base import QC
 
@@ -11,18 +12,13 @@ _RNNG_LO, _RNNG_HI = 0.8, 1.5
 
 def _hdr_float(hdr, key):
     """Return float value for a header key, or None if absent."""
-    if key not in hdr:
-        return None
-    val = hdr[key]
-    return float(val[0] if isinstance(val, tuple) else val)
+    val = HeaderParser.get(hdr, key)
+    return None if val is None else float(val)
 
 
 def _hdr_flag(hdr, key):
     """Return bool value for a header key, or False if absent."""
-    if key not in hdr:
-        return False
-    val = hdr[key]
-    return bool(val[0] if isinstance(val, tuple) else val)
+    return bool(HeaderParser.get(hdr, key, default=False))
 
 
 class QCL1(QC):

--- a/kpfpipe/quality_control/qc_booleans/level2.py
+++ b/kpfpipe/quality_control/qc_booleans/level2.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.quality_control.qc_booleans.base import QC
 
 _CHIPS = ["GREEN", "RED"]
@@ -15,10 +16,8 @@ _MIN_SCI_SNR = 1.0
 
 def _hdr_float(hdr, key):
     """Return float value for a header key, or None if absent."""
-    if key not in hdr:
-        return None
-    val = hdr[key]
-    return float(val[0] if isinstance(val, tuple) else val)
+    val = HeaderParser.get(hdr, key)
+    return None if val is None else float(val)
 
 
 class QCL2(QC):

--- a/kpfpipe/quality_control/quicklook/level0.py
+++ b/kpfpipe/quality_control/quicklook/level0.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import matplotlib.pyplot as plt
 import numpy as np
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.modules.image_assembly import ImageAssembly
 from kpfpipe.quality_control.quicklook._save_png import save_image_png, save_png
 
@@ -40,7 +41,7 @@ class PlotL0:
         self.obs_id = getattr(l0_obj, "obs_id", None) or ""
         self.name = ""
         if "PRIMARY" in l0_obj.headers:
-            self.name = l0_obj.headers["PRIMARY"].get("OBJECT", "")
+            self.name = HeaderParser.get(l0_obj.headers["PRIMARY"], "OBJECT", "")
 
     def _has_chip(self, chip):
         """Return True if any AMP extension for the chip holds data."""

--- a/kpfpipe/quality_control/quicklook/level1.py
+++ b/kpfpipe/quality_control/quicklook/level1.py
@@ -6,12 +6,9 @@ from datetime import UTC, datetime
 import matplotlib.pyplot as plt
 import numpy as np
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.modules.image_assembly import RN_KEYS
 from kpfpipe.quality_control.quicklook._save_png import save_image_png, save_png
-
-
-def _unwrap(val):
-    return val[0] if isinstance(val, tuple) else val
 
 
 class PlotL1:
@@ -43,7 +40,7 @@ class PlotL1:
         self.obs_id = getattr(l1_obj, "obs_id", None) or ""
         self.name = ""
         if "PRIMARY" in l1_obj.headers:
-            self.name = l1_obj.headers["PRIMARY"].get("OBJECT", "")
+            self.name = HeaderParser.get(l1_obj.headers["PRIMARY"], "OBJECT", "")
 
     def _read_noise_values(self, chip):
         """Return (rn_list, rnng_list) from PRIMARY header, or ([], []) if absent."""
@@ -54,8 +51,8 @@ class PlotL1:
             channel_ext = f"{chip.upper()}_AMP{i}"
             rn_key, rnng_key = RN_KEYS[channel_ext]
             if rn_key in primary and rnng_key in primary:
-                rn_values.append(float(_unwrap(primary[rn_key])))
-                rnng_values.append(float(_unwrap(primary[rnng_key])))
+                rn_values.append(float(HeaderParser.get(primary, rn_key)))
+                rnng_values.append(float(HeaderParser.get(primary, rnng_key)))
         return rn_values, rnng_values
 
     def image(self, chip, *, full_res=None):

--- a/kpfpipe/quality_control/quicklook/level2.py
+++ b/kpfpipe/quality_control/quicklook/level2.py
@@ -16,6 +16,7 @@ from datetime import UTC, datetime
 import matplotlib.pyplot as plt
 import numpy as np
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.quality_control.quicklook._save_png import save_png
 
 _DPI = 200
@@ -23,10 +24,6 @@ _FIBERS = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 _SCI_FIBERS = ["SCI1", "SCI2", "SCI3"]
 _SNR_PERCENTILE = 95
 _FLUX_PERCENTILE = 95
-
-
-def _unwrap(val):
-    return val[0] if isinstance(val, tuple) else val
 
 
 class PlotL2:
@@ -63,10 +60,10 @@ class PlotL2:
         self.obs_id = (
             obs_id
             or getattr(l2_obj, "obs_id", None)
-            or self._obsid_from_filename(_unwrap(primary.get("FILENAME", "")))
+            or self._obsid_from_filename(HeaderParser.get(primary, "FILENAME", ""))
             or ""
         )
-        self.name = _unwrap(primary.get("OBJECT", "")) if primary else ""
+        self.name = HeaderParser.get(primary, "OBJECT", "") if primary else ""
 
     @staticmethod
     def _obsid_from_filename(filename):

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -364,9 +364,10 @@ def build_master_path_from_fits_header(kpf_obj, cal_type):
         If `{PREFIX}FILE` is absent from the PRIMARY header (i.e.
         CalibrationAssociation has not run for this calibration).
     """
+    from kpfpipe.data_models.headers import HeaderParser
+
     prefix = cal_type.upper()
-    header = kpf_obj.headers["PRIMARY"]
-    master_file = header.get(f"{prefix}FILE")
+    master_file = HeaderParser.get(kpf_obj.headers["PRIMARY"], f"{prefix}FILE")
 
     if not master_file:
         raise FileNotFoundError(

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -14,6 +14,7 @@ from astropy.table import Table
 from astropy.time import Time
 
 from kpfpipe import DETECTOR
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.modules.barycentric_correction import BarycentricCorrection
 from kpfpipe.utils.validation import strictly_increasing
@@ -830,13 +831,13 @@ class TestPerform:
         for key in ["CCD1BJD", "CCD1BKMS", "CCD1BZ", "CCD2BJD", "CCD2BKMS", "CCD2BZ"]:
             assert key in prim, f"{key} missing from PRIMARY"
 
-        def _v(k):
-            x = prim[k]
-            return x[0] if isinstance(x, tuple) else x
-
         # All orders had the same delta_rv → green and red means are equal
-        np.testing.assert_allclose(_v("CCD1BKMS"), _v("CCD2BKMS"))
-        np.testing.assert_allclose(_v("CCD1BZ"), _v("CCD2BZ"))
+        np.testing.assert_allclose(
+            HeaderParser.get(prim, "CCD1BKMS"), HeaderParser.get(prim, "CCD2BKMS")
+        )
+        np.testing.assert_allclose(
+            HeaderParser.get(prim, "CCD1BZ"), HeaderParser.get(prim, "CCD2BZ")
+        )
 
     def test_receipt_entry_added(self, bc_monkeypatched):
         bc_monkeypatched.perform()
@@ -909,8 +910,8 @@ class TestPerform:
 
     def test_records_gaia_provenance(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.perform()
-        astrsrc = kpf2.headers["PRIMARY"]["ASTRSRC"]
-        assert (astrsrc[0] if isinstance(astrsrc, tuple) else astrsrc) == "Gaia DR3"
+        astrsrc = HeaderParser.get(kpf2.headers["PRIMARY"], "ASTRSRC")
+        assert astrsrc == "Gaia DR3"
 
     def test_perform_falls_back_and_records_wmko_provenance(
         self, synthetic_kpf2, monkeypatch
@@ -940,8 +941,8 @@ class TestPerform:
                 use_wmko_fallback=True
             )  # override the toggle for this call
 
-        astrsrc = kpf2.headers["PRIMARY"]["ASTRSRC"]
-        assert (astrsrc[0] if isinstance(astrsrc, tuple) else astrsrc) == "WMKO header"
+        astrsrc = HeaderParser.get(kpf2.headers["PRIMARY"], "ASTRSRC")
+        assert astrsrc == "WMKO header"
         assert bc._results["astrometry_source"] == "WMKO header"
 
     def test_real_outlier_filter_runs_end_to_end(self, synthetic_kpf2, monkeypatch):

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -6,6 +6,7 @@ import warnings
 
 import pytest
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.modules.calibration_association import CalibrationAssociation
 
 # ---------------------------------------------------------------------------
@@ -253,7 +254,7 @@ class TestPerform:
             / "20240405"
             / "KP.20240405.03637.74_master_bias_L1.fits"
         )
-        assert mod.l1_obj.headers["PRIMARY"]["BIASFILE"] == expected
+        assert HeaderParser.get(mod.l1_obj.headers["PRIMARY"], "BIASFILE") == expected
 
     def test_no_biasdir_header(self, masters_dir):
         mod = _make_module(masters_dir)
@@ -266,7 +267,7 @@ class TestPerform:
         # giving -0.422176 days.
         mod = _make_module(masters_dir)
         mod.perform(["bias"])
-        age = mod.l1_obj.headers["PRIMARY"]["BIASAGE"]
+        age = HeaderParser.get(mod.l1_obj.headers["PRIMARY"], "BIASAGE")
         assert isinstance(age, float)
         assert age == pytest.approx(-0.422176, abs=1e-5)
 
@@ -279,9 +280,9 @@ class TestPerform:
 
         mod = _make_module(tmp_path)
         mod.perform(["bias"])
-        assert mod.l1_obj.headers["PRIMARY"]["BIASAGE"] == pytest.approx(
-            -0.547604, abs=1e-5
-        )
+        assert HeaderParser.get(
+            mod.l1_obj.headers["PRIMARY"], "BIASAGE"
+        ) == pytest.approx(-0.547604, abs=1e-5)
 
     def test_sets_headers_for_dark_and_flat(self, masters_dir):
         mod = _make_module(masters_dir)
@@ -302,10 +303,12 @@ class TestPerform:
         mod = _make_module(masters_dir)
         mod.perform(["bias", "thar"])
         h = mod.l1_obj.headers["PRIMARY"]
-        assert h["WLSFILE"] == str(d / "KP.20240405.03637.74_master_thar_L2.fits")
+        assert HeaderParser.get(h, "WLSFILE") == str(
+            d / "KP.20240405.03637.74_master_thar_L2.fits"
+        )
         assert "WLSDIR" not in h
-        assert isinstance(h["WLSAGE"], float)
-        assert h["WLSAGE"] == pytest.approx(-0.422176, abs=1e-5)
+        assert isinstance(HeaderParser.get(h, "WLSAGE"), float)
+        assert HeaderParser.get(h, "WLSAGE") == pytest.approx(-0.422176, abs=1e-5)
 
     def test_raises_on_unknown_cal_type(self, masters_dir):
         mod = _make_module(masters_dir)

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.masters import KPFMasterL1
@@ -153,18 +154,14 @@ class TestToL1:
         assert l1.headers["PRIMARY"]["DATE-OBS"] == "2024-01-13T10:26:56"
         assert l1.headers["PRIMARY"]["OBJECT"] == "HD_10700"
 
-    @staticmethod
-    def _scalar(value):
-        return value[0] if isinstance(value, tuple) else value
-
     def test_to_l1_converts_native_to_eprv(self, synthetic_l0_file):
         """to_kpf1 renames WMKO natives to their EPRV PRIMARY counterparts."""
         l0 = KPF0.from_fits(synthetic_l0_file)
         l1 = l0.to_kpf1()
         prim = l1.headers["PRIMARY"]
-        assert self._scalar(prim["OBSTYPE"]) == "Object"  # IMTYPE -> OBSTYPE
-        assert self._scalar(prim["EXPTIME"]) == 300.0  # ELAPSED -> EXPTIME
-        assert self._scalar(prim["OBSERVER"]) == "Smith"  # GROBSERV -> OBSERVER
+        assert HeaderParser.get(prim, "OBSTYPE") == "Object"  # IMTYPE -> OBSTYPE
+        assert HeaderParser.get(prim, "EXPTIME") == 300.0  # ELAPSED -> EXPTIME
+        assert HeaderParser.get(prim, "OBSERVER") == "Smith"  # GROBSERV -> OBSERVER
         # Raw native names must not remain on the EPRV PRIMARY.
         assert "IMTYPE" not in prim
         assert "ELAPSED" not in prim
@@ -186,12 +183,14 @@ class TestToL1:
         l0 = KPF0.from_fits(synthetic_l0_file)
         l1 = l0.to_kpf1()
         prim = l1.headers["PRIMARY"]
-        assert self._scalar(prim["NUMORDER"]) == 67  # 35 green + 32 red, not 65
+        assert HeaderParser.get(prim, "NUMORDER") == 67  # 35 green + 32 red, not 65
         # JD_UTC is the full Julian Date of DATE-OBS (not a raw MJD).
-        assert self._scalar(prim["JD_UTC"]) == pytest.approx(2460322.93537, abs=1e-3)
+        assert HeaderParser.get(prim, "JD_UTC") == pytest.approx(
+            2460322.93537, abs=1e-3
+        )
         version = importlib.metadata.version("kpfpipe")
-        assert self._scalar(prim["DRPTAG"]) == version
-        assert self._scalar(prim["DRPVERNO"]) == version
+        assert HeaderParser.get(prim, "DRPTAG") == version
+        assert HeaderParser.get(prim, "DRPVERNO") == version
 
     def test_to_l1_stamps_native_program_ids(self, synthetic_l0_file):
         """PROGID/KOAID carry from the native L0 PRIMARY onto the L1 EPRV PRIMARY."""
@@ -199,8 +198,8 @@ class TestToL1:
         l0.headers["PRIMARY"]["PROGID"] = "U999"
         l0.headers["PRIMARY"]["KOAID"] = "KP.20201122.34567.89"
         prim = l0.to_kpf1().headers["PRIMARY"]
-        assert self._scalar(prim["PROGID"]) == "U999"
-        assert self._scalar(prim["KOAID"]) == "KP.20201122.34567.89"
+        assert HeaderParser.get(prim, "PROGID") == "U999"
+        assert HeaderParser.get(prim, "KOAID") == "KP.20201122.34567.89"
 
     def test_to_l1_defaults_program_ids_to_unknown(self, synthetic_l0_file):
         """Absent PROGID/KOAID default to UNKNOWN (the card is always written)."""
@@ -209,14 +208,14 @@ class TestToL1:
             if key in l0.headers["PRIMARY"]:
                 del l0.headers["PRIMARY"][key]
         prim = l0.to_kpf1().headers["PRIMARY"]
-        assert self._scalar(prim["PROGID"]) == "UNKNOWN"
-        assert self._scalar(prim["KOAID"]) == "UNKNOWN"
+        assert HeaderParser.get(prim, "PROGID") == "UNKNOWN"
+        assert HeaderParser.get(prim, "KOAID") == "UNKNOWN"
 
     def test_to_l1_sets_drpstatus_default(self, synthetic_l0_file):
         """to_kpf1 seeds DRPSTATU; its own to_l1 receipt is denylisted, so the
         default survives until the first real module runs."""
         prim = KPF0.from_fits(synthetic_l0_file).to_kpf1().headers["PRIMARY"]
-        assert self._scalar(prim["DRPSTATU"]) == "File ingested into KPF-DRP"
+        assert HeaderParser.get(prim, "DRPSTATU") == "File ingested into KPF-DRP"
 
     def test_to_l1_copies_passthrough_extensions(self, synthetic_l0_file):
         l0 = KPF0.from_fits(synthetic_l0_file)
@@ -265,20 +264,16 @@ class TestDrpStatus:
     receipt_add_entry override; data-model conversion/IO receipts are denylisted
     so it names the last real science/masters stage (DRP-RUN-20)."""
 
-    @staticmethod
-    def _scalar(value):
-        return value[0] if isinstance(value, tuple) else value
-
     def test_module_receipt_updates_status(self, synthetic_l0_file):
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()
         l1.receipt_add_entry("image_assembly", "PASS")
-        status = self._scalar(l1.headers["PRIMARY"]["DRPSTATU"])
+        status = HeaderParser.get(l1.headers["PRIMARY"], "DRPSTATU")
         assert status == "Image Assembly module complete"
 
     def test_master_receipt_updates_status(self, synthetic_l0_file):
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()
         l1.receipt_add_entry("master_bias", "PASS")
-        status = self._scalar(l1.headers["PRIMARY"]["DRPSTATU"])
+        status = HeaderParser.get(l1.headers["PRIMARY"], "DRPSTATU")
         assert status == "Master Bias module complete"
 
     def test_internal_receipts_do_not_change_status(self, synthetic_l0_file):
@@ -286,7 +281,7 @@ class TestDrpStatus:
         l1.receipt_add_entry("radial_velocity", "PASS")
         for internal in ("to_kpf2", "to_kpf4", "to_fits", "from_fits"):
             l1.receipt_add_entry(internal, "PASS")
-        status = self._scalar(l1.headers["PRIMARY"]["DRPSTATU"])
+        status = HeaderParser.get(l1.headers["PRIMARY"], "DRPSTATU")
         assert status == "Radial Velocity module complete"
 
 

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -13,6 +13,7 @@ from astropy.table import Table
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.aliased_dict import AliasedOrderedDict
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
@@ -62,10 +63,6 @@ def converted_l1(synthetic_l0_file):
     return KPF0.from_fits(synthetic_l0_file).to_kpf1()
 
 
-def _scalar(value):
-    return value[0] if isinstance(value, tuple) else value
-
-
 class TestToKPF2:
     def test_to_kpf2_creates_kpf2(self, converted_l1):
         kpf2 = converted_l1.to_kpf2()
@@ -76,21 +73,26 @@ class TestToKPF2:
         """Conversion happened in to_kpf1; to_kpf2 forwards the EPRV PRIMARY."""
         kpf2 = converted_l1.to_kpf2()
         prim = kpf2.headers["PRIMARY"]
-        assert _scalar(prim["EXPTIME"]) == 300.0  # from ELAPSED, set in to_kpf1
-        assert _scalar(prim["OBSTYPE"]) == "Object"  # from IMTYPE
-        assert _scalar(prim["OBSERVER"]) == "Smith"  # from GROBSERV
+        assert (
+            HeaderParser.get(prim, "EXPTIME") == 300.0
+        )  # from ELAPSED, set in to_kpf1
+        assert HeaderParser.get(prim, "OBSTYPE") == "Object"  # from IMTYPE
+        assert HeaderParser.get(prim, "OBSERVER") == "Smith"  # from GROBSERV
         # Raw natives never reach the EPRV PRIMARY.
         assert "ELAPSED" not in prim
         assert "IMTYPE" not in prim
 
     def test_to_kpf2_copies_same_name_keywords(self, converted_l1):
         kpf2 = converted_l1.to_kpf2()
-        assert _scalar(kpf2.headers["PRIMARY"]["INSTRUME"]) == "KPF"
-        assert _scalar(kpf2.headers["PRIMARY"]["DATE-OBS"]) == "2024-01-13T10:26:56"
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "INSTRUME") == "KPF"
+        assert (
+            HeaderParser.get(kpf2.headers["PRIMARY"], "DATE-OBS")
+            == "2024-01-13T10:26:56"
+        )
 
     def test_to_kpf2_sets_defaults(self, converted_l1):
         kpf2 = converted_l1.to_kpf2()
-        assert _scalar(kpf2.headers["PRIMARY"]["DATALVL"]) == "L2"
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "DATALVL") == "L2"
         origin = kpf2.headers["PRIMARY"].get("ORIGIN")
         assert origin is not None
 
@@ -157,7 +159,7 @@ class TestToKPF2:
         kpf2 = KPF1.from_fits(synthetic_l1_file).to_kpf2()
         kpf2.receipt_add_entry("barycentric_correction", "PASS")
         assert (
-            _scalar(kpf2.headers["PRIMARY"]["DRPSTATU"])
+            HeaderParser.get(kpf2.headers["PRIMARY"], "DRPSTATU")
             == "Barycentric Correction module complete"
         )
 
@@ -182,10 +184,8 @@ class TestToKPF2:
         l1 = KPF1.from_fits(fn)
         assert l1.obs_id == "KP.20240113.23249.10"
         kpf2 = l1.to_kpf2()
-        origid = kpf2.headers["PRIMARY"]["ORIGID"]
-        assert (
-            origid[0] if isinstance(origid, tuple) else origid
-        ) == "KP.20240113.23249.10"
+        origid = HeaderParser.get(kpf2.headers["PRIMARY"], "ORIGID")
+        assert origid == "KP.20240113.23249.10"
 
 
 class TestAliasedOrderedDict:

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -10,6 +10,7 @@ import pandas as pd
 import pytest
 
 from kpfpipe import DETECTOR
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.level4 import KPF4
@@ -38,8 +39,7 @@ class TestToKPF4:
     def test_to_kpf4_sets_datalvl(self):
         kpf2 = KPF2()
         kpf4 = kpf2.to_kpf4()
-        datalvl = kpf4.headers["PRIMARY"]["DATALVL"]
-        assert (datalvl[0] if isinstance(datalvl, tuple) else datalvl) == "L4"
+        assert HeaderParser.get(kpf4.headers["PRIMARY"], "DATALVL") == "L4"
 
     def test_to_kpf4_carries_receipt(self):
         kpf2 = KPF2()
@@ -61,11 +61,8 @@ class TestToKPF4:
         l1.headers["PRIMARY"]["KOAID"] = "KP.20201122.34567.89"
         prim = l1.to_kpf2().to_kpf4().headers["PRIMARY"]
 
-        def _scalar(v):
-            return v[0] if isinstance(v, tuple) else v
-
-        assert _scalar(prim["PROGID"]) == "U999"
-        assert _scalar(prim["KOAID"]) == "KP.20201122.34567.89"
+        assert HeaderParser.get(prim, "PROGID") == "U999"
+        assert HeaderParser.get(prim, "KOAID") == "KP.20201122.34567.89"
 
 
 class TestKPF4:

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -5,6 +5,7 @@ import pytest
 from astropy.io import fits
 
 from kpfpipe import DETECTOR
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.quality_control.diagnostics import DiagL0, DiagL1, DiagL2, Diagnostics
 
@@ -14,11 +15,6 @@ NCOL = DETECTOR["ccd"]["ncol"]
 
 _FIBERS = ("SCI1", "SCI2", "SCI3", "SKY", "CAL")
 _NAN_KEYS = ("NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL")
-
-
-def _hval(raw):
-    """Unpack header value from (value, comment) tuple or plain value."""
-    return raw[0] if isinstance(raw, tuple) else raw
 
 
 # ---------------------------------------------------------------------------
@@ -195,16 +191,16 @@ class TestDiagL2NanCounts:
         DiagL2(kpf2).run()
         for key in _NAN_KEYS:
             assert key in kpf2.headers["PRIMARY"], f"missing {key}"
-            assert _hval(kpf2.headers["PRIMARY"][key]) == 0
+            assert HeaderParser.get(kpf2.headers["PRIMARY"], key) == 0
 
     def test_counts_injected_nans_per_fiber(self):
         kpf2 = _make_kpf2_with_flux(nan_frac=0.0)
         # Inject one NaN into GREEN_SCI1_FLUX; expect NANSCI1==1, others==0.
         kpf2.data["GREEN_SCI1_FLUX"][0, 0] = np.nan
         DiagL2(kpf2).run()
-        assert _hval(kpf2.headers["PRIMARY"]["NANSCI1"]) == 1
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "NANSCI1") == 1
         for key in ("NANSCI2", "NANSCI3", "NANSKY", "NANCAL"):
-            assert _hval(kpf2.headers["PRIMARY"][key]) == 0
+            assert HeaderParser.get(kpf2.headers["PRIMARY"], key) == 0
 
     def test_writes_keys_even_when_no_data(self):
         """KPF2 with no FLUX extensions populated should still write all 5
@@ -244,7 +240,7 @@ class TestDiagL2NanCounts:
         kpf2 = l1.to_kpf2()
         DiagL2(kpf2).run()
         for key in _NAN_KEYS:
-            assert _hval(kpf2.headers["PRIMARY"][key]) == 0
+            assert HeaderParser.get(kpf2.headers["PRIMARY"], key) == 0
 
 
 class TestDiagL2ZeroFlux:
@@ -252,18 +248,22 @@ class TestDiagL2ZeroFlux:
         kpf2 = _make_kpf2_with_flux(zero_frac=0.0)  # all ones
         DiagL2(kpf2).run()
         assert "ZEROFRAC" in kpf2.headers["PRIMARY"]
-        assert _hval(kpf2.headers["PRIMARY"]["ZEROFRAC"]) == pytest.approx(0.0)
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "ZEROFRAC") == pytest.approx(
+            0.0
+        )
 
     def test_zerofrac_one_when_all_zero(self):
         kpf2 = _make_kpf2_with_flux(zero_frac=1.0)
         DiagL2(kpf2).run()
-        assert _hval(kpf2.headers["PRIMARY"]["ZEROFRAC"]) == pytest.approx(1.0)
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "ZEROFRAC") == pytest.approx(
+            1.0
+        )
 
     def test_zerofrac_approximate_when_partial(self):
         """50% zeros sprinkled randomly → ZEROFRAC ≈ 0.5 within sampling error."""
         kpf2 = _make_kpf2_with_flux(zero_frac=0.5)
         DiagL2(kpf2).run()
-        assert _hval(kpf2.headers["PRIMARY"]["ZEROFRAC"]) == pytest.approx(
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "ZEROFRAC") == pytest.approx(
             0.5, abs=0.01
         )
 
@@ -329,7 +329,7 @@ class TestDiagL2Snr:
         DiagL2(kpf2).run()
         for key in self._SNR_KEYS:
             assert key in kpf2.headers["PRIMARY"], f"missing {key}"
-            assert _hval(kpf2.headers["PRIMARY"][key]) > 0
+            assert HeaderParser.get(kpf2.headers["PRIMARY"], key) > 0
 
     def test_single_fiber_snr_value(self):
         # SKY flux=2, var=0.04 -> SNR = 2/sqrt(0.04) = 10.0 in every pixel.
@@ -337,10 +337,10 @@ class TestDiagL2Snr:
         _set_fiber_arrays(kpf2, "FLUX", 2.0, fibers=("SKY",))
         _set_fiber_arrays(kpf2, "VAR", 0.04, fibers=("SKY",))
         DiagL2(kpf2).run()
-        assert _hval(kpf2.headers["PRIMARY"]["GSNRSKY"]) == pytest.approx(
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "GSNRSKY") == pytest.approx(
             10.0, abs=0.01
         )
-        assert _hval(kpf2.headers["PRIMARY"]["RSNRSKY"]) == pytest.approx(
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "RSNRSKY") == pytest.approx(
             10.0, abs=0.01
         )
 
@@ -351,7 +351,7 @@ class TestDiagL2Snr:
         _set_fiber_arrays(kpf2, "FLUX", 2.0, fibers=("SCI1", "SCI2", "SCI3"))
         _set_fiber_arrays(kpf2, "VAR", 0.04, fibers=("SCI1", "SCI2", "SCI3"))
         DiagL2(kpf2).run()
-        assert _hval(kpf2.headers["PRIMARY"]["GSNRSCI"]) == pytest.approx(
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "GSNRSCI") == pytest.approx(
             17.32, abs=0.05
         )
 
@@ -395,11 +395,11 @@ class TestDiagL2OrderletFluxRatios:
         DiagL2(kpf2).run()
         for key in self._RATIO_KEYS:
             assert key in kpf2.headers["PRIMARY"], f"missing {key}"
-            assert _hval(kpf2.headers["PRIMARY"][key]) == pytest.approx(1.0)
+            assert HeaderParser.get(kpf2.headers["PRIMARY"], key) == pytest.approx(1.0)
 
     def test_ratio_value(self):
         # GREEN SCI1 flux=2 over SCI2 flux=1 -> GFR12 == 2.0.
         kpf2 = _make_kpf2_with_flux()
         _set_fiber_arrays(kpf2, "FLUX", 2.0, chips=("GREEN",), fibers=("SCI1",))
         DiagL2(kpf2).run()
-        assert _hval(kpf2.headers["PRIMARY"]["GFR12"]) == pytest.approx(2.0)
+        assert HeaderParser.get(kpf2.headers["PRIMARY"], "GFR12") == pytest.approx(2.0)

--- a/tests/regression/test_headers.py
+++ b/tests/regression/test_headers.py
@@ -1,0 +1,77 @@
+"""
+Tests for HeaderParser (the value/comment normalizer) in data_models/headers.py.
+
+HeaderConverter (native↔EPRV conversion/validation) is exercised end-to-end by
+the to_kpf1/to_kpf2 tests in test_data_models_l{1,2,4}.py; here we pin the
+read/write parsing contract that the rest of the pipeline relies on.
+"""
+
+from collections import OrderedDict
+
+from astropy.io import fits
+
+from kpfpipe.data_models.headers import HeaderParser
+from kpfpipe.data_models.level1 import KPF1
+
+
+class TestHeaderParserGet:
+    """get() returns the scalar regardless of the header's storage form."""
+
+    def test_fits_header(self):
+        hdr = fits.Header()
+        hdr["KEY"] = (1.5, "a comment")
+        assert HeaderParser.get(hdr, "KEY") == 1.5
+
+    def test_tuple_ordereddict(self):
+        hdr = OrderedDict({"KEY": (1.5, "a comment")})
+        assert HeaderParser.get(hdr, "KEY") == 1.5
+
+    def test_bare_scalar(self):
+        assert HeaderParser.get({"KEY": 1.5}, "KEY") == 1.5
+
+    def test_missing_returns_default(self):
+        assert HeaderParser.get({}, "KEY", "fallback") == "fallback"
+        assert HeaderParser.get({}, "KEY") is None
+
+    def test_present_none_is_not_default(self):
+        # A stored None (e.g. a non-finite RV written as FITS UNDEFINED) is
+        # returned as None; the default fires only on absence.
+        assert HeaderParser.get({"KEY": None}, "KEY", "fallback") is None
+
+
+class TestHeaderParserSet:
+    """set() chooses the card form from whether a comment is supplied."""
+
+    def test_with_comment_writes_tuple(self):
+        hdr = {}
+        HeaderParser.set(hdr, "KEY", 5, "the comment")
+        assert hdr["KEY"] == (5, "the comment")
+
+    def test_without_comment_writes_bare_value(self):
+        hdr = {}
+        HeaderParser.set(hdr, "KEY", 5)
+        assert hdr["KEY"] == 5
+
+    def test_set_then_get_on_fits_header(self):
+        # A commented write works on any fits.Header extension; get() reads the
+        # scalar back, comment retained on the card.
+        hdr = fits.Header()
+        HeaderParser.set(hdr, "KEY", 5, "the comment")
+        assert HeaderParser.get(hdr, "KEY") == 5
+        assert hdr.comments["KEY"] == "the comment"
+
+
+class TestHeaderParserRoundTrip:
+    """A commented PRIMARY write survives to_fits -> from_fits with its comment."""
+
+    def test_primary_comment_round_trips(self, tmp_path):
+        l1 = KPF1()
+        l1.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
+        HeaderParser.set(l1.headers["PRIMARY"], "BIASAGE", -0.5, "[day] bias age")
+
+        fn = str(tmp_path / "header_roundtrip_l1.fits")
+        l1.to_fits(fn)
+
+        prim = KPF1.from_fits(fn).headers["PRIMARY"]
+        assert HeaderParser.get(prim, "BIASAGE") == -0.5
+        assert prim.comments["BIASAGE"] == "[day] bias age"

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 from astropy.io import fits
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.modules.image_assembly import ImageAssembly
@@ -117,8 +118,7 @@ class TestImageAssemblyBias:
 
     def test_datalvl_set(self, l1_bias):
         l1, _ = l1_bias
-        datalvl = l1.headers["PRIMARY"]["DATALVL"]
-        val = datalvl[0] if isinstance(datalvl, tuple) else datalvl
+        val = HeaderParser.get(l1.headers["PRIMARY"], "DATALVL")
         assert val == "L1"
 
     def test_read_noise_in_header(self, l1_bias):
@@ -141,8 +141,7 @@ class TestImageAssemblyBias:
 
     def test_overscan_applied_in_header(self, l1_bias):
         l1, _ = l1_bias
-        oscan = l1.headers["PRIMARY"]["OSCANSUB"]
-        val = oscan[0] if isinstance(oscan, tuple) else oscan
+        val = HeaderParser.get(l1.headers["PRIMARY"], "OSCANSUB")
         assert val is True
 
     def test_receipt_chain(self, l1_bias):

--- a/tests/regression/test_master_bias.py
+++ b/tests/regression/test_master_bias.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.bias import Bias
 
@@ -182,8 +183,7 @@ class TestMasterBiasRoundTrip:
             ml1.to_fits(fn)
             ml1_read = KPFMasterL1.from_fits(fn)
 
-        datalvl = ml1_read.headers["PRIMARY"]["DATALVL"]
-        val = datalvl[0] if isinstance(datalvl, tuple) else datalvl
+        val = HeaderParser.get(ml1_read.headers["PRIMARY"], "DATALVL")
         assert val == "ML1"
 
     def test_roundtrip_mask_dtype(self):

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.dark import Dark
 from kpfpipe.utils.io import build_l0_file_lists
@@ -30,11 +31,6 @@ TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 TESTDATA_L0_DIR = TESTDATA_DIR / "L0" / "20240405"
 
 FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
-
-
-def _header_value(value):
-    """Return a header value, unwrapping a (value, comment) tuple if present."""
-    return value[0] if isinstance(value, tuple) else value
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +68,7 @@ class TestMasterDarkUnit:
 
     def test_bunit_is_rate(self, master_dark):
         for chip in CHIPS:
-            bunit = _header_value(master_dark.headers[f"{chip}_IMG"]["BUNIT"])
+            bunit = HeaderParser.get(master_dark.headers[f"{chip}_IMG"], "BUNIT")
             assert bunit == "electrons/sec"
 
     def test_datalvl_class_attribute(self, master_dark):
@@ -144,7 +140,7 @@ class TestMasterDarkRoundTrip:
             ml1.to_fits(fn)
             ml1_read = KPFMasterL1.from_fits(fn)
 
-        assert _header_value(ml1_read.headers["PRIMARY"]["DATALVL"]) == "ML1"
+        assert HeaderParser.get(ml1_read.headers["PRIMARY"], "DATALVL") == "ML1"
 
 
 # ---------------------------------------------------------------------------
@@ -902,7 +898,7 @@ class TestMasterDarkRegression:
 
     def test_bunit_is_rate(self, master_dark):
         for chip in CHIPS:
-            bunit = _header_value(master_dark.headers[f"{chip}_IMG"]["BUNIT"])
+            bunit = HeaderParser.get(master_dark.headers[f"{chip}_IMG"], "BUNIT")
             assert bunit == "electrons/sec"
 
     def test_snr_never_negative(self, master_dark):

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -13,6 +13,7 @@ import pytest
 
 import kpfpipe.modules.masters.base as base_module
 from kpfpipe import DETECTOR
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.masters import KPFMasterL2
 from kpfpipe.modules.masters.wls import WLS
 
@@ -244,12 +245,6 @@ def mock_make_master_l2(monkeypatch):
     monkeypatch.setattr(WLS, "_compute_wls_from_stack", mock_compute)
 
 
-def _header_value(header, key):
-    """Extract a header value whether stored as tuple or plain."""
-    val = header[key]
-    return val[0] if isinstance(val, tuple) else val
-
-
 class TestMakeMasterL2:
     def test_returns_kpf_master_l2(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)
@@ -327,10 +322,10 @@ class TestMakeMasterL2:
         wls = WLS(FILE_LIST)
         override_x = wls.polyorder_x + 4  # ensure different from default
         ml2 = wls.make_master_l2(polyorder_x=override_x)
-        assert _header_value(ml2.headers["PRIMARY"], "POLYORDX") == override_x
+        assert HeaderParser.get(ml2.headers["PRIMARY"], "POLYORDX") == override_x
         for chip in wls.chips:
             assert (
-                _header_value(ml2.headers[f"{chip}_WLS_COEFFS"], "POLYORDX")
+                HeaderParser.get(ml2.headers[f"{chip}_WLS_COEFFS"], "POLYORDX")
                 == override_x
             )
             # verify the override actually propagated into the fit, not just the header
@@ -536,7 +531,7 @@ class TestMakeMasterL2:
         np.testing.assert_array_equal(
             wls._linelist_df["WAVE"].values, np.array([4500.0, 5500.0, 6500.0])
         )
-        assert _header_value(ml2.headers["PRIMARY"], "LINELIST") == str(override)
+        assert HeaderParser.get(ml2.headers["PRIMARY"], "LINELIST") == str(override)
 
     def test_single_frame_stack(self, mock_make_master_l2):
         """A 1-frame stack should still produce a valid master L2."""

--- a/tests/regression/test_qc_booleans.py
+++ b/tests/regression/test_qc_booleans.py
@@ -21,6 +21,7 @@ import pytest
 from astropy.io import fits
 
 from kpfpipe import DETECTOR
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
@@ -578,8 +579,8 @@ class TestQCL1Run:
         l1 = _make_kpf1(tmp_path)
         results = QCL1(l1).run()
 
-        isgood = l1.headers["PRIMARY"]["ISGOOD"]
-        assert (isgood[0] if isinstance(isgood, tuple) else isgood) == 1
+        isgood = HeaderParser.get(l1.headers["PRIMARY"], "ISGOOD")
+        assert isgood == 1
 
         expected_keys = [
             "RNINRNG",
@@ -594,19 +595,18 @@ class TestQCL1Run:
             "FFIFIN",
         ]
         for k in expected_keys:
-            val = l1.headers["PRIMARY"][k]
-            v = val[0] if isinstance(val, tuple) else val
+            v = HeaderParser.get(l1.headers["PRIMARY"], k)
             assert v == 1, f"{k} should be 1 but is {v}"
             assert k in results
 
     def test_one_bad_check_isgood_0(self, tmp_path):
         l1 = _make_kpf1(tmp_path, biassub=False)
         QCL1(l1).run()
-        isgood = l1.headers["PRIMARY"]["ISGOOD"]
-        assert (isgood[0] if isinstance(isgood, tuple) else isgood) == 0
+        isgood = HeaderParser.get(l1.headers["PRIMARY"], "ISGOOD")
+        assert isgood == 0
 
-        biassub = l1.headers["PRIMARY"]["BIASSUB"]
-        assert (biassub[0] if isinstance(biassub, tuple) else biassub) == 0
+        biassub = HeaderParser.get(l1.headers["PRIMARY"], "BIASSUB")
+        assert biassub == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 
 from kpfpipe import DETECTOR
+from kpfpipe.data_models.headers import HeaderParser
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import build_filepath
@@ -137,18 +138,13 @@ class TestScienceRecipe:
         z = np.asarray(l2.data["BARYCORR_Z"])
         assert np.all(np.abs(z) < 1e-3)
 
-    @staticmethod
-    def _hval(header, key):
-        v = header[key]
-        return v[0] if isinstance(v, tuple) else v
-
     def test_per_ccd_barycorr_keywords(self, recipe_output):
         """Per-CCD scalar summaries should land on PRIMARY."""
         l2 = KPF2.from_fits(recipe_output)
         prim = l2.headers["PRIMARY"]
         for key in ("CCD1BJD", "CCD1BKMS", "CCD1BZ", "CCD2BJD", "CCD2BKMS", "CCD2BZ"):
             assert key in prim, f"{key} missing from PRIMARY"
-            assert np.isfinite(float(self._hval(prim, key))), f"{key} not finite"
+            assert np.isfinite(float(HeaderParser.get(prim, key))), f"{key} not finite"
 
     def test_calibration_headers_set(self, recipe_output):
         """CalibrationAssociation's PRIMARY writes (registered KPF-pipeline
@@ -168,19 +164,22 @@ class TestScienceRecipe:
         # WLSAGE = float days
         assert "WLSFILE" in prim
         assert "WLSDIR" not in prim
-        assert self._hval(prim, "WLSFILE").endswith("_master_thar_L2.fits")
-        assert isinstance(self._hval(prim, "WLSAGE"), float)
+        assert HeaderParser.get(prim, "WLSFILE").endswith("_master_thar_L2.fits")
+        assert isinstance(HeaderParser.get(prim, "WLSAGE"), float)
 
     def test_provenance_keywords_set(self, recipe_output):
         """DRP version/provenance/status keywords survive onto the L2 PRIMARY."""
         prim = KPF2.from_fits(recipe_output).headers["PRIMARY"]
         version = importlib.metadata.version("kpfpipe")
-        assert self._hval(prim, "DRPVERNO") == version
-        assert self._hval(prim, "DRPTAG") == version
+        assert HeaderParser.get(prim, "DRPVERNO") == version
+        assert HeaderParser.get(prim, "DRPTAG") == version
         assert "PROGID" in prim
         assert "KOAID" in prim
         # BarycentricCorrection is the last module to run before the L2 write.
-        assert self._hval(prim, "DRPSTATU") == "Barycentric Correction module complete"
+        assert (
+            HeaderParser.get(prim, "DRPSTATU")
+            == "Barycentric Correction module complete"
+        )
 
     def test_wave_arrays_populated(self, recipe_output):
         """WavelengthCalibration should fill the per-fiber WAVE extensions."""


### PR DESCRIPTION
## Summary

  Centralize all FITS-header keyword reading/writing behind a single `HeaderParser`,
  and reorganize `data_models/headers.py` into two cohesive classes. This removes the
  ~20 hand-rolled "unwrap the value if it's a `(value, comment)` tuple" helpers (under
  6+ different names) scattered across production and test code, which were a recurring
  source of bugs.

  ## Background

  Each extension header (`self.headers[ext]`) is **not** stored uniformly:

  - Headers read from disk are an astropy `fits.Header` (scalar values; comments held
    separately in `.comments[key]`).
  - Freshly-constructed headers are a plain `OrderedDict` whose **PRIMARY** keys may hold
    `(value, comment)` tuples, while non-PRIMARY extensions hold bare scalars.

  Readers couldn't tell which form they had, so the codebase carried duplicated
  "unwrap if tuple" helpers everywhere, and the inconsistency caused real bugs (a
  four-agent audit catalogued every read/write site). We deliberately do **not** migrate
  to uniform `fits.Header` storage — that would require overriding rvdata's
  `create_extension`/`_create_hdul`/serialization, conflicting with the principle of
  keeping KPF models as lightweight wrappers around rvdata. Instead we leave rvdata's
  storage/serialization untouched and centralize the parsing.

  ## Changes

  **`data_models/headers.py` — two classes:**

  - **`HeaderParser`** (new) — static read/write normalizer:
    - `HeaderParser.get(header, key, default=None)` → scalar value, unwrapping a
      `(value, comment)` tuple if present. `default` fires only when the key is **absent**
      (a stored `None` returns `None`).
    - `HeaderParser.set(header, key, value, comment=None)` → the single documented write
      path; writes a `(value, comment)` card when a comment is given, else a bare value.
  - **`HeaderConverter`** — bundles the existing WMKO↔EPRV↔KPF conversion/validation
    (`wmko_to_eprv`, `build_instrument_header`, `validate_eprv_primary`); no new logic,
    just reorganized. Its native-header reads use `HeaderParser.get` internally.
  - No rvdata overrides added.

  **Package version:**

  - Add standard `kpfpipe.__version__` (via `importlib.metadata`); `DRPTAG`/`DRPVERNO`
    are stamped from it (drops `HeaderConverter._drp_version`).
  - Inline the `MJD-OBS → JD_UTC` correction into `wmko_to_eprv` and drop the
    `DATE-BEG`/`DATE-OBS` fallback (MJD-OBS is KPF's canonical exposure time).

  **Repo-wide sweep:**

  - All read sites → `HeaderParser.get`; all standardized writes → `HeaderParser.set`,
    deleting every hand-rolled unwrap helper across `data_models/`, `modules/`,
    `quality_control/`, and `utils/io.py`.
  - Conversion call sites updated to the class API (`level0/1/2.py`).
  - Tests: dropped the ~20 duplicated unwrap helpers across 11 test files; added a focused
    `tests/regression/test_headers.py` (9 tests) pinning the parse/round-trip contract.

  **Folded-in audit bug fixes:**

  - Quicklook L0/L1 read `OBJECT` via `HeaderParser.get` (previously could put a raw tuple
    in plot titles).
  - `WLSAGE` read from PRIMARY (not `INSTRUMENT_HEADER`) in `wavelength_calibration.py`;
    fixed stale `WLSFILE`/`ASTRSRC` location docstrings.

  **Docs:**

  - `KPF_DRP_VNEXT_STYLE_GUIDE.md`: one rule — read with `HeaderParser.get`, write with
    `HeaderParser.set`, never hand-roll tuple unwrapping; conversions live in
    `HeaderConverter`.

  ## Testing

  - Full suite green: **1000 passed**.
  - `ruff format` + `ruff check` clean on all changed files.

  ## Out of scope / explicitly rejected

  - No `fits.Header` storage migration.
  - No rvdata overrides (`create_extension`/`_create_hdul`/`set_header` untouched).
  - Raw `fits.getheader` reads in `utils/io.py` stay as-is (already scalar).
  - The non-PRIMARY-plain-dict + comment serialization boundary is documented, not
    engineered around.