### PR TITLE
refactor: dissolve HeaderConverter onto KPF0 + the shared base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,14 +202,18 @@ L1.to_kpf2() → KPF2 (extracted spectra, EPRV-compliant)
 ### Header standardization (EPRV PRIMARY)
 
 The WMKO-native → EPRV-standard PRIMARY conversion lives in **exactly one place**:
-`KPF0.to_kpf1()`, via `kpfpipe/data_models/headers.py` (which drives rvdata's
-`header_map.csv`). Consequences every contributor must respect:
+`KPF0.to_kpf1()`, which calls the conversion methods **`KPF0.wmko_to_eprv()`** and
+**`KPF0.build_instrument_header()`** (L0 owns the WMKO→EPRV mapping). Those methods and the
+shared validator (below) draw their reference data — the rvdata `header_map.csv`, the EPRV/required
+keyword sets, the registry allowlist — from `kpfpipe/data_models/headers.py`, which is now a pure
+reference-data module (no class). Consequences every contributor must respect:
 
 - **L1 PRIMARY is already EPRV-standard.** From L1 onward, PRIMARY holds EPRV keyword *names*
   plus the registered KPF-pipeline keywords below — never raw WMKO natives.
-- **`INSTRUMENT_HEADER` is an immutable, verbatim copy of the raw L0 PRIMARY.** It is written
-  once in `to_kpf1` and **nothing else ever writes to it**. Code that needs a raw instrument
-  keyword (e.g. `ELAPSED`, `MJD-OBS`, `DATE-OBS`, `GAIAID`, `SCI-OBJ`, `TARGTEFF`) reads it from
+- **`INSTRUMENT_HEADER` is an immutable, verbatim copy of the raw L0 PRIMARY** (values **and**
+  comments — `build_instrument_header()` returns a `fits.Header` copy). It is written once in
+  `to_kpf1` and **nothing else ever writes to it**. Code that needs a raw instrument keyword
+  (e.g. `ELAPSED`, `MJD-OBS`, `DATE-OBS`, `GAIAID`, `SCI-OBJ`, `TARGTEFF`) reads it from
   `INSTRUMENT_HEADER`, not PRIMARY.
 - **KPF-pipeline keywords are written directly to PRIMARY** (read noise, OSCANMET, BIASSUB/
   DARKSUB, calibration ages/paths, QC booleans, diagnostics, and the RV/barycentric cards). Every
@@ -217,9 +221,11 @@ The WMKO-native → EPRV-standard PRIMARY conversion lives in **exactly one plac
   (each entry is an explicit ≤8-char FITS keyword — no wildcards; families are enumerated per
   member, e.g. `RNGREEN1`-`RNGREEN4`). **Add new PRIMARY keywords there** or the validator
   will reject the product.
-- **`to_kpf2`/`to_kpf4` are pure pass-throughs** that call `validate_eprv_primary()` and **fail
-  loudly** if a raw native keyword leaked onto PRIMARY, an unregistered keyword appears, or a
-  required EPRV keyword is missing.
+- **`to_kpf2`/`to_kpf4` are pure pass-throughs** that call the shared
+  `KPFDataModel.validate_eprv_primary(header, level)` and **fail loudly** if a raw native keyword
+  leaked onto PRIMARY, an unregistered keyword appears, or a required EPRV keyword is missing. (The
+  validator lives on the shared base — inherited by all levels — and reads its keyword sets from
+  `data_models/headers.py`.)
 - `to_kpf1` also corrects values the installed `header_map.csv` gets wrong: `NUMORDER` (→67 from
   `DETECTOR`), `JD_UTC` (full JD from `MJD-OBS`, the canonical KPF exposure time — native
   `DATE-OBS` is date-only), and the DRP version (`DRPTAG` for EPRV + `DRPVERNO` for WMKO

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -14,6 +14,16 @@ from astropy.io import fits
 from astropy.table import Table
 from rvdata.core.models.base import RVDataModel
 
+from kpfpipe.data_models.headers import (
+    _STRUCTURAL_KEYS,
+    EPRV_L2_KEYS,
+    EPRV_L4_KEYS,
+    HEADERMAP_STANDARD_KEYS,
+    KPFPIPE_PRIMARY_KEYS,
+    REQUIRED_L2_KEYS,
+    REQUIRED_L4_KEYS,
+    WMKO_PRIMARY_KEYS,
+)
 from kpfpipe.utils.kpf import _DATECODE_PATTERN, _OBS_ID_PATTERN
 
 # Receipt names that are data-model conversions / serialization rather than
@@ -151,6 +161,64 @@ class KPFDataModel(RVDataModel):
                 hdu_list[i] = fits.PrimaryHDU(header=self.as_fits_header(primary))
                 break
         return hdu_list
+
+    @staticmethod
+    def validate_eprv_primary(header, level):
+        """Validate a converted EPRV PRIMARY header, raising on any inconsistency.
+
+        The shared fail-loud guard (no silent fallback) for the L1->L2 and
+        L2->L4 boundaries; called by ``KPF1.to_kpf2`` / ``KPF2.to_kpf4``. Three
+        rules:
+
+        1. **WMKO leak** — a raw WMKO keyword name (header_map INSTRUMENT name
+           differing from its EPRV target) is present on PRIMARY; it should have
+           been converted or left in INSTRUMENT_HEADER.
+        2. **Unregistered keyword** — a card that is neither an EPRV-standard
+           keyword, a header_map STANDARD target, a registered KPF-pipeline
+           keyword (``config/L{0,1,2,4}-headers.csv``), nor a structural card.
+        3. **Missing required** — a Required EPRV PRIMARY keyword is absent.
+
+        Parameters
+        ----------
+        header : Mapping
+            The PRIMARY header to validate.
+        level : str
+            ``"L2"`` or ``"L4"`` (selects the EPRV keyword set).
+
+        Raises
+        ------
+        ValueError
+            On the first inconsistency found.
+        """
+        level = str(level).upper()
+        eprv_keys = EPRV_L4_KEYS if level == "L4" else EPRV_L2_KEYS
+        required_keys = REQUIRED_L4_KEYS if level == "L4" else REQUIRED_L2_KEYS
+
+        for raw_key in list(header):
+            key = str(raw_key).strip()
+            if key in _STRUCTURAL_KEYS or key.startswith("NAXIS"):
+                continue
+            if (
+                key in eprv_keys
+                or key in HEADERMAP_STANDARD_KEYS
+                or key in KPFPIPE_PRIMARY_KEYS
+            ):
+                continue
+            if key in WMKO_PRIMARY_KEYS:
+                raise ValueError(
+                    f"native WMKO keyword {key!r} found on {level} PRIMARY; it must "
+                    "be converted to its EPRV name or kept in INSTRUMENT_HEADER"
+                )
+            raise ValueError(
+                f"unregistered keyword {key!r} on {level} PRIMARY; add it to "
+                "config/L{0,1,2,4}-headers.csv or fix the writer"
+            )
+
+        missing = sorted(k for k in required_keys if k not in header)
+        if missing:
+            raise ValueError(
+                f"missing required EPRV PRIMARY keyword(s) on {level}: {missing}"
+            )
 
     def generate_standard_filename(self):
         """Abstract: every concrete KPF model builds its own standard filename.

--- a/kpfpipe/data_models/headers.py
+++ b/kpfpipe/data_models/headers.py
@@ -1,34 +1,32 @@
 """
-WMKO ↔ EPRV ↔ KPF PRIMARY header conversion.
+WMKO ↔ EPRV ↔ KPF PRIMARY header reference data.
 
-KPF stores every extension header as an ``astropy.io.fits.Header`` (see
-``data_models/base.py``), so reads use ``header.get(key)`` / ``header[key]`` and
-writes use ``header[key] = (value, comment)`` natively — there is no separate
-header parser.
+This module is the single source of truth for the WMKO→EPRV keyword mapping
+(rvdata's ``header_map.csv``) and the sets that define what may legitimately
+appear on a KPF EPRV PRIMARY header. It holds only module-level reference data —
+loaded once at import — consumed by the methods that actually convert and
+validate:
 
-:class:`HeaderConverter` is the single source of truth for the WMKO→EPRV keyword
-mapping (rvdata's ``header_map.csv``) and for what may legitimately appear on a
-KPF EPRV PRIMARY header:
+- ``KPF0.wmko_to_eprv`` / ``KPF0.build_instrument_header`` (``data_models/level0.py``)
+  convert the raw WMKO L0 PRIMARY to an EPRV-standard L1 PRIMARY and preserve the
+  verbatim raw PRIMARY in ``INSTRUMENT_HEADER``.
+- ``KPFDataModel.validate_eprv_primary`` (``data_models/base.py``), called by
+  ``KPF1.to_kpf2`` / ``KPF2.to_kpf4``, fails loudly if a raw WMKO keyword leaked
+  onto PRIMARY, an unregistered keyword appears, or a required EPRV keyword is
+  missing.
 
-- ``KPF0.to_kpf1`` calls :meth:`HeaderConverter.wmko_to_eprv` to build an
-  EPRV-standard L1 PRIMARY from the raw WMKO L0 PRIMARY, and
-  :meth:`HeaderConverter.build_instrument_header` to preserve the verbatim raw
-  L0 PRIMARY in an immutable ``INSTRUMENT_HEADER`` extension.
-- ``KPF1.to_kpf2`` / ``KPF2.to_kpf4`` call
-  :meth:`HeaderConverter.validate_eprv_primary` to fail loudly if a raw wmko
-  keyword leaked onto PRIMARY, an unregistered keyword appears, or a required
-  EPRV keyword is missing.
-
-KPF-pipeline keywords that are written directly to PRIMARY (read noise, QC
-booleans, diagnostics, RV/barycentric cards, …) are catalogued in the packaged
-registry (``config/L{0,1,2,4}-headers.csv``) and allowed by the validator.
+KPF stores every extension header as an ``astropy.io.fits.Header``, so reads use
+``header.get(key)`` / ``header[key]`` and writes use ``header[key] = (value,
+comment)`` natively. KPF-pipeline keywords written directly to PRIMARY (read
+noise, QC booleans, diagnostics, RV/barycentric cards, …) are catalogued in the
+packaged registry (``config/L{0,1,2,4}-headers.csv``) and allowed by the validator.
 """
 
 import importlib.resources
 
 import pandas as pd
 
-from kpfpipe import DETECTOR, __version__
+from kpfpipe import DETECTOR
 
 # --- Authoritative configs -------------------------------------------------
 # rvdata (installed package): the wmko↔EPRV map and the EPRV PRIMARY keyword
@@ -159,152 +157,3 @@ _NUMORDER = int(DETECTOR["norder"]["GREEN"]) + int(DETECTOR["norder"]["RED"])
 # Initial DRPSTATU value on the L1 EPRV PRIMARY, before any pipeline module runs.
 # Each module overwrites it via the receipt_add_entry override (see base.py).
 _DRPSTATU_DEFAULT = "File ingested into KPF-DRP"
-
-
-class HeaderConverter:
-    """Convert and validate KPF PRIMARY headers across the WMKO-native, EPRV,
-    and KPF-pipeline conventions.
-
-    Single source of truth for the wmko→EPRV mapping (rvdata's
-    ``header_map.csv``) and the EPRV PRIMARY allowlist. Stateless: the reference
-    data (``HEADER_MAP`` and the derived keyword sets) is module-level, loaded
-    once at import.
-    """
-
-    @staticmethod
-    def wmko_to_eprv(wmko_primary):
-        """Map a raw WMKO PRIMARY header to an EPRV-standard PRIMARY dict.
-
-        For each header_map row, take the instrument (wmko) value when present,
-        else the row default. Then apply the value corrections the installed
-        header_map gets wrong (NUMORDER, JD_UTC) and stamp the DRP version
-        (DRPTAG for EPRV, DRPVERNO for WMKO DRP-RUN-11).
-
-        Parameters
-        ----------
-        wmko_primary : Mapping
-            The raw L0 PRIMARY header (astropy ``fits.Header`` or dict).
-
-        Returns
-        -------
-        dict
-            EPRV-standard PRIMARY keyword → value (a few as ``(value, comment)``).
-        """
-        out = {}
-        for _, row in HEADER_MAP.iterrows():
-            standard_key = str(row["STANDARD"]).strip()
-            instrument_key = (
-                str(row["INSTRUMENT"]).strip() if pd.notna(row["INSTRUMENT"]) else ""
-            )
-            default_val = row["DEFAULT"] if pd.notna(row["DEFAULT"]) else None
-
-            if instrument_key and instrument_key in wmko_primary:
-                out[standard_key] = wmko_primary.get(instrument_key)
-            elif default_val is not None and str(default_val).strip():
-                out[standard_key] = default_val
-
-        # --- Value corrections (see notes/header_audit.md A1/A2/A3) ---
-        out["NUMORDER"] = (_NUMORDER, "Number of echelle orders (green+red)")
-        # header_map maps JD_UTC <- MJD-OBS but drops the epoch offset, leaving a
-        # raw MJD (A1); KPF's canonical exposure time is MJD-OBS, so add 2400000.5.
-        mjd = wmko_primary.get("MJD-OBS")
-        if mjd not in (None, "", "UNKNOWN"):
-            out["JD_UTC"] = (
-                float(mjd) + 2400000.5,
-                "[day] Julian date of exposure start",
-            )
-        out["DRPTAG"] = (__version__, "DRP version")
-        out["DRPVERNO"] = (__version__, "DRP version (WMKO DRP-RUN-11)")
-
-        # WMKO provenance (DRP-RUN-19): PROGID/KOAID, or 'UNKNOWN' if absent.
-        out["PROGID"] = (
-            wmko_primary.get("PROGID") or "UNKNOWN",
-            "WMKO program ID",
-        )
-        out["KOAID"] = (
-            wmko_primary.get("KOAID") or "UNKNOWN",
-            "KOA archive ID",
-        )
-        # Initial reduction status (DRP-RUN-20); modules overwrite it as they run.
-        out["DRPSTATU"] = (_DRPSTATU_DEFAULT, "DRP reduction status")
-        return out
-
-    @staticmethod
-    def build_instrument_header(wmko_primary):
-        """Verbatim scalar copy of the raw WMKO PRIMARY for INSTRUMENT_HEADER.
-
-        INSTRUMENT_HEADER is an ImageHDU header (scalar values only) and is an
-        immutable, pure pass-through of the raw instrument PRIMARY — nothing
-        writes to it after ``to_kpf1``.
-
-        Parameters
-        ----------
-        wmko_primary : Mapping
-            The raw L0 PRIMARY header.
-
-        Returns
-        -------
-        dict
-            keyword → scalar value.
-        """
-        # Iterate .items() (not keyed get): for a fits.Header this yields each
-        # commentary card's scalar string, where header["COMMENT"] would instead
-        # return an astropy commentary-card object that fits.Header(dict) cannot
-        # re-serialize.
-        return {key: value for key, value in wmko_primary.items()}
-
-    @staticmethod
-    def validate_eprv_primary(header, level):
-        """Validate a converted EPRV PRIMARY header, raising on any inconsistency.
-
-        Fail-loud guard (no silent fallback) for the L2/L4 boundary. Three rules:
-
-        1. **WMKO leak** — a raw WMKO keyword name (header_map INSTRUMENT name
-           differing from its EPRV target) is present on PRIMARY; it should have
-           been converted or left in INSTRUMENT_HEADER.
-        2. **Unregistered keyword** — a card that is neither an EPRV-standard
-           keyword, a header_map STANDARD target, a registered KPF-pipeline
-           keyword (``config/L{0,1,2,4}-headers.csv``), nor a structural card.
-        3. **Missing required** — a Required EPRV PRIMARY keyword is absent.
-
-        Parameters
-        ----------
-        header : Mapping
-            The PRIMARY header to validate.
-        level : str
-            ``"L2"`` or ``"L4"`` (selects the EPRV keyword set).
-
-        Raises
-        ------
-        ValueError
-            On the first inconsistency found.
-        """
-        level = str(level).upper()
-        eprv_keys = EPRV_L4_KEYS if level == "L4" else EPRV_L2_KEYS
-        required_keys = REQUIRED_L4_KEYS if level == "L4" else REQUIRED_L2_KEYS
-
-        for raw_key in list(header):
-            key = str(raw_key).strip()
-            if key in _STRUCTURAL_KEYS or key.startswith("NAXIS"):
-                continue
-            if (
-                key in eprv_keys
-                or key in HEADERMAP_STANDARD_KEYS
-                or key in KPFPIPE_PRIMARY_KEYS
-            ):
-                continue
-            if key in WMKO_PRIMARY_KEYS:
-                raise ValueError(
-                    f"native WMKO keyword {key!r} found on {level} PRIMARY; it must "
-                    "be converted to its EPRV name or kept in INSTRUMENT_HEADER"
-                )
-            raise ValueError(
-                f"unregistered keyword {key!r} on {level} PRIMARY; add it to "
-                "config/L{0,1,2,4}-headers.csv or fix the writer"
-            )
-
-        missing = sorted(k for k in required_keys if k not in header)
-        if missing:
-            raise ValueError(
-                f"missing required EPRV PRIMARY keyword(s) on {level}: {missing}"
-            )

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -19,7 +19,9 @@ import pandas as pd
 from astropy.io import fits
 from astropy.table import Table
 
+from kpfpipe import __version__
 from kpfpipe.data_models.base import KPFDataModel
+from kpfpipe.data_models.headers import _DRPSTATU_DEFAULT, _NUMORDER, HEADER_MAP
 from kpfpipe.utils.kpf import get_obs_id
 
 _config_path = importlib.resources.files("kpfpipe.data_models.config")
@@ -172,6 +174,63 @@ class KPF0(KPFDataModel):
         "CONFIG",
     ]
 
+    def wmko_to_eprv(self):
+        """Map this L0's raw WMKO PRIMARY to an EPRV-standard PRIMARY dict.
+
+        For each header_map row, take the instrument (WMKO) value when present,
+        else the row default. Then apply the value corrections the installed
+        header_map gets wrong (NUMORDER, JD_UTC) and stamp the DRP version
+        (DRPTAG for EPRV, DRPVERNO for WMKO DRP-RUN-11).
+
+        Returns
+        -------
+        dict
+            EPRV-standard PRIMARY keyword -> value (a few as ``(value, comment)``).
+        """
+        wmko_primary = self.headers["PRIMARY"]
+        out = {}
+        for _, row in HEADER_MAP.iterrows():
+            standard_key = str(row["STANDARD"]).strip()
+            instrument_key = (
+                str(row["INSTRUMENT"]).strip() if pd.notna(row["INSTRUMENT"]) else ""
+            )
+            default_val = row["DEFAULT"] if pd.notna(row["DEFAULT"]) else None
+
+            if instrument_key and instrument_key in wmko_primary:
+                out[standard_key] = wmko_primary.get(instrument_key)
+            elif default_val is not None and str(default_val).strip():
+                out[standard_key] = default_val
+
+        # --- Value corrections (see notes/header_audit.md A1/A2/A3) ---
+        out["NUMORDER"] = (_NUMORDER, "Number of echelle orders (green+red)")
+        # header_map maps JD_UTC <- MJD-OBS but drops the epoch offset, leaving a
+        # raw MJD (A1); KPF's canonical exposure time is MJD-OBS, so add 2400000.5.
+        mjd = wmko_primary.get("MJD-OBS")
+        if mjd not in (None, "", "UNKNOWN"):
+            out["JD_UTC"] = (
+                float(mjd) + 2400000.5,
+                "[day] Julian date of exposure start",
+            )
+        out["DRPTAG"] = (__version__, "DRP version")
+        out["DRPVERNO"] = (__version__, "DRP version (WMKO DRP-RUN-11)")
+
+        # WMKO provenance (DRP-RUN-19): PROGID/KOAID, or 'UNKNOWN' if absent.
+        out["PROGID"] = (wmko_primary.get("PROGID") or "UNKNOWN", "WMKO program ID")
+        out["KOAID"] = (wmko_primary.get("KOAID") or "UNKNOWN", "KOA archive ID")
+        # Initial reduction status (DRP-RUN-20); modules overwrite it as they run.
+        out["DRPSTATU"] = (_DRPSTATU_DEFAULT, "DRP reduction status")
+        return out
+
+    def build_instrument_header(self):
+        """Comment-preserving verbatim copy of the raw WMKO PRIMARY.
+
+        INSTRUMENT_HEADER is an immutable, pure pass-through of the raw instrument
+        PRIMARY -- nothing writes to it after ``to_kpf1``. Returning a
+        ``fits.Header`` copy preserves values *and* comments (and commentary
+        cards), unlike a scalar dict.
+        """
+        return self.as_fits_header(self.headers["PRIMARY"])
+
     def to_kpf1(self):
         """
         Create a KPF1 scaffold from this L0, carrying over headers and
@@ -190,26 +249,20 @@ class KPF0(KPFDataModel):
         obs_id copied over. GREEN_CCD, GREEN_VAR, RED_CCD, RED_VAR are created
         but empty — the caller (image assembly) fills those in.
         """
-        from kpfpipe.data_models.headers import HeaderConverter
         from kpfpipe.data_models.level1 import KPF1  # deferred: avoids circular import
 
         l1 = KPF1()
 
         # Convert the raw WMKO PRIMARY to EPRV-standard names/values, and
-        # preserve the verbatim raw L0 PRIMARY in INSTRUMENT_HEADER (immutable
-        # pure pass-through — nothing else ever writes to it).
+        # preserve the verbatim raw L0 PRIMARY (values + comments) in
+        # INSTRUMENT_HEADER (immutable pass-through — nothing else writes to it).
         if "PRIMARY" in self.headers:
-            wmko_primary = self.headers["PRIMARY"]
-            for key, value in HeaderConverter.wmko_to_eprv(wmko_primary).items():
+            for key, value in self.wmko_to_eprv().items():
                 l1.headers["PRIMARY"][key] = value
 
             if "INSTRUMENT_HEADER" not in l1.extensions:
                 l1.create_extension("INSTRUMENT_HEADER", "ImageHDU")
-            instrument_header = l1.headers["INSTRUMENT_HEADER"]
-            for key, value in HeaderConverter.build_instrument_header(
-                wmko_primary
-            ).items():
-                instrument_header[key] = value
+            l1.set_header("INSTRUMENT_HEADER", self.build_instrument_header())
 
         # Copy pass-through extensions (data + header)
         for ext_name in self._L0_TO_L1_PASSTHROUGH:

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -210,7 +210,6 @@ class KPF1(KPFDataModel):
         arrays are created but empty — the caller (spectral extraction) fills
         those in.
         """
-        from kpfpipe.data_models.headers import HeaderConverter
         from kpfpipe.data_models.level2 import KPF2  # deferred: avoids circular import
 
         kpf2 = KPF2()
@@ -252,7 +251,7 @@ class KPF1(KPFDataModel):
             )
 
         kpf2.headers["PRIMARY"]["DATALVL"] = ("L2", "Data product level")
-        HeaderConverter.validate_eprv_primary(kpf2.headers["PRIMARY"], "L2")
+        self.validate_eprv_primary(kpf2.headers["PRIMARY"], "L2")
         kpf2.receipt_add_entry("to_kpf2", "PASS")
         return kpf2
 

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -224,7 +224,6 @@ class KPF2(KPFDataModel, RV2):
         and the receipt chain preserved. RV and CCF data extensions are
         created but empty — the caller (RV computation) fills those in.
         """
-        from kpfpipe.data_models.headers import HeaderConverter
         from kpfpipe.data_models.level4 import KPF4  # deferred: avoids circular import
 
         kpf4 = KPF4()
@@ -245,7 +244,7 @@ class KPF2(KPFDataModel, RV2):
         kpf4.obs_id = self.obs_id
 
         kpf4.headers["PRIMARY"]["DATALVL"] = ("L4", "Data product level")
-        HeaderConverter.validate_eprv_primary(kpf4.headers["PRIMARY"], "L4")
+        self.validate_eprv_primary(kpf4.headers["PRIMARY"], "L4")
         kpf4.receipt_add_entry("to_kpf4", "PASS")
         return kpf4
 

--- a/tests/regression/test_headers.py
+++ b/tests/regression/test_headers.py
@@ -9,8 +9,9 @@ commented PRIMARY card survives ``to_fits`` -> ``from_fits`` with its comment
 intact -- the regression guard for the lossless-PRIMARY serialization in
 ``KPFDataModel._create_hdul`` / ``KPF2._create_hdul`` / ``KPF4._create_hdul``.
 
-HeaderConverter (WMKO->EPRV conversion/validation) is exercised end-to-end by the
-to_kpf1/to_kpf2 tests in test_data_models_l{1,2,4}.py.
+The WMKO->EPRV conversion (``KPF0.wmko_to_eprv`` / ``build_instrument_header``) and
+the shared ``KPFDataModel.validate_eprv_primary`` guard are exercised end-to-end by
+the to_kpf1/to_kpf2 tests in test_data_models_l{1,2,4}.py.
 """
 
 from astropy.io import fits


### PR DESCRIPTION
## Dissolve `HeaderConverter` → `KPF0` + the shared base

  Redistributes the `HeaderConverter` class by ownership and deletes it. `HeaderConverter` bundled WMKO→EPRV
  **conversion** (only ever used by `KPF0.to_kpf1`) with EPRV PRIMARY **validation** (used by `KPF1.to_kpf2` /
  `KPF2.to_kpf4`), hiding the real split: **L0 holds WMKO-native data and owns the conversion; L1/L2/L4 are 
  EPRV(-like) and share the validation.**

  ### Changes
  - **`KPF0` (`level0.py`)** — now owns `wmko_to_eprv()` and `build_instrument_header()`, reading the raw L0 PRIMARY
  from `self`; `to_kpf1` calls them.
  - **`KPFDataModel` (`base.py`)** — `validate_eprv_primary(header, level)` is now a shared `@staticmethod`;
  `KPF1.to_kpf2` / `KPF2.to_kpf4` call `self.validate_eprv_primary(...)`.
  - **`headers.py`** — `HeaderConverter` deleted; becomes a pure reference-data module. All module-level data
  (`HEADER_MAP`, EPRV/required keyword sets, `WMKO_PRIMARY_KEYS`, `_STRUCTURAL_KEYS`, `_NUMORDER`,
  `_DRPSTATU_DEFAULT`, loaders) stays and is imported by the relocated methods.

  ### One deliberate behavior change (fix)
  `build_instrument_header` now returns a `fits.Header` copy of the raw PRIMARY, so **`INSTRUMENT_HEADER` preserves 
  the raw WMKO comments** (and commentary cards) instead of flattening to scalars. Verified the comment survives in 
  memory **and** through `to_fits → from_fits`. Everything else is an identical relocation.

  ### Out of scope (follow-up)
  Calling validation at `to_kpf1`, and any new L0-native format checks.

  ### Notes
  - No import cycle — `base → headers → kpfpipe` is one-directional.
  - Stacked on `kpf-next-data-model-inheritance` (the PR base).

  ### Verification
  - Full suite green (**997 passed**); `ruff format` + `ruff check` clean.
  - Confirmed: conversion correct (JD_UTC offset, DRPTAG), validation still fires at the L2/L4 boundaries, and the 
  `INSTRUMENT_HEADER` comment round-trips through disk.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)