### PR TITLE
kpf-next headers QC cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ per-extension CSVs), columns `Keyword, Description, Extension, DataType, Populat
 (`.registered` is the keyword allowlist). **`keyword_registry.py` is imported only by
 `data_models/base.py`**: `KPFDataModel` surfaces the singleton as the **class attribute
 `keyword_registry`** and re-exports it (so `level2/4.py` call `keyword_registry.register_rvdata_extension`
-from `base`) — consumers handed a `kpf_obj` (the qc_booleans validator, level0's WMKO→EPRV mapping,
+from `base`) — consumers handed a `kpf_obj` (the checkpoints validator, level0's WMKO→EPRV mapping,
 tests) read the lookups off `kpf.keyword_registry.{table,routing,allowed,required,structural,registered,header_map}`
 rather than importing the registry.
 Consequences every contributor must respect:
@@ -320,7 +320,7 @@ The rvdata `RVDataModel` provides `extensions`, `headers`, `data` (top-level Ord
 Four read-only layers, consolidated under `kpfpipe/quality_control/`, consume data products. None of them mutate the scientific arrays — they only read data and write header keywords via `set_keyword` (routed to QUALITY_CONTROL — see *Header standardization*) (and, in Quicklook's case, to PNG files). Per-level files follow the `levelN.py` naming used by `data_models/`. The first three run in a strict order — **Diagnostics → QC → Checkpoints** — each consuming what the prior wrote:
 
 - **Diagnostics** (`kpfpipe/quality_control/diagnostics/`) — computes scalar/array metrics from finished data products and writes them via `set_keyword` (DiagL2 metrics land on QUALITY_CONTROL). Per-level classes (`DiagL0`/`DiagL1`/`DiagL2`) mirror the QC structure. Examples: per-fiber NaN counts in extracted spectra, zero-flux fraction.
-- **QC** (`kpfpipe/quality_control/qc_booleans/`) — reads metrics (mostly from headers populated by Diagnostics or pipeline modules) and applies pass/fail thresholds. Writes **only** 0/1 keywords (via `set_keyword`, routed to QUALITY_CONTROL) plus the `ISGOOD` aggregate. No validation or raising — that is the Checkpoints layer's job.
+- **QC** (`kpfpipe/quality_control/qc_flags/`) — reads metrics (mostly from headers populated by Diagnostics or pipeline modules) and applies pass/fail thresholds. Writes **only** 0/1 keywords (via `set_keyword`, routed to QUALITY_CONTROL) plus the `ISGOOD` aggregate. No validation or raising — that is the Checkpoints layer's job.
 - **Checkpoints** (`kpfpipe/quality_control/checkpoints/`) — reads the 0/1 QC flags and the product headers and **emits warnings or raises errors** (never writes). Two inherited base checkpoints: `unregistered_keywords` (structural header validation — see *Header standardization*) and `qc_flags` (raises a failed flag named in the per-level `RAISE_FLAGS`, warns the rest). `CheckpointL0`/`L1`/`L2` set `LEVEL` + `RAISE_FLAGS`.
 - **Quicklook** (`kpfpipe/quality_control/quicklook/`) — reads products and renders matplotlib plots. Pulls any annotation values from existing headers.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,17 +258,20 @@ Consequences every contributor must respect:
   `keyword_registry.register_rvdata_extension` (a method on `KeywordRegistry`, re-exposed via `base`,
   called from `level2.py`/`level4.py`) registers it into rvdata's in-memory `LEVEL{2,4}_EXTENSIONS` so
   a product written with it reads back.
-- **Header validation lives in `quality_control/qc_booleans` (`QC._validate_headers`), run at the end
-  of `QC.run()` — NOT in `to_kpf2`/`to_kpf4`** (the transforms no longer self-validate). For each
-  registry-governed extension present (PRIMARY, QUALITY_CONTROL, RECEIPT, the barycentric extensions,
-  RV#/CCF#), every card must be a registered keyword for that extension (`keyword_registry.table`) or a
-  structural card, else it **raises**; an absent `Required` keyword **warns**. PRIMARY *allowed* is
-  **not level-gated** (any registered PRIMARY keyword is allowed on any PRIMARY); *required*-warnings
-  are level-aware (only keywords required at `Level ≤ product level`, so an L2 product isn't warned
-  about missing L4-only `RV`). PRIMARY is validated only where it is EPRV-standard (L1/L2/L4); the raw
-  WMKO L0 PRIMARY is skipped. L4 is validated once `QCL4` is written (planned). The validator reads its
-  allowed/required lookups off the validated `kpf_obj` (`self.kpf.keyword_registry.allowed` /
-  `.required`), so qc_booleans imports nothing from `data_models`.
+- **Header validation lives in the `quality_control/checkpoints` layer
+  (`Checkpoint.unregistered_keywords`), NOT in QC or `to_kpf2`/`to_kpf4`.** QC writes only 0/1
+  flags; the Checkpoint stage runs after it (science → Diagnostics → QC → Checkpoints) and reads
+  the flags + headers to warn or raise. For each registry-governed extension present (PRIMARY,
+  QUALITY_CONTROL, RECEIPT, the barycentric extensions, RV#/CCF#), every card must be a registered
+  keyword for that extension (`keyword_registry.allowed`) or a structural card, else it **raises**.
+  PRIMARY is validated only where it is EPRV-standard (L1/L2/L4); the raw WMKO L0 PRIMARY is
+  skipped. The "required keywords present" concern is now a **QC flag** instead: `KWRDPRL{1,2,4}`
+  is 1 iff every registry-required PRIMARY keyword for the level is present (EPRV `Required` at
+  `Level ≤ product level`, unioned with the KPF-routed PRIMARY provenance cards); `KWRDPRL0` stays
+  hardcoded (raw L0 PRIMARY is not registry-governed). The `qc_flags` checkpoint then reads each
+  0/1 flag and **raises** it if it is in the level's `RAISE_FLAGS` (data-present only), else
+  **warns**. Checkpoints read all lookups off the validated `kpf_obj`
+  (`self.kpf.keyword_registry`), so `quality_control` imports nothing from `data_models`.
 - **`wmko_to_eprv` emits only registered keywords.** It applies `header_map.csv` but **filters each
   `STANDARD` target against the registry** (via `self.keyword_registry.registered`), so rvdata's
   header_map entries that aren't EPRV keywords (`PARANG`, `PARANG2`) are dropped, never leaking onto
@@ -290,8 +293,8 @@ Consequences every contributor must respect:
   `KPF0.wmko_to_eprv`/`build_instrument_header` (`data_models/level0.py`); the unified
   `KeywordRegistry` table and its derived routing/validation lookups live in
   `data_models/keyword_registry.py` (the `keyword_registry` singleton), surfaced through `KPFDataModel`
-  (`set_keyword` + the `keyword_registry` class attribute); the validator itself lives in
-  `quality_control/qc_booleans/base.py` (`QC._validate_headers`).
+  (`set_keyword` + the `keyword_registry` class attribute); header validation itself lives in
+  `quality_control/checkpoints/base.py` (`Checkpoint.unregistered_keywords`).
 
 ### Configuration
 
@@ -311,15 +314,16 @@ Two authorities encode this rule and **must agree per level**: `build_filepath(o
 
 The rvdata `RVDataModel` provides `extensions`, `headers`, `data` (top-level OrderedDicts), plus `create_extension()`, `set_data()`, `set_header()`, `from_fits()`, `to_fits()`, and a receipt system. The base `set_data()`/`set_header()` use `.keys()` checks that bypass `__contains__` overrides, so KPF2/KPF4 override these methods with a `hasattr` guard to resolve aliases during init before the dicts are upgraded. The base `create_extension()` initializes each extension *header* as an `OrderedDict`; the KPF models override it so every header is a `fits.Header` instead (see *Header standardization*).
 
-### Diagnostics, QC, and Quicklook
+### Diagnostics, QC, Checkpoints, and Quicklook
 
-Three read-only layers, consolidated under `kpfpipe/quality_control/`, consume data products. None of them mutate the scientific arrays — they only read data and write header keywords via `set_keyword` (routed to QUALITY_CONTROL — see *Header standardization*) (and, in Quicklook's case, to PNG files). Per-level files follow the `levelN.py` naming used by `data_models/`.
+Four read-only layers, consolidated under `kpfpipe/quality_control/`, consume data products. None of them mutate the scientific arrays — they only read data and write header keywords via `set_keyword` (routed to QUALITY_CONTROL — see *Header standardization*) (and, in Quicklook's case, to PNG files). Per-level files follow the `levelN.py` naming used by `data_models/`. The first three run in a strict order — **Diagnostics → QC → Checkpoints** — each consuming what the prior wrote:
 
 - **Diagnostics** (`kpfpipe/quality_control/diagnostics/`) — computes scalar/array metrics from finished data products and writes them via `set_keyword` (DiagL2 metrics land on QUALITY_CONTROL). Per-level classes (`DiagL0`/`DiagL1`/`DiagL2`) mirror the QC structure. Examples: per-fiber NaN counts in extracted spectra, zero-flux fraction.
-- **QC** (`kpfpipe/quality_control/qc_booleans/`) — reads metrics (mostly from headers populated by Diagnostics or pipeline modules) and applies pass/fail thresholds. Writes 0/1 keywords (via `set_keyword`, routed to QUALITY_CONTROL) plus the `ISGOOD` aggregate, then runs `_validate_headers` (the single home for header validation — see *Header standardization*).
+- **QC** (`kpfpipe/quality_control/qc_booleans/`) — reads metrics (mostly from headers populated by Diagnostics or pipeline modules) and applies pass/fail thresholds. Writes **only** 0/1 keywords (via `set_keyword`, routed to QUALITY_CONTROL) plus the `ISGOOD` aggregate. No validation or raising — that is the Checkpoints layer's job.
+- **Checkpoints** (`kpfpipe/quality_control/checkpoints/`) — reads the 0/1 QC flags and the product headers and **emits warnings or raises errors** (never writes). Two inherited base checkpoints: `unregistered_keywords` (structural header validation — see *Header standardization*) and `qc_flags` (raises a failed flag named in the per-level `RAISE_FLAGS`, warns the rest). `CheckpointL0`/`L1`/`L2` set `LEVEL` + `RAISE_FLAGS`.
 - **Quicklook** (`kpfpipe/quality_control/quicklook/`) — reads products and renders matplotlib plots. Pulls any annotation values from existing headers.
 
-This is unlike v2.12, which had one big `DiagnosticsFramework` primitive with a conditional dispatch tree over many functions and shared backend state with `AnalyzeL0/2D/L1/L2` classes. v3 uses per-level classes with method-attribute registration (`_diag_name` / `_qc_key`) and no shared state.
+This is unlike v2.12, which had one big `DiagnosticsFramework` primitive with a conditional dispatch tree over many functions and shared backend state with `AnalyzeL0/2D/L1/L2` classes. v3 uses per-level classes with method-attribute registration (`_diag_name` / `_qc_key` / `_checkpoint_name`) and no shared state.
 
 **Where metrics live.** Metrics that depend on intermediate processing state (read noise from raw overscan, master ages from header lookups during association) stay in the pipeline module that produces them — they cannot be recomputed from the finished product. Metrics that can be computed from the finished product alone live in Diagnostics.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,8 +242,7 @@ Consequences every contributor must respect:
   if its home extension does not exist on the object. Every such keyword must be registered in the
   per-level registry `data_models/config/L{0,1,2,4}-headers.csv` (explicit ≤8-char FITS keyword — no
   wildcards; families enumerated per member, e.g. `RNGREEN1`-`RNGREEN4`). The current homes:
-  - **PRIMARY** — DRP provenance (stamped at read), `DRPTAG`, and the L4 SCI-combined RV summaries
-    (`CCD1RV`/`CCD2RV`/`CCD1ERV`/`CCD2ERV`, `CCFRV`, `CCFERV`) plus the EPRV RV cards.
+  - **PRIMARY** — DRP provenance (stamped at read), `DRPTAG`, and the EPRV RV cards.
   - **QUALITY_CONTROL** (a KPF-only `BinTableHDU`, created on KPF0/1/2) — QC booleans + `ISGOOD`,
     read-noise (`RN*`), calibration **ages** (`BIASAGE`/`DARKAGE`/`FLATAGE`/`WLSAGE`), and DiagL2
     metrics (`NAN*`/`ZEROFRAC`/`*SNR*`/`*FR*`).
@@ -251,7 +250,9 @@ Consequences every contributor must respect:
     (`BIASFILE`/`DARKFILE`/`FLATFILE`/`WLSFILE`), `ASTRSRC`.
   - **BJD_TDB / BARYCORR_KMS / BARYCORR_Z** (EPRV L2 extensions) — the per-CCD barycentric summaries.
   - **RV1–RV5** (EPRV L4 tables) — the per-orderlet legacy RVs (`CCD<n>RV<sfx>`, sfx S→RV1, 1→RV2,
-    2→RV3, 3→RV4, C→RV5). Masters keep `MASTYPE` on their own PRIMARY (out of EPRV scope).
+    2→RV3, 3→RV4, C→RV5) plus the SCI-combined RV summaries on **RV3**
+    (`CCD1RV`/`CCD2RV`/`CCD1ERV`/`CCD2ERV`, `CCFRV`, `CCFERV`). Masters keep `MASTYPE` on their own
+    PRIMARY (out of EPRV scope).
 - **QUALITY_CONTROL + RECEIPT *headers* propagate L0→L1→L2** card-by-card in `to_kpf1`/`to_kpf2`
   (`set_header` with a comment-preserving `fits.Header` copy), alongside the receipt *table* copy.
   QUALITY_CONTROL is a KPF-custom extension unknown to rvdata's definition-driven L2/L4 reader, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,7 +326,7 @@ Four read-only layers, consolidated under `kpfpipe/quality_control/`, consume da
 
 This is unlike v2.12, which had one big `DiagnosticsFramework` primitive with a conditional dispatch tree over many functions and shared backend state with `AnalyzeL0/2D/L1/L2` classes. v3 uses per-level classes with method-attribute registration (`_diag_name` / `_qc_key` / `_checkpoint_name`) and no shared state.
 
-**Where metrics live.** Metrics that depend on intermediate processing state (read noise from raw overscan, master ages from header lookups during association) stay in the pipeline module that produces them — they cannot be recomputed from the finished product. Metrics that can be computed from the finished product alone live in Diagnostics.
+**Where metrics live.** Metrics that depend on intermediate processing state (e.g. read noise from raw overscan) stay in the pipeline module that produces them — they cannot be recomputed from the finished product. Metrics that can be computed from the finished product alone live in Diagnostics — including the master calibration **ages** (`BIASAGE`/`DARKAGE`/`FLATAGE`/`WLSAGE`), which `DiagL1` recomputes from the master paths `CalibrationAssociation` wrote to RECEIPT (`*FILE`) plus the `INSTRUMENT_HEADER` `DATE-OBS`; the association module writes only the paths.
 
 **Detector geometry.** Helpers like `count_amplifiers`, `orient_channels`, and `_RN_KEYS` are owned by `ImageAssembly`. Other consumers (Quicklook, future Diagnostics) import them rather than duplicating the logic.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -272,7 +272,7 @@ Consequences every contributor must respect:
   hardcoded (raw L0 PRIMARY is not registry-governed). The `qc_flags` checkpoint then reads each
   0/1 flag and **raises** it if it is in the level's `RAISE_FLAGS` (data-present only), else
   **warns**. Checkpoints read all lookups off the validated `kpf_obj`
-  (`self.kpf.keyword_registry`), so `quality_control` imports nothing from `data_models`.
+  (`self.kpf_obj.keyword_registry`), so `quality_control` imports nothing from `data_models`.
 - **`wmko_to_eprv` emits only registered keywords.** It applies `header_map.csv` but **filters each
   `STANDARD` target against the registry** (via `self.keyword_registry.registered`), so rvdata's
   header_map entries that aren't EPRV keywords (`PARANG`, `PARANG2`) are dropped, never leaking onto

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -459,8 +459,10 @@ consumes what the prior wrote (metrics → 0/1 flags → warn/raise):
 - **Writes go through `set_keyword`** (comment sourced from the registry, not the call site).
   QC writes integer `0/1` plus an `ISGOOD` aggregate and **does no validation**. Round floats
   before writing (`round(float(x), 6)`), and cast numpy scalars to Python `int`/`float`. The
-  `_qc_comment`/metric-dict comment is retained in `self.results`, but the FITS comment is the
-  registry `Description` — keep the two consistent.
+  per-check/metric comment lives **once, in the registry `Description`** — QC methods carry only
+  `_qc_key` (no `_qc_comment`); `run()` mirrors the registry `Description` into `self.results` for
+  reporting. (Diagnostics methods still return their own `(value, comment)` dicts, but the FITS
+  comment is always the registry `Description`.)
 - **Checkpoints validate; they do not write.** A `Checkpoint` subclass reads the 0/1 flags +
   headers and **warns or raises** (header validation lives in `Checkpoint.unregistered_keywords`).
   Per-flag severity is a per-level `RAISE_FLAGS` tuple on the subclass (a failed flag named there

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -68,7 +68,7 @@ guidance (environment, commands, architecture), which is documented separately.
   exception is documented at its definition. Don't add new public module constants on this
   precedent without the same justification.
 - **FITS keyword names**: ≤ 8 chars, uppercase, no underscores (`NANSCI1`, `ZEROFRAC`,
-  `RNINRNG`, `ISGOOD`). Encode the level into the keyword when needed for uniqueness
+  `RNOK`, `ISGOOD`). Encode the level into the keyword when needed for uniqueness
   (`DATAPRL0`, `L2NANOK`). **Before inventing a new PRIMARY/extension keyword, grep
   `reference/legacy_data_format.rst` and reuse the legacy spelling/casing wherever the
   science meaning matches** (e.g. `WLSFILE`, `BIASFILE`) — so downstream tools, notebooks,

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -429,10 +429,11 @@ class StageName:
 
 ---
 
-## 9. Quality-control layers (Diagnostics / QC / Quicklook)
+## 9. Quality-control layers (Diagnostics / QC / Checkpoints / Quicklook)
 
-These three read-only layers under `kpfpipe/quality_control/` share conventions that new
-QC code must follow:
+These four read-only layers under `kpfpipe/quality_control/` share conventions that new
+QC code must follow. Diagnostics, QC, and Checkpoints run in that strict order — each
+consumes what the prior wrote (metrics → 0/1 flags → warn/raise):
 
 - **Read-only discipline.** Diagnostics and QC write header keywords **only via `set_keyword`**
   (which routes them to QUALITY_CONTROL — see §11 *FITS PRIMARY header conventions*), never to
@@ -446,17 +447,24 @@ QC code must follow:
 
   def data_l0_red_green(self): ...
   data_l0_red_green._qc_key = "DATAPRL0"        # QC
-  data_l0_red_green._qc_comment = "QC: ..."
+
+  def unregistered_keywords(self): ...
+  unregistered_keywords._checkpoint_name = "unregistered_keywords"  # Checkpoints
   ```
   The base class's `_iter_*` generator walks `type(self).__mro__`, collects callables
-  carrying the tag, and dedupes overrides via a `seen` set (subclass beats base).
-- **Runners reset `self.results = {}` at entry** (determinism) and wrap each method call
-  in `try/except` re-raising as `RuntimeError` — loud failure, no silent suppression.
+  carrying the tag (`_diag_name` / `_qc_key` / `_checkpoint_name`), and dedupes overrides
+  via a `seen` set (subclass beats base).
+- **Runners reset `self.results = {}` at entry** (Diagnostics/QC; determinism) and wrap each
+  method call in `try/except` re-raising as `RuntimeError` — loud failure, no silent suppression.
 - **Writes go through `set_keyword`** (comment sourced from the registry, not the call site).
-  QC writes integer `0/1` plus an `ISGOOD` aggregate, then runs `_validate_headers` at the end of
-  `run()`. Round floats before writing (`round(float(x), 6)`), and cast numpy scalars to Python
-  `int`/`float`. The `_qc_comment`/metric-dict comment is retained in `self.results`, but the FITS
-  comment is the registry `Description` — keep the two consistent.
+  QC writes integer `0/1` plus an `ISGOOD` aggregate and **does no validation**. Round floats
+  before writing (`round(float(x), 6)`), and cast numpy scalars to Python `int`/`float`. The
+  `_qc_comment`/metric-dict comment is retained in `self.results`, but the FITS comment is the
+  registry `Description` — keep the two consistent.
+- **Checkpoints validate; they do not write.** A `Checkpoint` subclass reads the 0/1 flags +
+  headers and **warns or raises** (header validation lives in `Checkpoint.unregistered_keywords`).
+  Per-flag severity is a per-level `RAISE_FLAGS` tuple on the subclass (a failed flag named there
+  raises, every other failed flag warns).
 - **QC comments are namespaced `"QC: ..."`**; Diagnostics comments are bare descriptive
   phrases. (Both live in the registry `Description` column, the single source for the FITS comment.)
 - **Quicklook plotting**: pyplot state-machine API (`plt.figure(figsize=..., tight_layout=True)`);
@@ -570,7 +578,7 @@ documented, intentional ways — follow *its* conventions when adding masters co
   names in sync across `trace-map.csv`, `[KPFPIPE].fibers`, and `detector.toml`.
 - **`L{0,1,2,4}-headers.csv`** register every KPF-pipeline keyword and its home extension,
   split by the level that first writes the keyword (the combined set drives the `set_keyword`
-  routing map and the qc_booleans validator). Columns are
+  routing map and the checkpoints validator). Columns are
   `Keyword,Description,Extension,DataType,PopulatedBy`. The **`Extension`** column is the keyword's
   home header (`PRIMARY`, `QUALITY_CONTROL`, `RECEIPT`, `BJD_TDB`, `BARYCORR_KMS`, `BARYCORR_Z`,
   `RV1`–`RV5`) — `set_keyword` writes there, and `Description` becomes the FITS comment, so a
@@ -590,7 +598,7 @@ so there is no value-vs-`(value, comment)` ambiguity and no separate header pars
 (our `L*-headers.csv` ∪ the EPRV keyword defs) and its derived routing/validation lookups are owned by
 the `KeywordRegistry` class in `data_models/keyword_registry.py` — one module singleton
 `keyword_registry`, imported only by `base.py`, which surfaces it as the `KPFDataModel.keyword_registry`
-class attribute (and uses `.routing` in `set_keyword`); the qc_booleans validator reads `.allowed`/
+class attribute (and uses `.routing` in `set_keyword`); the checkpoints validator reads `.allowed`/
 `.required` off `kpf_obj.keyword_registry`. What this means when writing code:
 
 - **Reading a header value**: use `header.get(key, default)` (or `header[key]`) on the keyword's
@@ -602,7 +610,7 @@ class attribute (and uses `.routing` in `set_keyword`); the qc_booleans validato
   keyword to its registry-home extension with the registry `Description` as the comment — never
   hardcode an extension or comment, and never write `headers["PRIMARY"][key] = …` directly for a
   registered keyword. The keyword **must** be in `config/L{0,1,2,4}-headers.csv` first (with its
-  `Extension`), or `set_keyword` raises `KeyError` and the qc_booleans validator would reject the
+  `Extension`), or `set_keyword` raises `KeyError` and the checkpoints validator would reject the
   product. Never write to `INSTRUMENT_HEADER` (immutable snapshot of the L0 PRIMARY as ingested).
 - **Writing an unregistered/EPRV-conversion card** (the WMKO→EPRV mapping, provenance stamping):
   the conversion sites in `KPF0` assign `header[key] = (value, comment)` directly; outside those,

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -17,7 +17,7 @@ from rvdata.core.models.base import RVDataModel
 # The header/extension keyword registry lives in its own module as a single
 # KeywordRegistry instance; base.py is its only importer. The instance is
 # surfaced as a KPFDataModel class attribute (below) so consumers handed a
-# kpf_obj (the qc_booleans validator, level0's WMKO->EPRV mapping, tests) reach
+# kpf_obj (the checkpoints validator, level0's WMKO->EPRV mapping, tests) reach
 # it through kpf.keyword_registry, and re-exported so sibling data_models files
 # (level2/4) import the same singleton from base.
 from kpfpipe.data_models.keyword_registry import keyword_registry
@@ -46,7 +46,7 @@ class KPFDataModel(RVDataModel):
     DATECODE_PATTERN = _DATECODE_PATTERN
 
     # The keyword registry singleton, surfaced as a class attribute so anything
-    # handed a KPF data model (the qc_booleans header validator, level0's
+    # handed a KPF data model (the checkpoints header validator, level0's
     # WMKO->EPRV mapping, tests) reaches it via kpf.keyword_registry — keeping
     # data_models/keyword_registry imported only by base.py. set_keyword uses
     # .routing; the validator uses .allowed / .required / .structural; .table is

--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -3,8 +3,8 @@ PROGID,WMKO program ID (DRP-RUN-19),PRIMARY,str,KPF0.from_fits
 KOAID,KOA archive ID (DRP-RUN-19),PRIMARY,str,KPF0.from_fits
 DRPVERNO,Pipeline version (DRP-RUN-11; EPRV equivalent is DRPTAG),PRIMARY,str,KPF0.from_fits
 DRPSTATU,DRP reduction status (DRP-RUN-20),PRIMARY,str,KPF0.from_fits
-DATAPRL0,QC: L0 data present,QUALITY_CONTROL,int,QCL0
-KWRDPRL0,QC: required L0 keywords present,QUALITY_CONTROL,int,QCL0
-EXPTIMOK,QC: exposure time valid,QUALITY_CONTROL,int,QCL0
-NOTJUNK,QC: frame not junk,QUALITY_CONTROL,int,QCL0
+DATAPRL0,QC: GREEN/RED amp extensions present/non-empty,QUALITY_CONTROL,int,QCL0
+KWRDPRL0,QC: required L0 PRIMARY keywords present,QUALITY_CONTROL,int,QCL0
+EXPTIMOK,"QC: EXPTIME present, finite, non-negative",QUALITY_CONTROL,int,QCL0
+NOTJUNK,QC: obs_id not in junk list,QUALITY_CONTROL,int,QCL0
 ISGOOD,QC: aggregate pass/fail,QUALITY_CONTROL,int,QC

--- a/kpfpipe/data_models/config/L1-headers.csv
+++ b/kpfpipe/data_models/config/L1-headers.csv
@@ -1,4 +1,6 @@
 Keyword,Description,Extension,DataType,PopulatedBy
+DATAPRL1,QC: GREEN/RED CCD extensions present/non-empty,QUALITY_CONTROL,int,QCL1
+KWRDPRL1,QC: required L1 PRIMARY keywords present,QUALITY_CONTROL,int,QCL1
 RNGREEN1,Read noise GREEN amp 1 [e-],QUALITY_CONTROL,float,ImageAssembly
 RNGREEN2,Read noise GREEN amp 2 [e-],QUALITY_CONTROL,float,ImageAssembly
 RNGREEN3,Read noise GREEN amp 3 [e-],QUALITY_CONTROL,float,ImageAssembly
@@ -16,22 +18,19 @@ RNNGRD2,Non-Gaussian read noise RED amp 2,QUALITY_CONTROL,float,ImageAssembly
 RNNGRD3,Non-Gaussian read noise RED amp 3,QUALITY_CONTROL,float,ImageAssembly
 RNNGRD4,Non-Gaussian read noise RED amp 4,QUALITY_CONTROL,float,ImageAssembly
 OSCANSUB,Overscan subtraction applied (T/F),RECEIPT,int,ImageAssembly
+BIASFILE,Master bias full path,RECEIPT,str,CalibrationAssociation
+DARKFILE,Master dark full path,RECEIPT,str,CalibrationAssociation
+FLATFILE,Master flat full path,RECEIPT,str,CalibrationAssociation
+WLSFILE,WLS master full path,RECEIPT,str,CalibrationAssociation
 BIASSUB,Bias subtraction applied (T/F),RECEIPT,int,ImageProcessing
 DARKSUB,Dark subtraction applied (T/F),RECEIPT,int,ImageProcessing
 FLATDIV,Flat division applied (reserved) (T/F),RECEIPT,int,ImageProcessing
-BIASFILE,Master bias full path,RECEIPT,str,CalibrationAssociation
-BIASAGE,Master bias age [days],QUALITY_CONTROL,float,CalibrationAssociation
-DARKFILE,Master dark full path,RECEIPT,str,CalibrationAssociation
-DARKAGE,Master dark age [days],QUALITY_CONTROL,float,CalibrationAssociation
-FLATFILE,Master flat full path,RECEIPT,str,CalibrationAssociation
-FLATAGE,Master flat age [days],QUALITY_CONTROL,float,CalibrationAssociation
-WLSFILE,WLS master full path,RECEIPT,str,CalibrationAssociation
-WLSAGE,WLS master age [days],QUALITY_CONTROL,float,CalibrationAssociation
-DATAPRL1,QC: GREEN/RED CCD extensions present/non-empty,QUALITY_CONTROL,int,QCL1
-KWRDPRL1,QC: required L1 PRIMARY keywords present,QUALITY_CONTROL,int,QCL1
-RNINRNG,QC: per-amp RN within 2.0-6.0 e-,QUALITY_CONTROL,int,QCL1
-RNGAUSS,QC: non-Gaussian RN within 0.8-1.5,QUALITY_CONTROL,int,QCL1
-BIASAGEQ,QC: bias master age <= 7 days,QUALITY_CONTROL,int,QCL1
-DARKAGEQ,QC: dark master age <= 14 days,QUALITY_CONTROL,int,QCL1
-FLATAGEQ,QC: flat master age <= 30 days,QUALITY_CONTROL,int,QCL1
-FFIFIN,QC: GREEN/RED CCDs all finite,QUALITY_CONTROL,int,QCL1
+BIASAGE,Master bias age [days],QUALITY_CONTROL,float,DiagL1
+DARKAGE,Master dark age [days],QUALITY_CONTROL,float,DiagL1
+FLATAGE,Master flat age [days],QUALITY_CONTROL,float,DiagL1
+WLSAGE,WLS master age [days],QUALITY_CONTROL,float,DiagL1
+RNOK,QC: Read noise 2-6 e- & mad(RN)/std(RN) 0.8-1.5,QUALITY_CONTROL,int,QCL1
+BIASOK,QC: bias subtracted & master age <= 7 days,QUALITY_CONTROL,int,QCL1
+DARKOK,QC: dark subtracted & master age <= 14 days,QUALITY_CONTROL,int,QCL1
+FLATOK,QC: flat divided & master age <= 30 days,QUALITY_CONTROL,int,QCL1
+FFIOK,QC: GREEN/RED CCDs all finite,QUALITY_CONTROL,int,QCL1

--- a/kpfpipe/data_models/config/L1-headers.csv
+++ b/kpfpipe/data_models/config/L1-headers.csv
@@ -27,6 +27,8 @@ FLATFILE,Master flat full path,RECEIPT,str,CalibrationAssociation
 FLATAGE,Master flat age [days],QUALITY_CONTROL,float,CalibrationAssociation
 WLSFILE,WLS master full path,RECEIPT,str,CalibrationAssociation
 WLSAGE,WLS master age [days],QUALITY_CONTROL,float,CalibrationAssociation
+DATAPRL1,QC: L1 data present,QUALITY_CONTROL,int,QCL1
+KWRDPRL1,QC: required L1 keywords present,QUALITY_CONTROL,int,QCL1
 RNINRNG,QC: per-amp RN within range,QUALITY_CONTROL,int,QCL1
 RNGAUSS,QC: non-Gaussian RN within range,QUALITY_CONTROL,int,QCL1
 BIASAGEQ,QC: bias master age ok,QUALITY_CONTROL,int,QCL1

--- a/kpfpipe/data_models/config/L1-headers.csv
+++ b/kpfpipe/data_models/config/L1-headers.csv
@@ -29,7 +29,8 @@ BIASAGE,Master bias age [days],QUALITY_CONTROL,float,DiagL1
 DARKAGE,Master dark age [days],QUALITY_CONTROL,float,DiagL1
 FLATAGE,Master flat age [days],QUALITY_CONTROL,float,DiagL1
 WLSAGE,WLS master age [days],QUALITY_CONTROL,float,DiagL1
-RNOK,QC: Read noise 2-6 e- & mad(RN)/std(RN) 0.8-1.5,QUALITY_CONTROL,int,QCL1
+RNOK,QC: per-amp read noise 2-6 e-,QUALITY_CONTROL,int,QCL1
+RNNGOK,QC: non-Gaussian read noise (MAD/STD) 0.8-1.5,QUALITY_CONTROL,int,QCL1
 BIASOK,QC: bias subtracted & master age <= 7 days,QUALITY_CONTROL,int,QCL1
 DARKOK,QC: dark subtracted & master age <= 14 days,QUALITY_CONTROL,int,QCL1
 FLATOK,QC: flat divided & master age <= 30 days,QUALITY_CONTROL,int,QCL1

--- a/kpfpipe/data_models/config/L1-headers.csv
+++ b/kpfpipe/data_models/config/L1-headers.csv
@@ -27,11 +27,11 @@ FLATFILE,Master flat full path,RECEIPT,str,CalibrationAssociation
 FLATAGE,Master flat age [days],QUALITY_CONTROL,float,CalibrationAssociation
 WLSFILE,WLS master full path,RECEIPT,str,CalibrationAssociation
 WLSAGE,WLS master age [days],QUALITY_CONTROL,float,CalibrationAssociation
-DATAPRL1,QC: L1 data present,QUALITY_CONTROL,int,QCL1
-KWRDPRL1,QC: required L1 keywords present,QUALITY_CONTROL,int,QCL1
-RNINRNG,QC: per-amp RN within range,QUALITY_CONTROL,int,QCL1
-RNGAUSS,QC: non-Gaussian RN within range,QUALITY_CONTROL,int,QCL1
-BIASAGEQ,QC: bias master age ok,QUALITY_CONTROL,int,QCL1
-DARKAGEQ,QC: dark master age ok,QUALITY_CONTROL,int,QCL1
-FLATAGEQ,QC: flat master age ok,QUALITY_CONTROL,int,QCL1
-FFIFIN,QC: assembled CCDs all finite,QUALITY_CONTROL,int,QCL1
+DATAPRL1,QC: GREEN/RED CCD extensions present/non-empty,QUALITY_CONTROL,int,QCL1
+KWRDPRL1,QC: required L1 PRIMARY keywords present,QUALITY_CONTROL,int,QCL1
+RNINRNG,QC: per-amp RN within 2.0-6.0 e-,QUALITY_CONTROL,int,QCL1
+RNGAUSS,QC: non-Gaussian RN within 0.8-1.5,QUALITY_CONTROL,int,QCL1
+BIASAGEQ,QC: bias master age <= 7 days,QUALITY_CONTROL,int,QCL1
+DARKAGEQ,QC: dark master age <= 14 days,QUALITY_CONTROL,int,QCL1
+FLATAGEQ,QC: flat master age <= 30 days,QUALITY_CONTROL,int,QCL1
+FFIFIN,QC: GREEN/RED CCDs all finite,QUALITY_CONTROL,int,QCL1

--- a/kpfpipe/data_models/config/L2-headers.csv
+++ b/kpfpipe/data_models/config/L2-headers.csv
@@ -1,5 +1,6 @@
 Keyword,Description,Extension,DataType,PopulatedBy
 DATAPRL2,QC: L2 data present,QUALITY_CONTROL,int,QCL2
+KWRDPRL2,QC: required L2 keywords present,QUALITY_CONTROL,int,QCL2
 L2NANOK,QC: L2 NaN count ok,QUALITY_CONTROL,int,QCL2
 L2FLXOK,QC: L2 zero-flux fraction ok,QUALITY_CONTROL,int,QCL2
 L2VARPOS,QC: L2 variance positive,QUALITY_CONTROL,int,QCL2

--- a/kpfpipe/data_models/config/L2-headers.csv
+++ b/kpfpipe/data_models/config/L2-headers.csv
@@ -3,7 +3,7 @@ DATAPRL2,QC: L2 FLUX extensions present and non-empty,QUALITY_CONTROL,int,QCL2
 KWRDPRL2,QC: required L2 PRIMARY keywords present,QUALITY_CONTROL,int,QCL2
 L2NANOK,QC: L2 NaN fraction <= 1%,QUALITY_CONTROL,int,QCL2
 L2FLXOK,QC: L2 zero-flux fraction < 0.5,QUALITY_CONTROL,int,QCL2
-L2VARPOS,QC: no negative L2 variance where flux finite,QUALITY_CONTROL,int,QCL2
+L2VAROK,QC: no negative L2 variance where flux finite,QUALITY_CONTROL,int,QCL2
 L2SNROK,QC: science SNR finite and above floor,QUALITY_CONTROL,int,QCL2
 NANSCI1,NaN pixel count SCI1 (green+red),QUALITY_CONTROL,int,DiagL2
 NANSCI2,NaN pixel count SCI2 (green+red),QUALITY_CONTROL,int,DiagL2

--- a/kpfpipe/data_models/config/L2-headers.csv
+++ b/kpfpipe/data_models/config/L2-headers.csv
@@ -1,10 +1,10 @@
 Keyword,Description,Extension,DataType,PopulatedBy
-DATAPRL2,QC: L2 data present,QUALITY_CONTROL,int,QCL2
-KWRDPRL2,QC: required L2 keywords present,QUALITY_CONTROL,int,QCL2
-L2NANOK,QC: L2 NaN count ok,QUALITY_CONTROL,int,QCL2
-L2FLXOK,QC: L2 zero-flux fraction ok,QUALITY_CONTROL,int,QCL2
-L2VARPOS,QC: L2 variance positive,QUALITY_CONTROL,int,QCL2
-L2SNROK,QC: L2 SNR ok,QUALITY_CONTROL,int,QCL2
+DATAPRL2,QC: L2 FLUX extensions present and non-empty,QUALITY_CONTROL,int,QCL2
+KWRDPRL2,QC: required L2 PRIMARY keywords present,QUALITY_CONTROL,int,QCL2
+L2NANOK,QC: L2 NaN fraction <= 1%,QUALITY_CONTROL,int,QCL2
+L2FLXOK,QC: L2 zero-flux fraction < 0.5,QUALITY_CONTROL,int,QCL2
+L2VARPOS,QC: no negative L2 variance where flux finite,QUALITY_CONTROL,int,QCL2
+L2SNROK,QC: science SNR finite and above floor,QUALITY_CONTROL,int,QCL2
 NANSCI1,NaN pixel count SCI1 (green+red),QUALITY_CONTROL,int,DiagL2
 NANSCI2,NaN pixel count SCI2 (green+red),QUALITY_CONTROL,int,DiagL2
 NANSCI3,NaN pixel count SCI3 (green+red),QUALITY_CONTROL,int,DiagL2

--- a/kpfpipe/data_models/config/L4-headers.csv
+++ b/kpfpipe/data_models/config/L4-headers.csv
@@ -1,10 +1,10 @@
 Keyword,Description,Extension,DataType,PopulatedBy
-CCD1RV,GREEN SCI-combined RV [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCD2RV,RED SCI-combined RV [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCD1ERV,GREEN SCI-combined RV error [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCD2ERV,RED SCI-combined RV error [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCFRV,Cross-chip science-combined RV [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCFERV,Cross-chip science-combined RV error [km/s] (legacy),PRIMARY,float,RadialVelocity
+CCD1RV,GREEN SCI-combined RV [km/s] (legacy),RV3,float,RadialVelocity
+CCD2RV,RED SCI-combined RV [km/s] (legacy),RV3,float,RadialVelocity
+CCD1ERV,GREEN SCI-combined RV error [km/s] (legacy),RV3,float,RadialVelocity
+CCD2ERV,RED SCI-combined RV error [km/s] (legacy),RV3,float,RadialVelocity
+CCFRV,Cross-chip science-combined RV [km/s] (legacy),RV3,float,RadialVelocity
+CCFERV,Cross-chip science-combined RV error [km/s] (legacy),RV3,float,RadialVelocity
 CCD1RVS,GREEN SKY RV [km/s] (legacy),RV1,float,RadialVelocity
 CCD1RV1,GREEN SCI1 RV [km/s] (legacy),RV2,float,RadialVelocity
 CCD1RV2,GREEN SCI2 RV [km/s] (legacy),RV3,float,RadialVelocity

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -6,7 +6,7 @@ use-cases it serves. ``KeywordRegistry`` builds every lookup once in
 ``__init__`` from one source-of-truth table; the module exposes a single
 instance, ``keyword_registry``. ``KPFDataModel`` (data_models/base.py) is the
 only module that imports this one; it surfaces the instance as a class attribute
-so consumers handed a ``kpf_obj`` (the qc_booleans validator, level0's
+so consumers handed a ``kpf_obj`` (the checkpoints validator, level0's
 WMKO->EPRV mapping, tests) reach the registry through ``kpf.keyword_registry``
 rather than importing from here.
 

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -203,9 +203,9 @@ class KPF1(KPFDataModel):
         The L1 PRIMARY is already EPRV-standard (converted upstream in
         KPF0.to_kpf1), so headers are a pure pass-through: the EPRV PRIMARY and
         the immutable INSTRUMENT_HEADER are forwarded unchanged (value + comment).
-        Header validation no longer runs here — it moved to the QC runner
-        (quality_control/qc_booleans, QC._validate_headers). Pass-through
-        extensions (TELEMETRY,
+        Header validation no longer runs here — it moved to the checkpoints
+        layer (quality_control/checkpoints, Checkpoint.unregistered_keywords).
+        Pass-through extensions (TELEMETRY,
         EXPMETER_SCI→EXPMETER, CA_HK→ANCILLARY_SPECTRUM) and KPF-friendly
         aliases (e.g., SCI2_FLUX → TRACE3_FLUX) are handled below. Trace data
         arrays are created but empty — the caller (spectral extraction) fills

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -83,7 +83,7 @@ class CalibrationAssociation:
             setattr(self, k, params.get(k, v))
 
         self._masters_root = params.get("KPF_MASTERS_OUTPUT")
-        self._calibrations = None  # per-cal {filepath, age_days} for _set_headers
+        self._calibrations = None  # per-cal {filepath} for _set_headers
         self._info = None
 
     # ------------------------------------------------------------------
@@ -194,18 +194,18 @@ class CalibrationAssociation:
         }
 
     def _set_headers(self, l1_obj):
-        """Write all PRIMARY-header keywords for calibration association.
+        """Write the master-path keyword for each associated calibration.
 
         Reads self._calibrations (populated by perform()); the single place this
         module writes header keywords, called just before the receipt entry. Each
-        cal type contributes {PREFIX}FILE (full master path) and {PREFIX}AGE
-        (signed fractional-day age); set_keyword routes them to their registry
-        homes (RECEIPT for the paths, QUALITY_CONTROL for the ages).
+        cal type contributes {PREFIX}FILE (full master path), which set_keyword
+        routes to RECEIPT. The signed (master - obs) age ({PREFIX}AGE) is
+        recomputed downstream by DiagL1 from this path plus INSTRUMENT_HEADER
+        DATE-OBS, so this module no longer computes or writes it.
         """
         for cal_type, cal in self._calibrations.items():
             prefix = _HEADER_PREFIX[cal_type]
             l1_obj.set_keyword(f"{prefix}FILE", cal["filepath"])
-            l1_obj.set_keyword(f"{prefix}AGE", cal["age_days"])
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -248,7 +248,6 @@ class CalibrationAssociation:
             )
 
         date_obs = self.l1_obj.headers["INSTRUMENT_HEADER"]["DATE-OBS"]
-        obs_dt = datetime.fromisoformat(date_obs)
 
         self._calibrations = {}
         for cal_type in cal_types:
@@ -262,11 +261,7 @@ class CalibrationAssociation:
                     f"within window {masters_search_window_days} days"
                 )
 
-            # Signed fractional-day age (master - obs): negative when the master
-            # predates the obs.
-            master_dt = kpf_timestamp_to_datetime(get_timestamp(filepath))
-            age_days = (master_dt - obs_dt).total_seconds() / 86400.0
-            self._calibrations[cal_type] = {"filepath": filepath, "age_days": age_days}
+            self._calibrations[cal_type] = {"filepath": filepath}
 
         self._set_headers(self.l1_obj)
         self._track_info()
@@ -291,5 +286,4 @@ class CalibrationAssociation:
         print("  " + "-" * 60)
         for cal_type, cal in self._info.items():
             print(f"  {cal_type:<12s} {cal['filepath']}")
-            print(f"  {'':12s} age = {cal['age_days']}d")
             print()

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -959,11 +959,11 @@ class RadialVelocity:
             L4 with a CCF cube and per-order RV table per illuminated orderlet.
             Each CCF extension carries VELSTART/VELSTEP/VELNSTEP/CCFMASK; each RV
             extension carries RVMETHOD/SKYRMVD/TELLRMVD. The legacy combined-RV
-            keywords are registered KPF-pipeline PRIMARY keywords: per-fiber
-            CCD<n>RV<sfx>/CCD<n>ERV<sfx>, the SCI-combined CCD<n>RV/CCD<n>ERV,
-            and CCFRV/CCFERV. PRIMARY also carries the EPRV keywords RVMETHOD and
-            RV/RVERR/BERV/BJDTDB (the combined science RV). Unilluminated
-            ('none') fibers are skipped (empty extensions).
+            keywords are registered KPF-pipeline keywords routed to the RV# tables:
+            per-fiber CCD<n>RV<sfx>/CCD<n>ERV<sfx> by orderlet, and the SCI-combined
+            CCD<n>RV/CCD<n>ERV plus CCFRV/CCFERV on RV3. PRIMARY carries the EPRV
+            keywords RVMETHOD and RV/RVERR/BERV/BJDTDB (the combined science RV).
+            Unilluminated ('none') fibers are skipped (empty extensions).
         """
         if chips is None:
             chips = self.chips
@@ -1099,7 +1099,7 @@ class RadialVelocity:
             # CCD<n>RV<sfx>/CCD<n>ERV<sfx> (n: GREEN=1, RED=2; sfx: 1/2/3=SCI1/2/3,
             # C=CAL, S=SKY), routed by set_keyword to their RV# table header (e.g.
             # CCD1RV1 -> RV2). The bare CCD<n>RV/CCD<n>ERV names stay reserved for
-            # the SCI-combined RV (on PRIMARY). A non-finite value (failed fit) is
+            # the SCI-combined RV (on RV3). A non-finite value (failed fit) is
             # written as None so it becomes a FITS UNDEFINED card, not a NaN.
             sfx = {"SCI1": "1", "SCI2": "2", "SCI3": "3", "CAL": "C", "SKY": "S"}[fiber]
             for chip in ccd_rv:
@@ -1180,7 +1180,7 @@ class RadialVelocity:
         if not np.isfinite(ccfrv):
             print(
                 "  combined RV: no finite per-CCD science RV; "
-                "CCFRV/PRIMARY RV UNDEFINED"
+                "CCFRV (RV3) and PRIMARY RV UNDEFINED"
             )
 
         l4_obj.set_keyword("CCFRV", float(ccfrv) if np.isfinite(ccfrv) else None)

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -185,8 +185,8 @@ class WavelengthCalibration:
             print("  perform() has not been called")
             return
 
-        # WLSAGE is written to QUALITY_CONTROL by CalibrationAssociation (WLSFILE
-        # goes to RECEIPT).
+        # WLSAGE is written to QUALITY_CONTROL by DiagL1 (CalibrationAssociation
+        # writes WLSFILE to RECEIPT; DiagL1 derives the age from it).
         agewls = self.l2_obj.headers.get("QUALITY_CONTROL", {}).get("WLSAGE")
         print(f"  wls_path: {self._info['wls_path']}")
         if agewls is not None:

--- a/kpfpipe/quality_control/checkpoints/__init__.py
+++ b/kpfpipe/quality_control/checkpoints/__init__.py
@@ -1,0 +1,6 @@
+from kpfpipe.quality_control.checkpoints.base import Checkpoint
+from kpfpipe.quality_control.checkpoints.level0 import CheckpointL0
+from kpfpipe.quality_control.checkpoints.level1 import CheckpointL1
+from kpfpipe.quality_control.checkpoints.level2 import CheckpointL2
+
+__all__ = ["Checkpoint", "CheckpointL0", "CheckpointL1", "CheckpointL2"]

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -61,7 +61,7 @@ class Checkpoint:
     RAISE_FLAGS = ()  # QC keywords whose failure (0) raises; every other 0 warns.
 
     def __init__(self, kpf_obj):
-        self.kpf = kpf_obj
+        self.kpf_obj = kpf_obj
 
     def run(self):
         """Run every checkpoint method; each warns or raises (no return value)."""
@@ -78,14 +78,14 @@ class Checkpoint:
         This subsumes the old WMKO-native leak check: a raw instrument keyword
         kept in INSTRUMENT_HEADER is simply unregistered for an EPRV PRIMARY.
         """
-        reg = self.kpf.keyword_registry
+        reg = self.kpf_obj.keyword_registry
         skip_primary = str(self.LEVEL).upper() in ("L0", "NONE")
         for ext, allowed in reg.allowed.items():
-            if ext not in self.kpf.extensions:
+            if ext not in self.kpf_obj.extensions:
                 continue
             if ext == "PRIMARY" and skip_primary:
                 continue
-            header = self.kpf.headers.get(ext)
+            header = self.kpf_obj.headers.get(ext)
             if header is None:
                 continue
             for raw_key in list(header):
@@ -106,10 +106,10 @@ class Checkpoint:
         QC populator. A flag absent from the header is skipped (the check did not
         run); a flag equal to 0 raises if it is in ``RAISE_FLAGS``, else warns.
         """
-        header = self.kpf.headers.get("QUALITY_CONTROL")
+        header = self.kpf_obj.headers.get("QUALITY_CONTROL")
         if header is None:
             return
-        reg = self.kpf.keyword_registry
+        reg = self.kpf_obj.keyword_registry
         flag_keys = {
             row.Keyword
             for row in reg.table.itertuples(index=False)
@@ -136,7 +136,7 @@ class Checkpoint:
         extension-table/WCS cards astropy adds at serialization.
         """
         return (
-            key in self.kpf.keyword_registry.structural
+            key in self.kpf_obj.keyword_registry.structural
             or key in _EXT_STRUCTURAL_EXTRA
             or key.startswith(_EXT_STRUCTURAL_PREFIXES)
         )

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -1,0 +1,165 @@
+"""Checkpoint framework base class.
+
+The third quality-control stage (after Diagnostics and QC). A Checkpoint
+subclass READS the 0/1 QC flags written to QUALITY_CONTROL and the product
+headers, then emits warnings or raises errors -- it never writes keywords. A
+method opts in by setting ``_checkpoint_name`` on the function object; ``run()``
+walks all such methods (MRO order) and calls each. The pipeline order is:
+science modules -> Diagnostics -> QC -> Checkpoints.
+
+Two responsibilities, both inherited base checkpoints:
+  - ``unregistered_keywords`` -- structural header validation: any non-structural
+    card not registered for its extension raises ``ValueError`` (this logic used
+    to live in ``QC._validate_headers``).
+  - ``qc_flags`` -- read each 0/1 QC flag; a failed (0) flag named in the
+    subclass's ``RAISE_FLAGS`` raises, every other failed flag warns.
+
+Severity policy lives in the per-level subclasses (their ``RAISE_FLAGS``).
+"""
+
+import warnings
+
+# Bookkeeping/structural cards astropy adds to a serialized extension header
+# (BinTable column descriptors, image WCS); always permitted on any governed
+# extension and never treated as unregistered. These supplement the registry's
+# structural set (the PRIMARY/bookkeeping cards). Moved here from QC when header
+# validation became a Checkpoint responsibility.
+_EXT_STRUCTURAL_PREFIXES = (
+    "NAXIS",
+    "TTYPE",
+    "TFORM",
+    "TUNIT",
+    "TDIM",
+    "TDISP",
+    "TNULL",
+    "TSCAL",
+    "TZERO",
+    "CTYPE",
+    "CUNIT",
+    "CRPIX",
+    "CRVAL",
+    "CDELT",
+    "CROTA",
+)
+_EXT_STRUCTURAL_EXTRA = {"EXTNAME", "TFIELDS", "PCOUNT", "GCOUNT"}
+
+# Registry ``PopulatedBy`` values that mark a keyword as a 0/1 QC flag (so the
+# qc_flags checkpoint can find them without a hardcoded list).
+_QC_POPULATORS = {"QC", "QCL0", "QCL1", "QCL2"}
+
+
+class Checkpoint:
+    """Base runner for per-level checkpoint methods.
+
+    Parameters
+    ----------
+    kpf_obj : KPFDataModel
+        Finished data product whose flags/headers are read (never written).
+    """
+
+    LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2").
+    RAISE_FLAGS = ()  # QC keywords whose failure (0) raises; every other 0 warns.
+
+    def __init__(self, kpf_obj):
+        self.kpf = kpf_obj
+
+    def run(self):
+        """Run every checkpoint method; each warns or raises (no return value)."""
+        for _name, fn in self._iter_checkpoints():
+            fn()
+
+    def unregistered_keywords(self):
+        """Raise on any non-structural card not registered for its extension.
+
+        For each registry-governed extension present on the product (PRIMARY only
+        where it is EPRV-standard -- L1 onward; the raw WMKO L0 PRIMARY is
+        skipped), a card that is neither structural nor registered (in
+        ``keyword_registry.allowed[ext]``) raises ``ValueError`` and names it.
+        This subsumes the old WMKO-native leak check: a raw instrument keyword
+        kept in INSTRUMENT_HEADER is simply unregistered for an EPRV PRIMARY.
+        """
+        reg = self.kpf.keyword_registry
+        skip_primary = str(self.LEVEL).upper() in ("L0", "NONE")
+        for ext, allowed in reg.allowed.items():
+            if ext not in self.kpf.extensions:
+                continue
+            if ext == "PRIMARY" and skip_primary:
+                continue
+            header = self.kpf.headers.get(ext)
+            if header is None:
+                continue
+            for raw_key in list(header):
+                key = str(raw_key).strip()
+                if self._is_structural(key) or key in allowed:
+                    continue
+                raise ValueError(
+                    f"unregistered keyword {key!r} on {ext}; add it to "
+                    "config/L{0,1,2,4}-headers.csv or fix the writer"
+                )
+
+    unregistered_keywords._checkpoint_name = "unregistered_keywords"
+
+    def qc_flags(self):
+        """Read each 0/1 QC flag; raise a RAISE_FLAGS failure, warn the rest.
+
+        QC-flag keywords are the QUALITY_CONTROL rows the registry attributes to a
+        QC populator. A flag absent from the header is skipped (the check did not
+        run); a flag equal to 0 raises if it is in ``RAISE_FLAGS``, else warns.
+        """
+        header = self.kpf.headers.get("QUALITY_CONTROL")
+        if header is None:
+            return
+        reg = self.kpf.keyword_registry
+        flag_keys = {
+            row.Keyword
+            for row in reg.table.itertuples(index=False)
+            if row.Extension == "QUALITY_CONTROL" and row.PopulatedBy in _QC_POPULATORS
+        }
+        for key in sorted(flag_keys):
+            value = header.get(key)
+            if value is None or value != 0:
+                continue
+            if key in self.RAISE_FLAGS:
+                raise ValueError(f"QC checkpoint failed: {key} = 0 ({self.LEVEL})")
+            warnings.warn(
+                f"QC checkpoint flagged: {key} = 0 ({self.LEVEL})",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    qc_flags._checkpoint_name = "qc_flags"
+
+    def _is_structural(self, key):
+        """True for a FITS structural/bookkeeping card (not a registered keyword).
+
+        Combines the registry's structural cards (PRIMARY/bookkeeping) with the
+        extension-table/WCS cards astropy adds at serialization.
+        """
+        return (
+            key in self.kpf.keyword_registry.structural
+            or key in _EXT_STRUCTURAL_EXTRA
+            or key.startswith(_EXT_STRUCTURAL_PREFIXES)
+        )
+
+    def _iter_checkpoints(self):
+        """Yield each checkpoint method tagged with `_checkpoint_name`.
+
+        Walks the MRO so subclass methods come before the base class and ordering
+        is stable across runs.
+
+        Yields
+        ------
+        tuple
+            ``(name, bound_method)`` for each tagged checkpoint method.
+        """
+        seen = set()
+        for cls in type(self).__mro__:
+            for name, attr in cls.__dict__.items():
+                if name in seen:
+                    continue
+                if not callable(attr):
+                    continue
+                if getattr(attr, "_checkpoint_name", None) is None:
+                    continue
+                seen.add(name)
+                yield name, getattr(self, name)

--- a/kpfpipe/quality_control/checkpoints/level0.py
+++ b/kpfpipe/quality_control/checkpoints/level0.py
@@ -1,0 +1,15 @@
+"""Checkpoints for KPF Level 0 (raw CCD) data products."""
+
+from kpfpipe.quality_control.checkpoints.base import Checkpoint
+
+
+class CheckpointL0(Checkpoint):
+    """Checkpoints for KPF Level 0 raw data products.
+
+    The raw WMKO L0 PRIMARY is not registry-governed, so ``unregistered_keywords``
+    skips it and validates only the KPF-custom extensions (QUALITY_CONTROL,
+    RECEIPT) present on the product.
+    """
+
+    LEVEL = "L0"
+    RAISE_FLAGS = ("DATAPRL0",)  # missing raw data is fatal; other flags warn.

--- a/kpfpipe/quality_control/checkpoints/level1.py
+++ b/kpfpipe/quality_control/checkpoints/level1.py
@@ -1,0 +1,10 @@
+"""Checkpoints for KPF Level 1 (assembled FFI) data products."""
+
+from kpfpipe.quality_control.checkpoints.base import Checkpoint
+
+
+class CheckpointL1(Checkpoint):
+    """Checkpoints for KPF Level 1 assembled FFI products."""
+
+    LEVEL = "L1"
+    RAISE_FLAGS = ("DATAPRL1",)  # missing assembled CCDs is fatal; other flags warn.

--- a/kpfpipe/quality_control/checkpoints/level2.py
+++ b/kpfpipe/quality_control/checkpoints/level2.py
@@ -1,0 +1,10 @@
+"""Checkpoints for KPF Level 2 (extracted spectra) data products."""
+
+from kpfpipe.quality_control.checkpoints.base import Checkpoint
+
+
+class CheckpointL2(Checkpoint):
+    """Checkpoints for KPF Level 2 extracted spectra products."""
+
+    LEVEL = "L2"
+    RAISE_FLAGS = ("DATAPRL2",)  # missing extracted flux is fatal; other flags warn.

--- a/kpfpipe/quality_control/diagnostics/base.py
+++ b/kpfpipe/quality_control/diagnostics/base.py
@@ -54,9 +54,9 @@ class Diagnostics:
                 continue
             for kw, (value, comment) in output.items():
                 self.results[kw] = (value, comment)
-                # set_keyword routes each metric to its registry home (the method's
-                # _qc_comment is retained in self.results; the FITS comment comes
-                # from the registry Description).
+                # set_keyword routes each metric to its registry home; the FITS
+                # comment is the registry Description (the metric-dict comment is
+                # retained in self.results only).
                 self.kpf.set_keyword(kw, value)
 
         return self.results

--- a/kpfpipe/quality_control/diagnostics/base.py
+++ b/kpfpipe/quality_control/diagnostics/base.py
@@ -28,7 +28,7 @@ class Diagnostics:
     LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2").
 
     def __init__(self, kpf_obj):
-        self.kpf = kpf_obj
+        self.kpf_obj = kpf_obj
         self.results = {}  # Populated by run(): maps keyword to (value, comment).
 
     def run(self):
@@ -57,7 +57,7 @@ class Diagnostics:
                 # set_keyword routes each metric to its registry home; the FITS
                 # comment is the registry Description (the metric-dict comment is
                 # retained in self.results only).
-                self.kpf.set_keyword(kw, value)
+                self.kpf_obj.set_keyword(kw, value)
 
         return self.results
 

--- a/kpfpipe/quality_control/diagnostics/level1.py
+++ b/kpfpipe/quality_control/diagnostics/level1.py
@@ -1,15 +1,62 @@
 """Diagnostics for KPF Level 1 (assembled FFI) data products.
 
-Currently a placeholder. The L1 metrics consumed by QCL1 (read noise,
-master ages, BIASSUB flag) are all written by the modules that produce
-them — ImageAssembly, CalibrationAssociation, ImageProcessing — because
-they depend on intermediate processing state. Diagnostics that can be
-computed from the finished L1 product alone (e.g. flux percentiles,
-order-trace alignment metrics) will live here.
+The L1 metrics consumed by QCL1 that depend on intermediate processing
+state (read noise from raw overscan, the BIASSUB flag) are still written by
+the modules that produce them — ImageAssembly, ImageProcessing. Metrics that
+can be recomputed from the finished L1 product alone live here: the master
+calibration ages, derived from the master paths CalibrationAssociation wrote
+to RECEIPT plus the observation timestamp in INSTRUMENT_HEADER.
 """
 
+from datetime import datetime
+
 from kpfpipe.quality_control.diagnostics.base import Diagnostics
+from kpfpipe.utils.kpf import get_timestamp, kpf_timestamp_to_datetime
+
+# Master-calibration age metrics: the RECEIPT path keyword (written by
+# CalibrationAssociation) -> the age keyword whose signed (master - obs) value
+# this diagnostic computes. The FITS comment comes from the registry via
+# set_keyword; the comment here is retained only on self.results.
+_CAL_AGE_KEYS = {
+    "BIASFILE": ("BIASAGE", "Master bias age [days]"),
+    "DARKFILE": ("DARKAGE", "Master dark age [days]"),
+    "FLATFILE": ("FLATAGE", "Master flat age [days]"),
+    "WLSFILE": ("WLSAGE", "WLS master age [days]"),
+}
 
 
 class DiagL1(Diagnostics):
     LEVEL = "L1"
+
+    def calibration_ages(self):
+        """Signed fractional-day age (master - obs) for each associated master.
+
+        Recomputed from the finished L1 product: the master path is read from
+        RECEIPT (``{PREFIX}FILE``, written by CalibrationAssociation) and the
+        observation timestamp from INSTRUMENT_HEADER (DATE-OBS). The master
+        timestamp is parsed from its filename. A cal type is skipped when its
+        path is absent; the whole metric is skipped when DATE-OBS is missing.
+
+        Returns
+        -------
+        dict
+            Maps each present ``{PREFIX}AGE`` keyword to its ``(age, comment)``.
+        """
+        receipt = self.kpf_obj.headers.get("RECEIPT", {})
+        instrument = self.kpf_obj.headers.get("INSTRUMENT_HEADER", {})
+        date_obs = instrument.get("DATE-OBS")
+        if not date_obs:
+            return {}
+        obs_dt = datetime.fromisoformat(date_obs)
+
+        results = {}
+        for file_kw, (age_kw, comment) in _CAL_AGE_KEYS.items():
+            path = receipt.get(file_kw)
+            if not path:
+                continue
+            master_dt = kpf_timestamp_to_datetime(get_timestamp(path))
+            age_days = (master_dt - obs_dt).total_seconds() / 86400.0
+            results[age_kw] = (age_days, comment)
+        return results
+
+    calibration_ages._diag_name = "calibration_ages"

--- a/kpfpipe/quality_control/diagnostics/level2.py
+++ b/kpfpipe/quality_control/diagnostics/level2.py
@@ -38,7 +38,7 @@ class DiagL2(Diagnostics):
         for fiber, (kw, comment) in _NAN_KEYS.items():
             count = 0
             for chip in _CHIPS:
-                arr = self.kpf.data.get(f"{chip}_{fiber}_FLUX")
+                arr = self.kpf_obj.data.get(f"{chip}_{fiber}_FLUX")
                 if arr is not None and np.size(arr) > 0:
                     count += int(np.sum(np.isnan(arr)))
             results[kw] = (count, comment)
@@ -63,7 +63,7 @@ class DiagL2(Diagnostics):
         total_pix = 0
         for chip in _CHIPS:
             for fiber in _FIBERS:
-                arr = self.kpf.data.get(f"{chip}_{fiber}_FLUX")
+                arr = self.kpf_obj.data.get(f"{chip}_{fiber}_FLUX")
                 if arr is None or np.size(arr) == 0:
                     continue
                 total_zero += int(np.sum(arr == 0))
@@ -79,7 +79,7 @@ class DiagL2(Diagnostics):
 
     def _arr(self, chip, fiber, kind):
         """Return the (norder, ncol) FLUX or VAR array for a fiber, or None."""
-        arr = self.kpf.data.get(f"{chip}_{fiber}_{kind}")
+        arr = self.kpf_obj.data.get(f"{chip}_{fiber}_{kind}")
         if arr is None:
             return None
         arr = np.asarray(arr)

--- a/kpfpipe/quality_control/qc_booleans/__init__.py
+++ b/kpfpipe/quality_control/qc_booleans/__init__.py
@@ -1,6 +1,0 @@
-from kpfpipe.quality_control.qc_booleans.base import QC
-from kpfpipe.quality_control.qc_booleans.level0 import QCL0
-from kpfpipe.quality_control.qc_booleans.level1 import QCL1
-from kpfpipe.quality_control.qc_booleans.level2 import QCL2
-
-__all__ = ["QC", "QCL0", "QCL1", "QCL2"]

--- a/kpfpipe/quality_control/qc_booleans/base.py
+++ b/kpfpipe/quality_control/qc_booleans/base.py
@@ -1,11 +1,12 @@
 """QC framework base class.
 
 Each QC subclass defines check methods. A check is a method whose function
-object has `_qc_key` (8-char FITS keyword) and `_qc_comment` (short string)
-attributes. The runner walks all such methods, calls each one, writes a
-0/1 result via ``set_keyword`` (which routes it to its registry home,
-QUALITY_CONTROL), and aggregates ISGOOD = AND of all checks. If any check
-raises, run() raises (loud failure, no silent suppression).
+object has a `_qc_key` (8-char FITS keyword) attribute. The runner walks all
+such methods, calls each one, writes a 0/1 result via ``set_keyword`` (which
+routes it to its registry home, QUALITY_CONTROL, with the registry ``Description``
+as the FITS comment), and aggregates ISGOOD = AND of all checks. The per-check
+comment lives once — in the registry ``Description`` — not on the method. If any
+check raises, run() raises (loud failure, no silent suppression).
 
 QC writes only 0/1 keywords. Header validation (unregistered cards, missing
 required keywords) is NOT done here -- it lives in the separate ``checkpoints``
@@ -54,10 +55,10 @@ class QC:
                 raise RuntimeError(f"QC check {name!r} raised: {e}") from e
 
             kw = fn._qc_key
-            comment = fn._qc_comment
+            # The comment is the registry Description (the single source) — the same
+            # string set_keyword writes as the FITS comment; mirror it into results.
+            comment = self.kpf.keyword_registry.routing.get(kw, (None, ""))[1]
             self.results[kw] = (passed, comment)
-            # set_keyword routes the flag to its registry home (QUALITY_CONTROL)
-            # with the registry comment; fn._qc_comment is kept for self.results.
             self.kpf.set_keyword(kw, 1 if passed else 0)
 
         is_good = all(p for p, _ in self.results.values())

--- a/kpfpipe/quality_control/qc_booleans/base.py
+++ b/kpfpipe/quality_control/qc_booleans/base.py
@@ -7,42 +7,16 @@ attributes. The runner walks all such methods, calls each one, writes a
 QUALITY_CONTROL), and aggregates ISGOOD = AND of all checks. If any check
 raises, run() raises (loud failure, no silent suppression).
 
-After the checks, the runner validates every registry-governed extension
-header against the keyword registry (``_validate_headers``): an unexpected
-keyword raises, a missing required EPRV keyword warns. This is the single
-home for header validation (it used to live on ``KPFDataModel`` and run
-inside the level transforms).
+QC writes only 0/1 keywords. Header validation (unregistered cards, missing
+required keywords) is NOT done here -- it lives in the separate ``checkpoints``
+layer, which reads these flags plus the product headers and emits warnings or
+raises. The pipeline order is: science modules -> Diagnostics -> QC -> Checkpoints.
 """
 
-import warnings
-
-# Header-registry lookups are read off the validated kpf_obj (e.g.
-# self.kpf.keyword_registry.allowed / .required), so qc_booleans does not import
-# from data_models — the registry stays reachable purely through the data model.
-# The structural-card policy below is validator-specific and lives here.
-
-# Bookkeeping/structural cards astropy adds to a serialized extension header
-# (BinTable column descriptors, image WCS); always permitted on any governed
-# extension and never counted as a "missing required" keyword. These supplement
-# the registry's structural set (the PRIMARY/bookkeeping cards).
-_EXT_STRUCTURAL_PREFIXES = (
-    "NAXIS",
-    "TTYPE",
-    "TFORM",
-    "TUNIT",
-    "TDIM",
-    "TDISP",
-    "TNULL",
-    "TSCAL",
-    "TZERO",
-    "CTYPE",
-    "CUNIT",
-    "CRPIX",
-    "CRVAL",
-    "CDELT",
-    "CROTA",
-)
-_EXT_STRUCTURAL_EXTRA = {"EXTNAME", "TFIELDS", "PCOUNT", "GCOUNT"}
+# Level -> the EPRV PRIMARY Level a product is held to. L1 PRIMARY is already
+# EPRV-L2-standard, so it caps at 2 like L2. L0 (or an untagged subclass) is
+# absent here: its PRIMARY is raw WMKO, not registry-governed.
+_LEVEL_CAP = {"L1": 2, "L2": 2, "L4": 4}
 
 
 class QC:
@@ -51,7 +25,7 @@ class QC:
     Parameters
     ----------
     kpf_obj : KPFDataModel
-        Finished data product whose PRIMARY header receives the QC flags.
+        Finished data product whose QUALITY_CONTROL header receives the 0/1 flags.
     """
 
     LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2").
@@ -61,7 +35,7 @@ class QC:
         self.results = {}  # Populated by run(): maps keyword to (passed, comment).
 
     def run(self):
-        """Run all checks, write each result to PRIMARY, and aggregate ISGOOD.
+        """Run all checks, write each 0/1 result, and aggregate ISGOOD.
 
         Resets ``self.results`` at the start so calling ``run()`` repeatedly
         on the same instance is deterministic.
@@ -88,97 +62,36 @@ class QC:
 
         is_good = all(p for p, _ in self.results.values())
         self.kpf.set_keyword("ISGOOD", 1 if is_good else 0)
-
-        # Validate every governed extension header now that all keywords (this
-        # level's QC flags included) have been written.
-        self._validate_headers()
         return self.results
 
-    def _validate_headers(self):
-        """Validate every registry-governed extension header (fail loud).
+    def _required_primary_keywords(self):
+        """Keywords a level-N product must carry on PRIMARY (a presence set).
 
-        For each governed extension present on the product, every card must be a
-        registered keyword for that extension (KPF registry + EPRV per-extension
-        keywords) or a structural/bookkeeping card; an unexpected card raises
-        ValueError. A Required EPRV keyword that is absent emits a warning.
-        PRIMARY is validated only where it is EPRV-standard (L1/L2/L4); the raw
-        WMKO L0 PRIMARY is skipped.
+        The registry's EPRV ``Required`` PRIMARY keywords at or below this
+        product's level, unioned with the KPF-pipeline keywords routed to PRIMARY
+        (the provenance cards). Read off the validated model's registry singleton
+        (``self.kpf.keyword_registry``), so qc_booleans imports nothing from
+        data_models. L0 (or an untagged subclass) returns the empty set -- raw
+        WMKO L0 PRIMARY is not registry-governed.
         """
-        level = str(self.LEVEL).upper()
-        # Registry lookups are read off the validated model's keyword_registry
-        # singleton (kpf_obj), so data_models/keyword_registry stays imported only
-        # by base.py. PRIMARY allowed is NOT level-gated (the registry already
-        # lists every EPRV + KPF PRIMARY keyword); required-warnings ARE
-        # level-aware. L1 PRIMARY is already EPRV-L2-standard, so it caps at
-        # level 2 like L2.
+        cap = _LEVEL_CAP.get(str(self.LEVEL).upper())
+        if cap is None:
+            return set()
         reg = self.kpf.keyword_registry
-        cap = {"L1": 2, "L2": 2, "L4": 4}.get(level)
-
-        def required_at(ext):
-            """Keywords required for ``ext`` at or below this product's level."""
-            if cap is None:  # L0 (or an untagged QC subclass): no required-warnings.
-                return set()
-            return {k for k, lvl in reg.required.get(ext, {}).items() if lvl <= cap}
-
-        # PRIMARY is EPRV-standard from L1 onward; the raw WMKO L0 PRIMARY is not.
-        if cap is not None:
-            self._validate_extension(
-                "PRIMARY",
-                reg.allowed.get("PRIMARY", set()),
-                required_at("PRIMARY"),
-            )
-
-        # KPF/EPRV governed extensions (QUALITY_CONTROL, RECEIPT, BARYCORR_*,
-        # BJD_TDB, RV#/CCF#): validate each that exists on this product.
-        for ext, allowed in reg.allowed.items():
-            if ext == "PRIMARY" or ext not in self.kpf.extensions:
-                continue
-            self._validate_extension(ext, allowed, required_at(ext))
-
-    def _is_structural(self, key):
-        """True for a FITS structural/bookkeeping card (not a registered keyword).
-
-        Combines the registry's structural cards (PRIMARY/bookkeeping) with the
-        extension-table/WCS cards astropy adds at serialization.
-        """
-        return (
-            key in self.kpf.keyword_registry.structural
-            or key in _EXT_STRUCTURAL_EXTRA
-            or key.startswith(_EXT_STRUCTURAL_PREFIXES)
-        )
-
-    def _validate_extension(self, ext, allowed, required):
-        """Check one extension header: raise on an unexpected card, warn on an
-        absent required (non-structural) keyword.
-
-        Any card that is neither structural nor a registered keyword for ``ext``
-        raises -- this subsumes the old WMKO-native leak check, since a raw
-        instrument keyword (kept in INSTRUMENT_HEADER, never registered for an
-        EPRV PRIMARY) is simply unregistered here.
-        """
-        header = self.kpf.headers.get(ext)
-        if header is None:
-            return
-        present = set()
-        for raw_key in list(header):
-            key = str(raw_key).strip()
-            present.add(key)
-            if self._is_structural(key) or key in allowed:
-                continue
-            raise ValueError(
-                f"unregistered keyword {key!r} on {ext}; add it to "
-                "config/L{0,1,2,4}-headers.csv or fix the writer"
-            )
-
-        missing = sorted(
-            k for k in required if not self._is_structural(k) and k not in present
-        )
-        if missing:
-            warnings.warn(
-                f"missing required keyword(s) on {ext}: {missing}",
-                UserWarning,
-                stacklevel=2,
-            )
+        required = {
+            k for k, lvl in reg.required.get("PRIMARY", {}).items() if lvl <= cap
+        }
+        # KPF-routed PRIMARY keywords are the registry's PRIMARY rows that are not
+        # EPRV-sourced (PopulatedBy != the "EPRV" discriminator) -- the provenance
+        # cards; they are not flagged EPRV-Required, so add them explicitly.
+        kpf_primary = {
+            row.Keyword
+            for row in reg.table.itertuples(index=False)
+            if row.Extension == "PRIMARY"
+            and row.PopulatedBy != "EPRV"
+            and row.Level <= cap
+        }
+        return required | kpf_primary
 
     def _iter_checks(self):
         """Yield each check method tagged with `_qc_key`.

--- a/kpfpipe/quality_control/qc_booleans/base.py
+++ b/kpfpipe/quality_control/qc_booleans/base.py
@@ -32,7 +32,7 @@ class QC:
     LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2").
 
     def __init__(self, kpf_obj):
-        self.kpf = kpf_obj
+        self.kpf_obj = kpf_obj
         self.results = {}  # Populated by run(): maps keyword to (passed, comment).
 
     def run(self):
@@ -57,12 +57,12 @@ class QC:
             kw = fn._qc_key
             # The comment is the registry Description (the single source) — the same
             # string set_keyword writes as the FITS comment; mirror it into results.
-            comment = self.kpf.keyword_registry.routing.get(kw, (None, ""))[1]
+            comment = self.kpf_obj.keyword_registry.routing.get(kw, (None, ""))[1]
             self.results[kw] = (passed, comment)
-            self.kpf.set_keyword(kw, 1 if passed else 0)
+            self.kpf_obj.set_keyword(kw, 1 if passed else 0)
 
         is_good = all(p for p, _ in self.results.values())
-        self.kpf.set_keyword("ISGOOD", 1 if is_good else 0)
+        self.kpf_obj.set_keyword("ISGOOD", 1 if is_good else 0)
         return self.results
 
     def _required_primary_keywords(self):
@@ -71,14 +71,14 @@ class QC:
         The registry's EPRV ``Required`` PRIMARY keywords at or below this
         product's level, unioned with the KPF-pipeline keywords routed to PRIMARY
         (the provenance cards). Read off the validated model's registry singleton
-        (``self.kpf.keyword_registry``), so qc_booleans imports nothing from
+        (``self.kpf_obj.keyword_registry``), so qc_booleans imports nothing from
         data_models. L0 (or an untagged subclass) returns the empty set -- raw
         WMKO L0 PRIMARY is not registry-governed.
         """
         cap = _LEVEL_CAP.get(str(self.LEVEL).upper())
         if cap is None:
             return set()
-        reg = self.kpf.keyword_registry
+        reg = self.kpf_obj.keyword_registry
         required = {
             k for k, lvl in reg.required.get("PRIMARY", {}).items() if lvl <= cap
         }

--- a/kpfpipe/quality_control/qc_booleans/level0.py
+++ b/kpfpipe/quality_control/qc_booleans/level0.py
@@ -41,7 +41,6 @@ class QCL0(QC):
         return True
 
     data_l0_red_green._qc_key = "DATAPRL0"
-    data_l0_red_green._qc_comment = "QC: GREEN/RED amp extensions present and non-empty"
 
     def header_keywords_present(self):
         """Required PRIMARY keywords exist."""
@@ -49,7 +48,6 @@ class QCL0(QC):
         return all(k in hdr for k in _L0_REQUIRED_KEYS)
 
     header_keywords_present._qc_key = "KWRDPRL0"
-    header_keywords_present._qc_comment = "QC: required L0 PRIMARY keywords present"
 
     def exptime_sane(self):
         """EXPTIME is present, finite, and non-negative.
@@ -68,7 +66,6 @@ class QCL0(QC):
         return np.isfinite(f) and f >= 0
 
     exptime_sane._qc_key = "EXPTIMOK"
-    exptime_sane._qc_comment = "QC: EXPTIME present, finite, non-negative"
 
     def not_junk(self):
         """obs_id not in reference/junk_observations.csv."""
@@ -85,4 +82,3 @@ class QCL0(QC):
         return obs_id not in df["obs_id"].values
 
     not_junk._qc_key = "NOTJUNK"
-    not_junk._qc_comment = "QC: obs_id not in junk list"

--- a/kpfpipe/quality_control/qc_booleans/level0.py
+++ b/kpfpipe/quality_control/qc_booleans/level0.py
@@ -30,7 +30,7 @@ class QCL0(QC):
     def data_l0_red_green(self):
         """GREEN_AMP1..4 and RED_AMP1..4 exist and are non-empty."""
         for ext in _AMP_EXTENSIONS:
-            arr = self.kpf.data.get(ext)
+            arr = self.kpf_obj.data.get(ext)
             # KPF0 stores None-data as array(None, dtype=object); treat as absent.
             if (
                 arr is None
@@ -44,7 +44,7 @@ class QCL0(QC):
 
     def header_keywords_present(self):
         """Required PRIMARY keywords exist."""
-        hdr = self.kpf.headers["PRIMARY"]
+        hdr = self.kpf_obj.headers["PRIMARY"]
         return all(k in hdr for k in _L0_REQUIRED_KEYS)
 
     header_keywords_present._qc_key = "KWRDPRL0"
@@ -56,7 +56,7 @@ class QCL0(QC):
         positive. Tightening this requires frame-type-aware filtering, which
         is deferred until QC gains spectrum-type gating.
         """
-        hdr = self.kpf.headers["PRIMARY"]
+        hdr = self.kpf_obj.headers["PRIMARY"]
         if "EXPTIME" not in hdr:
             return False
         try:
@@ -71,7 +71,7 @@ class QCL0(QC):
         """obs_id not in reference/junk_observations.csv."""
         if not _JUNK_CSV.exists():
             return True
-        obs_id = self.kpf.obs_id
+        obs_id = self.kpf_obj.obs_id
         if not obs_id:
             return True
         df = pd.read_csv(_JUNK_CSV)

--- a/kpfpipe/quality_control/qc_booleans/level1.py
+++ b/kpfpipe/quality_control/qc_booleans/level1.py
@@ -39,14 +39,12 @@ class QCL1(QC):
         return True
 
     data_present._qc_key = "DATAPRL1"
-    data_present._qc_comment = "QC: GREEN/RED CCD extensions present and non-empty"
 
     def required_keywords_present(self):
         """Every registry-required PRIMARY keyword for L1 is present (presence only)."""
         return self._required_primary_keywords() <= set(self.kpf.headers["PRIMARY"])
 
     required_keywords_present._qc_key = "KWRDPRL1"
-    required_keywords_present._qc_comment = "QC: required L1 PRIMARY keywords present"
 
     def _present_rn_in_range(self, idx, lo, hi):
         """Validate a read-noise keyword across every amplifier present.
@@ -87,28 +85,24 @@ class QCL1(QC):
         return self._present_rn_in_range(0, _RN_LO, _RN_HI)
 
     read_noise_in_range._qc_key = "RNINRNG"
-    read_noise_in_range._qc_comment = "QC: per-amp RN within 2.0-6.0 e-"
 
     def read_noise_nongauss(self):
         """Every non-Gaussian RN value present in the header is in [0.8, 1.5]."""
         return self._present_rn_in_range(1, _RNNG_LO, _RNNG_HI)
 
     read_noise_nongauss._qc_key = "RNGAUSS"
-    read_noise_nongauss._qc_comment = "QC: non-Gaussian RN within 0.8-1.5"
 
     def overscan_subtracted(self):
         """OSCANSUB == True."""
         return _hdr_flag(self.kpf.headers["RECEIPT"], "OSCANSUB")
 
     overscan_subtracted._qc_key = "OSCANSUB"
-    overscan_subtracted._qc_comment = "QC: overscan subtraction applied"
 
     def bias_subtracted(self):
         """BIASSUB == True."""
         return _hdr_flag(self.kpf.headers["RECEIPT"], "BIASSUB")
 
     bias_subtracted._qc_key = "BIASSUB"
-    bias_subtracted._qc_comment = "QC: bias subtraction applied"
 
     def bias_age_ok(self):
         """abs(BIASAGE) <= 7 days."""
@@ -116,14 +110,12 @@ class QCL1(QC):
         return v is not None and abs(v) <= 7
 
     bias_age_ok._qc_key = "BIASAGEQ"
-    bias_age_ok._qc_comment = "QC: bias master age <= 7 days"
 
     def dark_subtracted(self):
         """DARKSUB == True."""
         return _hdr_flag(self.kpf.headers["RECEIPT"], "DARKSUB")
 
     dark_subtracted._qc_key = "DARKSUB"
-    dark_subtracted._qc_comment = "QC: dark subtraction applied"
 
     def dark_age_ok(self):
         """abs(DARKAGE) <= 14 days."""
@@ -131,14 +123,12 @@ class QCL1(QC):
         return v is not None and abs(v) <= 14
 
     dark_age_ok._qc_key = "DARKAGEQ"
-    dark_age_ok._qc_comment = "QC: dark master age <= 14 days"
 
     def flat_divided(self):
         """FLATDIV == True."""
         return _hdr_flag(self.kpf.headers["RECEIPT"], "FLATDIV")
 
     flat_divided._qc_key = "FLATDIV"
-    flat_divided._qc_comment = "QC: flat division applied"
 
     def flat_age_ok(self):
         """abs(FLATAGE) <= 30 days."""
@@ -146,7 +136,6 @@ class QCL1(QC):
         return v is not None and abs(v) <= 30
 
     flat_age_ok._qc_key = "FLATAGEQ"
-    flat_age_ok._qc_comment = "QC: flat master age <= 30 days"
 
     def ffi_finite(self):
         """All values in GREEN_CCD and RED_CCD are finite."""
@@ -159,4 +148,3 @@ class QCL1(QC):
         return True
 
     ffi_finite._qc_key = "FFIFIN"
-    ffi_finite._qc_comment = "QC: GREEN/RED CCDs all finite"

--- a/kpfpipe/quality_control/qc_booleans/level1.py
+++ b/kpfpipe/quality_control/qc_booleans/level1.py
@@ -28,7 +28,7 @@ class QCL1(QC):
     def data_present(self):
         """GREEN_CCD and RED_CCD exist and are non-empty."""
         for ext in ("GREEN_CCD", "RED_CCD"):
-            arr = self.kpf.data.get(ext)
+            arr = self.kpf_obj.data.get(ext)
             # A None-data extension is stored as array(None, dtype=object); absent.
             if (
                 arr is None
@@ -42,7 +42,7 @@ class QCL1(QC):
 
     def required_keywords_present(self):
         """Every registry-required PRIMARY keyword for L1 is present (presence only)."""
-        return self._required_primary_keywords() <= set(self.kpf.headers["PRIMARY"])
+        return self._required_primary_keywords() <= set(self.kpf_obj.headers["PRIMARY"])
 
     required_keywords_present._qc_key = "KWRDPRL1"
 
@@ -69,7 +69,7 @@ class QCL1(QC):
             out of range, or if no RN keyword is present at all (read noise
             should always be recorded).
         """
-        hdr = self.kpf.headers["QUALITY_CONTROL"]
+        hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         found = False
         for keys in RN_KEYS.values():
             v = _hdr_float(hdr, keys[idx])
@@ -94,45 +94,45 @@ class QCL1(QC):
 
     def overscan_subtracted(self):
         """OSCANSUB == True."""
-        return _hdr_flag(self.kpf.headers["RECEIPT"], "OSCANSUB")
+        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "OSCANSUB")
 
     overscan_subtracted._qc_key = "OSCANSUB"
 
     def bias_subtracted(self):
         """BIASSUB == True."""
-        return _hdr_flag(self.kpf.headers["RECEIPT"], "BIASSUB")
+        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "BIASSUB")
 
     bias_subtracted._qc_key = "BIASSUB"
 
     def bias_age_ok(self):
         """abs(BIASAGE) <= 7 days."""
-        v = _hdr_float(self.kpf.headers["QUALITY_CONTROL"], "BIASAGE")
+        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "BIASAGE")
         return v is not None and abs(v) <= 7
 
     bias_age_ok._qc_key = "BIASAGEQ"
 
     def dark_subtracted(self):
         """DARKSUB == True."""
-        return _hdr_flag(self.kpf.headers["RECEIPT"], "DARKSUB")
+        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "DARKSUB")
 
     dark_subtracted._qc_key = "DARKSUB"
 
     def dark_age_ok(self):
         """abs(DARKAGE) <= 14 days."""
-        v = _hdr_float(self.kpf.headers["QUALITY_CONTROL"], "DARKAGE")
+        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "DARKAGE")
         return v is not None and abs(v) <= 14
 
     dark_age_ok._qc_key = "DARKAGEQ"
 
     def flat_divided(self):
         """FLATDIV == True."""
-        return _hdr_flag(self.kpf.headers["RECEIPT"], "FLATDIV")
+        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "FLATDIV")
 
     flat_divided._qc_key = "FLATDIV"
 
     def flat_age_ok(self):
         """abs(FLATAGE) <= 30 days."""
-        v = _hdr_float(self.kpf.headers["QUALITY_CONTROL"], "FLATAGE")
+        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "FLATAGE")
         return v is not None and abs(v) <= 30
 
     flat_age_ok._qc_key = "FLATAGEQ"
@@ -140,7 +140,7 @@ class QCL1(QC):
     def ffi_finite(self):
         """All values in GREEN_CCD and RED_CCD are finite."""
         for ext in ("GREEN_CCD", "RED_CCD"):
-            arr = self.kpf.data.get(ext)
+            arr = self.kpf_obj.data.get(ext)
             if arr is None or np.size(arr) == 0:
                 return False
             if not np.all(np.isfinite(arr)):

--- a/kpfpipe/quality_control/qc_booleans/level1.py
+++ b/kpfpipe/quality_control/qc_booleans/level1.py
@@ -25,6 +25,29 @@ class QCL1(QC):
 
     LEVEL = "L1"
 
+    def data_present(self):
+        """GREEN_CCD and RED_CCD exist and are non-empty."""
+        for ext in ("GREEN_CCD", "RED_CCD"):
+            arr = self.kpf.data.get(ext)
+            # A None-data extension is stored as array(None, dtype=object); absent.
+            if (
+                arr is None
+                or getattr(arr, "dtype", None) == np.dtype(object)
+                or np.size(arr) == 0
+            ):
+                return False
+        return True
+
+    data_present._qc_key = "DATAPRL1"
+    data_present._qc_comment = "QC: GREEN/RED CCD extensions present and non-empty"
+
+    def required_keywords_present(self):
+        """Every registry-required PRIMARY keyword for L1 is present (presence only)."""
+        return self._required_primary_keywords() <= set(self.kpf.headers["PRIMARY"])
+
+    required_keywords_present._qc_key = "KWRDPRL1"
+    required_keywords_present._qc_comment = "QC: required L1 PRIMARY keywords present"
+
     def _present_rn_in_range(self, idx, lo, hi):
         """Validate a read-noise keyword across every amplifier present.
 

--- a/kpfpipe/quality_control/qc_booleans/level2.py
+++ b/kpfpipe/quality_control/qc_booleans/level2.py
@@ -37,6 +37,13 @@ class QCL2(QC):
     extraction_present._qc_key = "DATAPRL2"
     extraction_present._qc_comment = "QC: L2 FLUX extensions present and non-empty"
 
+    def required_keywords_present(self):
+        """Every registry-required PRIMARY keyword for L2 is present (presence only)."""
+        return self._required_primary_keywords() <= set(self.kpf.headers["PRIMARY"])
+
+    required_keywords_present._qc_key = "KWRDPRL2"
+    required_keywords_present._qc_comment = "QC: required L2 PRIMARY keywords present"
+
     def flux_finite_fraction(self):
         """NaN count from headers <= 1% of total L2 flux pixels."""
         hdr = self.kpf.headers["QUALITY_CONTROL"]

--- a/kpfpipe/quality_control/qc_booleans/level2.py
+++ b/kpfpipe/quality_control/qc_booleans/level2.py
@@ -29,7 +29,7 @@ class QCL2(QC):
         for chip in _CHIPS:
             for fiber in _FIBERS:
                 ext = f"{chip}_{fiber}_FLUX"
-                arr = self.kpf.data.get(ext)
+                arr = self.kpf_obj.data.get(ext)
                 if arr is None or np.size(arr) == 0:
                     return False
         return True
@@ -38,18 +38,18 @@ class QCL2(QC):
 
     def required_keywords_present(self):
         """Every registry-required PRIMARY keyword for L2 is present (presence only)."""
-        return self._required_primary_keywords() <= set(self.kpf.headers["PRIMARY"])
+        return self._required_primary_keywords() <= set(self.kpf_obj.headers["PRIMARY"])
 
     required_keywords_present._qc_key = "KWRDPRL2"
 
     def flux_finite_fraction(self):
         """NaN count from headers <= 1% of total L2 flux pixels."""
-        hdr = self.kpf.headers["QUALITY_CONTROL"]
+        hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         total_pixels = 0
         for chip in _CHIPS:
             for fiber in _FIBERS:
                 ext = f"{chip}_{fiber}_FLUX"
-                arr = self.kpf.data.get(ext)
+                arr = self.kpf_obj.data.get(ext)
                 if arr is not None:
                     total_pixels += np.size(arr)
 
@@ -69,7 +69,7 @@ class QCL2(QC):
 
     def nonzero_flux(self):
         """ZEROFRAC < 0.5."""
-        v = _hdr_float(self.kpf.headers["QUALITY_CONTROL"], "ZEROFRAC")
+        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "ZEROFRAC")
         return v is not None and v < 0.5
 
     nonzero_flux._qc_key = "L2FLXOK"
@@ -84,8 +84,8 @@ class QCL2(QC):
         saw_data = False
         for chip in _CHIPS:
             for fiber in _FIBERS:
-                flux = self.kpf.data.get(f"{chip}_{fiber}_FLUX")
-                var = self.kpf.data.get(f"{chip}_{fiber}_VAR")
+                flux = self.kpf_obj.data.get(f"{chip}_{fiber}_FLUX")
+                var = self.kpf_obj.data.get(f"{chip}_{fiber}_VAR")
                 if flux is None or var is None:
                     continue
                 flux = np.asarray(flux)
@@ -106,7 +106,7 @@ class QCL2(QC):
         before QCL2, mirroring the flux_finite_fraction -> nan_counts
         dependency). Guards against a silently failed extraction.
         """
-        hdr = self.kpf.headers["QUALITY_CONTROL"]
+        hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         values = [_hdr_float(hdr, k) for k in ("GSNRSCI", "RSNRSCI")]
         values = [v for v in values if v is not None]
         if not values:

--- a/kpfpipe/quality_control/qc_booleans/level2.py
+++ b/kpfpipe/quality_control/qc_booleans/level2.py
@@ -35,14 +35,12 @@ class QCL2(QC):
         return True
 
     extraction_present._qc_key = "DATAPRL2"
-    extraction_present._qc_comment = "QC: L2 FLUX extensions present and non-empty"
 
     def required_keywords_present(self):
         """Every registry-required PRIMARY keyword for L2 is present (presence only)."""
         return self._required_primary_keywords() <= set(self.kpf.headers["PRIMARY"])
 
     required_keywords_present._qc_key = "KWRDPRL2"
-    required_keywords_present._qc_comment = "QC: required L2 PRIMARY keywords present"
 
     def flux_finite_fraction(self):
         """NaN count from headers <= 1% of total L2 flux pixels."""
@@ -68,7 +66,6 @@ class QCL2(QC):
         return (nan_total / total_pixels) <= 0.01
 
     flux_finite_fraction._qc_key = "L2NANOK"
-    flux_finite_fraction._qc_comment = "QC: L2 NaN fraction <= 1%"
 
     def nonzero_flux(self):
         """ZEROFRAC < 0.5."""
@@ -76,7 +73,6 @@ class QCL2(QC):
         return v is not None and v < 0.5
 
     nonzero_flux._qc_key = "L2FLXOK"
-    nonzero_flux._qc_comment = "QC: L2 zero-flux fraction < 0.5"
 
     def variance_positive(self):
         """No strictly-negative variance where the flux is finite.
@@ -102,7 +98,6 @@ class QCL2(QC):
         return saw_data
 
     variance_positive._qc_key = "L2VARPOS"
-    variance_positive._qc_comment = "QC: no negative L2 variance where flux finite"
 
     def science_snr(self):
         """Science SNR is finite and above a minimum floor.
@@ -119,4 +114,3 @@ class QCL2(QC):
         return all(np.isfinite(v) and v > _MIN_SCI_SNR for v in values)
 
     science_snr._qc_key = "L2SNROK"
-    science_snr._qc_comment = "QC: science SNR finite and above floor"

--- a/kpfpipe/quality_control/qc_flags/__init__.py
+++ b/kpfpipe/quality_control/qc_flags/__init__.py
@@ -1,0 +1,6 @@
+from kpfpipe.quality_control.qc_flags.base import QC
+from kpfpipe.quality_control.qc_flags.level0 import QCL0
+from kpfpipe.quality_control.qc_flags.level1 import QCL1
+from kpfpipe.quality_control.qc_flags.level2 import QCL2
+
+__all__ = ["QC", "QCL0", "QCL1", "QCL2"]

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -71,7 +71,7 @@ class QC:
         The registry's EPRV ``Required`` PRIMARY keywords at or below this
         product's level, unioned with the KPF-pipeline keywords routed to PRIMARY
         (the provenance cards). Read off the validated model's registry singleton
-        (``self.kpf_obj.keyword_registry``), so qc_booleans imports nothing from
+        (``self.kpf_obj.keyword_registry``), so qc_flags imports nothing from
         data_models. L0 (or an untagged subclass) returns the empty set -- raw
         WMKO L0 PRIMARY is not registry-governed.
         """

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 
 from kpfpipe import REPO_ROOT
-from kpfpipe.quality_control.qc_booleans.base import QC
+from kpfpipe.quality_control.qc_flags.base import QC
 
 _JUNK_CSV = REPO_ROOT / "reference" / "junk_observations.csv"
 

--- a/kpfpipe/quality_control/qc_flags/level1.py
+++ b/kpfpipe/quality_control/qc_flags/level1.py
@@ -80,17 +80,13 @@ class QCL1(QC):
                 return False
         return found
 
-    def read_noise_in_range(self):
-        """Every per-amp RN value present in the header is in [2.0, 6.0] e-."""
-        return self._present_rn_in_range(0, _RN_LO, _RN_HI)
+    def read_noise_ok(self):
+        """Per-amp RN in [2.0, 6.0] e- and non-Gaussian RN in [0.8, 1.5]."""
+        return self._present_rn_in_range(
+            0, _RN_LO, _RN_HI
+        ) and self._present_rn_in_range(1, _RNNG_LO, _RNNG_HI)
 
-    read_noise_in_range._qc_key = "RNINRNG"
-
-    def read_noise_nongauss(self):
-        """Every non-Gaussian RN value present in the header is in [0.8, 1.5]."""
-        return self._present_rn_in_range(1, _RNNG_LO, _RNNG_HI)
-
-    read_noise_nongauss._qc_key = "RNGAUSS"
+    read_noise_ok._qc_key = "RNOK"
 
     def overscan_subtracted(self):
         """OSCANSUB == True."""
@@ -98,44 +94,32 @@ class QCL1(QC):
 
     overscan_subtracted._qc_key = "OSCANSUB"
 
-    def bias_subtracted(self):
-        """BIASSUB == True."""
-        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "BIASSUB")
-
-    bias_subtracted._qc_key = "BIASSUB"
-
-    def bias_age_ok(self):
-        """abs(BIASAGE) <= 7 days."""
+    def bias_ok(self):
+        """Bias subtracted (RECEIPT BIASSUB) and master bias age <= 7 days."""
+        if not _hdr_flag(self.kpf_obj.headers["RECEIPT"], "BIASSUB"):
+            return False
         v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "BIASAGE")
         return v is not None and abs(v) <= 7
 
-    bias_age_ok._qc_key = "BIASAGEQ"
+    bias_ok._qc_key = "BIASOK"
 
-    def dark_subtracted(self):
-        """DARKSUB == True."""
-        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "DARKSUB")
-
-    dark_subtracted._qc_key = "DARKSUB"
-
-    def dark_age_ok(self):
-        """abs(DARKAGE) <= 14 days."""
+    def dark_ok(self):
+        """Dark subtracted (RECEIPT DARKSUB) and master dark age <= 14 days."""
+        if not _hdr_flag(self.kpf_obj.headers["RECEIPT"], "DARKSUB"):
+            return False
         v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "DARKAGE")
         return v is not None and abs(v) <= 14
 
-    dark_age_ok._qc_key = "DARKAGEQ"
+    dark_ok._qc_key = "DARKOK"
 
-    def flat_divided(self):
-        """FLATDIV == True."""
-        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "FLATDIV")
-
-    flat_divided._qc_key = "FLATDIV"
-
-    def flat_age_ok(self):
-        """abs(FLATAGE) <= 30 days."""
+    def flat_ok(self):
+        """Flat divided (RECEIPT FLATDIV) and master flat age <= 30 days."""
+        if not _hdr_flag(self.kpf_obj.headers["RECEIPT"], "FLATDIV"):
+            return False
         v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "FLATAGE")
         return v is not None and abs(v) <= 30
 
-    flat_age_ok._qc_key = "FLATAGEQ"
+    flat_ok._qc_key = "FLATOK"
 
     def ffi_finite(self):
         """All values in GREEN_CCD and RED_CCD are finite."""
@@ -147,4 +131,4 @@ class QCL1(QC):
                 return False
         return True
 
-    ffi_finite._qc_key = "FFIFIN"
+    ffi_finite._qc_key = "FFIOK"

--- a/kpfpipe/quality_control/qc_flags/level1.py
+++ b/kpfpipe/quality_control/qc_flags/level1.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from kpfpipe.modules.image_assembly import RN_KEYS
-from kpfpipe.quality_control.qc_booleans.base import QC
+from kpfpipe.quality_control.qc_flags.base import QC
 
 _RN_LO, _RN_HI = 2.0, 6.0
 _RNNG_LO, _RNNG_HI = 0.8, 1.5

--- a/kpfpipe/quality_control/qc_flags/level1.py
+++ b/kpfpipe/quality_control/qc_flags/level1.py
@@ -81,12 +81,16 @@ class QCL1(QC):
         return found
 
     def read_noise_ok(self):
-        """Per-amp RN in [2.0, 6.0] e- and non-Gaussian RN in [0.8, 1.5]."""
-        return self._present_rn_in_range(
-            0, _RN_LO, _RN_HI
-        ) and self._present_rn_in_range(1, _RNNG_LO, _RNNG_HI)
+        """Every per-amp read noise present is in [2.0, 6.0] e-."""
+        return self._present_rn_in_range(0, _RN_LO, _RN_HI)
 
     read_noise_ok._qc_key = "RNOK"
+
+    def read_noise_nongauss_ok(self):
+        """Every per-amp non-Gaussian read noise present is in [0.8, 1.5]."""
+        return self._present_rn_in_range(1, _RNNG_LO, _RNNG_HI)
+
+    read_noise_nongauss_ok._qc_key = "RNNGOK"
 
     def overscan_subtracted(self):
         """OSCANSUB == True."""

--- a/kpfpipe/quality_control/qc_flags/level1.py
+++ b/kpfpipe/quality_control/qc_flags/level1.py
@@ -92,12 +92,6 @@ class QCL1(QC):
 
     read_noise_nongauss_ok._qc_key = "RNNGOK"
 
-    def overscan_subtracted(self):
-        """OSCANSUB == True."""
-        return _hdr_flag(self.kpf_obj.headers["RECEIPT"], "OSCANSUB")
-
-    overscan_subtracted._qc_key = "OSCANSUB"
-
     def bias_ok(self):
         """Bias subtracted (RECEIPT BIASSUB) and master bias age <= 7 days."""
         if not _hdr_flag(self.kpf_obj.headers["RECEIPT"], "BIASSUB"):

--- a/kpfpipe/quality_control/qc_flags/level2.py
+++ b/kpfpipe/quality_control/qc_flags/level2.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 
-from kpfpipe.quality_control.qc_booleans.base import QC
+from kpfpipe.quality_control.qc_flags.base import QC
 
 _CHIPS = ["GREEN", "RED"]
 _FIBERS = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]

--- a/kpfpipe/quality_control/qc_flags/level2.py
+++ b/kpfpipe/quality_control/qc_flags/level2.py
@@ -97,7 +97,7 @@ class QCL2(QC):
                     return False
         return saw_data
 
-    variance_positive._qc_key = "L2VARPOS"
+    variance_positive._qc_key = "L2VAROK"
 
     def science_snr(self):
         """Science SNR is finite and above a minimum floor.

--- a/kpfpipe/quality_control/quicklook/level0.py
+++ b/kpfpipe/quality_control/quicklook/level0.py
@@ -34,7 +34,7 @@ class PlotL0:
     _PLOT_METHODS = ("stitched_image",)
 
     def __init__(self, l0_obj, output_dir=None, full_res=False):
-        self.l0 = l0_obj
+        self.l0_obj = l0_obj
         self.output_dir = output_dir
         self.full_res = full_res
         self.obs_id = getattr(l0_obj, "obs_id", None) or ""
@@ -46,7 +46,7 @@ class PlotL0:
         """Return True if any AMP extension for the chip holds data."""
         for i in range(1, 5):
             ext = f"{chip.upper()}_AMP{i}"
-            arr = self.l0.data.get(ext)
+            arr = self.l0_obj.data.get(ext)
             if arr is not None and np.size(arr) > 0:
                 return True
         return False
@@ -63,18 +63,18 @@ class PlotL0:
         chip = chip.upper()
 
         # Count amplifiers via ImageAssembly (non-destructive).
-        ia = ImageAssembly(self.l0)
+        ia = ImageAssembly(self.l0_obj)
         ia.count_amplifiers(chip)
         namp = ia.namp[chip]
 
         if namp == 2:
             image = np.concatenate(
-                (self.l0.data[f"{chip}_AMP1"], self.l0.data[f"{chip}_AMP2"]),
+                (self.l0_obj.data[f"{chip}_AMP1"], self.l0_obj.data[f"{chip}_AMP2"]),
                 axis=1,
             )
         elif namp == 4:
             # orient_channels mutates l0.data, so operate on a copy.
-            l0_copy = deepcopy(self.l0)
+            l0_copy = deepcopy(self.l0_obj)
             ia = ImageAssembly(l0_copy)
             ia.count_amplifiers(chip)
             ia.orient_channels(chip)

--- a/kpfpipe/quality_control/quicklook/level1.py
+++ b/kpfpipe/quality_control/quicklook/level1.py
@@ -33,7 +33,7 @@ class PlotL1:
     _PLOT_METHODS = ("image",)
 
     def __init__(self, l1_obj, output_dir=None, full_res=False):
-        self.l1 = l1_obj
+        self.l1_obj = l1_obj
         self.output_dir = output_dir
         self.full_res = full_res
         self.obs_id = getattr(l1_obj, "obs_id", None) or ""
@@ -47,7 +47,7 @@ class PlotL1:
         ImageAssembly writes the RN*/RNNG* read-noise keywords via set_keyword,
         which routes them to QUALITY_CONTROL (their registry home), not PRIMARY.
         """
-        qc = self.l1.headers.get("QUALITY_CONTROL", {})
+        qc = self.l1_obj.headers.get("QUALITY_CONTROL", {})
         rn_values = []
         rnng_values = []
         for i in range(1, 5):
@@ -82,7 +82,7 @@ class PlotL1:
 
         chip_upper = chip.upper()
         ext = f"{chip_upper}_CCD"
-        image = np.asarray(self.l1.data[ext])
+        image = np.asarray(self.l1_obj.data[ext])
 
         # Interior percentile (strip 100-pixel border to avoid edge effects)
         interior = image[100:-100, 100:-100] if min(image.shape) > 200 else image
@@ -205,9 +205,9 @@ class PlotL1:
 
     def _has_chip(self, chip):
         ext = f"{chip.upper()}_CCD"
-        if ext not in self.l1.data or self.l1.data[ext] is None:
+        if ext not in self.l1_obj.data or self.l1_obj.data[ext] is None:
             return False
-        return np.size(self.l1.data[ext]) > 0
+        return np.size(self.l1_obj.data[ext]) > 0
 
     def run(self, which, *, full_res=None):
         """

--- a/kpfpipe/quality_control/quicklook/level2.py
+++ b/kpfpipe/quality_control/quicklook/level2.py
@@ -47,7 +47,7 @@ class PlotL2:
     )
 
     def __init__(self, l2_obj, output_dir=None, obs_id=None):
-        self.l2 = l2_obj
+        self.l2_obj = l2_obj
         self.output_dir = output_dir
         self.fibers = _FIBERS
 
@@ -83,14 +83,14 @@ class PlotL2:
 
     def _flux(self, chip, fiber):
         """Return the (norder, ncol) flux array for one fiber, or None."""
-        arr = self.l2.data.get(f"{chip.upper()}_{fiber.upper()}_FLUX")
+        arr = self.l2_obj.data.get(f"{chip.upper()}_{fiber.upper()}_FLUX")
         arr = np.asarray(arr) if arr is not None else None
         if arr is None or arr.ndim != 2 or arr.size == 0:
             return None
         return arr
 
     def _var(self, chip, fiber):
-        arr = self.l2.data.get(f"{chip.upper()}_{fiber.upper()}_VAR")
+        arr = self.l2_obj.data.get(f"{chip.upper()}_{fiber.upper()}_VAR")
         arr = np.asarray(arr) if arr is not None else None
         if arr is None or arr.ndim != 2 or arr.size == 0:
             return None
@@ -98,7 +98,7 @@ class PlotL2:
 
     def _wave(self, chip, fiber):
         """Return the (norder, ncol) wavelength array, or None if not populated."""
-        arr = self.l2.data.get(f"{chip.upper()}_{fiber.upper()}_WAVE")
+        arr = self.l2_obj.data.get(f"{chip.upper()}_{fiber.upper()}_WAVE")
         arr = np.asarray(arr) if arr is not None else None
         if arr is None or arr.ndim != 2 or arr.size == 0:
             return None

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -22,7 +22,7 @@ from kpfpipe.modules.spectral_extraction import SpectralExtraction
 from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
 from kpfpipe.quality_control.checkpoints import CheckpointL1, CheckpointL2
 from kpfpipe.quality_control.diagnostics import DiagL1, DiagL2
-from kpfpipe.quality_control.qc_booleans import QCL1, QCL2
+from kpfpipe.quality_control.qc_flags import QCL1, QCL2
 from kpfpipe.quality_control.quicklook.level0 import PlotL0
 from kpfpipe.quality_control.quicklook.level1 import PlotL1
 from kpfpipe.quality_control.quicklook.level2 import PlotL2

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -20,6 +20,7 @@ from kpfpipe.modules.image_processing import ImageProcessing
 from kpfpipe.modules.radial_velocity import RadialVelocity
 from kpfpipe.modules.spectral_extraction import SpectralExtraction
 from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
+from kpfpipe.quality_control.checkpoints import CheckpointL1, CheckpointL2
 from kpfpipe.quality_control.diagnostics import DiagL1, DiagL2
 from kpfpipe.quality_control.qc_booleans import QCL1, QCL2
 from kpfpipe.quality_control.quicklook.level0 import PlotL0
@@ -70,10 +71,12 @@ def main(config, args):
     image_processing = ImageProcessing(l1, config)
     l1 = image_processing.perform()
 
-    # Run L1 diagnostics and QC here so the pass/fail thresholds see the
-    # processed image before extraction collapses it to 1D.
+    # Run L1 diagnostics, QC, and checkpoints here so the pass/fail thresholds
+    # see the processed image before extraction collapses it to 1D. Order is
+    # Diagnostics (metrics) -> QC (0/1 flags) -> Checkpoints (warn/raise).
     DiagL1(l1).run()
     QCL1(l1).run()
+    CheckpointL1(l1).run()
 
     # Extract the 2D FFI down to 1D spectra (2D --> 1D), since the RV analysis
     # operates on per-order flux rather than the raw image.
@@ -85,10 +88,12 @@ def main(config, args):
     wavelength_calibration = WavelengthCalibration(l2, config)
     l2 = wavelength_calibration.perform()
 
-    # Run L2 diagnostics and QC on the extracted spectra to flag NaN counts and
-    # zero-flux orders before they propagate into the RV measurement.
+    # Run L2 diagnostics, QC, and checkpoints on the extracted spectra to flag
+    # NaN counts and zero-flux orders before they propagate into the RV
+    # measurement (Diagnostics -> QC -> Checkpoints).
     DiagL2(l2).run()
     QCL2(l2).run()
+    CheckpointL2(l2).run()
 
     # Apply the per-order barycentric correction so the spectra are placed in
     # the Solar System barycentric frame for long-term RV stability. Writes

--- a/scripts/qc.py
+++ b/scripts/qc.py
@@ -19,14 +19,15 @@ import sys
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.quality_control.checkpoints import CheckpointL0, CheckpointL1, CheckpointL2
 from kpfpipe.quality_control.qc_booleans import QCL0, QCL1, QCL2
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import build_filepath
 
 _LEVEL_MAP = {
-    "L0": (KPF0, QCL0),
-    "L1": (KPF1, QCL1),
-    "L2": (KPF2, QCL2),
+    "L0": (KPF0, QCL0, CheckpointL0),
+    "L1": (KPF1, QCL1, CheckpointL1),
+    "L2": (KPF2, QCL2, CheckpointL2),
 }
 
 
@@ -72,7 +73,7 @@ def main():
     # Load data
     # ------------------------------------------------------------------ #
     try:
-        DataClass, QCClass = _LEVEL_MAP[args.level]
+        DataClass, QCClass, CheckpointClass = _LEVEL_MAP[args.level]
         data = DataClass.from_fits(input_file)
     except Exception as exc:
         print(f"Error loading {input_file}: {exc}", file=sys.stderr)
@@ -92,6 +93,14 @@ def main():
         results = qc.run()
     except RuntimeError as exc:
         print(f"Error: QC raised unexpectedly: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+    # Checkpoints read the QC flags + headers and warn or raise (e.g. an
+    # unregistered keyword). A raised checkpoint is a structural failure -> exit 2.
+    try:
+        CheckpointClass(data).run()
+    except Exception as exc:
+        print(f"Error: checkpoint failed: {exc}", file=sys.stderr)
         sys.exit(2)
 
     # ------------------------------------------------------------------ #

--- a/scripts/qc.py
+++ b/scripts/qc.py
@@ -20,7 +20,7 @@ from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.quality_control.checkpoints import CheckpointL0, CheckpointL1, CheckpointL2
-from kpfpipe.quality_control.qc_booleans import QCL0, QCL1, QCL2
+from kpfpipe.quality_control.qc_flags import QCL0, QCL1, QCL2
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import build_filepath
 

--- a/tests/profiling/_profiling.py
+++ b/tests/profiling/_profiling.py
@@ -497,7 +497,7 @@ def _summary_bucket(filename, name):
         if label.startswith("quality_control/quicklook/"):
             return QUICKLOOK_LABEL, "quicklook"
         if label.startswith(
-            ("quality_control/qc_booleans/", "quality_control/diagnostics/")
+            ("quality_control/qc_flags/", "quality_control/diagnostics/")
         ):
             return QC_LABEL, "qc"
         if label.startswith("modules/"):

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -33,14 +33,10 @@ class MockL1:
         self._receipt.append((name, status))
 
     def set_keyword(self, key, value):
-        # Mirror the real routing: master paths ({PREFIX}FILE) land on RECEIPT,
-        # signed ages ({PREFIX}AGE) on QUALITY_CONTROL.
-        if key.endswith("FILE"):
-            ext = "RECEIPT"
-        elif key.endswith("AGE"):
-            ext = "QUALITY_CONTROL"
-        else:
-            ext = "PRIMARY"
+        # Mirror the real routing: master paths ({PREFIX}FILE) land on RECEIPT.
+        # The signed ages ({PREFIX}AGE) are written downstream by DiagL1, not by
+        # this module.
+        ext = "RECEIPT" if key.endswith("FILE") else "PRIMARY"
         self.headers[ext][key] = value
 
 
@@ -280,28 +276,13 @@ class TestPerform:
         mod.perform(["bias"])
         assert "BIASDIR" not in mod.l1_obj.headers["RECEIPT"]
 
-    def test_sets_biasage_same_day(self, masters_dir):
-        # BIASAGE is a signed fractional-day float (master - obs). The master
-        # shares the obs's date but sits at 01:00:37 UTC vs obs 11:08:33 UTC,
-        # giving -0.422176 days.
+    def test_does_not_write_biasage(self, masters_dir):
+        # The signed master-obs age (BIASAGE) is now recomputed downstream by
+        # DiagL1 from the path this module writes; the module itself emits only
+        # the path. (DiagL1.calibration_ages is covered in test_diagnostics.py.)
         mod = _make_module(masters_dir)
         mod.perform(["bias"])
-        age = mod.l1_obj.headers["QUALITY_CONTROL"].get("BIASAGE")
-        assert isinstance(age, float)
-        assert age == pytest.approx(-0.422176, abs=1e-5)
-
-    def test_sets_biasage_previous_day(self, tmp_path):
-        # Master at 2024-04-04 22:00:00 UTC vs obs 2024-04-05 11:08:33 UTC gives
-        # delta = -13h 08m 33s = -47313 s = -0.547604 days.
-        d = tmp_path / "masters" / "20240404"
-        d.mkdir(parents=True)
-        _stub_master(d, "KP.20240404.79200.00", "bias")
-
-        mod = _make_module(tmp_path)
-        mod.perform(["bias"])
-        assert mod.l1_obj.headers["QUALITY_CONTROL"].get("BIASAGE") == pytest.approx(
-            -0.547604, abs=1e-5
-        )
+        assert "BIASAGE" not in mod.l1_obj.headers["QUALITY_CONTROL"]
 
     def test_sets_headers_for_dark_and_flat(self, masters_dir):
         mod = _make_module(masters_dir)
@@ -309,26 +290,22 @@ class TestPerform:
         for prefix in ("BIAS", "DARK", "FLAT"):
             assert f"{prefix}FILE" in mod.l1_obj.headers["RECEIPT"]
             assert f"{prefix}DIR" not in mod.l1_obj.headers["RECEIPT"]
-            assert f"{prefix}AGE" in mod.l1_obj.headers["QUALITY_CONTROL"]
+            assert f"{prefix}AGE" not in mod.l1_obj.headers["QUALITY_CONTROL"]
 
     def test_sets_headers_for_thar(self, masters_dir):
         # WLS follows the same unified convention: WLSFILE holds the full path
-        # (no WLSDIR), and WLSAGE is float days with sign = (master_dt -
-        # obs_dt). Master at 2024-04-05 01:00:37 UTC vs obs at 2024-04-05
-        # 11:08:33 UTC gives delta = -10h 07m 56s = -36476 s = -0.422176 days.
+        # (no WLSDIR). The WLSAGE is written downstream by DiagL1.
         d = masters_dir / "masters" / "20240405"
         _stub_master(d, "KP.20240405.03637.74", "thar")
 
         mod = _make_module(masters_dir)
         mod.perform(["bias", "thar"])
         receipt = mod.l1_obj.headers["RECEIPT"]
-        qc = mod.l1_obj.headers["QUALITY_CONTROL"]
         assert receipt.get("WLSFILE") == str(
             d / "KP.20240405.03637.74_master_thar_L2.fits"
         )
         assert "WLSDIR" not in receipt
-        assert isinstance(qc.get("WLSAGE"), float)
-        assert qc.get("WLSAGE") == pytest.approx(-0.422176, abs=1e-5)
+        assert "WLSAGE" not in mod.l1_obj.headers["QUALITY_CONTROL"]
 
     def test_raises_on_unknown_cal_type(self, masters_dir):
         mod = _make_module(masters_dir)

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -1,0 +1,90 @@
+"""Tests for the Checkpoint layer (quality_control/checkpoints).
+
+Checkpoints are the third QC stage: they READ the 0/1 QC flags and the product
+headers, then warn or raise (never write). This pins:
+
+  - ``unregistered_keywords`` — raises on a card not registered for a governed
+    extension (including a raw WMKO native leaked onto an EPRV PRIMARY); skips the
+    raw WMKO L0 PRIMARY; passes a clean product. (Migrated from the old
+    ``QC._validate_headers`` tests.)
+  - ``qc_flags`` — a failed (0) flag named in the level's ``RAISE_FLAGS`` raises;
+    any other failed flag warns; all-pass is silent.
+"""
+
+import warnings
+
+import pytest
+
+from kpfpipe.data_models.level0 import KPF0
+from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.quality_control.checkpoints import CheckpointL0, CheckpointL2
+
+
+class TestUnregisteredKeywords:
+    def test_clean_product_passes(self):
+        # Fresh KPF2: EPRV-seeded PRIMARY (all registered) + empty governed
+        # extensions -> no unregistered card, and no QC flags present -> qc_flags
+        # is a no-op, so run() is fully silent.
+        l2 = KPF2()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any warning would fail this
+            CheckpointL2(l2).run()
+
+    def test_unexpected_keyword_on_governed_extension_raises(self):
+        l2 = KPF2()
+        l2.headers["QUALITY_CONTROL"]["BOGUSKEY"] = (1, "not registered")
+        with pytest.raises(ValueError, match="unregistered keyword 'BOGUSKEY'"):
+            CheckpointL2(l2).unregistered_keywords()
+
+    def test_native_wmko_leak_on_primary_raises(self):
+        l2 = KPF2()
+        # GAIAID is a raw WMKO native (kept in INSTRUMENT_HEADER, never on PRIMARY).
+        # It is not a registered PRIMARY keyword, so it fails the general
+        # unregistered-keyword check (no dedicated WMKO-leak branch needed).
+        l2.headers["PRIMARY"]["GAIAID"] = (12345, "leaked native")
+        with pytest.raises(ValueError, match="unregistered keyword 'GAIAID'"):
+            CheckpointL2(l2).unregistered_keywords()
+
+    def test_registered_keyword_on_its_extension_passes(self):
+        l2 = KPF2()
+        l2.set_keyword("NANSCI1", 3)  # registered -> QUALITY_CONTROL
+        CheckpointL2(l2).unregistered_keywords()  # no raise
+
+    def test_raw_l0_primary_is_skipped(self):
+        # The raw WMKO L0 PRIMARY is not registry-governed, so an unregistered
+        # native on it must NOT raise at L0.
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["GAIAID"] = (12345, "raw native")
+        CheckpointL0(l0).unregistered_keywords()  # no raise
+
+
+class TestQCFlags:
+    def test_raise_flag_zero_raises(self):
+        # DATAPRL2 is in CheckpointL2.RAISE_FLAGS, so a 0 is fatal.
+        l2 = KPF2()
+        l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (0, "data present")
+        with pytest.raises(ValueError, match="DATAPRL2 = 0"):
+            CheckpointL2(l2).qc_flags()
+
+    def test_nonraise_flag_zero_warns(self):
+        # KWRDPRL2 is not a RAISE_FLAG, so a 0 warns (data present so DATAPRL2 ok).
+        l2 = KPF2()
+        l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")
+        l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (0, "required present")
+        with pytest.warns(UserWarning, match="KWRDPRL2 = 0"):
+            CheckpointL2(l2).qc_flags()
+
+    def test_all_pass_silent(self):
+        l2 = KPF2()
+        l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")
+        l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (1, "required present")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            CheckpointL2(l2).qc_flags()
+
+    def test_absent_flag_is_ignored(self):
+        # A flag the QC stage never wrote is absent -> neither warns nor raises.
+        l2 = KPF2()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            CheckpointL2(l2).qc_flags()

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -15,8 +15,8 @@ RV2/RV4, so their round-trip guards live in test_data_models_l{2,4}.py.
 
 The WMKO->EPRV conversion (``KPF0.wmko_to_eprv`` / ``build_instrument_header``) is
 exercised end-to-end by the to_kpf1/to_kpf2 tests in test_data_models_l{1,2,4}.py.
-PRIMARY-header validation no longer lives on the data models (it moved to the QC
-runner, ``quality_control/qc_booleans/base.py``).
+PRIMARY-header validation no longer lives on the data models (it moved to the
+checkpoints layer, ``quality_control/checkpoints/base.py``).
 """
 
 import warnings

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -84,15 +84,16 @@ class TestUndefinedRoundTrip:
         l1.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
         # radial_velocity writes None for a non-finite fit; astropy stores it as
         # an UNDEFINED card. The value must round-trip as a blank/undefined card
-        # (read back as None), never as a finite number.
-        l1.headers["PRIMARY"]["CCFRV"] = None
+        # (read back as None), never as a finite number. RV is the EPRV combined
+        # RV on PRIMARY, written None on a failed fit.
+        l1.headers["PRIMARY"]["RV"] = None
 
         fn = str(tmp_path / "header_undefined_l1.fits")
         l1.to_fits(fn)
 
         prim = KPF1.from_fits(fn).headers["PRIMARY"]
-        assert "CCFRV" in prim
-        val = prim["CCFRV"]
+        assert "RV" in prim
+        val = prim["RV"]
         assert val is None or isinstance(val, fits.card.Undefined)
 
 

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -126,9 +126,9 @@ class TestSetKeyword:
     def test_routes_l4_orderlet_rv_to_rv_table(self):
         l4 = KPF4()
         l4.set_keyword("CCD1RV1", 1.2345)  # GREEN SCI1 -> RV2
-        l4.set_keyword("CCD1RV", 6.789)  # combined -> PRIMARY
+        l4.set_keyword("CCD1RV", 6.789)  # GREEN SCI-combined -> RV3
         assert l4.headers["RV2"]["CCD1RV1"] == 1.2345
-        assert l4.headers["PRIMARY"]["CCD1RV"] == 6.789
+        assert l4.headers["RV3"]["CCD1RV"] == 6.789
 
     def test_unregistered_keyword_raises_keyerror(self):
         l1 = KPF1()

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -527,11 +527,14 @@ class TestKPF2HeaderStorage:
         # Guards the KPF2._create_hdul override (not the inherited base path):
         # a commented PRIMARY card must survive to_fits -> from_fits.
         kpf2 = KPF2()
-        kpf2.headers["PRIMARY"]["CCFRV"] = (1.2345, "[km/s] Combined radial velocity")
+        # A KPF-custom PRIMARY keyword (not an EPRV keyword rvdata rewrites from its
+        # L2 definition): provenance DRPVERNO exercises the KPF comment-preservation
+        # path this guards.
+        kpf2.headers["PRIMARY"]["DRPVERNO"] = ("1.2.3", "Pipeline version (DRP-RUN-11)")
 
         fn = str(tmp_path / "kpf_SL2_20240113T102656.fits")
         kpf2.to_fits(fn)
 
         prim = KPF2.from_fits(fn).headers["PRIMARY"]
-        assert prim.get("CCFRV") == 1.2345
-        assert prim.comments["CCFRV"] == "[km/s] Combined radial velocity"
+        assert prim.get("DRPVERNO") == "1.2.3"
+        assert prim.comments["DRPVERNO"] == "Pipeline version (DRP-RUN-11)"

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -92,7 +92,7 @@ class TestDiagnosticsBase:
 
         class MyDiag(Diagnostics):
             def metric(self):
-                return {"VAL": (self.kpf.value, "value")}
+                return {"VAL": (self.kpf_obj.value, "value")}
 
             metric._diag_name = "metric"
 

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -115,7 +115,7 @@ class TestDiagnosticsBase:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 / DiagL1 — currently empty placeholders
+# DiagL0 — empty placeholder; DiagL1 with no calibrations is a clean no-op
 # ---------------------------------------------------------------------------
 
 
@@ -132,7 +132,83 @@ class TestEmptyLevels:
         assert results == {}
 
     def test_diag_l1_runs_cleanly(self):
+        # No RECEIPT/INSTRUMENT_HEADER -> calibration_ages returns {} (no crash).
         results = DiagL1(self._make_obj()).run()
+        assert results == {}
+
+
+# ---------------------------------------------------------------------------
+# DiagL1 — master calibration ages
+# ---------------------------------------------------------------------------
+
+
+def _make_kpf1_with_calibrations(date_obs="2024-04-05T11:08:33", files=None):
+    """A KPF1 carrying an INSTRUMENT_HEADER DATE-OBS and RECEIPT master paths.
+
+    Mirrors the finished-L1 state DiagL1 reads: CalibrationAssociation has
+    written each ``{PREFIX}FILE`` to RECEIPT (via set_keyword) and to_kpf1 has
+    populated INSTRUMENT_HEADER.
+    """
+    l1 = KPF1()
+    l1.create_extension("INSTRUMENT_HEADER", "ImageHDU")
+    l1.headers["INSTRUMENT_HEADER"]["DATE-OBS"] = date_obs
+    for kw, path in (files or {}).items():
+        l1.set_keyword(kw, path)  # *FILE routes to RECEIPT
+    return l1
+
+
+class TestDiagL1CalibrationAges:
+    def test_signed_age_same_day(self):
+        # Master at 2024-04-05 01:00:37 UTC vs obs 11:08:33 UTC -> -0.422176 d.
+        l1 = _make_kpf1_with_calibrations(
+            files={"BIASFILE": "/m/KP.20240405.03637.74_master_bias_L1.fits"}
+        )
+        results = DiagL1(l1).run()
+        assert results["BIASAGE"][0] == pytest.approx(-0.422176, abs=1e-5)
+        # Routed to QUALITY_CONTROL with the registry comment.
+        qc = l1.headers["QUALITY_CONTROL"]
+        assert qc["BIASAGE"] == pytest.approx(-0.422176, abs=1e-5)
+        assert qc.comments["BIASAGE"] == "Master bias age [days]"
+
+    def test_signed_age_previous_day(self):
+        # Master 2024-04-04 22:00:00 UTC vs obs 2024-04-05 11:08:33 UTC.
+        l1 = _make_kpf1_with_calibrations(
+            files={"BIASFILE": "/m/KP.20240404.79200.00_master_bias_L1.fits"}
+        )
+        results = DiagL1(l1).run()
+        assert results["BIASAGE"][0] == pytest.approx(-0.547604, abs=1e-5)
+
+    def test_all_cal_types(self):
+        l1 = _make_kpf1_with_calibrations(
+            files={
+                "BIASFILE": "/m/KP.20240405.03637.74_master_bias_L1.fits",
+                "DARKFILE": "/m/KP.20240405.03637.74_master_dark_L1.fits",
+                "FLATFILE": "/m/KP.20240405.03637.74_master_flat_L1.fits",
+                "WLSFILE": "/m/KP.20240405.03637.74_master_thar_L2.fits",
+            }
+        )
+        results = DiagL1(l1).run()
+        assert set(results) == {"BIASAGE", "DARKAGE", "FLATAGE", "WLSAGE"}
+        for kw in results:
+            assert l1.headers["QUALITY_CONTROL"][kw] == pytest.approx(
+                -0.422176, abs=1e-5
+            )
+
+    def test_missing_cal_type_skipped(self):
+        # Only a bias path present -> only BIASAGE written.
+        l1 = _make_kpf1_with_calibrations(
+            files={"BIASFILE": "/m/KP.20240405.03637.74_master_bias_L1.fits"}
+        )
+        results = DiagL1(l1).run()
+        assert set(results) == {"BIASAGE"}
+        assert "DARKAGE" not in l1.headers["QUALITY_CONTROL"]
+
+    def test_no_date_obs_skips_all(self):
+        l1 = _make_kpf1_with_calibrations(
+            files={"BIASFILE": "/m/KP.20240405.03637.74_master_bias_L1.fits"}
+        )
+        del l1.headers["INSTRUMENT_HEADER"]["DATE-OBS"]
+        results = DiagL1(l1).run()
         assert results == {}
 
 

--- a/tests/regression/test_qc_booleans.py
+++ b/tests/regression/test_qc_booleans.py
@@ -281,7 +281,7 @@ class TestQCBase:
 
         class MyQC(QC):
             def check_flag(self):
-                return self.kpf.flag
+                return self.kpf_obj.flag
 
             check_flag._qc_key = "FLAG"
 

--- a/tests/regression/test_qc_booleans.py
+++ b/tests/regression/test_qc_booleans.py
@@ -15,8 +15,6 @@ All tests use synthetic in-memory data — no real KPF files required.
 import os
 import subprocess
 import sys
-import types
-import warnings
 
 import numpy as np
 import pytest
@@ -62,6 +60,16 @@ def _make_kpf0(
 
     fits.HDUList(hdus).writeto(fn, overwrite=True)
     return KPF0.from_fits(fn)
+
+
+def _seed_required_primary(kpf, qc_cls):
+    """Seed every PRIMARY keyword ``qc_cls`` requires present, skipping any already
+    set. The KWRDPR* check is presence-only, so placeholder sentinel values are
+    fine; reusing the production ``_required_primary_keywords`` avoids drift.
+    """
+    for kw in qc_cls(kpf)._required_primary_keywords():
+        if kw not in kpf.headers["PRIMARY"]:
+            kpf.headers["PRIMARY"][kw] = ("UNKNOWN", "seeded for test")
 
 
 def _make_kpf1(
@@ -120,6 +128,9 @@ def _make_kpf1(
             qc[f"RNNGGR{i}"] = (1.0, "RNNG")
             qc[f"RNNGRD{i}"] = (1.0, "RNNG")
 
+    # Seed the full required-PRIMARY set so KWRDPRL1 (presence of all 44 keywords)
+    # passes; KPF1 is not rvdata-seeded, so a synthetic L1 PRIMARY is otherwise sparse.
+    _seed_required_primary(l1, QCL1)
     return l1
 
 
@@ -179,21 +190,13 @@ class TestQCBase:
     def _make_obj(self):
         """Minimal object with a headers dict and a set_keyword router.
 
-        The QC runner now writes each result via ``set_keyword`` and validates
-        governed extensions at the end of ``run()``, reading the registry lookups
-        off the model (``self.kpf.keyword_registry``). This fake stores every
-        keyword on QUALITY_CONTROL (value only) and exposes empty ``extensions``
-        plus a registry stub with empty lookups so ``_validate_headers`` is a
-        no-op (LEVEL=None skips PRIMARY; no governed extensions to check).
+        QC.run() writes each result via ``set_keyword`` and aggregates ISGOOD; it
+        does NOT validate headers (that moved to the checkpoints layer). This fake
+        stores every keyword on QUALITY_CONTROL (value only).
         """
 
         class _FakeObj:
-            extensions = {}
             headers = {"PRIMARY": {}, "QUALITY_CONTROL": {}}
-            data = {}
-            keyword_registry = types.SimpleNamespace(
-                allowed={}, required={}, structural=set()
-            )
 
             def set_keyword(self, key, value):
                 self.headers["QUALITY_CONTROL"][key] = value
@@ -430,6 +433,30 @@ class TestQCL0:
 
 
 class TestQCL1:
+    def test_data_present_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        assert QCL1(l1).data_present() is True
+
+    def test_data_present_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        l1.data["GREEN_CCD"] = None
+        assert QCL1(l1).data_present() is False
+
+    def test_data_present_fail_empty(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        l1.data["RED_CCD"] = np.array([], dtype=np.float32)
+        assert QCL1(l1).data_present() is False
+
+    def test_required_keywords_present_pass(self, tmp_path):
+        # _make_kpf1 seeds the full required-PRIMARY set.
+        l1 = _make_kpf1(tmp_path)
+        assert QCL1(l1).required_keywords_present() is True
+
+    def test_required_keywords_present_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path)
+        del l1.headers["PRIMARY"]["INSTRUME"]  # a registry-required PRIMARY keyword
+        assert QCL1(l1).required_keywords_present() is False
+
     def test_read_noise_in_range_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, with_rn=True)
         assert QCL1(l1).read_noise_in_range() is True
@@ -579,6 +606,8 @@ class TestQCL1:
 
     def test_qc_keys_correct(self):
         expected = {
+            "data_present": "DATAPRL1",
+            "required_keywords_present": "KWRDPRL1",
             "read_noise_in_range": "RNINRNG",
             "read_noise_nongauss": "RNGAUSS",
             "overscan_subtracted": "OSCANSUB",
@@ -613,7 +642,16 @@ class TestQCL1Run:
         # QC flags route to their registry home: the read-noise / age / finite
         # checks land in QUALITY_CONTROL; the applied-step flags reuse the
         # RECEIPT keyword names and so route to RECEIPT.
-        qc_keys = ["RNINRNG", "RNGAUSS", "BIASAGEQ", "DARKAGEQ", "FLATAGEQ", "FFIFIN"]
+        qc_keys = [
+            "DATAPRL1",
+            "KWRDPRL1",
+            "RNINRNG",
+            "RNGAUSS",
+            "BIASAGEQ",
+            "DARKAGEQ",
+            "FLATAGEQ",
+            "FFIFIN",
+        ]
         receipt_keys = ["OSCANSUB", "BIASSUB", "DARKSUB", "FLATDIV"]
         for k in qc_keys:
             v = l1.headers["QUALITY_CONTROL"].get(k)
@@ -644,6 +682,19 @@ class TestQCL2:
     def test_extraction_present_pass(self):
         kpf2 = _make_kpf2_with_flux()
         assert QCL2(kpf2).extraction_present() is True
+
+    def test_required_keywords_present_pass(self):
+        # Fresh KPF2 is rvdata-seeded with the EPRV-required PRIMARY keywords; seed
+        # the KPF provenance cards too so all 44 are present.
+        kpf2 = _make_kpf2_with_flux()
+        _seed_required_primary(kpf2, QCL2)
+        assert QCL2(kpf2).required_keywords_present() is True
+
+    def test_required_keywords_present_fail_missing(self):
+        kpf2 = _make_kpf2_with_flux()
+        _seed_required_primary(kpf2, QCL2)
+        del kpf2.headers["PRIMARY"]["INSTRUME"]
+        assert QCL2(kpf2).required_keywords_present() is False
 
     def test_extraction_present_fail_empty_kpf2(self):
         """A freshly constructed KPF2 with no flux data → all chip-prefix sizes=0."""
@@ -751,6 +802,7 @@ class TestQCL2:
     def test_qc_keys_correct(self):
         expected = {
             "extraction_present": "DATAPRL2",
+            "required_keywords_present": "KWRDPRL2",
             "flux_finite_fraction": "L2NANOK",
             "nonzero_flux": "L2FLXOK",
             "variance_positive": "L2VARPOS",
@@ -861,47 +913,3 @@ class TestQCScript:
             text=True,
         )
         assert result.returncode != 0
-
-
-class TestValidateHeaders:
-    """QC._validate_headers raises on an unexpected card, warns on missing required.
-
-    The validator reads its reference sets off the kpf_obj (self.kpf.*); these
-    exercise it via the QCL2 runner on a fresh KPF2.
-    """
-
-    def test_clean_product_passes(self):
-        # A fresh KPF2 has RV2-seeded EPRV PRIMARY defaults (all required present)
-        # and empty governed extensions -> no unexpected card, no missing required.
-        l2 = KPF2()
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")  # any warning would fail this
-            QCL2(l2)._validate_headers()
-
-    def test_unexpected_keyword_on_governed_extension_raises(self):
-        l2 = KPF2()
-        l2.headers["QUALITY_CONTROL"]["BOGUSKEY"] = (1, "not registered")
-        with pytest.raises(ValueError, match="unregistered keyword 'BOGUSKEY'"):
-            QCL2(l2)._validate_headers()
-
-    def test_native_wmko_leak_on_primary_raises(self):
-        l2 = KPF2()
-        # GAIAID is a raw WMKO native (kept in INSTRUMENT_HEADER, never on PRIMARY).
-        # It is not a registered PRIMARY keyword, so it fails the general
-        # unregistered-keyword check (no dedicated WMKO-leak branch needed).
-        l2.headers["PRIMARY"]["GAIAID"] = (12345, "leaked native")
-        with pytest.raises(ValueError, match="unregistered keyword 'GAIAID'"):
-            QCL2(l2)._validate_headers()
-
-    def test_missing_required_primary_keyword_warns(self):
-        l2 = KPF2()
-        del l2.headers["PRIMARY"]["INSTRUME"]  # a Required EPRV PRIMARY keyword
-        with pytest.warns(UserWarning, match="missing required keyword"):
-            QCL2(l2)._validate_headers()
-
-    def test_registered_keyword_on_its_extension_passes(self):
-        l2 = KPF2()
-        l2.set_keyword("NANSCI1", 3)  # registered -> QUALITY_CONTROL
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            QCL2(l2)._validate_headers()

--- a/tests/regression/test_qc_booleans.py
+++ b/tests/regression/test_qc_booleans.py
@@ -15,6 +15,7 @@ All tests use synthetic in-memory data — no real KPF files required.
 import os
 import subprocess
 import sys
+import types
 
 import numpy as np
 import pytest
@@ -191,12 +192,15 @@ class TestQCBase:
         """Minimal object with a headers dict and a set_keyword router.
 
         QC.run() writes each result via ``set_keyword`` and aggregates ISGOOD; it
-        does NOT validate headers (that moved to the checkpoints layer). This fake
-        stores every keyword on QUALITY_CONTROL (value only).
+        does NOT validate headers (that moved to the checkpoints layer). It also
+        reads each check's comment off ``keyword_registry.routing``; these synthetic
+        check keys aren't registered, so the stubbed routing is empty (comment "").
+        This fake stores every keyword on QUALITY_CONTROL (value only).
         """
 
         class _FakeObj:
             headers = {"PRIMARY": {}, "QUALITY_CONTROL": {}}
+            keyword_registry = types.SimpleNamespace(routing={})
 
             def set_keyword(self, key, value):
                 self.headers["QUALITY_CONTROL"][key] = value
@@ -211,20 +215,18 @@ class TestQCBase:
                 return True
 
             check_a._qc_key = "CHECKA"
-            check_a._qc_comment = "check a"
 
             def check_b(self):
                 return True
 
             check_b._qc_key = "CHECKB"
-            check_b._qc_comment = "check b"
 
         results = MyQC(obj).run()
         assert obj.headers["QUALITY_CONTROL"]["ISGOOD"] == 1
         assert obj.headers["QUALITY_CONTROL"]["CHECKA"] == 1
         assert obj.headers["QUALITY_CONTROL"]["CHECKB"] == 1
-        assert results["CHECKA"] == (True, "check a")
-        assert results["CHECKB"] == (True, "check b")
+        assert results["CHECKA"][0] is True
+        assert results["CHECKB"][0] is True
 
     def test_one_failing_isgood_0(self):
         obj = self._make_obj()
@@ -234,13 +236,11 @@ class TestQCBase:
                 return True
 
             check_ok._qc_key = "CHKOK"
-            check_ok._qc_comment = "passes"
 
             def check_fail(self):
                 return False
 
             check_fail._qc_key = "CHKFAIL"
-            check_fail._qc_comment = "fails"
 
         MyQC(obj).run()
         assert obj.headers["QUALITY_CONTROL"]["ISGOOD"] == 0
@@ -255,7 +255,6 @@ class TestQCBase:
                 raise ValueError("boom!")
 
             check_boom._qc_key = "BOOM"
-            check_boom._qc_comment = "raises"
 
         with pytest.raises(RuntimeError, match="QC check 'check_boom' raised"):
             MyQC(obj).run()
@@ -285,17 +284,18 @@ class TestQCBase:
                 return self.kpf.flag
 
             check_flag._qc_key = "FLAG"
-            check_flag._qc_comment = "flag check"
 
         qc = MyQC(obj)
         qc.run()
         assert obj.headers["QUALITY_CONTROL"]["ISGOOD"] == 0
-        assert qc.results == {"FLAG": (False, "flag check")}
+        assert list(qc.results) == ["FLAG"]
+        assert qc.results["FLAG"][0] is False
 
         obj.flag = True
         qc.run()
         assert obj.headers["QUALITY_CONTROL"]["ISGOOD"] == 1
-        assert qc.results == {"FLAG": (True, "flag check")}
+        assert list(qc.results) == ["FLAG"]
+        assert qc.results["FLAG"][0] is True
 
 
 # ---------------------------------------------------------------------------
@@ -424,7 +424,8 @@ class TestQCL0:
     def test_dataprl0_key_and_comment(self):
         fn = QCL0.__dict__["data_l0_red_green"]
         assert fn._qc_key == "DATAPRL0"
-        assert "GREEN" in fn._qc_comment
+        # The comment now lives in the registry Description (not on the method).
+        assert "GREEN" in KPF0.keyword_registry.routing["DATAPRL0"][1]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -462,14 +462,9 @@ class TestQCL1:
         l1 = _make_kpf1(tmp_path, with_rn=True)
         assert QCL1(l1).read_noise_ok() is True
 
-    def test_read_noise_ok_fail_rn_too_high(self, tmp_path):
+    def test_read_noise_ok_fail_too_high(self, tmp_path):
         l1 = _make_kpf1(tmp_path, with_rn=True)
         l1.headers["QUALITY_CONTROL"]["RNGREEN1"] = (99.0, "bad RN")
-        assert QCL1(l1).read_noise_ok() is False
-
-    def test_read_noise_ok_fail_nongauss_too_high(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, with_rn=True)
-        l1.headers["QUALITY_CONTROL"]["RNNGGR1"] = (9.9, "bad RNNG")
         assert QCL1(l1).read_noise_ok() is False
 
     def test_read_noise_ok_fail_missing(self, tmp_path):
@@ -477,15 +472,33 @@ class TestQCL1:
         assert QCL1(l1).read_noise_ok() is False
 
     def test_read_noise_ok_pass_2amp(self, tmp_path):
-        # 2-amp readout: only AMP1/AMP2 keys present (AMP3/4 absent), for both
-        # the Gaussian (RN*) and non-Gaussian (RNNG*) families.
+        # 2-amp readout: only AMP1/AMP2 keys present (AMP3/4 absent).
         l1 = _make_kpf1(tmp_path, with_rn=True)
         for i in (3, 4):
             del l1.headers["QUALITY_CONTROL"][f"RNGREEN{i}"]
             del l1.headers["QUALITY_CONTROL"][f"RNRED{i}"]
+        assert QCL1(l1).read_noise_ok() is True
+
+    def test_read_noise_nongauss_ok_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, with_rn=True)
+        assert QCL1(l1).read_noise_nongauss_ok() is True
+
+    def test_read_noise_nongauss_ok_fail_too_high(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, with_rn=True)
+        l1.headers["QUALITY_CONTROL"]["RNNGGR1"] = (9.9, "bad RNNG")
+        assert QCL1(l1).read_noise_nongauss_ok() is False
+
+    def test_read_noise_nongauss_ok_fail_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, with_rn=False)
+        assert QCL1(l1).read_noise_nongauss_ok() is False
+
+    def test_read_noise_nongauss_ok_pass_2amp(self, tmp_path):
+        # 2-amp readout: only AMP1/AMP2 keys present (AMP3/4 absent).
+        l1 = _make_kpf1(tmp_path, with_rn=True)
+        for i in (3, 4):
             del l1.headers["QUALITY_CONTROL"][f"RNNGGR{i}"]
             del l1.headers["QUALITY_CONTROL"][f"RNNGRD{i}"]
-        assert QCL1(l1).read_noise_ok() is True
+        assert QCL1(l1).read_noise_nongauss_ok() is True
 
     def test_overscan_subtracted_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, oscansub=True)
@@ -575,6 +588,7 @@ class TestQCL1:
             "data_present": "DATAPRL1",
             "required_keywords_present": "KWRDPRL1",
             "read_noise_ok": "RNOK",
+            "read_noise_nongauss_ok": "RNNGOK",
             "overscan_subtracted": "OSCANSUB",
             "bias_ok": "BIASOK",
             "dark_ok": "DARKOK",
@@ -610,6 +624,7 @@ class TestQCL1Run:
             "DATAPRL1",
             "KWRDPRL1",
             "RNOK",
+            "RNNGOK",
             "BIASOK",
             "DARKOK",
             "FLATOK",

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -458,47 +458,34 @@ class TestQCL1:
         del l1.headers["PRIMARY"]["INSTRUME"]  # a registry-required PRIMARY keyword
         assert QCL1(l1).required_keywords_present() is False
 
-    def test_read_noise_in_range_pass(self, tmp_path):
+    def test_read_noise_ok_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, with_rn=True)
-        assert QCL1(l1).read_noise_in_range() is True
+        assert QCL1(l1).read_noise_ok() is True
 
-    def test_read_noise_in_range_fail_too_high(self, tmp_path):
+    def test_read_noise_ok_fail_rn_too_high(self, tmp_path):
         l1 = _make_kpf1(tmp_path, with_rn=True)
         l1.headers["QUALITY_CONTROL"]["RNGREEN1"] = (99.0, "bad RN")
-        assert QCL1(l1).read_noise_in_range() is False
+        assert QCL1(l1).read_noise_ok() is False
 
-    def test_read_noise_in_range_fail_missing(self, tmp_path):
+    def test_read_noise_ok_fail_nongauss_too_high(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, with_rn=True)
+        l1.headers["QUALITY_CONTROL"]["RNNGGR1"] = (9.9, "bad RNNG")
+        assert QCL1(l1).read_noise_ok() is False
+
+    def test_read_noise_ok_fail_missing(self, tmp_path):
         l1 = _make_kpf1(tmp_path, with_rn=False)
-        assert QCL1(l1).read_noise_in_range() is False
+        assert QCL1(l1).read_noise_ok() is False
 
-    def test_read_noise_in_range_pass_2amp(self, tmp_path):
-        # 2-amp readout: only AMP1/AMP2 keys present (AMP3/4 absent).
+    def test_read_noise_ok_pass_2amp(self, tmp_path):
+        # 2-amp readout: only AMP1/AMP2 keys present (AMP3/4 absent), for both
+        # the Gaussian (RN*) and non-Gaussian (RNNG*) families.
         l1 = _make_kpf1(tmp_path, with_rn=True)
         for i in (3, 4):
             del l1.headers["QUALITY_CONTROL"][f"RNGREEN{i}"]
             del l1.headers["QUALITY_CONTROL"][f"RNRED{i}"]
-        assert QCL1(l1).read_noise_in_range() is True
-
-    def test_read_noise_nongauss_pass(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, with_rn=True)
-        assert QCL1(l1).read_noise_nongauss() is True
-
-    def test_read_noise_nongauss_fail_too_high(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, with_rn=True)
-        l1.headers["QUALITY_CONTROL"]["RNNGGR1"] = (9.9, "bad RNNG")
-        assert QCL1(l1).read_noise_nongauss() is False
-
-    def test_read_noise_nongauss_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, with_rn=False)
-        assert QCL1(l1).read_noise_nongauss() is False
-
-    def test_read_noise_nongauss_pass_2amp(self, tmp_path):
-        # 2-amp readout: only AMP1/AMP2 keys present (AMP3/4 absent).
-        l1 = _make_kpf1(tmp_path, with_rn=True)
-        for i in (3, 4):
             del l1.headers["QUALITY_CONTROL"][f"RNNGGR{i}"]
             del l1.headers["QUALITY_CONTROL"][f"RNNGRD{i}"]
-        assert QCL1(l1).read_noise_nongauss() is True
+        assert QCL1(l1).read_noise_ok() is True
 
     def test_overscan_subtracted_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, oscansub=True)
@@ -513,83 +500,61 @@ class TestQCL1:
         del l1.headers["RECEIPT"]["OSCANSUB"]
         assert QCL1(l1).overscan_subtracted() is False
 
-    def test_bias_subtracted_pass(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, biassub=True)
-        assert QCL1(l1).bias_subtracted() is True
+    def test_bias_ok_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, biassub=True, agebias=3.0)
+        assert QCL1(l1).bias_ok() is True
 
-    def test_bias_subtracted_fail_false(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, biassub=False)
-        assert QCL1(l1).bias_subtracted() is False
+    def test_bias_ok_fail_not_subtracted(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, biassub=False, agebias=3.0)
+        assert QCL1(l1).bias_ok() is False
 
-    def test_bias_subtracted_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path)
-        del l1.headers["RECEIPT"]["BIASSUB"]
-        assert QCL1(l1).bias_subtracted() is False
-
-    def test_dark_subtracted_pass(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, darksub=True)
-        assert QCL1(l1).dark_subtracted() is True
-
-    def test_dark_subtracted_fail_false(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, darksub=False)
-        assert QCL1(l1).dark_subtracted() is False
-
-    def test_dark_subtracted_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path)
-        del l1.headers["RECEIPT"]["DARKSUB"]
-        assert QCL1(l1).dark_subtracted() is False
-
-    def test_flat_divided_pass(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, flatdiv=True)
-        assert QCL1(l1).flat_divided() is True
-
-    def test_flat_divided_fail_false(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, flatdiv=False)
-        assert QCL1(l1).flat_divided() is False
-
-    def test_flat_divided_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path)
-        del l1.headers["RECEIPT"]["FLATDIV"]
-        assert QCL1(l1).flat_divided() is False
-
-    def test_bias_age_ok_pass(self, tmp_path):
+    def test_bias_ok_fail_subtract_flag_missing(self, tmp_path):
         l1 = _make_kpf1(tmp_path, agebias=3.0)
-        assert QCL1(l1).bias_age_ok() is True
+        del l1.headers["RECEIPT"]["BIASSUB"]
+        assert QCL1(l1).bias_ok() is False
 
-    def test_bias_age_ok_fail_too_old(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, agebias=10.0)
-        assert QCL1(l1).bias_age_ok() is False
+    def test_bias_ok_fail_too_old(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, biassub=True, agebias=10.0)
+        assert QCL1(l1).bias_ok() is False
 
-    def test_bias_age_ok_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path)
+    def test_bias_ok_fail_age_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, biassub=True)
         del l1.headers["QUALITY_CONTROL"]["BIASAGE"]
-        assert QCL1(l1).bias_age_ok() is False
+        assert QCL1(l1).bias_ok() is False
 
-    def test_dark_age_ok_pass(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, agedark=7.0)
-        assert QCL1(l1).dark_age_ok() is True
+    def test_dark_ok_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=True, agedark=7.0)
+        assert QCL1(l1).dark_ok() is True
 
-    def test_dark_age_ok_fail_too_old(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, agedark=20.0)
-        assert QCL1(l1).dark_age_ok() is False
+    def test_dark_ok_fail_not_subtracted(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=False, agedark=7.0)
+        assert QCL1(l1).dark_ok() is False
 
-    def test_dark_age_ok_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path)
+    def test_dark_ok_fail_too_old(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=True, agedark=20.0)
+        assert QCL1(l1).dark_ok() is False
+
+    def test_dark_ok_fail_age_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, darksub=True)
         del l1.headers["QUALITY_CONTROL"]["DARKAGE"]
-        assert QCL1(l1).dark_age_ok() is False
+        assert QCL1(l1).dark_ok() is False
 
-    def test_flat_age_ok_pass(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, ageflat=15.0)
-        assert QCL1(l1).flat_age_ok() is True
+    def test_flat_ok_pass(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=True, ageflat=15.0)
+        assert QCL1(l1).flat_ok() is True
 
-    def test_flat_age_ok_fail_too_old(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, ageflat=45.0)
-        assert QCL1(l1).flat_age_ok() is False
+    def test_flat_ok_fail_not_divided(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=False, ageflat=15.0)
+        assert QCL1(l1).flat_ok() is False
 
-    def test_flat_age_ok_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path)
+    def test_flat_ok_fail_too_old(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=True, ageflat=45.0)
+        assert QCL1(l1).flat_ok() is False
+
+    def test_flat_ok_fail_age_missing(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, flatdiv=True)
         del l1.headers["QUALITY_CONTROL"]["FLATAGE"]
-        assert QCL1(l1).flat_age_ok() is False
+        assert QCL1(l1).flat_ok() is False
 
     def test_ffi_finite_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, finite_ccd=True)
@@ -609,16 +574,12 @@ class TestQCL1:
         expected = {
             "data_present": "DATAPRL1",
             "required_keywords_present": "KWRDPRL1",
-            "read_noise_in_range": "RNINRNG",
-            "read_noise_nongauss": "RNGAUSS",
+            "read_noise_ok": "RNOK",
             "overscan_subtracted": "OSCANSUB",
-            "bias_subtracted": "BIASSUB",
-            "bias_age_ok": "BIASAGEQ",
-            "dark_subtracted": "DARKSUB",
-            "dark_age_ok": "DARKAGEQ",
-            "flat_divided": "FLATDIV",
-            "flat_age_ok": "FLATAGEQ",
-            "ffi_finite": "FFIFIN",
+            "bias_ok": "BIASOK",
+            "dark_ok": "DARKOK",
+            "flat_ok": "FLATOK",
+            "ffi_finite": "FFIOK",
         }
         for method_name, key in expected.items():
             fn = QCL1.__dict__[method_name]
@@ -640,20 +601,21 @@ class TestQCL1Run:
         isgood = l1.headers["QUALITY_CONTROL"].get("ISGOOD")
         assert isgood == 1
 
-        # QC flags route to their registry home: the read-noise / age / finite
-        # checks land in QUALITY_CONTROL; the applied-step flags reuse the
-        # RECEIPT keyword names and so route to RECEIPT.
+        # QC flags route to their registry home. All L1 QC flags now land on
+        # QUALITY_CONTROL, except overscan_subtracted, which reuses the RECEIPT
+        # OSCANSUB keyword name and so routes to RECEIPT. The per-calibration
+        # OK flags (BIASOK/DARKOK/FLATOK) read RECEIPT *SUB / DiagL1 *AGE but are
+        # themselves QUALITY_CONTROL keywords.
         qc_keys = [
             "DATAPRL1",
             "KWRDPRL1",
-            "RNINRNG",
-            "RNGAUSS",
-            "BIASAGEQ",
-            "DARKAGEQ",
-            "FLATAGEQ",
-            "FFIFIN",
+            "RNOK",
+            "BIASOK",
+            "DARKOK",
+            "FLATOK",
+            "FFIOK",
         ]
-        receipt_keys = ["OSCANSUB", "BIASSUB", "DARKSUB", "FLATDIV"]
+        receipt_keys = ["OSCANSUB"]
         for k in qc_keys:
             v = l1.headers["QUALITY_CONTROL"].get(k)
             assert v == 1, f"{k} should be 1 but is {v}"
@@ -669,9 +631,9 @@ class TestQCL1Run:
         isgood = l1.headers["QUALITY_CONTROL"].get("ISGOOD")
         assert isgood == 0
 
-        # BIASSUB reuses the RECEIPT keyword name, so the QC flag routes there.
-        biassub = l1.headers["RECEIPT"].get("BIASSUB")
-        assert biassub == 0
+        # Bias not subtracted -> BIASOK fails (a QUALITY_CONTROL flag); the
+        # RECEIPT BIASSUB provenance keyword is untouched by QC.
+        assert l1.headers["QUALITY_CONTROL"].get("BIASOK") == 0
 
 
 # ---------------------------------------------------------------------------
@@ -758,7 +720,7 @@ class TestQCL2:
         kpf2 = _make_kpf2_with_flux(zero_frac=0.5)
         assert QCL2(kpf2).nonzero_flux() is False
 
-    # --- variance_positive (L2VARPOS) ---
+    # --- variance_positive (L2VAROK) ---
 
     def test_variance_positive_pass(self):
         kpf2 = _make_kpf2_with_flux()
@@ -806,7 +768,7 @@ class TestQCL2:
             "required_keywords_present": "KWRDPRL2",
             "flux_finite_fraction": "L2NANOK",
             "nonzero_flux": "L2FLXOK",
-            "variance_positive": "L2VARPOS",
+            "variance_positive": "L2VAROK",
             "science_snr": "L2SNROK",
         }
         for method_name, key in expected.items():

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -25,10 +25,10 @@ from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
-from kpfpipe.quality_control.qc_booleans.base import QC
-from kpfpipe.quality_control.qc_booleans.level0 import QCL0
-from kpfpipe.quality_control.qc_booleans.level1 import QCL1
-from kpfpipe.quality_control.qc_booleans.level2 import QCL2
+from kpfpipe.quality_control.qc_flags.base import QC
+from kpfpipe.quality_control.qc_flags.level0 import QCL0
+from kpfpipe.quality_control.qc_flags.level1 import QCL1
+from kpfpipe.quality_control.qc_flags.level2 import QCL2
 
 _NORDER = {"GREEN": DETECTOR["norder"]["GREEN"], "RED": DETECTOR["norder"]["RED"]}
 _NCOLS = 10  # small column count for fast tests
@@ -356,7 +356,7 @@ class TestQCL0:
 
     def test_not_junk_pass_no_file(self, tmp_path, monkeypatch):
         """No junk CSV → pass by default."""
-        import kpfpipe.quality_control.qc_booleans.level0 as mod
+        import kpfpipe.quality_control.qc_flags.level0 as mod
 
         monkeypatch.setattr(
             mod, "_JUNK_CSV", tmp_path / "reference" / "junk_observations.csv"
@@ -367,7 +367,7 @@ class TestQCL0:
     def test_not_junk_pass_not_in_list(self, tmp_path, monkeypatch):
         import pandas as pd
 
-        import kpfpipe.quality_control.qc_booleans.level0 as mod
+        import kpfpipe.quality_control.qc_flags.level0 as mod
 
         csv_path = tmp_path / "junk_observations.csv"
         pd.DataFrame({"obs_id": ["KP.20240101.99999.00"]}).to_csv(csv_path, index=False)
@@ -379,7 +379,7 @@ class TestQCL0:
     def test_not_junk_fail_in_list(self, tmp_path, monkeypatch):
         import pandas as pd
 
-        import kpfpipe.quality_control.qc_booleans.level0 as mod
+        import kpfpipe.quality_control.qc_flags.level0 as mod
 
         obs_id = "KP.20240405.00001.00"
         csv_path = tmp_path / "junk_observations.csv"
@@ -393,7 +393,7 @@ class TestQCL0:
         """obs_id=None → passes (can't be in junk list)."""
         import pandas as pd
 
-        import kpfpipe.quality_control.qc_booleans.level0 as mod
+        import kpfpipe.quality_control.qc_flags.level0 as mod
 
         csv_path = tmp_path / "junk_observations.csv"
         pd.DataFrame({"obs_id": ["KP.20240405.00001.00"]}).to_csv(csv_path, index=False)
@@ -407,7 +407,7 @@ class TestQCL0:
         """CSV without 'obs_id' column → raises ValueError."""
         import pandas as pd
 
-        import kpfpipe.quality_control.qc_booleans.level0 as mod
+        import kpfpipe.quality_control.qc_flags.level0 as mod
 
         csv_path = tmp_path / "junk_observations.csv"
         pd.DataFrame({"wrong_col": ["whatever"]}).to_csv(csv_path, index=False)

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -500,19 +500,6 @@ class TestQCL1:
             del l1.headers["QUALITY_CONTROL"][f"RNNGRD{i}"]
         assert QCL1(l1).read_noise_nongauss_ok() is True
 
-    def test_overscan_subtracted_pass(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, oscansub=True)
-        assert QCL1(l1).overscan_subtracted() is True
-
-    def test_overscan_subtracted_fail_false(self, tmp_path):
-        l1 = _make_kpf1(tmp_path, oscansub=False)
-        assert QCL1(l1).overscan_subtracted() is False
-
-    def test_overscan_subtracted_fail_missing(self, tmp_path):
-        l1 = _make_kpf1(tmp_path)
-        del l1.headers["RECEIPT"]["OSCANSUB"]
-        assert QCL1(l1).overscan_subtracted() is False
-
     def test_bias_ok_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, biassub=True, agebias=3.0)
         assert QCL1(l1).bias_ok() is True
@@ -589,7 +576,6 @@ class TestQCL1:
             "required_keywords_present": "KWRDPRL1",
             "read_noise_ok": "RNOK",
             "read_noise_nongauss_ok": "RNNGOK",
-            "overscan_subtracted": "OSCANSUB",
             "bias_ok": "BIASOK",
             "dark_ok": "DARKOK",
             "flat_ok": "FLATOK",
@@ -615,11 +601,11 @@ class TestQCL1Run:
         isgood = l1.headers["QUALITY_CONTROL"].get("ISGOOD")
         assert isgood == 1
 
-        # QC flags route to their registry home. All L1 QC flags now land on
-        # QUALITY_CONTROL, except overscan_subtracted, which reuses the RECEIPT
-        # OSCANSUB keyword name and so routes to RECEIPT. The per-calibration
-        # OK flags (BIASOK/DARKOK/FLATOK) read RECEIPT *SUB / DiagL1 *AGE but are
-        # themselves QUALITY_CONTROL keywords.
+        # Every L1 QC flag lands on QUALITY_CONTROL. The per-calibration OK flags
+        # (BIASOK/DARKOK/FLATOK) read the RECEIPT *SUB flags and DiagL1 *AGE
+        # values but are themselves QUALITY_CONTROL keywords. The applied-step
+        # flags (OSCANSUB/BIASSUB/DARKSUB/FLATDIV) stay RECEIPT-only provenance
+        # and are not QC checks.
         qc_keys = [
             "DATAPRL1",
             "KWRDPRL1",
@@ -630,13 +616,8 @@ class TestQCL1Run:
             "FLATOK",
             "FFIOK",
         ]
-        receipt_keys = ["OSCANSUB"]
         for k in qc_keys:
             v = l1.headers["QUALITY_CONTROL"].get(k)
-            assert v == 1, f"{k} should be 1 but is {v}"
-            assert k in results
-        for k in receipt_keys:
-            v = l1.headers["RECEIPT"].get(k)
             assert v == 1, f"{k} should be 1 but is {v}"
             assert k in results
 

--- a/tests/regression/test_quicklook_l0.py
+++ b/tests/regression/test_quicklook_l0.py
@@ -107,7 +107,7 @@ class TestPlotL0Constructor:
         from kpfpipe.quality_control.quicklook.level0 import PlotL0
 
         qlp = PlotL0(synthetic_4amp_l0)
-        assert qlp.l0 is synthetic_4amp_l0
+        assert qlp.l0_obj is synthetic_4amp_l0
         assert qlp.obs_id == "KP.20240405.00001.00"
         assert qlp.name == "synthetic-4amp"
         assert qlp.output_dir is None

--- a/tests/regression/test_quicklook_l1.py
+++ b/tests/regression/test_quicklook_l1.py
@@ -90,7 +90,7 @@ class TestPlotL1Constructor:
         from kpfpipe.quality_control.quicklook.level1 import PlotL1
 
         qlp = PlotL1(synthetic_l1)
-        assert qlp.l1 is synthetic_l1
+        assert qlp.l1_obj is synthetic_l1
         assert qlp.obs_id == "KP.20240405.00001.00"
         assert qlp.name == "synthetic-l1"
         assert qlp.output_dir is None

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -743,21 +743,21 @@ class TestPerform:
         assert rv_hdr["CCD1RV2"] == pytest.approx(_V_INJECT, abs=0.1)
         assert rv_hdr["CCD2RV2"] == pytest.approx(_V_INJECT, abs=0.1)
         assert rv_hdr["CCD1ERV2"] > 0 and rv_hdr["CCD2ERV2"] > 0
-        # The per-orderlet keywords do not leak onto PRIMARY (only the
-        # SCI-combined CCD<n>RV/CCFRV do).
+        # The per-orderlet keywords do not leak onto PRIMARY; they live on the RV#
+        # tables (the SCI-combined CCD<n>RV/CCFRV land on RV3).
         assert "CCD1RV2" not in l4.headers["PRIMARY"]
 
-    def test_primary_combined_rv_populated(self, rv_module):
-        # The science combine: SCI-combined CCD1RV/CCD2RV and CCFRV/CCFERV on
-        # PRIMARY (registered KPF keywords) alongside the EPRV RV/RVERR. RV ~
-        # injected value.
+    def test_combined_rv_populated(self, rv_module):
+        # The science combine: SCI-combined CCD1RV/CCD2RV and CCFRV/CCFERV on the
+        # RV3 table (registered KPF keywords), alongside the EPRV RV/RVERR on
+        # PRIMARY. RV ~ injected value.
         l4 = rv_module.perform()
-        inst = l4.headers["PRIMARY"]
-        assert inst["CCD1RV"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert inst["CCD2RV"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert inst["CCD1ERV"] > 0 and inst["CCD2ERV"] > 0
-        assert inst["CCFRV"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert inst["CCFERV"] > 0
+        rv3 = l4.headers["RV3"]
+        assert rv3["CCD1RV"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert rv3["CCD2RV"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert rv3["CCD1ERV"] > 0 and rv3["CCD2ERV"] > 0
+        assert rv3["CCFRV"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert rv3["CCFERV"] > 0
 
         prim = l4.headers["PRIMARY"]
         assert prim["RV"] == pytest.approx(_V_INJECT, abs=0.1)
@@ -769,7 +769,7 @@ class TestPerform:
         # CCFRV = (CCD1RV*Wg + CCD2RV*Wr)/(Wg+Wr), Wg/Wr the summed order weights;
         # CCFERV = inverse-variance combination of the per-CCD errors.
         l4 = rv_module.perform()
-        inst = l4.headers["PRIMARY"]
+        inst = l4.headers["RV3"]
         wg = np.nansum(rv_module._get_order_weights("GREEN", "SCI1"))
         wr = np.nansum(rv_module._get_order_weights("RED", "SCI1"))
         expect_rv = (inst["CCD1RV"] * wg + inst["CCD2RV"] * wr) / (wg + wr)
@@ -814,7 +814,7 @@ class TestPerform:
     def test_single_chip_combine_warns(self, rv_module, capsys):
         # One chip present: CCFRV uses it alone (== CCD1RV) and a warning prints.
         l4 = rv_module.perform(chips=["GREEN"])
-        inst = l4.headers["PRIMARY"]
+        inst = l4.headers["RV3"]
         assert inst["CCFRV"] == pytest.approx(inst["CCD1RV"], abs=1e-9)
         assert "only chip GREEN present" in capsys.readouterr().out
 


### PR DESCRIPTION
  ## Summary

  Cleans up the `quality_control` suite on top of the recent headers-handling
  refactor. Establishes a strict, single-responsibility pipeline order —
  **science modules → Diagnostics → QC → Checkpoints** — and consolidates the
  L1 QC flag set into higher-level pass/fail booleans while keeping the
  underlying provenance distinct on RECEIPT / QUALITY_CONTROL.

  ## Changes

  ### New Checkpoints layer (header/flag validation out of QC)
  - Adds `kpfpipe/quality_control/checkpoints/` (`Checkpoint` base + `CheckpointL0/1/2`),
    mirroring the Diagnostics/QC per-level class shape.
  - QC now writes **only** 0/1 flags including `ISGOOD` aggregate; the unregistered-keyword structural
    scan and the flag→severity (warn/raise) policy move to Checkpoints. Per-level
    `RAISE_FLAGS` decides which failed flags raise vs warn (`DATAPR*` raises;
    everything else warns).
  - Recipe + `scripts/qc.py` run the new `Checkpoint*` stage after QC.

  ### QC flag consolidation (L1)
  - Merge each applied-flag + age pair into one QUALITY_CONTROL flag:
    `BIASSUB`/`BIASAGEQ` → **`BIASOK`** (subtracted AND age ≤ 7 d),
    `DARKSUB`/`DARKAGEQ` → **`DARKOK`** (≤ 14 d),
    `FLATDIV`/`FLATAGEQ` → **`FLATOK`** (≤ 30 d). RECEIPT applied-flags
    (written by ImageProcessing) and DiagL1 ages stay as distinct provenance.
  - Read-noise checks: split into **`RNOK`** (per-amp RN in [2.0, 6.0] e⁻) and
    **`RNNGOK`** (non-Gaussian RN, MAD/STD, in [0.8, 1.5]).
  - Renames: `FFIFIN` → **`FFIOK`**, `L2VARPOS` → **`L2VAROK`**.

  ### Calibration ages → DiagL1
  - Move master-age computation out of `CalibrationAssociation` into a new
    `DiagL1.calibration_ages` diagnostic; the association module now writes only
    the master paths (`{PREFIX}FILE` → RECEIPT). DiagL1 recomputes the signed
    `(master − obs)` age from that path plus `INSTRUMENT_HEADER` `DATE-OBS`; the
    ages still land on QUALITY_CONTROL.

  ### Header routing / RV
  - Route SCI-combined RVs (`CCD1RV`/`CCD2RV`/`CCFRV`/`*ERV`) to **RV3** instead of
    PRIMARY; update tests + docs.

  ### Plumbing / conventions
  - Rename package `qc_booleans` → **`qc_flags`** (+ test file).
  - Source QC comments from the keyword registry; drop the redundant `_qc_comment`
    attributes.
  - Name KPF data-model attributes with the `_obj` suffix (`self.kpf` → `self.kpf_obj`, etc.).

  ## Docs
  - `CLAUDE.md`: four read-only QC layers + the science→Diag→QC→Checkpoints order;
    "Where metrics live" now lists calibration ages as Diagnostics-owned.
  - `KPF_DRP_VNEXT_STYLE_GUIDE.md`: validation lives in the checkpoints layer;
    keyword-name example updated.

  ## Testing
  - Full suite green: **1030 passed** (`make test`).
  - New `tests/regression/test_checkpoints.py`; `test_qc_flags.py`,
    `test_diagnostics.py`, `test_calibration_association.py`,
    `test_radial_velocity.py` updated for the new flag set / routing.

  ## Notes
  - On real frames, `RNOK = 0` is **expected & warn-only**: the RED amps read out
    at ~6.1–6.3 e⁻, marginally above the nominal 6.0 e⁻ ceiling (`RNNGOK` passes).
    Not a regression — re-tune `_RN_HI` if that bound is too tight for KPF.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)