### PR TITLE
Kpf next instrument header

### DIFF
--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -200,8 +200,8 @@ class CalibrationAssociation:
         module writes header keywords, called just before the receipt entry. Each
         cal type contributes {PREFIX}FILE (full master path), which set_keyword
         routes to RECEIPT. The signed (master - obs) age ({PREFIX}AGE) is
-        recomputed downstream by DiagL1 from this path plus INSTRUMENT_HEADER
-        DATE-OBS, so this module no longer computes or writes it.
+        recomputed downstream by DiagL1 from this path plus PRIMARY DATE-OBS,
+        so this module no longer computes or writes it.
         """
         for cal_type, cal in self._calibrations.items():
             prefix = _HEADER_PREFIX[cal_type]
@@ -247,7 +247,7 @@ class CalibrationAssociation:
                 f"expected subset of {sorted(_HEADER_PREFIX)}"
             )
 
-        date_obs = self.l1_obj.headers["INSTRUMENT_HEADER"]["DATE-OBS"]
+        date_obs = self.l1_obj.headers["PRIMARY"]["DATE-OBS"]
 
         self._calibrations = {}
         for cal_type in cal_types:

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -911,7 +911,13 @@ class WLS(BaseMasterModule):
             self._coeffs_stack[chip] = coeffs_stack
             self._lines_stack[chip] = lines_stack
 
-            for i, fiber in enumerate(self.fibers):
+            # W's fiber planes are ordered by physical slicer position (the fit
+            # ranks fibers via fiber_positions and _evaluate_wls_coeffs emits
+            # planes in that order). Assign by that same canonical order, not
+            # self.fibers' (config-overridable) order, so a reordered self.fibers
+            # cannot mis-route a solution (e.g. SKY's onto CAL).
+            canonical = sorted(self.fibers, key=lambda fb: self.fiber_positions[fb])
+            for i, fiber in enumerate(canonical):
                 if W.ndim == 2:
                     self.ml2_obj.data[f"{chip}_{fiber}_WAVE"] = W
                 else:

--- a/kpfpipe/quality_control/diagnostics/level1.py
+++ b/kpfpipe/quality_control/diagnostics/level1.py
@@ -33,7 +33,7 @@ class DiagL1(Diagnostics):
 
         Recomputed from the finished L1 product: the master path is read from
         RECEIPT (``{PREFIX}FILE``, written by CalibrationAssociation) and the
-        observation timestamp from INSTRUMENT_HEADER (DATE-OBS). The master
+        observation timestamp from PRIMARY (DATE-OBS). The master
         timestamp is parsed from its filename. A cal type is skipped when its
         path is absent; the whole metric is skipped when DATE-OBS is missing.
 
@@ -43,8 +43,8 @@ class DiagL1(Diagnostics):
             Maps each present ``{PREFIX}AGE`` keyword to its ``(age, comment)``.
         """
         receipt = self.kpf_obj.headers.get("RECEIPT", {})
-        instrument = self.kpf_obj.headers.get("INSTRUMENT_HEADER", {})
-        date_obs = instrument.get("DATE-OBS")
+        primary = self.kpf_obj.headers.get("PRIMARY", {})
+        date_obs = primary.get("DATE-OBS")
         if not date_obs:
             return {}
         obs_dt = datetime.fromisoformat(date_obs)

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -16,14 +16,15 @@ from kpfpipe.modules.calibration_association import CalibrationAssociation
 
 class MockL1:
     def __init__(self, date_obs="2024-04-05T11:08:33"):
-        # DATE-OBS is a raw WMKO native read from INSTRUMENT_HEADER; the
-        # calibration ages/paths are KPF-pipeline keywords written to PRIMARY.
-        # Headers are fits.Header, mirroring the real KPF data models.
-        inst = fits.Header()
-        inst["DATE-OBS"] = date_obs
+        # DATE-OBS is read from the EPRV-standard PRIMARY (identity-mapped from
+        # the native WMKO DATE-OBS); the calibration ages/paths are KPF-pipeline
+        # keywords written to PRIMARY/RECEIPT. Headers are fits.Header, mirroring
+        # the real KPF data models.
+        primary = fits.Header()
+        primary["DATE-OBS"] = date_obs
         self.headers = {
-            "PRIMARY": fits.Header(),
-            "INSTRUMENT_HEADER": inst,
+            "PRIMARY": primary,
+            "INSTRUMENT_HEADER": fits.Header(),
             "RECEIPT": fits.Header(),
             "QUALITY_CONTROL": fits.Header(),
         }

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -143,15 +143,14 @@ class TestEmptyLevels:
 
 
 def _make_kpf1_with_calibrations(date_obs="2024-04-05T11:08:33", files=None):
-    """A KPF1 carrying an INSTRUMENT_HEADER DATE-OBS and RECEIPT master paths.
+    """A KPF1 carrying a PRIMARY DATE-OBS and RECEIPT master paths.
 
     Mirrors the finished-L1 state DiagL1 reads: CalibrationAssociation has
     written each ``{PREFIX}FILE`` to RECEIPT (via set_keyword) and to_kpf1 has
-    populated INSTRUMENT_HEADER.
+    populated the EPRV PRIMARY (DATE-OBS).
     """
     l1 = KPF1()
-    l1.create_extension("INSTRUMENT_HEADER", "ImageHDU")
-    l1.headers["INSTRUMENT_HEADER"]["DATE-OBS"] = date_obs
+    l1.headers["PRIMARY"]["DATE-OBS"] = date_obs
     for kw, path in (files or {}).items():
         l1.set_keyword(kw, path)  # *FILE routes to RECEIPT
     return l1
@@ -207,7 +206,7 @@ class TestDiagL1CalibrationAges:
         l1 = _make_kpf1_with_calibrations(
             files={"BIASFILE": "/m/KP.20240405.03637.74_master_bias_L1.fits"}
         )
-        del l1.headers["INSTRUMENT_HEADER"]["DATE-OBS"]
+        del l1.headers["PRIMARY"]["DATE-OBS"]
         results = DiagL1(l1).run()
         assert results == {}
 

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -259,6 +259,47 @@ class TestMakeMasterL2:
                 assert np.size(wave) > 0
                 assert np.all(wave == 5500.0)
 
+    def test_wave_routing_uses_physical_position_not_fiber_order(self, monkeypatch):
+        """Each W plane routes to its fiber by physical slicer position, even
+        when self.fibers is reordered. W's planes are ordered by fiber_positions
+        (SKY=0..CAL=4), so the write loop must sort by that, not trust
+        self.fibers' (config-overridable) order -- else SKY's solution lands on
+        CAL and vice versa.
+        """
+        monkeypatch.setattr(
+            WLS, "_load_frame", lambda self, fn, cache=False, **kw: (MockL1(), True)
+        )
+        monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kw: l1)
+        monkeypatch.setattr(WLS, "_extract_frame", lambda self, l1, **kw: MockL2())
+
+        def mock_compute(self, chip, fibers, **kwargs):
+            # Plane i carries the constant value i (its physical-position rank).
+            norder = NORDER_GREEN if chip == "GREEN" else NORDER_RED
+            W = np.empty((norder, NCOL_TEST, len(fibers)))
+            for i in range(len(fibers)):
+                W[:, :, i] = float(i)
+            coeffs = np.zeros((self.polyorder_x + 1, self.polyorder_m + 1, 1))
+            lines = [
+                {"wav": np.array([5500.0]), "bad": np.array([False])} for _ in range(3)
+            ]
+            return W, coeffs, np.array([coeffs] * 3), lines
+
+        monkeypatch.setattr(WLS, "_compute_wls_from_stack", mock_compute)
+
+        wls = WLS(FILE_LIST)
+        # Reorder away from physical-slicer order (here: TRACE order).
+        wls.fibers = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]
+        ml2 = wls.make_master_l2()
+
+        # Ground truth from detector.toml [fiber_positions].
+        physical_rank = {"SKY": 0, "SCI1": 1, "SCI2": 2, "SCI3": 3, "CAL": 4}
+        for chip in wls.chips:
+            for fiber, rank in physical_rank.items():
+                wave = ml2.data[f"{chip}_{fiber}_WAVE"]
+                assert np.all(wave == float(rank)), (
+                    f"{chip}_{fiber}_WAVE routed to the wrong W plane"
+                )
+
     def test_wave_is_float64_and_survives_roundtrip(
         self, mock_make_master_l2, tmp_path
     ):


### PR DESCRIPTION
## Summary

  Two small, independent fixes from an audit of `INSTRUMENT_HEADER` usage. Neither changes
  scientific output.

  ### 1. Read `DATE-OBS` from `PRIMARY`, not `INSTRUMENT_HEADER`
  
  First step in migrating reads onto the EPRV-standard `PRIMARY`. `DATE-OBS` is identity-mapped
  (native → PRIMARY, same value), so this is a value-identical swap. Updated:
  - `calibration_association.py` — timestamp for master association
  - `diagnostics/level1.py` (`DiagL1.calibration_ages`) — timestamp for the calibration-age metric

  ### 2. Harden master-WLS per-fiber WAVE routing

  `make_master_l2` assigned `W` plane `i` to `self.fibers[i]`, but `W`'s planes are ordered by
  physical slicer position (`detector.toml [fiber_positions]`). The default order matched, but
  `self.fibers` is config-overridable — a reordered list could route SKY's solution onto CAL.
  Now sorts by `fiber_positions` (the same order the fit uses), making the assignment order-proof.

  The fiber→TRACE alias map was already correct; the audit found no actual CAL/SKY swap — this
  was the only positional spot exposed to reconfiguration.

  ## Testing

  - New `test_wave_routing_uses_physical_position_not_fiber_order` (fails on the old code).
  - DATE-OBS test fixtures moved to `PRIMARY`.
  - Full suite green: 1055 passed.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)