### PR TITLE
Upgrade rvdata to v0.4.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,11 +23,9 @@ KPF-DRP vNext: a cleanroom rebuild of the Keck Planet Finder (KPF) data reductio
 - **Python 3.14.3** (pinned exactly)
 - **Conda env**: `kpfpipe` — set up via `conda env create -f KPF-Pipeline/environment.yml`
 - **Install package**: `pip install -e KPF-Pipeline/` (editable install)
-- **Key dependency**: `rv-data-standard` (RVData), pinned to a specific commit
-  (`git+https://github.com/EPRV-RCN/RVData.git@7413775…`) rather than the moving `@develop`
-  branch — RVData's `develop` has since introduced breaking changes (a `MinBitDepth` upcast
-  of WAVE arrays, and a `receipt_add_entry` signature change). Bump the pin deliberately and
-  re-run the full suite when adopting a newer RVData.
+- **Key dependency**: `rv-data-standard` (RVData), pinned to the released version
+  `rv-data-standard==0.4.0` (a tagged PyPI release, not a moving branch). Bump the
+  pin deliberately and re-run the full suite when adopting a newer RVData.
 
 ## Git workflow
 
@@ -235,9 +233,9 @@ see the style guide §11.)* The architecture invariants:
 - **Masters carry their own minimal PRIMARY, not the EPRV science skeleton** (`KPFMasterL1`/`L2` stamp
   `DATALVL` `"ML1"`/`"ML2"`; see *Masters Pipeline*).
 - **Every extension header is an `astropy.io.fits.Header`** (`KPFDataModel.create_extension` override;
-  `from_fits` already returns one). rvdata's base `_create_hdul` drops comments on serialize, so the
-  `KPFDataModel._create_hdul` override rebuilds PRIMARY via `_restore_primary_comments` to preserve them
-  through `to_fits`.
+  `from_fits` already returns one). rvdata's base `_create_hdul` (>=0.4.0) copies a `fits.Header`
+  directly when serializing PRIMARY, preserving its keyword comments through `to_fits`; the
+  `KPFDataModel._create_hdul` override only syncs the receipt table into the RECEIPT extension.
 
 ### Configuration
 

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -168,7 +168,7 @@ class StageName:
         ...                                    # populate header-source attributes
         self._set_headers(self.l2_obj)         # consolidates ALL header writes
         self._track_info(chips)                # populates _info, just before the receipt
-        self.l2_obj.receipt_add_entry("stage_name", "PASS")
+        self.l2_obj.receipt_add_entry("stage_name", "", "PASS")
         return self.l2_obj
 
     def info(self): ...   # human-readable reporter, always last
@@ -325,7 +325,8 @@ class StageName:
   against an explicit allowed set, raising `ValueError` that names the valid options.
 - **Return patterns**:
   - A transform's `perform()` returns the next-level data object after mutating
-    headers and calling `receipt_add_entry("<module>", "PASS")`.
+    headers and calling `receipt_add_entry("<module>", "", "PASS")` (the middle
+    arg is the rvdata `ARGS` provenance string — `""` when not applicable).
   - Step methods that mutate `*_obj.data` in place return `None` and document
     *"Modifies … in-place"*.
   - Helpers return a single value or a fixed tuple; validators return `None`.

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
       - astropy==7.2.0
       - astroquery==0.4.11
       - barycorrpy==0.4.4
-      - rv-data-standard @ git+https://github.com/EPRV-RCN/RVData.git@7413775939ca0366dbba0df8c2e5b48c76595634
+      - rv-data-standard==0.4.0
       # --- development tools --- #
       - ipykernel==7.2.0
       - jupyterlab==4.5.4

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -24,10 +24,11 @@ from kpfpipe.data_models.keyword_registry import keyword_registry
 
 # Receipt names that are data-model conversions / serialization rather than
 # pipeline modules — excluded from DRPSTATU so it names the last real stage.
-# ``from_fits`` is here too: reading a product back must not clobber the status
-# the writer stamped.
+# ``read``/``from_fits`` are here too: reading a product back must not clobber
+# the status the writer stamped (rvdata >=0.4.0 logs a ``read`` receipt via its
+# ``@receipt_logged`` decorator on ``RVDataModel.read``).
 _INTERNAL_RECEIPTS = frozenset(
-    {"to_kpf1", "to_kpf2", "to_kpf4", "to_fits", "from_fits"}
+    {"to_kpf1", "to_kpf2", "to_kpf4", "to_fits", "from_fits", "read"}
 )
 
 # Re-exported for sibling data_models modules: KPF2/KPF4 call
@@ -173,58 +174,43 @@ class KPFDataModel(RVDataModel):
                 for card in self.as_fits_header(self.headers[ext]).cards:
                     target.headers[ext][card.keyword] = (card.value, card.comment)
 
-    def receipt_add_entry(self, module, status):
-        """Record a processing step, and update DRPSTATU for pipeline modules."""
-        super().receipt_add_entry(module, status)
-        if status == "PASS":
-            self._update_drpstatus(module)
+    def receipt_add_entry(self, function, args, status):
+        """Record a processing step, and update DRPSTATU for pipeline modules.
 
-    def _update_drpstatus(self, module):
+        Signature matches rvdata >=0.4.0: ``function`` names the step, ``args``
+        is a key=value provenance string (``""`` when not applicable), ``status``
+        is ``"PASS"``/``"FAIL"``.
+        """
+        super().receipt_add_entry(function, args, status)
+        if status == "PASS":
+            self._update_drpstatus(function)
+
+    def _update_drpstatus(self, function):
         """Stamp DRPSTATU = '<Module Name> module complete' for a completed module.
 
         Called from ``receipt_add_entry``; conversions/serialization receipts
         (``_INTERNAL_RECEIPTS``) are skipped so DRPSTATU names the last real stage.
         DRPSTATU's registry home is RECEIPT, so ``set_keyword`` routes it there.
         """
-        if module in _INTERNAL_RECEIPTS:
+        if function in _INTERNAL_RECEIPTS:
             return
         if "RECEIPT" not in self.extensions:
             return
-        label = module.replace("_", " ").title()
+        label = function.replace("_", " ").title()
         self.set_keyword("DRPSTATU", f"{label} module complete")
 
     def _create_hdul(self):
-        """Sync self.receipt into the RECEIPT extension before writing; rvdata
-        serializes self.data["RECEIPT"], not self.receipt. L0/L1 omit RECEIPT
-        from their default extensions, so create it if absent."""
+        """Sync ``self.receipt`` into the RECEIPT extension before writing; rvdata
+        serializes ``self.data["RECEIPT"]``, not ``self.receipt``. L0/L1 omit
+        RECEIPT from their default extensions, so create it if absent. PRIMARY
+        keyword comments are preserved by rvdata's own ``_create_hdul`` (it copies
+        a ``fits.Header`` directly) as of rvdata >=0.4.0, so no PRIMARY rebuild is
+        needed here."""
         if self.receipt is not None and not self.receipt.empty:
             if "RECEIPT" not in self.extensions:
                 self.create_extension("RECEIPT", "BinTableHDU")
-            self.data["RECEIPT"] = Table.from_pandas(self.receipt)
-        return self._restore_primary_comments(super()._create_hdul())
-
-    def _restore_primary_comments(self, hdu_list):
-        """Rebuild the PRIMARY HDU so its keyword comments survive serialization.
-
-        RVData's ``_create_hdul`` builds PRIMARY by iterating
-        ``headers["PRIMARY"].items()``, which on a ``fits.Header`` yields only
-        ``(key, value)`` and silently drops the comments. Replace that one HDU with
-        a fresh ``PrimaryHDU`` built from the stored header (a ``fits.Header`` that
-        holds the comments). The ``PrimaryHDU`` constructor re-adds the structural
-        cards. ``data=hdu.data`` carries through any PRIMARY array: it is ``None``
-        for KPF's header-only PRIMARY today, but omitting it would silently drop a
-        PRIMARY data array if one were ever introduced.
-        """
-        primary = self.headers.get("PRIMARY")
-        if primary is None:
-            return hdu_list
-        for i, hdu in enumerate(hdu_list):
-            if isinstance(hdu, fits.PrimaryHDU):
-                hdu_list[i] = fits.PrimaryHDU(
-                    data=hdu.data, header=self.as_fits_header(primary)
-                )
-                break
-        return hdu_list
+            self._sync_receipt_to_extension()
+        return super()._create_hdul()
 
     def generate_standard_filename(self):
         """Abstract: every concrete KPF model builds its own standard filename.

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -9,6 +9,8 @@ multiple inheritance alongside rvdata's RV2/RV4 (KPFDataModel listed first so
 its overrides win while RV2/RV4 remain reachable through ``super()``).
 """
 
+import warnings
+
 import numpy as np
 from astropy.io import fits
 from astropy.table import Table
@@ -128,12 +130,17 @@ class KPFDataModel(RVDataModel):
         extension aliases before the base class ``.keys()`` check. The
         ``hasattr`` guards make it a no-op passthrough for non-aliased L0/L1.
         """
-        if (
-            hasattr(self.data, "_chip_split")
-            and self.data._chip_split(ext_name) is not None
-        ):
-            self.data[ext_name] = data
-            return
+        if hasattr(self.data, "_chip_split"):
+            split = self.data._chip_split(ext_name)
+            if split is not None:
+                # The chip-prefix write goes straight into the underlying
+                # canonical array (sized from the first write's dtype), bypassing
+                # rvdata's MinBitDepth check in super().set_data. Enforce it here
+                # so both write paths honor the born-64 WAVE / 8-bit policy.
+                canonical = self.data._resolve(split[0])
+                data = self._coerce_to_min_bit_depth(canonical, data, ext_name)
+                self.data[ext_name] = data
+                return
         if hasattr(self.extensions, "_resolve"):
             ext_name = self.extensions._resolve(ext_name)
         # astropy reads BinTableHDUs back as numpy record arrays; convert to Table.
@@ -148,6 +155,38 @@ class KPFDataModel(RVDataModel):
         # Sync self.receipt when the RECEIPT extension is loaded from FITS.
         if ext_name == "RECEIPT" and isinstance(data, Table):
             self.receipt = data.to_pandas()
+
+    def _coerce_to_min_bit_depth(self, canonical_ext, data, label):
+        """Upcast ``data`` to satisfy ``canonical_ext``'s MinBitDepth, mirroring
+        rvdata's base ``set_data`` enforcement (incl. its warning) for the
+        chip-prefix write path that bypasses it. ``canonical_ext`` is the resolved
+        extension whose requirement applies (e.g. ``TRACE3_WAVE``); ``label`` is
+        the name shown in the warning (the chip-prefix key the caller passed).
+        A no-op when there is no requirement, the array is empty, or it already
+        meets the depth (and for KPF4, whose ``_get_min_bit_depth`` returns None).
+        """
+        min_depth = self._get_min_bit_depth(canonical_ext)
+        if (
+            min_depth is None
+            or not isinstance(data, np.ndarray)
+            or data.size == 0
+            or data.dtype.itemsize * 8 >= min_depth
+        ):
+            return data
+        if np.issubdtype(data.dtype, np.floating):
+            target = np.dtype(f"float{min_depth}")
+        elif np.issubdtype(data.dtype, np.unsignedinteger):
+            target = np.dtype(f"uint{min_depth}")
+        else:
+            target = np.dtype(f"int{min_depth}")
+        warnings.warn(
+            f"Extension '{label}' has dtype {data.dtype} "
+            f"({data.dtype.itemsize * 8}-bit) but MinBitDepth={min_depth}. "
+            f"Upcasting to {target.name}.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return data.astype(target)
 
     def set_header(self, ext_name, header):
         """Set an extension header, resolving KPF aliases before the base class

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -18,6 +18,7 @@ import numpy as np
 import pandas as pd
 from astropy.io import fits
 from astropy.table import Table
+from rvdata.core.models.definitions import BASE_RECEIPT_COLUMNS
 from rvdata.core.tools.headers import parse_value_to_datatype
 
 from kpfpipe import __version__
@@ -136,14 +137,7 @@ class KPF0(KPFDataModel):
             elif ext_name == "RECEIPT":
                 t = Table.read(hdu)
                 df = t.to_pandas()
-                receipt_columns = [
-                    "Time",
-                    "Code_Release",
-                    "Commit_Hash",
-                    "Branch_Name",
-                    "Module_Name",
-                    "Status",
-                ]
+                receipt_columns = BASE_RECEIPT_COLUMNS["Name"].tolist()
                 if df.empty:
                     df = pd.DataFrame(columns=receipt_columns)
                 else:
@@ -184,7 +178,7 @@ class KPF0(KPFDataModel):
         if not fn.endswith(".fits"):
             raise NameError("Filename must end with .fits")
 
-        self.receipt_add_entry("to_fits", "PASS")
+        self.receipt_add_entry("to_fits", f"out_filepath={fn}", "PASS")
 
         if "PRIMARY" in self.headers:
             self.headers["PRIMARY"]["FILENAME"] = (
@@ -328,7 +322,7 @@ class KPF0(KPFDataModel):
 
         # DATALVL is set by KPF1.__init__ (= KPF1._DATALVL) and _map_header no
         # longer emits it (dropped from header_map), so no fixup is needed here.
-        kpf1.receipt_add_entry("to_kpf1", "PASS")
+        kpf1.receipt_add_entry("to_kpf1", "", "PASS")
         return kpf1
 
     def info(self):

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -19,6 +19,7 @@ import numpy as np
 import pandas as pd
 from astropy.io import fits
 from astropy.table import Table
+from rvdata.core.models.definitions import BASE_RECEIPT_COLUMNS
 
 from kpfpipe.data_models.base import KPFDataModel
 from kpfpipe.data_models.level2 import KPF2
@@ -118,14 +119,7 @@ class KPF1(KPFDataModel):
             elif ext_name == "RECEIPT":
                 t = Table.read(hdu)
                 df = t.to_pandas()
-                receipt_columns = [
-                    "Time",
-                    "Code_Release",
-                    "Commit_Hash",
-                    "Branch_Name",
-                    "Module_Name",
-                    "Status",
-                ]
+                receipt_columns = BASE_RECEIPT_COLUMNS["Name"].tolist()
                 if df.empty:
                     df = pd.DataFrame(columns=receipt_columns)
                 else:
@@ -181,7 +175,7 @@ class KPF1(KPFDataModel):
         if not fn.endswith(".fits"):
             raise NameError("Filename must end with .fits")
 
-        self.receipt_add_entry("to_fits", "PASS")
+        self.receipt_add_entry("to_fits", f"out_filepath={fn}", "PASS")
 
         if "PRIMARY" in self.headers:
             self.set_keyword("FILENAME", os.path.basename(fn))
@@ -262,7 +256,7 @@ class KPF1(KPFDataModel):
             kpf2.set_keyword("ORIGID", self.obs_id)
 
         kpf2.set_keyword("DATALVL", "L2")
-        kpf2.receipt_add_entry("to_kpf2", "PASS")
+        kpf2.receipt_add_entry("to_kpf2", "", "PASS")
         return kpf2
 
     def info(self):

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -231,6 +231,12 @@ class KPF2(KPFDataModel, RV2):
         """KPF L2 is EPRV-standard (SL2 name); delegate to rvdata's builder."""
         return RV2.generate_standard_filename(self)
 
+    def to_fits(self, fn=None):
+        """KPF keeps a single-filepath ``to_fits``; rvdata >=0.4.0 renamed the
+        parameter to ``out_filename``. Delegate so all our call sites can keep
+        passing one path (``to_fits(fn)``)."""
+        return super().to_fits(out_filename=fn)
+
     def to_kpf4(self):
         """
         Create a KPF4 scaffold from this KPF2, carrying over headers and receipt.
@@ -259,7 +265,7 @@ class KPF2(KPFDataModel, RV2):
         kpf4.obs_id = self.obs_id
 
         kpf4.set_keyword("DATALVL", "L4")
-        kpf4.receipt_add_entry("to_kpf4", "PASS")
+        kpf4.receipt_add_entry("to_kpf4", "", "PASS")
         return kpf4
 
     def info(self):

--- a/kpfpipe/data_models/level4.py
+++ b/kpfpipe/data_models/level4.py
@@ -224,6 +224,12 @@ class KPF4(KPFDataModel, RV4):
         """KPF L4 is EPRV-standard (SL4 name); delegate to rvdata's builder."""
         return RV4.generate_standard_filename(self)
 
+    def to_fits(self, fn=None):
+        """KPF keeps a single-filepath ``to_fits``; rvdata >=0.4.0 renamed the
+        parameter to ``out_filename``. Delegate so all our call sites can keep
+        passing one path (``to_fits(fn)``)."""
+        return super().to_fits(out_filename=fn)
+
     def info(self):
         """Print summary of KPF4 data model contents."""
         if self.filename:

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -31,6 +31,7 @@ import numpy as np
 import pandas as pd
 from astropy.io import fits
 from astropy.table import Table
+from rvdata.core.models.definitions import BASE_RECEIPT_COLUMNS
 
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.masters.base import KPFMasterModel
@@ -131,7 +132,7 @@ class KPFMasterL2(KPFMasterModel, KPF2):
             obj.filename = os.path.basename(fn)
             obj.dirname = os.path.dirname(fn)
             obj.read(hdul, instrument, **kwargs)
-        obj.receipt_add_entry("from_fits", "PASS")
+        obj.receipt_add_entry("from_fits", f"fn={fn}, instrument={instrument}", "PASS")
         return obj
 
     def read(self, hdul, instrument=None, overwrite=False, **kwargs):
@@ -178,14 +179,7 @@ class KPFMasterL2(KPFMasterModel, KPF2):
             elif ext_name == "RECEIPT":
                 t = Table.read(hdu)
                 df = t.to_pandas()
-                receipt_columns = [
-                    "Time",
-                    "Code_Release",
-                    "Commit_Hash",
-                    "Branch_Name",
-                    "Module_Name",
-                    "Status",
-                ]
+                receipt_columns = BASE_RECEIPT_COLUMNS["Name"].tolist()
                 if df.empty:
                     df = pd.DataFrame(columns=receipt_columns)
                 else:

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -783,7 +783,7 @@ class BarycentricCorrection:
 
         self._set_headers(self.l2_obj)
         self._track_info()
-        self.l2_obj.receipt_add_entry("barycentric_correction", "PASS")
+        self.l2_obj.receipt_add_entry("barycentric_correction", "", "PASS")
 
         return self.l2_obj
 

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -265,7 +265,7 @@ class CalibrationAssociation:
 
         self._set_headers(self.l1_obj)
         self._track_info()
-        self.l1_obj.receipt_add_entry("calibration_association", "PASS")
+        self.l1_obj.receipt_add_entry("calibration_association", "", "PASS")
 
         return self.l1_obj
 

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -607,7 +607,7 @@ class ImageAssembly:
         self._convert_expmeter_wavelengths_to_angstroms(l1_obj)
         self._set_headers(l1_obj)
         self._track_info(chips)
-        l1_obj.receipt_add_entry("image_assembly", "PASS")
+        l1_obj.receipt_add_entry("image_assembly", "", "PASS")
 
         return l1_obj
 

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -368,7 +368,7 @@ class ImageProcessing:
 
         self._set_headers(self.l1_obj)
         self._track_info()
-        self.l1_obj.receipt_add_entry("image_processing", "PASS")
+        self.l1_obj.receipt_add_entry("image_processing", "", "PASS")
 
         return self.l1_obj
 

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -844,7 +844,7 @@ class BaseMasterModule:
                 ml1_obj.headers[f"{chip}_IMG"]["BUNIT"] = bunit
 
         ml1_obj.set_input_files(l0_file_list, master_type)
-        ml1_obj.receipt_add_entry(receipt_key, "PASS")
+        ml1_obj.receipt_add_entry(receipt_key, "", "PASS")
 
         return ml1_obj
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -941,7 +941,7 @@ class WLS(BaseMasterModule):
         self.ml2_obj.set_keyword("POLYORDM", polyorder_m)
         self.ml2_obj.set_keyword("POLYORDF", polyorder_f)
 
-        self.ml2_obj.receipt_add_entry("master_wls", "PASS")
+        self.ml2_obj.receipt_add_entry("master_wls", "", "PASS")
 
         if master_path is not None:
             self.save_master("L2", master_path, overwrite=True)

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -1131,7 +1131,7 @@ class RadialVelocity:
                 "  combined RV: no science orderlet requested; "
                 "PRIMARY RV left UNDEFINED"
             )
-            l4_obj.receipt_add_entry("radial_velocity", "PASS")
+            l4_obj.receipt_add_entry("radial_velocity", "", "PASS")
             return l4_obj
         if not sci:
             raise ValueError(
@@ -1217,7 +1217,7 @@ class RadialVelocity:
         l4_obj.set_keyword("BERV", float(berv_p) if np.isfinite(berv_p) else None)
         l4_obj.set_keyword("BJDTDB", float(bjd_p) if np.isfinite(bjd_p) else None)
 
-        l4_obj.receipt_add_entry("radial_velocity", "PASS")
+        l4_obj.receipt_add_entry("radial_velocity", "", "PASS")
         return l4_obj
 
     def info(self):

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -526,7 +526,7 @@ class SpectralExtraction:
 
         self._set_headers(l2_obj)
         self._track_info(chips, fibers)
-        l2_obj.receipt_add_entry("spectral_extraction", "PASS")
+        l2_obj.receipt_add_entry("spectral_extraction", "", "PASS")
 
         return l2_obj
 

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -168,7 +168,7 @@ class WavelengthCalibration:
 
         self._set_headers(self.l2_obj)
         self._track_info()
-        self.l2_obj.receipt_add_entry("wavelength_calibration", "PASS")
+        self.l2_obj.receipt_add_entry("wavelength_calibration", "", "PASS")
 
         return self.l2_obj
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pillow==12.1.1",
     "scipy==1.17.0",
     "tqdm==4.67.3",
-    "rv-data-standard @ git+https://github.com/EPRV-RCN/RVData.git@7413775939ca0366dbba0df8c2e5b48c76595634"
+    "rv-data-standard==0.4.0"
 ]
 
 # Optional dependencies for development (linting, testing, formatting)

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -73,7 +73,7 @@ def synthetic_kpf2():
         n = NORDER_GREEN if chip == "GREEN" else NORDER_RED
         for fiber in ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]:
             kpf2.set_data(
-                f"{chip}_{fiber}_WAVE", np.full((n, NCOL), 5000.0, dtype=np.float32)
+                f"{chip}_{fiber}_WAVE", np.full((n, NCOL), 5000.0, dtype=np.float64)
             )
 
     return kpf2
@@ -450,10 +450,10 @@ class TestFluxWeightedMidpointOrders:
         """Front-weighted flux + GREEN orders at 5000Å vs RED at 5100Å:
         GREEN orders should get an earlier midpoint than RED."""
         synthetic_kpf2.set_data(
-            "GREEN_SCI2_WAVE", np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float32)
+            "GREEN_SCI2_WAVE", np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float64)
         )
         synthetic_kpf2.set_data(
-            "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float32)
+            "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float64)
         )
         # Front-weighted at 5000Å, back-weighted at 5100Å
         data = {
@@ -510,12 +510,12 @@ class TestFluxWeightedMidpointCcds:
     def test_flux_weighting_biases_ccd_time_toward_bright_orders(self, synthetic_kpf2):
         """A bright bluest GREEN order pulls the chip summary toward its
         (earlier) midpoint relative to the unweighted chip mean."""
-        green_waves = np.linspace(5000.0, 5300.0, NORDER_GREEN, dtype=np.float32)
+        green_waves = np.linspace(5000.0, 5300.0, NORDER_GREEN, dtype=np.float64)
         synthetic_kpf2.set_data(
             "GREEN_SCI2_WAVE", np.repeat(green_waves[:, None], NCOL, axis=1)
         )
         synthetic_kpf2.set_data(
-            "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5300.0, dtype=np.float32)
+            "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5300.0, dtype=np.float64)
         )
         # Chromatic flux gradient: bluest channel early, reddest channel late.
         data = {
@@ -576,10 +576,10 @@ class TestFluxWeightedMidpointCcds:
         """With GREEN orders at 5000Å and RED orders at 5100Å plus a chromatic
         flux gradient, 'ccds' should report distinguishable times per chip."""
         synthetic_kpf2.set_data(
-            "GREEN_SCI2_WAVE", np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float32)
+            "GREEN_SCI2_WAVE", np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float64)
         )
         synthetic_kpf2.set_data(
-            "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float32)
+            "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float64)
         )
         # Front-weighted at 5000Å, back-weighted at 5100Å → distinct midpoints
         data = {

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -842,7 +842,7 @@ class TestPerform:
 
     def test_receipt_entry_added(self, bc_monkeypatched):
         bc_monkeypatched.perform()
-        modules = bc_monkeypatched.l2_obj.receipt["Module_Name"].values
+        modules = bc_monkeypatched.l2_obj.receipt["FUNCTION"].values
         assert "barycentric_correction" in modules
 
     def test_targradv_converted_km_to_m_and_passed_through(

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -30,8 +30,8 @@ class MockL1:
         }
         self._receipt = []
 
-    def receipt_add_entry(self, name, status):
-        self._receipt.append((name, status))
+    def receipt_add_entry(self, name, args, status):
+        self._receipt.append((name, args, status))
 
     def set_keyword(self, key, value):
         # Mirror the real routing: master paths ({PREFIX}FILE) land on RECEIPT.
@@ -258,7 +258,7 @@ class TestPerform:
     def test_adds_receipt_entry(self, masters_dir):
         mod = _make_module(masters_dir)
         mod.perform(["bias"])
-        assert ("calibration_association", "PASS") in mod.l1_obj._receipt
+        assert ("calibration_association", "", "PASS") in mod.l1_obj._receipt
 
     def test_sets_biasfile_header(self, masters_dir):
         # BIASFILE is the master's full path (no separate BIASDIR).

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -6,12 +6,13 @@ KPF stores every extension header as an ``astropy.io.fits.Header``, so reads use
 comment)`` natively. These tests pin the contract every model inherits from the
 shared base: (1) headers are ``fits.Header`` from construction onward, and (2) a
 commented PRIMARY card survives ``to_fits`` -> ``from_fits`` with its comment
-intact -- the regression guard for the lossless-PRIMARY serialization in
-``KPFDataModel._create_hdul`` / ``_restore_primary_comments``.
+intact -- the regression guard for lossless-PRIMARY serialization (rvdata's base
+``_create_hdul`` copies a ``fits.Header`` directly, preserving its comments, as
+of rvdata >=0.4.0).
 
-KPF1 is the representative vehicle for the inherited base path (L0/L1 use
-``KPFDataModel._create_hdul`` directly). KPF2/KPF4 override ``_create_hdul`` via
-RV2/RV4, so their round-trip guards live in test_data_models_l{2,4}.py.
+KPF1 is the representative vehicle for the inherited base path. All KPF models
+serialize PRIMARY through rvdata's comment-preserving base ``_create_hdul``;
+KPF2/KPF4 round-trip guards live in test_data_models_l{2,4}.py.
 
 The WMKO->EPRV conversion (``KPF0._map_header``) is exercised end-to-end by the
 to_kpf1/to_kpf2 tests in test_data_models_l{1,2,4}.py.
@@ -43,10 +44,8 @@ class TestHeaderStorage:
 class TestPrimaryCommentRoundTrip:
     """A commented PRIMARY write survives to_fits -> from_fits with its comment.
 
-    rvdata's base _create_hdul serializes PRIMARY by iterating ``.items()``, which
-    drops a fits.Header's comments; KPFDataModel._create_hdul rebuilds the PRIMARY
-    HDU (via _restore_primary_comments) so the comments survive. This test would
-    fail without that override.
+    rvdata's base _create_hdul (>=0.4.0) copies a fits.Header directly when
+    serializing PRIMARY, preserving its keyword comments through the round-trip.
     """
 
     def test_primary_comment_round_trips(self, tmp_path):

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -58,22 +58,22 @@ class TestKPF0:
     def test_receipt_tracking(self, synthetic_l0_file, tmp_path):
         l0 = KPF0.from_fits(synthetic_l0_file)
         assert len(l0.receipt) >= 1
-        assert "from_fits" in l0.receipt["Module_Name"].values
+        assert "from_fits" in l0.receipt["FUNCTION"].values
 
         out_fn = str(tmp_path / "receipt_test.fits")
         l0.to_fits(out_fn)
-        assert "to_fits" in l0.receipt["Module_Name"].values
+        assert "to_fits" in l0.receipt["FUNCTION"].values
 
     def test_receipt_survives_roundtrip(self, synthetic_l0_file, tmp_path):
         """The processing history must reach the FITS RECEIPT extension, not just
         live in memory; KPFDataModel._create_hdul syncs it (and creates the
         extension, which L0's default extension set lacks)."""
         l0 = KPF0.from_fits(synthetic_l0_file)
-        l0.receipt_add_entry("image_assembly", "PASS")
+        l0.receipt_add_entry("image_assembly", "", "PASS")
         out_fn = str(tmp_path / "roundtrip_receipt_l0.fits")
         l0.to_fits(out_fn)
 
-        modules = KPF0.from_fits(out_fn).receipt["Module_Name"].values
+        modules = KPF0.from_fits(out_fn).receipt["FUNCTION"].values
         assert "image_assembly" in modules
         assert "to_fits" in modules
 
@@ -113,23 +113,23 @@ class TestKPF0ErrorPaths:
             KPF0.from_fits(fn)
 
     def test_parses_receipt_with_entries(self, tmp_path):
-        receipt = Table({"Module_Name": ["init"], "Status": ["PASS"]})
+        receipt = Table({"FUNCTION": ["init"], "STATUS": ["PASS"]})
         rec_hdu = fits.BinTableHDU(data=receipt, name="RECEIPT")
         fn = self._minimal_l0(tmp_path, extra_hdus=[rec_hdu])
         l0 = KPF0.from_fits(fn)
-        assert "init" in l0.receipt["Module_Name"].values
+        assert "init" in l0.receipt["FUNCTION"].values
         # The receipt is reindexed to include the standard provenance columns.
-        assert "Commit_Hash" in l0.receipt.columns
+        assert "COMMIT_HASH" in l0.receipt.columns
 
     def test_parses_empty_receipt(self, tmp_path):
-        receipt = Table(names=["Module_Name"], dtype=["U10"])  # zero rows
+        receipt = Table(names=["FUNCTION"], dtype=["U10"])  # zero rows
         rec_hdu = fits.BinTableHDU(data=receipt, name="RECEIPT")
         fn = self._minimal_l0(tmp_path, extra_hdus=[rec_hdu])
         l0 = KPF0.from_fits(fn)
         # An empty receipt is seeded with the standard columns; from_fits then
         # appends its own entry.
-        assert "Code_Release" in l0.receipt.columns
-        assert "from_fits" in l0.receipt["Module_Name"].values
+        assert "CODE_RELEASE" in l0.receipt.columns
+        assert "from_fits" in l0.receipt["FUNCTION"].values
 
     def test_generate_filename_without_obs_id_raises(self):
         with pytest.raises(ValueError, match="obs_id not set"):

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -95,7 +95,7 @@ class TestKPF1:
 
         out_fn = str(tmp_path / "receipt_l1.fits")
         l1.to_fits(out_fn)
-        assert "to_fits" in l1.receipt["Module_Name"].values
+        assert "to_fits" in l1.receipt["FUNCTION"].values
 
     def test_receipt_survives_roundtrip(self, synthetic_l1_file, tmp_path):
         """The processing history must be written to the FITS RECEIPT extension,
@@ -103,11 +103,11 @@ class TestKPF1:
         self.data["RECEIPT"], so KPFDataModel._create_hdul syncs self.receipt
         into it before writing; without that the receipt is silently lost."""
         l1 = KPF1.from_fits(synthetic_l1_file)
-        l1.receipt_add_entry("image_assembly", "PASS")
+        l1.receipt_add_entry("image_assembly", "", "PASS")
         out_fn = str(tmp_path / "roundtrip_l1.fits")
         l1.to_fits(out_fn)
 
-        modules = KPF1.from_fits(out_fn).receipt["Module_Name"].values
+        modules = KPF1.from_fits(out_fn).receipt["FUNCTION"].values
         assert "image_assembly" in modules
         assert "to_fits" in modules
 
@@ -323,7 +323,7 @@ class TestToKpf1:
         l0 = KPF0.from_fits(synthetic_l0_file)
         l1 = l0.to_kpf1()
         assert len(l1.receipt) >= 2  # from_fits + to_kpf1
-        assert "to_kpf1" in l1.receipt["Module_Name"].values
+        assert "to_kpf1" in l1.receipt["FUNCTION"].values
 
     def test_to_kpf1_copies_obs_id(self, synthetic_l0_file):
         l0 = KPF0.from_fits(synthetic_l0_file)
@@ -345,21 +345,21 @@ class TestDrpStatus:
 
     def test_module_receipt_updates_status(self, synthetic_l0_file):
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()
-        l1.receipt_add_entry("image_assembly", "PASS")
+        l1.receipt_add_entry("image_assembly", "", "PASS")
         status = l1.headers["RECEIPT"].get("DRPSTATU")
         assert status == "Image Assembly module complete"
 
     def test_master_receipt_updates_status(self, synthetic_l0_file):
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()
-        l1.receipt_add_entry("master_bias", "PASS")
+        l1.receipt_add_entry("master_bias", "", "PASS")
         status = l1.headers["RECEIPT"].get("DRPSTATU")
         assert status == "Master Bias module complete"
 
     def test_internal_receipts_do_not_change_status(self, synthetic_l0_file):
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()
-        l1.receipt_add_entry("radial_velocity", "PASS")
+        l1.receipt_add_entry("radial_velocity", "", "PASS")
         for internal in ("to_kpf2", "to_kpf4", "to_fits", "from_fits"):
-            l1.receipt_add_entry(internal, "PASS")
+            l1.receipt_add_entry(internal, "", "PASS")
         status = l1.headers["RECEIPT"].get("DRPSTATU")
         assert status == "Radial Velocity module complete"
 

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -388,6 +388,29 @@ class TestDtypeProvenance:
         assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_FLUX", FLUX, tmp_path)
         assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_WAVE", WAVE, tmp_path)
 
+    def test_chip_prefix_wave_write_enforces_min_bit_depth(self):
+        """A float32 WAVE written via a chip-prefix key (which bypasses rvdata's
+        base set_data) is still upcast to float64 with the MinBitDepth warning —
+        the chip-split path enforces the born-64 WAVE policy like the canonical
+        path does."""
+        kpf2 = KPF2()
+        with pytest.warns(UserWarning, match="MinBitDepth=64"):
+            kpf2.set_data(
+                "GREEN_SCI2_WAVE", np.ones((NORDER_GREEN, 8), dtype=np.float32)
+            )
+        assert_dtype(kpf2.data["TRACE3_WAVE"], WAVE, "underlying TRACE3_WAVE")
+
+    def test_chip_prefix_flux_write_keeps_float32(self):
+        """FLUX has no MinBitDepth requirement, so a float32 chip-prefix write is
+        kept as-is (no upcast, no warning) — the enforcement is WAVE/QUALITY-only."""
+        kpf2 = KPF2()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            kpf2.set_data(
+                "GREEN_SCI2_FLUX", np.ones((NORDER_GREEN, 8), dtype=np.float32)
+            )
+        assert_dtype(kpf2.data["TRACE3_FLUX"], FLUX, "underlying TRACE3_FLUX")
+
 
 class TestKPFMasterL2:
     def test_wls_extensions_created(self):

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -49,7 +49,9 @@ def synthetic_masters_l2_file(tmp_path):
     primary.header["MASTYPE"] = "thar"  # from_fits infers kind="wls" from this
 
     n_pix = 64
-    wave = rng.random((NORDER_GREEN + NORDER_RED, n_pix)).astype(np.float32)
+    # WAVE is born-64 (EPRV / dtype policy); float32 would trip rvdata's
+    # MinBitDepth upcast-and-warn on read.
+    wave = rng.random((NORDER_GREEN + NORDER_RED, n_pix)).astype(np.float64)
     trace3_wave = fits.ImageHDU(data=wave)
     trace3_wave.name = "TRACE3_WAVE"
 
@@ -158,13 +160,13 @@ class TestToKPF2:
     def test_to_kpf2_carries_receipt(self, synthetic_l1_file):
         l1 = KPF1.from_fits(synthetic_l1_file)
         kpf2 = l1.to_kpf2()
-        assert "to_kpf2" in kpf2.receipt["Module_Name"].values
+        assert "to_kpf2" in kpf2.receipt["FUNCTION"].values
 
     def test_to_kpf2_receipt_updates_drpstatus(self, synthetic_l1_file):
         """The DRPSTATU receipt override is active on KPF2 too (it subclasses
         RV2, not KPFDataModel, so it carries its own override)."""
         kpf2 = KPF1.from_fits(synthetic_l1_file).to_kpf2()
-        kpf2.receipt_add_entry("barycentric_correction", "PASS")
+        kpf2.receipt_add_entry("barycentric_correction", "", "PASS")
         assert (
             kpf2.headers["RECEIPT"].get("DRPSTATU")
             == "Barycentric Correction module complete"
@@ -456,7 +458,7 @@ class TestKPFMasterL2:
 
     def test_from_fits_adds_receipt_entry(self, synthetic_masters_l2_file):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
-        assert "from_fits" in m.receipt["Module_Name"].values
+        assert "from_fits" in m.receipt["FUNCTION"].values
 
     def test_round_trip(self, synthetic_masters_l2_file, tmp_path):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -43,7 +43,7 @@ class TestToKPF4:
     def test_to_kpf4_carries_receipt(self):
         kpf2 = KPF2()
         kpf4 = kpf2.to_kpf4()
-        assert "to_kpf4" in kpf4.receipt["Module_Name"].values
+        assert "to_kpf4" in kpf4.receipt["FUNCTION"].values
 
     def test_to_kpf4_leaves_rv_empty(self):
         kpf2 = KPF2()

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -145,7 +145,7 @@ class TestImageAssemblyBias:
 
     def test_receipt_chain(self, l1_bias):
         l1, _ = l1_bias
-        modules = l1.receipt["Module_Name"].values
+        modules = l1.receipt["FUNCTION"].values
         assert "from_fits" in modules
         assert "to_kpf1" in modules
         assert "image_assembly" in modules

--- a/tests/regression/test_image_processing.py
+++ b/tests/regression/test_image_processing.py
@@ -62,8 +62,8 @@ class MockL1:
         ext = "RECEIPT" if key in ("BIASSUB", "DARKSUB") else "PRIMARY"
         self.headers[ext][key] = value
 
-    def receipt_add_entry(self, name, status):
-        self._receipt.append((name, status))
+    def receipt_add_entry(self, name, args, status):
+        self._receipt.append((name, args, status))
 
 
 def _make_module(bias_file=None, bias_dir=None, dark_file=None, dark_dir=None):
@@ -433,7 +433,7 @@ class TestPerform:
 
     def test_receipt_entry_added(self, mod_with_bias):
         mod_with_bias.perform()
-        assert ("image_processing", "PASS") in mod_with_bias.l1_obj._receipt
+        assert ("image_processing", "", "PASS") in mod_with_bias.l1_obj._receipt
 
     def test_chips_override_processes_only_requested(self, mod_with_bias):
         mod_with_bias.perform(chips=["GREEN"])

--- a/tests/regression/test_master_bias.py
+++ b/tests/regression/test_master_bias.py
@@ -111,7 +111,7 @@ class TestMasterBiasUnit:
         assert np.all(master_bias.data["RED_SNR"] >= 0)
 
     def test_receipt_entry(self, master_bias):
-        assert "master_bias" in master_bias.receipt["Module_Name"].values
+        assert "master_bias" in master_bias.receipt["FUNCTION"].values
 
     def test_bunit_is_electrons(self, master_bias):
         for chip in CHIPS:
@@ -293,7 +293,7 @@ class TestMasterBiasRegression:
             assert master_bias.data[f"{chip}_SNR"].dtype == np.float32
 
     def test_receipt_chain(self, master_bias):
-        assert "master_bias" in master_bias.receipt["Module_Name"].values
+        assert "master_bias" in master_bias.receipt["FUNCTION"].values
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -63,7 +63,7 @@ class TestMasterDarkUnit:
         assert np.all(master_dark.data["RED_SNR"] >= 0)
 
     def test_receipt_entry(self, master_dark):
-        assert "master_dark" in master_dark.receipt["Module_Name"].values
+        assert "master_dark" in master_dark.receipt["FUNCTION"].values
 
     def test_bunit_is_rate(self, master_dark):
         for chip in CHIPS:
@@ -913,4 +913,4 @@ class TestMasterDarkRegression:
             assert np.mean(mask) > 0.9
 
     def test_bias_subtracted_via_receipt(self, master_dark):
-        assert "master_dark" in master_dark.receipt["Module_Name"].values
+        assert "master_dark" in master_dark.receipt["FUNCTION"].values

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -393,7 +393,7 @@ class TestMakeMasterL2:
     def test_receipt_entry(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)
         ml2 = wls.make_master_l2()
-        assert "master_wls" in ml2.receipt["Module_Name"].tolist()
+        assert "master_wls" in ml2.receipt["FUNCTION"].tolist()
 
     def test_resets_l2_cache(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -113,7 +113,7 @@ class TestScienceRecipe:
 
     def test_receipt_chain(self, recipe_output):
         l2 = KPF2.from_fits(recipe_output)
-        modules = l2.receipt["Module_Name"].values
+        modules = l2.receipt["FUNCTION"].values
         assert "image_assembly" in modules
         assert "calibration_association" in modules
         assert "spectral_extraction" in modules

--- a/tests/regression/test_spectral_extraction.py
+++ b/tests/regression/test_spectral_extraction.py
@@ -258,7 +258,7 @@ class TestPerformShapes:
         )
         se = SpectralExtraction(minimal_l1)
         l2 = se.perform()
-        modules = l2.receipt["Module_Name"].values
+        modules = l2.receipt["FUNCTION"].values
         assert "to_kpf2" in modules
         assert "spectral_extraction" in modules
 
@@ -307,7 +307,7 @@ class TestSpectralExtractionRealData:
 
     def test_receipt_chain(self, l2_from_flat):
         l2, _ = l2_from_flat
-        modules = l2.receipt["Module_Name"].values
+        modules = l2.receipt["FUNCTION"].values
         assert "image_assembly" in modules
         assert "spectral_extraction" in modules
 

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -53,7 +53,9 @@ def _make_master_l2(seed=42):
     for chip in _CHIPS:
         norder = NORDER_GREEN if chip == "GREEN" else NORDER_RED
         for fiber in _FIBERS:
-            arr = rng.uniform(4000.0, 8000.0, size=(norder, NCOL)).astype(np.float32)
+            # WAVE is born-64 (EPRV / dtype policy); rvdata's MinBitDepth would
+            # otherwise upcast-and-warn a float32 WAVE on read.
+            arr = rng.uniform(4000.0, 8000.0, size=(norder, NCOL)).astype(np.float64)
             master.data[f"{chip}_{fiber}_WAVE"] = arr
     return master
 
@@ -159,7 +161,7 @@ class TestPerform:
     def test_adds_receipt_entry(self, master_wls_path):
         l2 = _make_science_l2(wls_path=master_wls_path)
         WavelengthCalibration(l2).perform()
-        assert (l2.receipt["Module_Name"] == "wavelength_calibration").any()
+        assert (l2.receipt["FUNCTION"] == "wavelength_calibration").any()
 
     def test_attributes_populated_after_perform(self, master_wls_path):
         l2 = _make_science_l2(wls_path=master_wls_path)
@@ -181,9 +183,12 @@ class TestPerform:
                 np.testing.assert_array_equal(l2.data[key], master.data[key])
 
     def test_wave_arrays_are_float64(self, master_wls_path):
-        # The fixture master is float32 (4-byte); the science WAVE must be float64.
+        # WAVE is born-64 everywhere (EPRV / dtype policy; rvdata MinBitDepth also
+        # enforces 64-bit WAVE on read). Both the master and the science WAVE it is
+        # copied onto must be float64.
         master = KPFMasterL2.from_fits(master_wls_path)
-        assert master.data["GREEN_SCI2_WAVE"].dtype.itemsize == 4
+        # from_fits yields big-endian (>f8); compare precision, not byte order.
+        assert_dtype(master.data["GREEN_SCI2_WAVE"], WAVE, "master GREEN_SCI2_WAVE")
         l2 = _make_science_l2(wls_path=master_wls_path)
         WavelengthCalibration(l2).perform()
         for chip in _CHIPS:
@@ -239,7 +244,7 @@ class TestPerform:
             norder = NORDER_GREEN if chip == "GREEN" else NORDER_RED
             master.data[f"{chip}_SCI2_WAVE"] = rng.uniform(
                 4000.0, 8000.0, size=(norder, NCOL)
-            ).astype(np.float32)
+            ).astype(np.float64)  # WAVE is born-64 (EPRV / dtype policy)
         master_path = str(tmp_path / "partial_master.fits")
         master.to_fits(master_path)
 


### PR DESCRIPTION
  ## Upgrade rvdata to v0.4.0

  Bumps the `rv-data-standard` pin to the released **v0.4.0** and adapts our data
  models to its breaking changes. Also hardens a pre-existing dtype-enforcement gap
  that v0.4.0 exposed.

  ### Commits

  **1. `deps(rvdata): upgrade to rv-data-standard==0.4.0`**
  - Pin `rv-data-standard==0.4.0` (released PyPI version, replacing the git+commit URL).
  - `receipt_add_entry`: adopt the new `(function, args, status)` signature; add
    `"read"` to `_INTERNAL_RECEIPTS` so v0.4.0's decorated `read` no longer advances
    `DRPSTATU` on a plain read. Update all call sites to the rvdata `ARGS` convention.
  - RECEIPT schema: derive column names from rvdata's `BASE_RECEIPT_COLUMNS`
    (`TIME/.../FUNCTION/ARGS/STATUS`); migrate test reads to `["FUNCTION"]`.
  - `to_fits`: keep our single-filepath `to_fits(fn=None)` via explicit KPF2/KPF4
    overrides that delegate to rvdata's renamed `out_filename`.
  - Remove now-redundant workarounds: `_restore_primary_comments` (base preserves
    PRIMARY comments in 0.4.0) and the manual receipt sync (use base
    `_sync_receipt_to_extension`).
  - Kept the NUMORDER 65→67 override (rvdata still defaults 65). MinBitDepth needed
    no code change (our policy is already born-64 WAVE); corrected three test
    fixtures writing float32 WAVE.

  **2. `fix(data-models): enforce MinBitDepth on the chip-prefix set_data path`**
  - A chip-prefix write (e.g. `set_data("GREEN_SCI2_WAVE", ...)`) bypassed rvdata's
    MinBitDepth check and could silently store float32 WAVE. Enforce the born-64
    WAVE / 8-bit policy on that path too, via a shared `_coerce_to_min_bit_depth`
    helper that mirrors rvdata's upcast-and-warn. FLUX (no requirement) is untouched.
  - Adds regression tests for both directions.

  ### Notes
  - Docs kept minimal: CLAUDE.md pin note + the style-guide `receipt_add_entry`
    snippets only.
  - The recurring `PARANG/PARANG2` warning is a pre-existing rvdata header_map
    inconsistency (unchanged by this bump), surfaced intentionally — not addressed here.

  ### Testing
  - Full suite: **1050 passed**, 0 MinBitDepth warnings. `ruff format`/`check` clean.
  - 34 files changed (+203 / −156).