### PR TITLE
RV: persist per-order CCF weights as the L4 RV-table WEIGHT column

### DIFF
--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -994,6 +994,7 @@ class RadialVelocity:
         for fiber in fibers:
             rv = np.full(norder, np.nan)
             rv_err = np.full(norder, np.nan)
+            weight = np.full(norder, np.nan)
 
             # Dispatch the mask/barycorr/grid-center from the fiber's illumination
             # source; unilluminated or not-yet-implemented sources are skipped
@@ -1032,6 +1033,7 @@ class RadialVelocity:
                 )
                 rv[rows] = result["rv"]
                 rv_err[rows] = result["rv_err"]
+                weight[rows] = self._get_order_weights(chip, fiber)
 
             # Per-fiber per-CCD weighted RV (orders collapsed, single fiber).
             per_ccd = self.compute_weighted_rvs(
@@ -1053,7 +1055,9 @@ class RadialVelocity:
                 "ccd_rv_err": ccd_rv_err,
             }
 
-            # Per-orderlet RV table, one row per spectral order.
+            # Per-orderlet RV table, one row per spectral order. WEIGHT is the
+            # per-order CCF-combination weight (ccf_order_weights.csv, by mask),
+            # persisted for downstream weighting (e.g. DiagL4 BJD/BCV statistics).
             wave = np.asarray(self.l2_obj.data[f"{fiber}_WAVE"], dtype=np.float64)
             l4_obj.set_data(
                 f"{fiber}_RV",
@@ -1066,6 +1070,7 @@ class RadialVelocity:
                         "WAVE_END": np.nanmax(wave, axis=1),
                         "RV": rv,
                         "RV_ERR": rv_err,
+                        "WEIGHT": weight,
                     }
                 ),
             )

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -690,6 +690,7 @@ class TestPerform:
                 "WAVE_END",
                 "RV",
                 "RV_ERR",
+                "WEIGHT",
             }
             # EPRV L4: time/wavelength columns are 64-bit; order index is integer.
             assert table["BJD_TDB"].dtype == np.float64
@@ -715,6 +716,22 @@ class TestPerform:
         for fiber in self._ILLUMINATED:
             rv = np.asarray(l4.data[f"{fiber}_RV"]["RV"])
             np.testing.assert_allclose(rv, _V_INJECT, atol=0.1)
+
+    def test_rv_table_weight_column_matches_order_weights(self, rv_module):
+        # The per-order CCF-combination weights (ccf_order_weights.csv, column
+        # by the orderlet's mask) are persisted as the WEIGHT column, green
+        # orders then red, matching _get_order_weights.
+        l4 = rv_module.perform()
+        for fiber in self._ILLUMINATED:
+            weight = np.asarray(l4.data[f"{fiber}_RV"]["WEIGHT"], dtype=float)
+            expected = np.concatenate(
+                [
+                    rv_module._get_order_weights("GREEN", fiber),
+                    rv_module._get_order_weights("RED", fiber),
+                ]
+            )
+            assert weight.shape == (NORDER,)
+            np.testing.assert_array_equal(weight, expected)
 
     def test_per_fiber_ccf_and_rv_headers(self, rv_module):
         # EPRV L4 keywords on each orderlet's CCF/RV extension; RVMETHOD on PRIMARY.


### PR DESCRIPTION
## What

Adds a per-order **`WEIGHT`** column to each `{fiber}_RV` table in the L4 product.

`RadialVelocity` already loads per-order CCF-combination weights from `reference/ccf_order_weights.csv` (column selected by the orderlet's mask) via `_get_order_weights`, and uses them to build the weighted CCF/RV combine. Those weights were never retained in the output. This persists them — green orders then red — so downstream consumers can weight per-order quantities exactly as the combine does.

`WEIGHT` is an EPRV-standard optional RV-table column; it round-trips through `to_fits`/`from_fits`.

## Why

This is the small prerequisite for **`DiagL4`** (next PR): the BJD / barycentric-RV dispersion diagnostics ported from the v2.12 pipeline (`CCFBCV`, `CCFBJD`, `BJDSTD`/`BJDRNG`, `BCVSTD`/`BCVRNG`, `MAXPCBCV`/`MINPCBCV`) are all **weighted** by the old pipeline's per-order "CCF Weights" column, which vNext's L4 RV table did not carry.

## Tests

`tests/regression/test_radial_velocity.py`: the `{fiber}_RV` column set now includes `WEIGHT`, and a new test asserts the column equals `_get_order_weights` (green+red concatenated) for every illuminated orderlet. Full `test_radial_velocity.py` passes (95); `test_data_models_l4.py` passes (22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
