### PR TITLE
L4 QC flags (QCL4) + checkpoint (CheckpointL4)

### DIFF
--- a/kpfpipe/data_models/config/L4-headers.csv
+++ b/kpfpipe/data_models/config/L4-headers.csv
@@ -33,3 +33,7 @@ BCVSTD,Weighted std of per-order BERV [m/s] (SCI2),QUALITY_CONTROL,float,DiagL4
 BCVRNG,Per-order BERV range [m/s] (SCI2),QUALITY_CONTROL,float,DiagL4
 MAXPCBCV,Max per-order BERV deviation from mean [%] (SCI2),QUALITY_CONTROL,float,DiagL4
 MINPCBCV,Min per-order BERV deviation from mean [%] (SCI2),QUALITY_CONTROL,float,DiagL4
+DATAPRL4,QC: L4 CCF/RV present,QUALITY_CONTROL,int,QCL4
+KWRDPRL4,QC: required L4 PRIMARY keywords present,QUALITY_CONTROL,int,QCL4
+TIMCHKL4,QC: L4 times consistent (DATE-BEG/MID/END/ELAPSED),QUALITY_CONTROL,int,QCL4
+QCPCBCV,QC: per-order BERV within +/-1% of mean,QUALITY_CONTROL,int,QCL4

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -118,7 +118,7 @@ class KeywordRegistry:
     # a level-N check. ``qc_flag_keywords`` unions them (drives the ISGOOD
     # aggregate); ``qc_flag_keywords_by_level`` keys the level-N checks by their
     # LEVEL tag (drives the per-level checkpoint, which flags only its own checks).
-    _QC_POPULATORS = frozenset({"QC", "QCL0", "QCL1", "QCL2"})
+    _QC_POPULATORS = frozenset({"QC", "QCL0", "QCL1", "QCL2", "QCL4"})
 
     # FITS structural / bookkeeping cards that are always permitted on any
     # extension and are never registered keywords. This is the single source of

--- a/kpfpipe/quality_control/checkpoints/__init__.py
+++ b/kpfpipe/quality_control/checkpoints/__init__.py
@@ -2,5 +2,6 @@ from kpfpipe.quality_control.checkpoints.base import Checkpoint
 from kpfpipe.quality_control.checkpoints.level0 import CheckpointL0
 from kpfpipe.quality_control.checkpoints.level1 import CheckpointL1
 from kpfpipe.quality_control.checkpoints.level2 import CheckpointL2
+from kpfpipe.quality_control.checkpoints.level4 import CheckpointL4
 
-__all__ = ["Checkpoint", "CheckpointL0", "CheckpointL1", "CheckpointL2"]
+__all__ = ["Checkpoint", "CheckpointL0", "CheckpointL1", "CheckpointL2", "CheckpointL4"]

--- a/kpfpipe/quality_control/checkpoints/level4.py
+++ b/kpfpipe/quality_control/checkpoints/level4.py
@@ -1,0 +1,14 @@
+"""Checkpoints for KPF Level 4 (RVs and CCFs) data products."""
+
+from kpfpipe.quality_control.checkpoints.base import Checkpoint
+from kpfpipe.quality_control.diagnostics import DiagL4
+from kpfpipe.quality_control.qc_flags import QCL4
+
+
+class CheckpointL4(Checkpoint):
+    """Checkpoints for KPF Level 4 RV/CCF products."""
+
+    LEVEL = "L4"
+    RAISE_FLAGS = ("DATAPRL4",)  # missing science CCF/RV is fatal; other flags warn.
+    DIAGNOSTICS = DiagL4
+    QC = QCL4

--- a/kpfpipe/quality_control/qc_flags/__init__.py
+++ b/kpfpipe/quality_control/qc_flags/__init__.py
@@ -2,5 +2,6 @@ from kpfpipe.quality_control.qc_flags.base import QC
 from kpfpipe.quality_control.qc_flags.level0 import QCL0
 from kpfpipe.quality_control.qc_flags.level1 import QCL1
 from kpfpipe.quality_control.qc_flags.level2 import QCL2
+from kpfpipe.quality_control.qc_flags.level4 import QCL4
 
-__all__ = ["QC", "QCL0", "QCL1", "QCL2"]
+__all__ = ["QC", "QCL0", "QCL1", "QCL2", "QCL4"]

--- a/kpfpipe/quality_control/qc_flags/level4.py
+++ b/kpfpipe/quality_control/qc_flags/level4.py
@@ -1,0 +1,103 @@
+"""QC checks for KPF Level 4 (RVs and CCFs) data products.
+
+Ports the v2.12 RV/CCF QC checks (``data_L2`` presence, ``L2_datetime`` timing,
+``L2_barycentric_rv_percent_change``) to vNext L4, plus the framework
+required-PRIMARY-keyword presence check. Every result is a 0/1 flag written to
+QUALITY_CONTROL via ``set_keyword`` (QC/diagnostic keywords never live on
+INSTRUMENT_HEADER -- that holds only the raw instrument snapshot, which this
+module *reads* for the raw DATE-*/ELAPSED timing).
+"""
+
+from datetime import datetime
+
+import numpy as np
+
+from kpfpipe.quality_control.qc_flags.base import QC
+
+_SCI_FIBERS = ("SCI1", "SCI2", "SCI3")
+# DATE-END - DATE-BEG vs ELAPSED tolerance, and max |per-order BERV % deviation|
+# (both from v2.12 quality_control.py).
+_TIME_TOL_S = 0.1
+_BCV_PCT_TOL = 1.0
+
+
+def _hdr_float(hdr, key):
+    """Return float value for a header key, or None if absent."""
+    val = hdr.get(key)
+    return None if val is None else float(val)
+
+
+def _parse_iso(value):
+    """Parse an ISO-8601 datetime string, or None if missing/unparseable."""
+    if value is None:
+        return None
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+
+
+class QCL4(QC):
+    """QC checks for KPF Level 4 RV/CCF products."""
+
+    LEVEL = "L4"
+
+    def ccf_rv_present(self):
+        """Each science orderlet has a non-empty CCF cube and RV table."""
+        for fiber in _SCI_FIBERS:
+            ccf = self.kpf_obj.data.get(f"{fiber}_CCF")
+            rv = self.kpf_obj.data.get(f"{fiber}_RV")
+            if ccf is None or np.size(ccf) == 0:
+                return False
+            if rv is None or len(rv) == 0:
+                return False
+        return True
+
+    ccf_rv_present._qc_key = "DATAPRL4"
+
+    def required_keywords_present(self):
+        """Every registry-required PRIMARY keyword for L4 is present (presence only)."""
+        return self._required_primary_keywords() <= set(self.kpf_obj.headers["PRIMARY"])
+
+    required_keywords_present._qc_key = "KWRDPRL4"
+
+    def times_consistent(self):
+        """DATE-BEG < DATE-MID < DATE-END and |(END-BEG) - ELAPSED| < 0.1 s.
+
+        Ports v2.12 ``L2_datetime``. The raw instrument times live on
+        INSTRUMENT_HEADER in vNext (the verbatim L0 PRIMARY snapshot).
+        """
+        inst = self.kpf_obj.headers.get("INSTRUMENT_HEADER", {})
+        beg, mid, end = (
+            _parse_iso(inst.get(k)) for k in ("DATE-BEG", "DATE-MID", "DATE-END")
+        )
+        if beg is None or mid is None or end is None:
+            return False
+        if not (beg <= mid <= end):
+            return False
+        elapsed = _hdr_float(inst, "ELAPSED")
+        if (
+            elapsed is not None
+            and abs((end - beg).total_seconds() - elapsed) > _TIME_TOL_S
+        ):
+            return False
+        return True
+
+    times_consistent._qc_key = "TIMCHKL4"
+
+    def barycentric_rv_percent_change(self):
+        """Per-order BERV deviation within +/-1% of the weighted mean.
+
+        Ports v2.12 ``L2_barycentric_rv_percent_change``, reading MAXPCBCV /
+        MINPCBCV written by DiagL4 (run DiagL4 before QCL4). Passes when the
+        metrics are absent (e.g. a calibration frame with no science RV) -- there
+        is nothing to flag.
+        """
+        hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
+        mx = _hdr_float(hdr, "MAXPCBCV")
+        mn = _hdr_float(hdr, "MINPCBCV")
+        if mx is None or mn is None:
+            return True
+        return mx <= _BCV_PCT_TOL and mn >= -_BCV_PCT_TOL
+
+    barycentric_rv_percent_change._qc_key = "QCPCBCV"

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -18,7 +18,12 @@ from kpfpipe.modules.image_processing import ImageProcessing
 from kpfpipe.modules.radial_velocity import RadialVelocity
 from kpfpipe.modules.spectral_extraction import SpectralExtraction
 from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
-from kpfpipe.quality_control.checkpoints import CheckpointL0, CheckpointL1, CheckpointL2
+from kpfpipe.quality_control.checkpoints import (
+    CheckpointL0,
+    CheckpointL1,
+    CheckpointL2,
+    CheckpointL4,
+)
 from kpfpipe.quality_control.quicklook import PlotL0, PlotL1, PlotL2
 from kpfpipe.utils.io import build_filepath, build_qlp_dir
 
@@ -107,13 +112,13 @@ def main(config, args):
     radial_velocity = RadialVelocity(l2, config)
     l4 = radial_velocity.perform()
 
-    # L4 quicklook plots
+    # L4 quicklook plots (PlotL4 lands with the L4 QLP PR; wire it in there).
     # l4_qlp_dir = build_qlp_dir(obs_id, "L4", data_root=data_root_science)
     # PlotL4(l4, output_dir=l4_qlp_dir, obs_id=obs_id).run("all")
 
-    # L4 processing complete: CheckpointL4.run() would fold in Diagnostics + QC
-    # (no QCL4/CheckpointL4 implemented yet).
-    # CheckpointL4(l4).run()
+    # L4 processing complete: CheckpointL4.run() folds in Diagnostics (DiagL4)
+    # and QC (QCL4), then validates (science -> Diagnostics -> QC -> Checkpoints).
+    CheckpointL4(l4).run()
 
     # Write the final L4 data product (RVs and CCFs) to disk
     l4_out_path = build_filepath(obs_id, "L4", data_root=data_root_science)

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -16,11 +16,23 @@ checkpoint methods; that orchestration is pinned in ``TestRunFoldsDiagnosticsAnd
 
 import warnings
 
+import numpy as np
 import pytest
+from astropy.io import fits
+from astropy.table import Table
 
+from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level2 import KPF2
-from kpfpipe.quality_control.checkpoints import Checkpoint, CheckpointL0, CheckpointL2
+from kpfpipe.data_models.level4 import KPF4
+from kpfpipe.quality_control.checkpoints import (
+    Checkpoint,
+    CheckpointL0,
+    CheckpointL2,
+    CheckpointL4,
+)
+
+_NORDER_TOTAL = DETECTOR["norder"]["GREEN"] + DETECTOR["norder"]["RED"]
 
 
 class TestUnregisteredKeywords:
@@ -173,3 +185,66 @@ class TestRunFoldsDiagnosticsAndQC:
             warnings.simplefilter("error")
             chk.run()
         assert chk.qc_results == {}
+
+
+# ---------------------------------------------------------------------------
+# CheckpointL4 — folds DiagL4 + QCL4, then validates the RV/CCF product
+# ---------------------------------------------------------------------------
+
+
+def _make_l4(*, sci=True):
+    """KPF4 good enough for CheckpointL4.run(): science CCF + RV tables (with
+    BJD_TDB/BERV/WEIGHT for DiagL4), consistent INSTRUMENT_HEADER times, and the
+    required PRIMARY keywords seeded so KWRDPRL4 passes."""
+    l4 = KPF4()
+    if sci:
+        rng = np.random.default_rng(3)
+        for fiber in ("SCI1", "SCI2", "SCI3"):
+            l4.set_data(f"{fiber}_CCF", np.ones((_NORDER_TOTAL, 5)))
+            l4.set_data(
+                f"{fiber}_RV",
+                Table(
+                    {
+                        "ORDER_INDEX": np.arange(_NORDER_TOTAL),
+                        "BJD_TDB": 2460000.0 + rng.normal(0, 1e-4, _NORDER_TOTAL),
+                        "BERV": 7.9 + rng.normal(0, 1e-4, _NORDER_TOTAL),
+                        "WEIGHT": np.ones(_NORDER_TOTAL),
+                    }
+                ),
+            )
+    if "INSTRUMENT_HEADER" not in l4.headers:
+        l4.set_header("INSTRUMENT_HEADER", fits.Header())
+    ih = l4.headers["INSTRUMENT_HEADER"]
+    ih["DATE-BEG"] = "2024-09-23T09:12:09.484"
+    ih["DATE-MID"] = "2024-09-23T09:12:15.519"
+    ih["DATE-END"] = "2024-09-23T09:12:21.554"
+    ih["ELAPSED"] = 12.07
+    for kw in CheckpointL4.QC(l4)._required_primary_keywords():
+        l4.headers["PRIMARY"][kw] = ("UNKNOWN", "seeded for test")
+    return l4
+
+
+class TestCheckpointL4:
+    def test_run_good_product_passes_and_writes_flags(self):
+        l4 = _make_l4()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # a good product must not warn
+            CheckpointL4(l4).run()
+        qc = l4.headers["QUALITY_CONTROL"]
+        # Folded DiagL4 metrics + QCL4 flags both landed on QUALITY_CONTROL.
+        assert qc["CCFBCV"] is not None and qc["CCFBJD"] is not None
+        assert qc["DATAPRL4"] == 1 and qc["TIMCHKL4"] == 1
+        assert qc["ISGOOD"] == 1
+
+    def test_run_raises_when_science_ccf_rv_missing(self):
+        # DATAPRL4 is fatal (in RAISE_FLAGS): no science CCF/RV -> run() raises.
+        l4 = _make_l4(sci=False)
+        with pytest.raises(ValueError, match="DATAPRL4 = 0"):
+            CheckpointL4(l4).run()
+
+    def test_nonraise_flag_warns(self):
+        # Bad timing -> TIMCHKL4 = 0; not a RAISE_FLAG, so it warns (not raises).
+        l4 = _make_l4()
+        l4.headers["INSTRUMENT_HEADER"]["ELAPSED"] = 999.0  # END-BEG != ELAPSED
+        with pytest.warns(UserWarning, match="TIMCHKL4 = 0"):
+            CheckpointL4(l4).run()

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -20,17 +20,21 @@ import types
 import numpy as np
 import pytest
 from astropy.io import fits
+from astropy.table import Table
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.quality_control.qc_flags.base import QC
 from kpfpipe.quality_control.qc_flags.level0 import QCL0
 from kpfpipe.quality_control.qc_flags.level1 import QCL1
 from kpfpipe.quality_control.qc_flags.level2 import QCL2
+from kpfpipe.quality_control.qc_flags.level4 import QCL4
 
 _NORDER = {"GREEN": DETECTOR["norder"]["GREEN"], "RED": DETECTOR["norder"]["RED"]}
+_NORDER_TOTAL = _NORDER["GREEN"] + _NORDER["RED"]
 _NCOLS = 10  # small column count for fast tests
 
 
@@ -923,3 +927,109 @@ class TestQCScript:
             text=True,
         )
         assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# QCL4 — CCF/RV presence, times, and BERV percent-change (ported from v2.12)
+# ---------------------------------------------------------------------------
+
+_GOOD_DATES = {
+    "DATE-BEG": "2024-09-23T09:12:09.484",
+    "DATE-MID": "2024-09-23T09:12:15.519",
+    "DATE-END": "2024-09-23T09:12:21.554",
+    "ELAPSED": 12.07,
+}
+
+
+def _make_l4(*, sci=True, dates=_GOOD_DATES, maxpc=None, minpc=None):
+    """KPF4 with science CCF/RV, INSTRUMENT_HEADER times, and optional BCV %."""
+    l4 = KPF4()
+    if sci:
+        for fiber in ("SCI1", "SCI2", "SCI3"):
+            l4.set_data(f"{fiber}_CCF", np.ones((_NORDER_TOTAL, 5)))
+            l4.set_data(
+                f"{fiber}_RV",
+                Table(
+                    {
+                        "ORDER_INDEX": np.arange(_NORDER_TOTAL),
+                        "RV": np.zeros(_NORDER_TOTAL),
+                    }
+                ),
+            )
+    if "INSTRUMENT_HEADER" not in l4.headers:
+        l4.set_header("INSTRUMENT_HEADER", fits.Header())
+    for k, v in (dates or {}).items():
+        l4.headers["INSTRUMENT_HEADER"][k] = v
+    if maxpc is not None:
+        l4.headers["QUALITY_CONTROL"]["MAXPCBCV"] = maxpc
+    if minpc is not None:
+        l4.headers["QUALITY_CONTROL"]["MINPCBCV"] = minpc
+    return l4
+
+
+class TestQCL4:
+    def test_ccf_rv_present_pass(self):
+        assert QCL4(_make_l4()).ccf_rv_present() is True
+
+    def test_ccf_rv_present_fail_when_missing(self):
+        assert QCL4(_make_l4(sci=False)).ccf_rv_present() is False
+
+    def test_times_consistent_pass(self):
+        assert QCL4(_make_l4()).times_consistent() is True
+
+    def test_times_out_of_order_fails(self):
+        bad = dict(_GOOD_DATES, **{"DATE-MID": "2024-09-23T09:12:25.000"})  # mid > end
+        assert QCL4(_make_l4(dates=bad)).times_consistent() is False
+
+    def test_times_duration_mismatch_fails(self):
+        bad = dict(_GOOD_DATES, ELAPSED=99.0)  # END-BEG != ELAPSED
+        assert QCL4(_make_l4(dates=bad)).times_consistent() is False
+
+    def test_times_missing_keys_fail(self):
+        assert QCL4(_make_l4(dates={})).times_consistent() is False
+
+    def test_bcv_percent_change_pass(self):
+        assert (
+            QCL4(_make_l4(maxpc=0.3, minpc=-0.4)).barycentric_rv_percent_change()
+            is True
+        )
+
+    def test_bcv_percent_change_fail(self):
+        assert (
+            QCL4(_make_l4(maxpc=1.5, minpc=-0.2)).barycentric_rv_percent_change()
+            is False
+        )
+
+    def test_bcv_percent_change_absent_passes(self):
+        # No MAXPCBCV/MINPCBCV (e.g. calibration frame) -> nothing to flag.
+        assert QCL4(_make_l4()).barycentric_rv_percent_change() is True
+
+    def test_required_keywords_present(self):
+        l4 = _make_l4()
+        req = QCL4(l4)._required_primary_keywords()
+        for kw in req:
+            l4.headers["PRIMARY"][kw] = 1.0
+        assert QCL4(l4).required_keywords_present() is True
+        if req:
+            del l4.headers["PRIMARY"][sorted(req)[0]]
+            assert QCL4(l4).required_keywords_present() is False
+
+    def test_run_all_good_isgood(self):
+        l4 = _make_l4(maxpc=0.1, minpc=-0.1)
+        for kw in QCL4(l4)._required_primary_keywords():
+            l4.headers["PRIMARY"][kw] = 1.0
+        results = QCL4(l4).run()
+        assert set(results) >= {"DATAPRL4", "KWRDPRL4", "TIMCHKL4", "QCPCBCV"}
+        qc = l4.headers["QUALITY_CONTROL"]
+        assert qc["DATAPRL4"] == 1 and qc["TIMCHKL4"] == 1 and qc["QCPCBCV"] == 1
+        assert qc["ISGOOD"] == 1
+
+    def test_run_flags_failure_in_isgood(self):
+        l4 = _make_l4(sci=False, maxpc=2.0, minpc=-2.0)  # no CCF/RV, bad BCV
+        for kw in QCL4(l4)._required_primary_keywords():
+            l4.headers["PRIMARY"][kw] = 1.0
+        l4.headers["QUALITY_CONTROL"]  # ensure present
+        QCL4(l4).run()
+        qc = l4.headers["QUALITY_CONTROL"]
+        assert qc["DATAPRL4"] == 0 and qc["QCPCBCV"] == 0
+        assert qc["ISGOOD"] == 0


### PR DESCRIPTION
## Summary

Completes the L4 quality-control stack by porting the v2.12 RV/CCF QC checks to vNext and wiring them into the science recipe through `CheckpointL4.run()` (Diagnostics → QC → Checkpoints). Builds on **#1496 (DiagL4)** — stacked, so this targets `kpf-next-l4-diag` and GitHub will retarget it to `kpf-next` once #1496 merges.

### `QCL4` (`quality_control/qc_flags/level4.py`)
Writes four 0/1 flags to `QUALITY_CONTROL` via `set_keyword` (QC/diagnostic keywords never live on `INSTRUMENT_HEADER` — that holds only the raw L0 snapshot, which `QCL4` *reads* for the raw timing):

| Flag | Check | Ports v2.12 |
|------|-------|-------------|
| `DATAPRL4` | each science orderlet (SCI1/2/3) has a non-empty CCF cube + RV table | `data_L2` presence |
| `KWRDPRL4` | every registry-required PRIMARY keyword for L4 is present | framework required-keyword check |
| `TIMCHKL4` | `DATE-BEG < DATE-MID < DATE-END` and `|(END−BEG) − ELAPSED| < 0.1 s` (read from `INSTRUMENT_HEADER`) | `L2_datetime` |
| `QCPCBCV` | per-order BERV within ±1% of the weighted mean (reads `MAXPCBCV`/`MINPCBCV` from DiagL4) | `L2_barycentric_rv_percent_change` |

`QCPCBCV` passes when the BERV metrics are absent (e.g. a calibration frame with no science RV) — nothing to flag.

### `CheckpointL4` (`quality_control/checkpoints/level4.py`)
Pairs `DiagL4` + `QCL4`; `RAISE_FLAGS = ("DATAPRL4",)` (missing science CCF/RV is fatal), the rest warn.

### Plumbing
- `keyword_registry._QC_POPULATORS` gains `"QCL4"` so the four flags register as L4 QC flags — they feed `ISGOOD` (cross-level running AND) and scope the per-level checkpoint to its own flags.
- Four `QCL4` rows registered in `L4-headers.csv` (homed on `QUALITY_CONTROL`).
- `recipes/kpf_drp_science.py`: activate `CheckpointL4(l4).run()` after RV computation.

## Verification
- Full fast subset green on the env aligned to the `rv-data-standard==0.4.0` pin: **975 passed**, including 19 new L4 tests (DiagL4 + QCL4 + CheckpointL4).
- End-to-end on real Tau Ceti data: all four L4 flags pass (`DATAPRL4/KWRDPRL4/TIMCHKL4/QCPCBCV = 1`); `ISGOOD = 0` correctly reflects propagated lower-level flags (`FLATOK` — flat correction disabled; `RNOK`), and `CheckpointL4` does not raise (only `DATAPRL4` is fatal and it passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)