### PR TITLE
Cleanup RV/CCF outputs to be EPRV standard compliant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,14 +212,21 @@ see the style guide §11.)* The architecture invariants:
   cards; no KPF-registered keywords, no raw WMKO natives). `KPF1.__init__` seeds the EPRV Required
   PRIMARY skeleton (`keyword_registry.eprv_primary_seed`); `to_kpf1` then overlays native values on top
   (native wins). The required-keyword *presence* check is a QC flag (`KWRDPRL{1,2,4}`).
+  **One deliberate exception:** the L4 SCI-combined per-CCD RV keywords
+  `CCD1RV`/`CCD2RV`/`CCD1ERV`/`CCD2ERV` are KPF-registered (`config/L4-headers.csv`) yet homed on
+  PRIMARY, because they are the pipeline's final RV measurements and belong with the EPRV
+  `RV`/`RVERR`. (`RV`/`RVERR` themselves are EPRV PRIMARY keywords, not KPF-registered, so they are not
+  the exception.)
 - **`INSTRUMENT_HEADER` is an immutable verbatim copy of the raw L0 PRIMARY** (values **and** comments),
   written once in `to_kpf1` and never again. Code needing a raw instrument keyword (`ELAPSED`,
   `MJD-OBS`, `DATE-OBS`, `GAIAID`, `SCI-OBJ`, `TARGTEFF`, …) reads it from here, not PRIMARY.
 - **Each registered keyword has one home extension** (the registry `Extension` column), which
-  `set_keyword` routes to: **PRIMARY** (EPRV only), **QUALITY_CONTROL** (QC flags + `ISGOOD`, read-noise,
+  `set_keyword` routes to: **PRIMARY** (EPRV keywords, plus the L4 final-RV exception
+  `CCD{1,2}RV`/`CCD{1,2}ERV` above), **QUALITY_CONTROL** (QC flags + `ISGOOD`, read-noise,
   calibration ages, DiagL2 metrics), **RECEIPT** (DRP provenance, applied flags, calibration paths), the
-  **barycentric** L2 extensions, and **RV1–RV5** (L4). Masters route their PRIMARY keywords the same way
-  (registered in `config/Masters-headers.csv`); `BUNIT` is structural, not registered.
+  **barycentric** L2 extensions, and **RV1–RV5** (L4 per-orderlet `CCD{1,2}RV<sfx>`). Masters route their
+  PRIMARY keywords the same way (registered in `config/Masters-headers.csv`); `BUNIT` is structural, not
+  registered.
 - **DRP provenance is stamped at read** (`KPF0.from_fits` → `_stamp_wmko_tracking`) onto RECEIPT, not at
   `to_kpf1`: `DRPVERNO`/`DRPSTATU`/`PROGID`/`KOAID`. It rides the RECEIPT header forward downstream;
   `DRPSTATU` is advanced per module by `_update_drpstatus`.

--- a/EPRV_DATA_STANDARD.md
+++ b/EPRV_DATA_STANDARD.md
@@ -63,8 +63,8 @@ while `KPF2`/`KPF4` subclass the EPRV `RV2`/`RV4` and must satisfy everything be
 - **Required vs optional**: `Required=True` extensions must be present *and meaningfully
   populated*; `Required=False` are optional enhancements.
 - **MinBitDepth**: the standard enforces minimum precision — **`*_WAVE` and `BJD_TDB` are
-  64-bit**; quality arrays are 8-bit. (Newer RVData upcasts 32-bit `*_WAVE` to float64 and
-  warns — see §8.)
+  64-bit**; quality arrays are 8-bit. (rvdata 0.4.0 enforces this on serialize, upcasting any
+  sub-64-bit `*_WAVE`/`BJD_TDB` and warning; KPF `*_WAVE`/`BJD_TDB` are already born-64.)
 - Undefined values (e.g. unextracted orders) are **NaN**.
 
 ### Shared extensions (present at L2, L3, L4)
@@ -124,10 +124,18 @@ optional** (supports non-CCF methods).
 L4 PRIMARY gains: `BJDTDB`, `RV`, `RVERR`, `BERV`, `RVMETHOD`, `SYSVEL`.
 `RV2`/`CCF2`/… replicate per trace.
 
-> **vNext note:** the `RV1` required column is listed above as `BC_VELOCITY` (the
-> standard's develop docs), but the pinned RVData (§8) and our code use `BERV`. The
-> code correctly emits `BERV`; this is the same doc-vs-pin drift as the
-> `receipt_add_entry` signature note in §7. Reconcile when bumping the pin.
+> **vNext note (reconciled against rvdata 0.4.0):** the table cell above mirrors
+> the standard's *develop* readthedocs, which drift from the released package KPF pins:
+> - **Barycentric column** — develop docs say `BC_VELOCITY`, but 0.4.0's machine-readable
+>   `L4-RV_TABLE-columns.csv` (what its compliance checker uses) names it **`BERV`**. Our
+>   code emits `BERV`; we are compliant. The develop-doc name is upstream drift, not ours.
+> - **Headers** — develop docs list `RVMETHOD/RVSTART/RVSTEP/MASK` on `RVn`, but 0.4.0
+>   registers `RVMETHOD/SKYRMVD/TELLRMVD` on `RVn` and puts the velocity-grid keywords
+>   (`VELSTART/VELSTEP/VELNSTEP/CCFMASK`) on `CCFn`. Our code emits exactly the 0.4.0 set.
+> - **Optional columns** — KPF populates the EPRV-optional `ORDER_INDEX`, `ECHELLE_ORDER`
+>   (physical grating order, blue→red), and `WEIGHT` (per-order CCF-combination weight),
+>   plus a KPF-custom `ORDER_ID` (chip/fiber/order name, 1-based per chip — the standard
+>   permits team-added columns).
 
 ---
 
@@ -181,9 +189,10 @@ levels. The standard's logged columns: **time, code release, branch name, commit
 function, args, status**. Adding an entry takes **three caller-supplied strings: function
 name, relevant parameters (args), and status**; time/version/branch are filled automatically.
 
-> **vNext note:** our code currently calls `receipt_add_entry(module, status)` (2 args)
-> because we pin an older RVData (§8); the standard/newer RVData expects
-> `receipt_add_entry(module, args, status)` (3 args). Reconcile when bumping the pin.
+> **vNext note (reconciled on rvdata 0.4.0):** our code now calls the 3-arg
+> `receipt_add_entry(function, args, status)` matching the standard — `KPFDataModel`
+> overrides it (`data_models/base.py`) and every module passes the three strings (most an
+> empty `args`). The earlier 2-arg form is gone; this drift is resolved.
 
 ---
 

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -654,6 +654,8 @@ class attribute (and uses `.routing` in `set_keyword`); the checkpoints validato
   `TARGTEFF`, …): read it from `headers["INSTRUMENT_HEADER"]` (via `.get`), never from
   PRIMARY. No silent fallback — let a missing key raise.
 - Use EPRV keyword *names* on PRIMARY (e.g. `EXPTIME`, not `ELAPSED`; `OBSTYPE`, not `IMTYPE`).
+  Exception: the L4 final-RV measurements `CCD{1,2}RV`/`CCD{1,2}ERV` are KPF-registered keywords
+  deliberately homed on PRIMARY (alongside the EPRV `RV`/`RVERR`).
 
 ---
 

--- a/kpfpipe/data_models/config/L4-headers.csv
+++ b/kpfpipe/data_models/config/L4-headers.csv
@@ -1,10 +1,8 @@
 Keyword,Description,Extension,DataType,PopulatedBy
-CCD1RV,GREEN SCI-combined RV [km/s] (legacy),RV3,float,RadialVelocity
-CCD2RV,RED SCI-combined RV [km/s] (legacy),RV3,float,RadialVelocity
-CCD1ERV,GREEN SCI-combined RV error [km/s] (legacy),RV3,float,RadialVelocity
-CCD2ERV,RED SCI-combined RV error [km/s] (legacy),RV3,float,RadialVelocity
-CCFRV,Cross-chip science-combined RV [km/s] (legacy),RV3,float,RadialVelocity
-CCFERV,Cross-chip science-combined RV error [km/s] (legacy),RV3,float,RadialVelocity
+CCD1RV,GREEN SCI-combined RV [km/s] (legacy),PRIMARY,float,RadialVelocity
+CCD2RV,RED SCI-combined RV [km/s] (legacy),PRIMARY,float,RadialVelocity
+CCD1ERV,GREEN SCI-combined RV error [km/s] (legacy),PRIMARY,float,RadialVelocity
+CCD2ERV,RED SCI-combined RV error [km/s] (legacy),PRIMARY,float,RadialVelocity
 CCD1RVS,GREEN SKY RV [km/s] (legacy),RV1,float,RadialVelocity
 CCD1RV1,GREEN SCI1 RV [km/s] (legacy),RV2,float,RadialVelocity
 CCD1RV2,GREEN SCI2 RV [km/s] (legacy),RV3,float,RadialVelocity

--- a/kpfpipe/data_models/config/L4-headers.csv
+++ b/kpfpipe/data_models/config/L4-headers.csv
@@ -1,25 +1,25 @@
 Keyword,Description,Extension,DataType,PopulatedBy
-CCD1RV,GREEN SCI-combined RV [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCD2RV,RED SCI-combined RV [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCD1ERV,GREEN SCI-combined RV error [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCD2ERV,RED SCI-combined RV error [km/s] (legacy),PRIMARY,float,RadialVelocity
-CCD1RVS,GREEN SKY RV [km/s] (legacy),RV1,float,RadialVelocity
-CCD1RV1,GREEN SCI1 RV [km/s] (legacy),RV2,float,RadialVelocity
-CCD1RV2,GREEN SCI2 RV [km/s] (legacy),RV3,float,RadialVelocity
-CCD1RV3,GREEN SCI3 RV [km/s] (legacy),RV4,float,RadialVelocity
-CCD1RVC,GREEN CAL RV [km/s] (legacy),RV5,float,RadialVelocity
-CCD2RVS,RED SKY RV [km/s] (legacy),RV1,float,RadialVelocity
-CCD2RV1,RED SCI1 RV [km/s] (legacy),RV2,float,RadialVelocity
-CCD2RV2,RED SCI2 RV [km/s] (legacy),RV3,float,RadialVelocity
-CCD2RV3,RED SCI3 RV [km/s] (legacy),RV4,float,RadialVelocity
-CCD2RVC,RED CAL RV [km/s] (legacy),RV5,float,RadialVelocity
-CCD1ERVS,GREEN SKY RV error [km/s] (legacy),RV1,float,RadialVelocity
-CCD1ERV1,GREEN SCI1 RV error [km/s] (legacy),RV2,float,RadialVelocity
-CCD1ERV2,GREEN SCI2 RV error [km/s] (legacy),RV3,float,RadialVelocity
-CCD1ERV3,GREEN SCI3 RV error [km/s] (legacy),RV4,float,RadialVelocity
-CCD1ERVC,GREEN CAL RV error [km/s] (legacy),RV5,float,RadialVelocity
-CCD2ERVS,RED SKY RV error [km/s] (legacy),RV1,float,RadialVelocity
-CCD2ERV1,RED SCI1 RV error [km/s] (legacy),RV2,float,RadialVelocity
-CCD2ERV2,RED SCI2 RV error [km/s] (legacy),RV3,float,RadialVelocity
-CCD2ERV3,RED SCI3 RV error [km/s] (legacy),RV4,float,RadialVelocity
-CCD2ERVC,RED CAL RV error [km/s] (legacy),RV5,float,RadialVelocity
+CCD1RV,GREEN SCI-combined RV [km/s],PRIMARY,float,RadialVelocity
+CCD2RV,RED SCI-combined RV [km/s],PRIMARY,float,RadialVelocity
+CCD1ERV,GREEN SCI-combined RV error [km/s],PRIMARY,float,RadialVelocity
+CCD2ERV,RED SCI-combined RV error [km/s],PRIMARY,float,RadialVelocity
+CCD1RVS,GREEN SKY RV [km/s],RV1,float,RadialVelocity
+CCD1RV1,GREEN SCI1 RV [km/s],RV2,float,RadialVelocity
+CCD1RV2,GREEN SCI2 RV [km/s],RV3,float,RadialVelocity
+CCD1RV3,GREEN SCI3 RV [km/s],RV4,float,RadialVelocity
+CCD1RVC,GREEN CAL RV [km/s],RV5,float,RadialVelocity
+CCD2RVS,RED SKY RV [km/s],RV1,float,RadialVelocity
+CCD2RV1,RED SCI1 RV [km/s],RV2,float,RadialVelocity
+CCD2RV2,RED SCI2 RV [km/s],RV3,float,RadialVelocity
+CCD2RV3,RED SCI3 RV [km/s],RV4,float,RadialVelocity
+CCD2RVC,RED CAL RV [km/s],RV5,float,RadialVelocity
+CCD1ERVS,GREEN SKY RV error [km/s],RV1,float,RadialVelocity
+CCD1ERV1,GREEN SCI1 RV error [km/s],RV2,float,RadialVelocity
+CCD1ERV2,GREEN SCI2 RV error [km/s],RV3,float,RadialVelocity
+CCD1ERV3,GREEN SCI3 RV error [km/s],RV4,float,RadialVelocity
+CCD1ERVC,GREEN CAL RV error [km/s],RV5,float,RadialVelocity
+CCD2ERVS,RED SKY RV error [km/s],RV1,float,RadialVelocity
+CCD2ERV1,RED SCI1 RV error [km/s],RV2,float,RadialVelocity
+CCD2ERV2,RED SCI2 RV error [km/s],RV3,float,RadialVelocity
+CCD2ERV3,RED SCI3 RV error [km/s],RV4,float,RadialVelocity
+CCD2ERVC,RED CAL RV error [km/s],RV5,float,RadialVelocity

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -1055,15 +1055,41 @@ class RadialVelocity:
                 "ccd_rv_err": ccd_rv_err,
             }
 
-            # Per-orderlet RV table, one row per spectral order. WEIGHT is the
-            # per-order CCF-combination weight (ccf_order_weights.csv, by mask),
-            # persisted for downstream weighting (e.g. DiagL4 BJD/BCV statistics).
+            # Per-orderlet RV table, one row per spectral order (green orders
+            # then red). ORDER_ID is the KPF chip/fiber/order name, 1-based per
+            # chip (a KPF-custom extra column). ECHELLE_ORDER is the physical
+            # grating order from detector.toml echelle_orders, listed blue->red,
+            # so order index 0 -- the bluest -- carries the highest echelle
+            # number. WEIGHT is the per-order CCF-combination weight
+            # (ccf_order_weights.csv, by mask), persisted for downstream
+            # weighting (e.g. DiagL4 BJD/BCV statistics).
+            order_id = np.array(
+                [
+                    f"{chip}_{fiber}_{order}"
+                    for chip in ("GREEN", "RED")
+                    for order in range(1, self.norder[chip] + 1)
+                ]
+            )
+            echelle_order = np.concatenate(
+                [
+                    np.linspace(
+                        self.echelle_orders[chip][0],
+                        self.echelle_orders[chip][1],
+                        self.norder[chip],
+                    )
+                    .round()
+                    .astype(np.int64)
+                    for chip in ("GREEN", "RED")
+                ]
+            )
             wave = np.asarray(self.l2_obj.data[f"{fiber}_WAVE"], dtype=np.float64)
             l4_obj.set_data(
                 f"{fiber}_RV",
                 pd.DataFrame(
                     {
                         "ORDER_INDEX": np.arange(norder, dtype=np.int64),
+                        "ORDER_ID": order_id,
+                        "ECHELLE_ORDER": echelle_order,
                         "BJD_TDB": bjd_tdb,
                         "BERV": berv,
                         "WAVE_START": np.nanmin(wave, axis=1),

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -958,11 +958,13 @@ class RadialVelocity:
         l4_obj : KPF4
             L4 with a CCF cube and per-order RV table per illuminated orderlet.
             Each CCF extension carries VELSTART/VELSTEP/VELNSTEP/CCFMASK; each RV
-            extension carries RVMETHOD/SKYRMVD/TELLRMVD. The legacy combined-RV
-            keywords are registered KPF-pipeline keywords routed to the RV# tables:
-            per-fiber CCD<n>RV<sfx>/CCD<n>ERV<sfx> by orderlet, and the SCI-combined
-            CCD<n>RV/CCD<n>ERV plus CCFRV/CCFERV on RV3. PRIMARY carries the EPRV
-            keywords RVMETHOD and RV/RVERR/BERV/BJDTDB (the combined science RV).
+            extension carries RVMETHOD/SKYRMVD/TELLRMVD. The per-fiber legacy RV
+            keywords CCD<n>RV<sfx>/CCD<n>ERV<sfx> are registered KPF-pipeline
+            keywords routed to their RV# table by orderlet. PRIMARY carries the
+            final science RV: the EPRV keywords RVMETHOD/RV/RVERR/BERV/BJDTDB, plus
+            the KPF SCI-combined per-CCD CCD<n>RV/CCD<n>ERV -- KPF-registered yet
+            homed on PRIMARY as a deliberate exception to the EPRV-only-PRIMARY
+            rule, since these are the pipeline's final RV measurements.
             Unilluminated ('none') fibers are skipped (empty extensions).
         """
         if chips is None:
@@ -1130,7 +1132,7 @@ class RadialVelocity:
             # CCD<n>RV<sfx>/CCD<n>ERV<sfx> (n: GREEN=1, RED=2; sfx: 1/2/3=SCI1/2/3,
             # C=CAL, S=SKY), routed by set_keyword to their RV# table header (e.g.
             # CCD1RV1 -> RV2). The bare CCD<n>RV/CCD<n>ERV names stay reserved for
-            # the SCI-combined RV (on RV3). A non-finite value (failed fit) is
+            # the SCI-combined RV (on PRIMARY). A non-finite value (failed fit) is
             # written as None so it becomes a FITS UNDEFINED card, not a NaN.
             sfx = {"SCI1": "1", "SCI2": "2", "SCI3": "3", "CAL": "C", "SKY": "S"}[fiber]
             for chip in ccd_rv:
@@ -1146,12 +1148,13 @@ class RadialVelocity:
         # PRIMARY (EPRV L4): always record the RV method.
         l4_obj.set_keyword("RVMETHOD", "CCF")
 
-        # Final science RV (legacy CCD<n>RV / CCFRV). Sum the science orderlets'
-        # CCFs per chip and fit (bare CCD<n>RV), then combine the two CCDs at the
-        # RV level, weighted by their summed order-weights (CCFRV); the error is
-        # the inverse-variance combination (CCFERV). RVs are already in the
-        # barycentric frame (compute_ccfs folds barycorr into the mask shift), so
-        # the reported BERV/BJDTDB are descriptive, not applied.
+        # Final science RV (PRIMARY RV/RVERR + the KPF per-CCD CCD<n>RV/CCD<n>ERV).
+        # Sum the science orderlets' CCFs per chip and fit (bare CCD<n>RV), then
+        # combine the two CCDs at the RV level, weighted by their summed
+        # order-weights (PRIMARY RV); the error is the inverse-variance
+        # combination (PRIMARY RVERR). RVs are already in the barycentric frame
+        # (compute_ccfs folds barycorr into the mask shift), so the reported
+        # BERV/BJDTDB are descriptive, not applied.
         sci_req = [f for f in fibers if f in ("SCI1", "SCI2", "SCI3")]
         sci = [f for f in sci_req if self._info[f]["source"] not in (None, "none")]
         if not sci_req:
@@ -1171,7 +1174,10 @@ class RadialVelocity:
             )
         rep = sci[0]
         if len(chips) == 1:
-            print(f"  combined RV: only chip {chips[0]} present; CCFRV uses it alone")
+            print(
+                f"  combined RV: only chip {chips[0]} present; "
+                "the combined RV uses it alone"
+            )
 
         # Per CCD: bare SCI-combined RV/error (the science orderlets' CCFs summed
         # within each chip, then orders collapsed). The three science fibers are
@@ -1189,15 +1195,16 @@ class RadialVelocity:
             v, e = per_ccd[chip]
             if not np.isfinite(v):
                 print(
-                    f"  combined RV: {chip} science fit non-finite; excluded from CCFRV"
+                    f"  combined RV: {chip} science fit non-finite; "
+                    "excluded from the combined RV"
                 )
             n = 1 if chip == "GREEN" else 2
             l4_obj.set_keyword(f"CCD{n}RV", float(v) if np.isfinite(v) else None)
             l4_obj.set_keyword(f"CCD{n}ERV", float(e) if np.isfinite(e) else None)
 
-        # Cross-chip weighted RV (CCFRV) and inverse-variance error (CCFERV): the
-        # per-CCD science RVs combined at the RV level by their summed order
-        # weights.
+        # Cross-chip weighted RV and inverse-variance error (the PRIMARY RV/RVERR,
+        # written below): the per-CCD science RVs combined at the RV level by their
+        # summed order weights.
         ccfrv, ccferv = self.compute_weighted_rvs(
             chips,
             sci,
@@ -1208,18 +1215,12 @@ class RadialVelocity:
             min_npts=min_npts,
         )
         if not np.isfinite(ccfrv):
-            print(
-                "  combined RV: no finite per-CCD science RV; "
-                "CCFRV (RV3) and PRIMARY RV UNDEFINED"
-            )
-
-        l4_obj.set_keyword("CCFRV", float(ccfrv) if np.isfinite(ccfrv) else None)
-        l4_obj.set_keyword("CCFERV", float(ccferv) if np.isfinite(ccferv) else None)
+            print("  combined RV: no finite per-CCD science RV; PRIMARY RV UNDEFINED")
 
         # PRIMARY BERV/BJDTDB: chip-weighted mean of the per-CCD photon-weighted
         # bary summaries (CCD<n>BKMS/CCD<n>BJD from BarycentricCorrection), using
-        # the same summed-order-weight chip weights as the CCFRV combine so the
-        # two stay consistent. Not a CCF operation, so computed here.
+        # the same summed-order-weight chip weights as the combined-RV combine so
+        # the two stay consistent. Not a CCF operation, so computed here.
         bnum = jnum = bden = 0.0
         for chip in chips:
             n = 1 if chip == "GREEN" else 2

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -112,9 +112,9 @@ class TestSetKeyword:
     def test_routes_l4_orderlet_rv_to_rv_table(self):
         l4 = KPF4()
         l4.set_keyword("CCD1RV1", 1.2345)  # GREEN SCI1 -> RV2
-        l4.set_keyword("CCD1RV", 6.789)  # GREEN SCI-combined -> RV3
+        l4.set_keyword("CCD1RV", 6.789)  # GREEN SCI-combined -> PRIMARY
         assert l4.headers["RV2"]["CCD1RV1"] == 1.2345
-        assert l4.headers["RV3"]["CCD1RV"] == 6.789
+        assert l4.headers["PRIMARY"]["CCD1RV"] == 6.789
 
     def test_unregistered_keyword_raises_keyerror(self):
         l1 = KPF1()

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -796,38 +796,37 @@ class TestPerform:
         assert rv_hdr["CCD2RV2"] == pytest.approx(_V_INJECT, abs=0.1)
         assert rv_hdr["CCD1ERV2"] > 0 and rv_hdr["CCD2ERV2"] > 0
         # The per-orderlet keywords do not leak onto PRIMARY; they live on the RV#
-        # tables (the SCI-combined CCD<n>RV/CCFRV land on RV3).
+        # tables (only the SCI-combined CCD<n>RV/CCD<n>ERV land on PRIMARY).
         assert "CCD1RV2" not in l4.headers["PRIMARY"]
 
     def test_combined_rv_populated(self, rv_module):
-        # The science combine: SCI-combined CCD1RV/CCD2RV and CCFRV/CCFERV on the
-        # RV3 table (registered KPF keywords), alongside the EPRV RV/RVERR on
-        # PRIMARY. RV ~ injected value.
+        # The final science RV is on PRIMARY: the EPRV RV/RVERR plus the KPF
+        # SCI-combined per-CCD CCD1RV/CCD2RV/CCD1ERV/CCD2ERV (KPF-registered, homed
+        # on PRIMARY). RV ~ injected value.
         l4 = rv_module.perform()
-        rv3 = l4.headers["RV3"]
-        assert rv3["CCD1RV"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert rv3["CCD2RV"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert rv3["CCD1ERV"] > 0 and rv3["CCD2ERV"] > 0
-        assert rv3["CCFRV"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert rv3["CCFERV"] > 0
-
         prim = l4.headers["PRIMARY"]
+        assert prim["CCD1RV"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert prim["CCD2RV"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert prim["CCD1ERV"] > 0 and prim["CCD2ERV"] > 0
         assert prim["RV"] == pytest.approx(_V_INJECT, abs=0.1)
         assert prim["RVERR"] > 0
         assert prim["RVMETHOD"] == "CCF"
         assert prim["SYSVEL"] is None  # absolute RVs; nothing removed
+        # The combined-RV keywords are not duplicated onto the RV3 table.
+        assert "CCD1RV" not in l4.headers["RV3"]
+        assert "RV" not in l4.headers["RV3"]
 
-    def test_ccfrv_is_weighted_ccd_combine(self, rv_module):
-        # CCFRV = (CCD1RV*Wg + CCD2RV*Wr)/(Wg+Wr), Wg/Wr the summed order weights;
-        # CCFERV = inverse-variance combination of the per-CCD errors.
+    def test_combined_rv_is_weighted_ccd_combine(self, rv_module):
+        # PRIMARY RV = (CCD1RV*Wg + CCD2RV*Wr)/(Wg+Wr), Wg/Wr the summed order
+        # weights; RVERR = inverse-variance combination of the per-CCD errors.
         l4 = rv_module.perform()
-        inst = l4.headers["RV3"]
+        prim = l4.headers["PRIMARY"]
         wg = np.nansum(rv_module._get_order_weights("GREEN", "SCI1"))
         wr = np.nansum(rv_module._get_order_weights("RED", "SCI1"))
-        expect_rv = (inst["CCD1RV"] * wg + inst["CCD2RV"] * wr) / (wg + wr)
-        expect_err = (1.0 / inst["CCD1ERV"] ** 2 + 1.0 / inst["CCD2ERV"] ** 2) ** -0.5
-        assert inst["CCFRV"] == pytest.approx(expect_rv, abs=1e-9)
-        assert inst["CCFERV"] == pytest.approx(expect_err, rel=1e-9)
+        expect_rv = (prim["CCD1RV"] * wg + prim["CCD2RV"] * wr) / (wg + wr)
+        expect_err = (1.0 / prim["CCD1ERV"] ** 2 + 1.0 / prim["CCD2ERV"] ** 2) ** -0.5
+        assert prim["RV"] == pytest.approx(expect_rv, abs=1e-9)
+        assert prim["RVERR"] == pytest.approx(expect_err, rel=1e-9)
 
     def test_primary_berv_bjdtdb_from_per_ccd(self, rv_module):
         # PRIMARY BERV/BJDTDB are the chip-weighted mean of the per-CCD bary
@@ -864,10 +863,11 @@ class TestPerform:
         assert "no science orderlet requested" in capsys.readouterr().out
 
     def test_single_chip_combine_warns(self, rv_module, capsys):
-        # One chip present: CCFRV uses it alone (== CCD1RV) and a warning prints.
+        # One chip present: the combined RV uses it alone (== CCD1RV) and a
+        # warning prints.
         l4 = rv_module.perform(chips=["GREEN"])
-        inst = l4.headers["RV3"]
-        assert inst["CCFRV"] == pytest.approx(inst["CCD1RV"], abs=1e-9)
+        prim = l4.headers["PRIMARY"]
+        assert prim["RV"] == pytest.approx(prim["CCD1RV"], abs=1e-9)
         assert "only chip GREEN present" in capsys.readouterr().out
 
     def test_l4_serializes_to_fits(self, rv_module, tmp_path):

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -684,6 +684,8 @@ class TestPerform:
             assert len(table) == NORDER
             assert set(table.columns) >= {
                 "ORDER_INDEX",
+                "ORDER_ID",
+                "ECHELLE_ORDER",
                 "BJD_TDB",
                 "BERV",
                 "WAVE_START",
@@ -692,11 +694,13 @@ class TestPerform:
                 "RV_ERR",
                 "WEIGHT",
             }
-            # EPRV L4: time/wavelength columns are 64-bit; order index is integer.
+            # EPRV L4: time/wavelength columns are 64-bit; order/echelle indices
+            # are integer.
             assert table["BJD_TDB"].dtype == np.float64
             assert table["WAVE_START"].dtype == np.float64
             assert table["WAVE_END"].dtype == np.float64
             assert np.issubdtype(table["ORDER_INDEX"].dtype, np.integer)
+            assert np.issubdtype(table["ECHELLE_ORDER"].dtype, np.integer)
 
     def test_unilluminated_fiber_skipped(self, rv_module):
         # CAL-OBJ='None' -> no CCF cube or RV table written.
@@ -732,6 +736,37 @@ class TestPerform:
             )
             assert weight.shape == (NORDER,)
             np.testing.assert_array_equal(weight, expected)
+
+    def test_rv_table_order_id_and_echelle_columns(self, rv_module):
+        # ORDER_ID is the KPF chip/fiber/order name, 1-based per chip
+        # (green orders then red). ECHELLE_ORDER is the physical grating order
+        # from detector.toml echelle_orders, blue->red, so order index 0 (the
+        # bluest) carries the highest echelle number: GREEN 137..103, RED
+        # 102..71.
+        l4 = rv_module.perform()
+        for fiber in self._ILLUMINATED:
+            table = l4.data[f"{fiber}_RV"]
+            order_id = np.asarray(table["ORDER_ID"])
+            echelle = np.asarray(table["ECHELLE_ORDER"])
+            assert order_id.shape == (NORDER,)
+            assert echelle.shape == (NORDER,)
+            # 1-based per-chip naming, green-then-red.
+            assert order_id[0] == f"GREEN_{fiber}_1"
+            assert order_id[NORDER_GREEN - 1] == f"GREEN_{fiber}_{NORDER_GREEN}"
+            assert order_id[NORDER_GREEN] == f"RED_{fiber}_1"
+            assert order_id[-1] == f"RED_{fiber}_{NORDER_RED}"
+            # Physical echelle orders at the chip edges (detector.toml).
+            assert echelle[0] == 137
+            assert echelle[NORDER_GREEN - 1] == 103
+            assert echelle[NORDER_GREEN] == 102
+            assert echelle[-1] == 71
+            # Consecutive, strictly decreasing within each chip.
+            np.testing.assert_array_equal(
+                echelle[:NORDER_GREEN], np.arange(137, 102, -1)
+            )
+            np.testing.assert_array_equal(
+                echelle[NORDER_GREEN:], np.arange(102, 70, -1)
+            )
 
     def test_per_fiber_ccf_and_rv_headers(self, rv_module):
         # EPRV L4 keywords on each orderlet's CCF/RV extension; RVMETHOD on PRIMARY.
@@ -855,6 +890,10 @@ class TestPerform:
             # The EPRV combined RV survives on PRIMARY.
             assert hdul["PRIMARY"].header["RV"] == pytest.approx(_V_INJECT, abs=0.1)
             assert hdul["PRIMARY"].header["RVERR"] > 0
+            # The string ORDER_ID and integer ECHELLE_ORDER columns round-trip.
+            rv_table = hdul["RV3"].data
+            assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_1"
+            assert rv_table["ECHELLE_ORDER"][0] == 137
 
     def test_failed_combined_fit_written_as_undefined(self, rv_module, monkeypatch):
         # A non-finite fit (failed fit) is written as a FITS UNDEFINED card


### PR DESCRIPTION
## Summary

  Two small L4 RV/CCF cleanups bringing outputs in line with the EPRV standard (rvdata 0.4.0).

  **1. Populate two more optional RV-table columns** (alongside the existing `WEIGHT`):
  - `ECHELLE_ORDER` — physical grating order from `detector.toml` (blue→red; index 0 = bluest =
  highest order).
  - `ORDER_ID` — KPF chip/fiber/order name, 1-based per chip (`GREEN_SCI1_1`…), a KPF-custom extra
  column.

  **2. Route the final combined-RV keywords to PRIMARY:**
  - `RV`/`RVERR` are EPRV PRIMARY keywords (already written there); dropped the redundant
  `CCFRV`/`CCFERV` registrations + writes.
  - `CCD{1,2}RV`/`CCD{1,2}ERV` (SCI-combined per-CCD) re-homed RV3 → PRIMARY — a deliberate,
  documented exception to the EPRV-only-PRIMARY rule.

  Also reconciled `EPRV_DATA_STANDARD.md` to the 0.4.0 pin (the `BERV`-vs-`BC_VELOCITY` and
  `receipt_add_entry` "reconcile when bumping" notes are now resolved).

  ## Notes
  - Per-fiber suffixed `CCD{n}RV<sfx>` unchanged (still on `RV1–RV5`).
  - No registry change for the new columns (they're BinTable columns, not header cards); string
  `ORDER_ID` round-trips through FITS.
  - Docs: `CLAUDE.md` + style-guide note for the PRIMARY exception.

  ## Test
  Full suite green (1052 passed); ruff clean.