### PR TITLE
Keyword-registry cleanup + EPRV/FITS compliance sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,20 @@ see the style guide §11.)* The architecture invariants:
   `RV`/`RVERR`. (`RV`/`RVERR` themselves are EPRV PRIMARY keywords, not KPF-registered, so they are not
   the exception.)
 - **`INSTRUMENT_HEADER` is an immutable verbatim copy of the raw L0 PRIMARY** (values **and** comments),
-  written once in `to_kpf1` and never again. Code needing a raw instrument keyword (`ELAPSED`,
-  `MJD-OBS`, `DATE-OBS`, `GAIAID`, `SCI-OBJ`, `TARGTEFF`, …) reads it from here, not PRIMARY.
+  written once in `to_kpf1` and never again.
+- **Read from PRIMARY whenever the keyword lands there after `to_kpf1`** (same value); read from
+  `INSTRUMENT_HEADER` only when PRIMARY can't serve the read cleanly. `_map_header` carries just some
+  natives to PRIMARY, and mostly under **renamed** EPRV keys (`ELAPSED`→`EXPTIME`, `IMTYPE`→`OBSTYPE`,
+  `GAIAID`→`CID4`, `TARGRA`→`CRA4`, `SCI-OBJ`/`SKY-OBJ`/`CAL-OBJ`→`TRACE4`/`TRACE1`/`CLSRC5`, …); a few
+  (`DATE-BEG`/`MID`/`END`, `MJD-OBS`, `TARGFRAM`, `TARGTEFF`, `GAIAMAG`, native `EXPTIME`, `OFNAME`) are
+  **not on PRIMARY at all**. So: a native that survives to PRIMARY under its **own name** and is read in
+  isolation is read from **PRIMARY** (e.g. `DATE-OBS`, `OBJECT`). Read from **INSTRUMENT_HEADER** when
+  the native (a) never reaches PRIMARY, or (b) is one of a **coherent block of natives** where mixing
+  PRIMARY + INSTRUMENT reads (or the cryptic renamed keys) would obscure intent — the WMKO astrometry/
+  catalog block (`TARGRA`/`DEC`/`PM*`/`PLAX`/`TARGFRAM`/`TARGEPOC`/`TARGRADV`/`GAIAID`) in
+  `barycentric_correction`, the per-fiber illumination source (`SCI-OBJ`/`SKY-OBJ`/`CAL-OBJ`) in
+  `radial_velocity`, and the `EXPTIME`-vs-`ELAPSED` pair in masters (which name **different** quantities —
+  requested vs. elapsed — that only coexist as distinct cards on INSTRUMENT_HEADER).
 - **Each registered keyword has one home extension** (the registry `Extension` column), which
   `set_keyword` routes to: **PRIMARY** (EPRV keywords, plus the L4 final-RV exception
   `CCD{1,2}RV`/`CCD{1,2}ERV` above), **QUALITY_CONTROL** (QC flags + `ISGOOD`, read-noise,
@@ -280,7 +292,7 @@ Four read-only layers, consolidated under `kpfpipe/quality_control/`, consume da
 
 This is unlike v2.12, which had one big `DiagnosticsFramework` primitive with a conditional dispatch tree over many functions and shared backend state with `AnalyzeL0/2D/L1/L2` classes. v3 uses per-level classes with method-attribute registration (`_diag_name` / `_qc_key` / `_checkpoint_name`) and no shared state.
 
-**Where metrics live.** Metrics that depend on intermediate processing state (e.g. read noise from raw overscan) stay in the pipeline module that produces them — they cannot be recomputed from the finished product. Metrics that can be computed from the finished product alone live in Diagnostics — including the master calibration **ages** (`BIASAGE`/`DARKAGE`/`FLATAGE`/`WLSAGE`), which `DiagL1` recomputes from the master paths `CalibrationAssociation` wrote to RECEIPT (`*FILE`) plus the `INSTRUMENT_HEADER` `DATE-OBS`; the association module writes only the paths.
+**Where metrics live.** Metrics that depend on intermediate processing state (e.g. read noise from raw overscan) stay in the pipeline module that produces them — they cannot be recomputed from the finished product. Metrics that can be computed from the finished product alone live in Diagnostics — including the master calibration **ages** (`BIASAGE`/`DARKAGE`/`FLATAGE`/`WLSAGE`), which `DiagL1` recomputes from the master paths `CalibrationAssociation` wrote to RECEIPT (`*FILE`) plus the PRIMARY `DATE-OBS` (an EPRV keyword carried to PRIMARY under its own name); the association module writes only the paths.
 
 **Detector geometry.** Helpers like `count_amplifiers`, `orient_channels`, and `RN_KEYS` are owned by `ImageAssembly`. Other consumers (Quicklook, future Diagnostics) import them rather than duplicating the logic.
 

--- a/EPRV_DATA_STANDARD.md
+++ b/EPRV_DATA_STANDARD.md
@@ -136,6 +136,16 @@ L4 PRIMARY gains: `BJDTDB`, `RV`, `RVERR`, `BERV`, `RVMETHOD`, `SYSVEL`.
 >   (physical grating order, blue→red), and `WEIGHT` (per-order CCF-combination weight),
 >   plus a KPF-custom `ORDER_ID` (chip/fiber/order name, 1-based per chip — the standard
 >   permits team-added columns).
+> - **Structural cards as keywords** — 0.4.0's per-extension keyword CSVs redundantly
+>   register FITS *structural* cards astropy writes on its own (`XTENSION`, `EXTNAME`) as
+>   if they were content keywords. The registry sanitizes these out at build so structural
+>   and registered stay disjoint (see `keyword_registry._build_registry`).
+> - **CTYPE on 1-D extensions** — 0.4.0 marks both `CTYPE1` *and* `CTYPE2` Required on every
+>   RV/CCF/barycorr extension with identical boilerplate. The barycentric extensions
+>   (`BJD_TDB`/`BARYCORR_KMS`/`BARYCORR_Z`) are 1-D per-order arrays, so only `CTYPE1`
+>   (`Order-N`) applies; KPF stamps that and treats `CTYPE2` as N/A for 1-D. RV/CCF (2-D)
+>   carry both. KPF treats `CTYPE` as registered content (axis meaning), not a structural
+>   WCS card.
 
 ---
 

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -650,9 +650,15 @@ class attribute (and uses `.routing` in `set_keyword`); the checkpoints validato
   the conversion sites in `KPF0` assign `header[key] = (value, comment)` directly; outside those,
   prefer `set_keyword`.
 - **Conversion**: call `KPF0._map_header`; don't re-implement the WMKO→EPRV mapping.
-- **Reading a raw instrument keyword** (`ELAPSED`, `MJD-OBS`, `DATE-OBS`, `GAIAID`, `SCI-OBJ`,
-  `TARGTEFF`, …): read it from `headers["INSTRUMENT_HEADER"]` (via `.get`), never from
-  PRIMARY. No silent fallback — let a missing key raise.
+- **Reading a header keyword: prefer PRIMARY when the keyword lands there** after `to_kpf1` with the
+  same value (e.g. `DATE-OBS`, `OBJECT` — carried to PRIMARY under their own names). Read from
+  `headers["INSTRUMENT_HEADER"]` only when PRIMARY can't serve the read cleanly: the native never
+  reaches PRIMARY (`DATE-BEG`/`MID`/`END`, `MJD-OBS`, `TARGFRAM`, `TARGTEFF`, `GAIAMAG`, native
+  `EXPTIME`, `OFNAME`), or it belongs to a **coherent native block** where mixing PRIMARY + INSTRUMENT
+  reads or the cryptic renamed keys (`GAIAID`→`CID4`, `TARGRA`→`CRA4`, `SCI-OBJ`→`TRACE4`, …) would
+  obscure intent — the astrometry/catalog block, the per-fiber illumination source
+  (`SCI-OBJ`/`SKY-OBJ`/`CAL-OBJ`), and the `EXPTIME`-vs-`ELAPSED` pair (distinct quantities that only
+  coexist on INSTRUMENT_HEADER). Read via `.get`; no silent fallback — let a missing key raise.
 - Use EPRV keyword *names* on PRIMARY (e.g. `EXPTIME`, not `ELAPSED`; `OBSTYPE`, not `IMTYPE`).
   Exception: the L4 final-RV measurements `CCD{1,2}RV`/`CCD{1,2}ERV` are KPF-registered keywords
   deliberately homed on PRIMARY (alongside the EPRV `RV`/`RVERR`).

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -34,11 +34,13 @@ The three use-cases:
 
 It also exposes ``eprv_primary_seed`` (the typed EPRV Required PRIMARY skeleton
 ``KPF1.__init__`` stamps, mirroring rvdata's ``RV2.__init__``). The header_map
-corrections live in one place each: ``NUMORDER``/``DRPTAG`` via ``_DEFAULT_OVERRIDES``
-(table sanitization), ``DATALVL`` via ``KPF1.__init__`` (the model level), and the
-``JD_UTC`` epoch transform in ``_map_header`` (a per-frame value, not a static default).
+corrections live in one place each: ``NUMORDER``/``DRPTAG``/``EPRVTAG``/``VOCLASS``
+via ``_DEFAULT_OVERRIDES`` (table sanitization), ``DATALVL`` via ``KPF1.__init__``
+(the model level), and the ``JD_UTC`` epoch transform in ``_map_header`` (a
+per-frame value, not a static default).
 """
 
+import importlib.metadata
 import importlib.resources
 import warnings
 from types import MappingProxyType
@@ -58,6 +60,13 @@ _kpf_data_cfg = importlib.resources.files("kpfpipe.data_models.config")
 
 # Number of echelle orders (green + red); the value header_map.csv gets wrong (65).
 _NUMORDER = int(DETECTOR["norder"]["GREEN"]) + int(DETECTOR["norder"]["RED"])
+
+# EPRV-standard compliance is pinned to the installed rv-data-standard release
+# (environment.yml pins it exactly): EPRVTAG is its version ("v0.4.0"), VOCLASS
+# the release month ("EPRVSTANDARD2026.06"). The release date is not in package
+# metadata (PyPI-only), so map it from the exact pin here; bump both together.
+_RVDATA_VERSION = importlib.metadata.version("rv-data-standard")
+_RVDATA_RELEASE_MONTHS = {"0.4.0": "2026.06"}
 
 
 class KeywordRegistry:
@@ -97,11 +106,17 @@ class KeywordRegistry:
 
     # Table Default corrections applied during the __init__ sanitize phase, for
     # keywords header_map.csv gets wrong (NUMORDER's default is 65; KPF has 67) or
-    # whose default is runtime (DRPTAG is the DRP version). Stored as strings like
-    # every other Default (the column is string-typed); parse_value_to_datatype
-    # types them. After sanitization the table is clean, so _eprv_primary_lookup
-    # seeds them without special-casing.
-    _DEFAULT_OVERRIDES = {"NUMORDER": str(_NUMORDER), "DRPTAG": __version__}
+    # whose default is runtime: DRPTAG is the DRP version, and EPRVTAG/VOCLASS are
+    # the EPRV compliance tags derived from the pinned rv-data-standard release.
+    # Stored as strings like every other Default (the column is string-typed);
+    # parse_value_to_datatype types them. After sanitization the table is clean, so
+    # _eprv_primary_lookup seeds them without special-casing.
+    _DEFAULT_OVERRIDES = {
+        "NUMORDER": str(_NUMORDER),
+        "DRPTAG": __version__,
+        "EPRVTAG": f"v{_RVDATA_VERSION}",
+        "VOCLASS": f"EPRVSTANDARD{_RVDATA_RELEASE_MONTHS[_RVDATA_VERSION]}",
+    }
 
     # Per-extension EPRV keyword CSVs (rvdata does not load these as constants).
     # RV#/CCF# share one template CSV; BARYCORR_*/BJD_TDB are per-extension.

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -188,33 +188,33 @@ class KeywordRegistry:
     )
 
     def __init__(self):
-        # --- Read the raw reference inputs ---
-        # The unified keyword table (EPRV rows first, then KPF rows; KPF wins a
-        # collision) and the rvdata WMKO-native -> EPRV-standard header_map.
+        # Build the source table and its derived lookups, then load the header_map
+        # -- order matters: the header_map is filtered against self.registered, the
+        # allowlist the table build produces.
+        self._build_registry()
+        self._load_header_map()
+
+    def _build_registry(self):
+        """Build ``self.table`` and every lookup derived from it.
+
+        Assembles the unified table (EPRV rows first, then KPF rows; KPF wins a
+        collision), corrects the Defaults header_map.csv gets wrong (NUMORDER
+        65 -> 67) or that are runtime (DRPTAG -> version) so downstream lookups
+        read a clean table, then derives the read-only lookups. All are shared
+        process-wide via the singleton, so they are frozen (frozenset /
+        MappingProxyType) against a stray consumer mutation; ``self.table`` is
+        only ever read.
+        """
         eprv_rows, kpf_rows = self._build_rows()
         table = pd.DataFrame(eprv_rows + kpf_rows, columns=self._COLUMNS)
-        header_map = pd.read_csv(_rvdata_inst_cfg / "header_map.csv")
-
-        # --- Sanitize the inputs once, here, before any lookup is derived ---
-        # Correct the Defaults header_map.csv gets wrong (NUMORDER 65 -> 67) or that
-        # are runtime (DRPTAG -> version); these feed eprv_primary_seed, so the build
-        # step reads a clean table with no per-keyword special-casing. None-valued
-        # overrides carry no static default (value supplied elsewhere), so skip them.
+        # None-valued overrides carry no static default (value supplied
+        # elsewhere), so skip them.
         for keyword, value in self._DEFAULT_OVERRIDES.items():
             if value is not None:
                 table.loc[table["Keyword"] == keyword, "Default"] = value
         self.table = table
-        # The keyword allowlist -- a distributed lookup, and the gate header_map
-        # sanitization filters against (so it is derived before that runs).
         self.registered = frozenset(self.table["Keyword"])
-        # Drop header_map rows that aren't genuine static native -> EPRV mappings.
-        self.header_map = self._sanitize_header_map(header_map)
 
-        # --- Build / distribute the derived lookups from the sanitized table ---
-        # All are read-only reference data shared process-wide via the singleton;
-        # freeze them (frozenset / MappingProxyType) so a stray consumer mutation
-        # can't corrupt the registry for everyone (notably under parallel tests).
-        # self.table is only ever read.
         self.routing = MappingProxyType(self._routing_lookup())
         allowed, required = self._validation_lookup()
         self.allowed = MappingProxyType(
@@ -237,6 +237,36 @@ class KeywordRegistry:
         seed, datatypes = self._eprv_primary_lookup()
         self.eprv_primary_seed = MappingProxyType(seed)
         self.eprv_primary_datatypes = MappingProxyType(datatypes)
+
+    def _load_header_map(self):
+        """Read and sanitize rvdata's WMKO-native -> EPRV-standard ``header_map``.
+
+        Keeps only genuine static native->EPRV mapping rows, so KPF0._map_header
+        applies the map with no in-loop filter or per-keyword correction. Two row
+        classes are dropped:
+          - STANDARD keys absent from the registry (PARANG/PARANG2) -- warned, so
+            the rvdata header_map / registry inconsistency stays visible;
+          - ``_DEFAULT_OVERRIDES`` keys, whose value comes from the corrected table
+            default, the model level, or the _map_header epoch transform, not a
+            static map row.
+        Runs after ``_build_registry`` -- it filters against ``self.registered``.
+        """
+        raw = pd.read_csv(_rvdata_inst_cfg / "header_map.csv")
+        eprv_keys = raw["STANDARD"].astype(str).str.strip()
+        unregistered = sorted(
+            set(eprv_keys[raw["STANDARD"].notna()]) - self.registered - {""}
+        )
+        if unregistered:
+            warnings.warn(
+                "header_map.csv maps to STANDARD keys absent from the keyword "
+                f"registry; they are dropped (not emitted): {unregistered}",
+                UserWarning,
+                stacklevel=2,
+            )
+        keep = eprv_keys.isin(self.registered) & ~eprv_keys.isin(
+            self._DEFAULT_OVERRIDES.keys()
+        )
+        self.header_map = raw[keep].reset_index(drop=True)
 
     def is_structural(self, key):
         """True for a FITS structural / bookkeeping card (never a registered keyword).
@@ -501,35 +531,6 @@ class KeywordRegistry:
             if row.PopulatedBy != "QC":  # "QCL0"/"QCL1"/"QCL2" -> "L0"/"L1"/"L2"
                 by_level.setdefault(row.PopulatedBy[2:], set()).add(row.Keyword)
         return all_flags, by_level
-
-    # --- Input sanitization (run once in __init__ before the lookups) --------
-
-    def _sanitize_header_map(self, raw):
-        """Return header_map with only genuine static native->EPRV mapping rows.
-
-        _map_header then applies the map with no in-loop filter or per-keyword
-        correction. Two row classes are dropped:
-          - STANDARD keys absent from the registry (PARANG/PARANG2) -- warned,
-            so the rvdata header_map / registry inconsistency stays visible;
-          - ``_DEFAULT_OVERRIDES`` keys, whose value comes from the corrected table
-            default, the model level, or the _map_header epoch transform, not a
-            static map row.
-        """
-        eprv_keys = raw["STANDARD"].astype(str).str.strip()
-        unregistered = sorted(
-            set(eprv_keys[raw["STANDARD"].notna()]) - self.registered - {""}
-        )
-        if unregistered:
-            warnings.warn(
-                "header_map.csv maps to STANDARD keys absent from the keyword "
-                f"registry; they are dropped (not emitted): {unregistered}",
-                UserWarning,
-                stacklevel=2,
-            )
-        keep = eprv_keys.isin(self.registered) & ~eprv_keys.isin(
-            self._DEFAULT_OVERRIDES.keys()
-        )
-        return raw[keep].reset_index(drop=True)
 
     # --- rvdata extension registration ---------------------------------------
 

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -149,9 +149,13 @@ class KeywordRegistry:
     # the cross-level ISGOOD aggregate, "QCL{n}" a level-N check.
     _QC_POPULATORS = frozenset({"QC", "QCL0", "QCL1", "QCL2", "QCL4"})
 
-    # FITS structural cards permitted on any extension (never registered keywords) --
-    # the validator's allowlist. Exact matches here; enumerated families in
-    # _STRUCTURAL_PREFIXES.
+    # FITS structural cards: written by the I/O layer (astropy) from the HDU's
+    # structure, never authored by the pipeline -- so always permitted on any
+    # extension and never registered keywords (the build-time sanitizer in
+    # _build_registry enforces registered & structural == empty). Exact matches
+    # here; enumerated families in _STRUCTURAL_PREFIXES. The lone exception is
+    # BUNIT: it carries content (physical units) but is stamped directly on the
+    # masters images rather than registered (see masters/base.py).
     _STRUCTURAL = {
         "SIMPLE",
         "BITPIX",
@@ -168,13 +172,13 @@ class KeywordRegistry:
         "CHECKSUM",
         "DATASUM",
         "",
-        "FILENAME",
-        "DATE",
         "EXTNAME",
         "TFIELDS",
     }
 
-    # Structural card families (NAXIS*, bintable column descriptors, WCS); by prefix.
+    # Structural card families (NAXIS*, bintable column descriptors); by prefix. No
+    # WCS family here: KPF authors no WCS, and CTYPE is registered content (rvdata
+    # uses it to name each extension's axes), so a stray WCS card should be flagged.
     _STRUCTURAL_PREFIXES = (
         "NAXIS",
         "TTYPE",
@@ -185,12 +189,6 @@ class KeywordRegistry:
         "TNULL",
         "TSCAL",
         "TZERO",
-        "CTYPE",
-        "CUNIT",
-        "CRPIX",
-        "CRVAL",
-        "CDELT",
-        "CROTA",
     )
 
     def __init__(self):
@@ -204,9 +202,9 @@ class KeywordRegistry:
 
         Assembles the unified table (EPRV rows first, then KPF rows; KPF wins a
         collision), corrects the Defaults header_map.csv gets wrong (NUMORDER
-        65 -> 67) or that are runtime (DRPTAG -> version) so downstream lookups
-        read a clean table, then derives the read-only lookups. All are shared
-        process-wide via the singleton, so they are frozen (frozenset /
+        65 -> 67) or that are runtime (DRPTAG -> version), drops structural cards
+        rvdata redundantly registers, then derives the read-only lookups. All are
+        shared process-wide via the singleton, so they are frozen (frozenset /
         MappingProxyType) against a stray consumer mutation; ``self.table`` is
         only ever read.
         """
@@ -215,6 +213,12 @@ class KeywordRegistry:
         for keyword, value in self._DEFAULT_OVERRIDES.items():
             if value is not None:
                 table.loc[table["Keyword"] == keyword, "Default"] = value
+        # Structural cards are written by astropy, never registered: drop any that
+        # rvdata redundantly declares as keywords (e.g. XTENSION/EXTNAME), so
+        # registered & structural stay disjoint. (structural is derived first so
+        # is_structural is available here.)
+        self.structural = frozenset(self._STRUCTURAL)
+        table = table[~table["Keyword"].map(self.is_structural)].reset_index(drop=True)
         self.table = table
         self.registered = frozenset(self.table["Keyword"])
 
@@ -226,7 +230,6 @@ class KeywordRegistry:
         self.required = MappingProxyType(
             {ext: MappingProxyType(d) for ext, d in required.items()}
         )
-        self.structural = frozenset(self._STRUCTURAL)
         qc_all, qc_by_level = self._qc_flag_sets_lookup()
         self.qc_flag_keywords = frozenset(qc_all)
         self.qc_flag_keywords_by_level = MappingProxyType(

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -25,7 +25,7 @@ The three use-cases:
       ``eprv_primary_datatypes`` types the values it emits. ``header_map`` is
       **sanitized on load** so it holds only genuine static native->EPRV mappings:
       rows whose key is unregistered (PARANG/PARANG2) or handled elsewhere
-      (``_HEADER_MAP_NON_NATIVE``) are dropped, so ``_map_header`` needs no
+      (``_DEFAULT_OVERRIDES``) are dropped, so ``_map_header`` needs no
       in-loop filter or per-keyword correction.
   (2) Validation — ``allowed`` / ``required`` (per-extension, from the table)
       plus ``structural`` (FITS bookkeeping cards).
@@ -54,9 +54,9 @@ from rvdata.core.tools.headers import parse_value_to_datatype
 
 from kpfpipe import DETECTOR, __version__
 
-_kpf_cfg = importlib.resources.files("rvdata.instruments.kpf.config")
-_rv_cfg = importlib.resources.files("rvdata.core.models.config")
-_kpf_data_cfg = importlib.resources.files("kpfpipe.data_models.config")
+_rvdata_inst_cfg = importlib.resources.files("rvdata.instruments.kpf.config")
+_rvdata_core_cfg = importlib.resources.files("rvdata.core.models.config")
+_kpf_pipe_cfg = importlib.resources.files("kpfpipe.data_models.config")
 
 # Number of echelle orders (green + red); the value header_map.csv gets wrong (65).
 _NUMORDER = int(DETECTOR["norder"]["GREEN"]) + int(DETECTOR["norder"]["RED"])
@@ -96,36 +96,38 @@ class KeywordRegistry:
         "Units",
     ]
 
-    # header_map.csv STANDARD keys that are NOT genuine static native->EPRV
-    # mappings, so they are dropped when header_map is sanitized on load (and the
-    # raw header_map default/native they carried is wrong or vestigial). Each one's
-    # real value home: NUMORDER/DRPTAG -> _DEFAULT_OVERRIDES (table), DATALVL ->
-    # KPF1.__init__ (the model's data level), JD_UTC -> the _map_header epoch
-    # transform (a per-frame value, not a static default).
-    _HEADER_MAP_NON_NATIVE = frozenset({"NUMORDER", "DATALVL", "DRPTAG", "JD_UTC"})
-
-    # Table Default corrections applied during the __init__ sanitize phase, for
-    # keywords header_map.csv gets wrong (NUMORDER's default is 65; KPF has 67) or
-    # whose default is runtime: DRPTAG is the DRP version, and EPRVTAG/VOCLASS are
-    # the EPRV compliance tags derived from the pinned rv-data-standard release.
-    # Stored as strings like every other Default (the column is string-typed);
-    # parse_value_to_datatype types them. After sanitization the table is clean, so
-    # _eprv_primary_lookup seeds them without special-casing.
+    # header_map.csv STANDARD keys whose entry is not a genuine static
+    # native->EPRV mapping, each paired with its real value. Two consumers read
+    # this map (see __init__): the non-None values correct the table Default (so
+    # _eprv_primary_lookup seeds them cleanly), and every key is dropped from
+    # header_map (so _map_header applies it with no per-keyword correction).
+    # Values are strings like every Default; parse_value_to_datatype types them.
+    # None means no static default -- the value is supplied elsewhere at build
+    # time: DATALVL by the model level (KPF1.__init__), JD_UTC by the _map_header
+    # epoch transform. (NUMORDER's header_map default is 65; KPF has 67. DRPTAG is
+    # the DRP version; EPRVTAG/VOCLASS the pinned rv-data-standard tags.)
     _DEFAULT_OVERRIDES = {
         "NUMORDER": str(_NUMORDER),
         "DRPTAG": __version__,
         "EPRVTAG": f"v{_RVDATA_VERSION}",
         "VOCLASS": f"EPRVSTANDARD{_RVDATA_RELEASE_MONTHS[_RVDATA_VERSION]}",
+        "DATALVL": None,
+        "JD_UTC": None,
     }
 
     # Per-extension EPRV keyword CSVs (rvdata does not load these as constants).
     # RV#/CCF# share one template CSV; BARYCORR_*/BJD_TDB are per-extension.
     _EPRV_EXT_CSV = {
-        "BJD_TDB": (_rv_cfg / "L2-BJD_TDB-keywords.csv", 2),
-        "BARYCORR_KMS": (_rv_cfg / "L2-BARYCORR_KMS-keywords.csv", 2),
-        "BARYCORR_Z": (_rv_cfg / "L2-BARYCORR_Z-keywords.csv", 2),
-        **{f"RV{i}": (_rv_cfg / "L4-RV1-keywords.csv", 4) for i in range(1, 6)},
-        **{f"CCF{i}": (_rv_cfg / "L4-CCF1-keywords.csv", 4) for i in range(1, 6)},
+        "BJD_TDB": (_rvdata_core_cfg / "L2-BJD_TDB-keywords.csv", 2),
+        "BARYCORR_KMS": (_rvdata_core_cfg / "L2-BARYCORR_KMS-keywords.csv", 2),
+        "BARYCORR_Z": (_rvdata_core_cfg / "L2-BARYCORR_Z-keywords.csv", 2),
+        **{
+            f"RV{i}": (_rvdata_core_cfg / "L4-RV1-keywords.csv", 4) for i in range(1, 6)
+        },
+        **{
+            f"CCF{i}": (_rvdata_core_cfg / "L4-CCF1-keywords.csv", 4)
+            for i in range(1, 6)
+        },
     }
 
     # Registry "PopulatedBy" values that mark a QUALITY_CONTROL row as a 0/1 QC
@@ -191,14 +193,16 @@ class KeywordRegistry:
         # collision) and the rvdata WMKO-native -> EPRV-standard header_map.
         eprv_rows, kpf_rows = self._build_rows()
         table = pd.DataFrame(eprv_rows + kpf_rows, columns=self._COLUMNS)
-        header_map = pd.read_csv(_kpf_cfg / "header_map.csv")
+        header_map = pd.read_csv(_rvdata_inst_cfg / "header_map.csv")
 
         # --- Sanitize the inputs once, here, before any lookup is derived ---
         # Correct the Defaults header_map.csv gets wrong (NUMORDER 65 -> 67) or that
         # are runtime (DRPTAG -> version); these feed eprv_primary_seed, so the build
-        # step reads a clean table with no per-keyword special-casing.
+        # step reads a clean table with no per-keyword special-casing. None-valued
+        # overrides carry no static default (value supplied elsewhere), so skip them.
         for keyword, value in self._DEFAULT_OVERRIDES.items():
-            table.loc[table["Keyword"] == keyword, "Default"] = value
+            if value is not None:
+                table.loc[table["Keyword"] == keyword, "Default"] = value
         self.table = table
         # The keyword allowlist -- a distributed lookup, and the gate header_map
         # sanitization filters against (so it is derived before that runs).
@@ -247,18 +251,6 @@ class KeywordRegistry:
 
     # --- Source table construction -------------------------------------------
 
-    @staticmethod
-    def _load_keyword_csv(handle):
-        """Read an rvdata keyword CSV, stripping any UTF-8 BOM on column 1."""
-        df = pd.read_csv(handle)
-        df.columns = [str(c).lstrip("﻿").strip() for c in df.columns]
-        return df
-
-    @staticmethod
-    def _family_base(first_token):
-        """'CDEC1' -> 'CDEC' (strip the trailing index)."""
-        return first_token.rstrip("0123456789")
-
     @classmethod
     def _eprv_rows(cls, df, extension, level):
         """Expand an EPRV keyword CSV into unified-registry rows.
@@ -283,7 +275,8 @@ class KeywordRegistry:
             units = df["Units"].iloc[i] if "Units" in df else ""
             required = bool(req.iloc[i])
             if "..." in name:
-                base = cls._family_base(name.split("...")[0].strip())
+                # "CDEC1 ... CDEC#" -> "CDEC" (strip the trailing index).
+                base = name.split("...")[0].strip().rstrip("0123456789")
                 for j in range(1, 10):
                     rows.append(
                         [
@@ -326,7 +319,7 @@ class KeywordRegistry:
         """
         rows = []
         for level in (0, 1, 2, 4):
-            df = pd.read_csv(_kpf_data_cfg / f"L{level}-headers.csv")
+            df = pd.read_csv(_kpf_pipe_cfg / f"L{level}-headers.csv")
             for _, r in df.iterrows():
                 descr = (
                     "" if pd.isna(r["Description"]) else str(r["Description"]).strip()
@@ -366,7 +359,7 @@ class KeywordRegistry:
         per-file level). The EPRV-tag guard mirrors ``_kpf_rows``.
         """
         rows = []
-        df = pd.read_csv(_kpf_data_cfg / "Masters-headers.csv")
+        df = pd.read_csv(_kpf_pipe_cfg / "Masters-headers.csv")
         for _, r in df.iterrows():
             descr = "" if pd.isna(r["Description"]) else str(r["Description"]).strip()
             populated_by = str(r.get("PopulatedBy", "")).strip()
@@ -409,7 +402,7 @@ class KeywordRegistry:
         # EPRV per-extension keywords (governed extensions with standard cards).
         ext = []
         for name, (path, level) in cls._EPRV_EXT_CSV.items():
-            ext += cls._eprv_rows(cls._load_keyword_csv(path), name, level)
+            ext += cls._eprv_rows(pd.read_csv(path), name, level)
         return l2 + l4 + ext, cls._kpf_rows() + cls._masters_rows()
 
     # --- Derived lookups (all read self.table) -------------------------------
@@ -518,9 +511,9 @@ class KeywordRegistry:
         correction. Two row classes are dropped:
           - STANDARD keys absent from the registry (PARANG/PARANG2) -- warned,
             so the rvdata header_map / registry inconsistency stays visible;
-          - ``_HEADER_MAP_NON_NATIVE`` keys, whose value comes from the seed
-            (NUMORDER/DRPTAG), the model level (DATALVL), or the _map_header epoch
-            transform (JD_UTC), not a static map row.
+          - ``_DEFAULT_OVERRIDES`` keys, whose value comes from the corrected table
+            default, the model level, or the _map_header epoch transform, not a
+            static map row.
         """
         eprv_keys = raw["STANDARD"].astype(str).str.strip()
         unregistered = sorted(
@@ -534,7 +527,7 @@ class KeywordRegistry:
                 stacklevel=2,
             )
         keep = eprv_keys.isin(self.registered) & ~eprv_keys.isin(
-            self._HEADER_MAP_NON_NATIVE
+            self._DEFAULT_OVERRIDES.keys()
         )
         return raw[keep].reset_index(drop=True)
 

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -77,13 +77,11 @@ class KeywordRegistry:
     three use-cases (mapping / validation / routing).
     """
 
-    # Sentinel written into the "PopulatedBy" column for EPRV-sourced rows; the
-    # derived lookups use it to tell EPRV rows from KPF rows, so it is the single
-    # source of that string (and _kpf_rows asserts no KPF row reuses it).
+    # "PopulatedBy" value marking an EPRV-sourced row -- the discriminator the
+    # derived lookups use to tell EPRV rows from KPF rows.
     _EPRV_TAG = "EPRV"
 
-    # Unified-table column order. All names are valid Python identifiers so the
-    # derived lookups can read rows by attribute via itertuples (row.PopulatedBy).
+    # Unified-table columns; valid identifiers for itertuples attribute access.
     _COLUMNS = [
         "Keyword",
         "Description",
@@ -96,16 +94,11 @@ class KeywordRegistry:
         "Units",
     ]
 
-    # header_map.csv STANDARD keys whose entry is not a genuine static
-    # native->EPRV mapping, each paired with its real value. Two consumers read
-    # this map (see __init__): the non-None values correct the table Default (so
-    # _eprv_primary_lookup seeds them cleanly), and every key is dropped from
-    # header_map (so _map_header applies it with no per-keyword correction).
-    # Values are strings like every Default; parse_value_to_datatype types them.
-    # None means no static default -- the value is supplied elsewhere at build
-    # time: DATALVL by the model level (KPF1.__init__), JD_UTC by the _map_header
-    # epoch transform. (NUMORDER's header_map default is 65; KPF has 67. DRPTAG is
-    # the DRP version; EPRVTAG/VOCLASS the pinned rv-data-standard tags.)
+    # header_map keys whose entry is not a genuine native->EPRV mapping. Two
+    # consumers: non-None values correct the table Default (NUMORDER 65->67; DRPTAG,
+    # EPRVTAG, VOCLASS are runtime tags), and every key is dropped from header_map.
+    # None = no static default; value set elsewhere (DATALVL by KPF1.__init__,
+    # JD_UTC by the _map_header epoch transform).
     _DEFAULT_OVERRIDES = {
         "NUMORDER": str(_NUMORDER),
         "DRPTAG": __version__,
@@ -115,8 +108,8 @@ class KeywordRegistry:
         "JD_UTC": None,
     }
 
-    # Per-extension EPRV keyword CSVs (rvdata does not load these as constants).
-    # RV#/CCF# share one template CSV; BARYCORR_*/BJD_TDB are per-extension.
+    # Per-extension EPRV keyword CSVs (rvdata exposes no constant). RV#/CCF# share a
+    # template; BARYCORR_*/BJD_TDB are per-extension.
     _EPRV_EXT_CSV = {
         "BJD_TDB": (_rvdata_core_cfg / "L2-BJD_TDB-keywords.csv", 2),
         "BARYCORR_KMS": (_rvdata_core_cfg / "L2-BARYCORR_KMS-keywords.csv", 2),
@@ -130,21 +123,13 @@ class KeywordRegistry:
         },
     }
 
-    # Registry "PopulatedBy" values that mark a QUALITY_CONTROL row as a 0/1 QC
-    # flag. The generic "QC" tags the cross-level aggregate ISGOOD; "QCL{n}" tags
-    # a level-N check. ``qc_flag_keywords`` unions them (drives the ISGOOD
-    # aggregate); ``qc_flag_keywords_by_level`` keys the level-N checks by their
-    # LEVEL tag (drives the per-level checkpoint, which flags only its own checks).
+    # "PopulatedBy" values marking a QUALITY_CONTROL row as a 0/1 QC flag: "QC" tags
+    # the cross-level ISGOOD aggregate, "QCL{n}" a level-N check.
     _QC_POPULATORS = frozenset({"QC", "QCL0", "QCL1", "QCL2", "QCL4"})
 
-    # FITS structural / bookkeeping cards that are always permitted on any
-    # extension and are never registered keywords. This is the single source of
-    # truth for "structural" (see is_structural); the checkpoint validator reads
-    # it rather than keeping its own list. Two parts: exact-match cards below, and
-    # the enumerated card families in _STRUCTURAL_PREFIXES (matched by prefix, e.g.
-    # NAXIS1/TTYPE3). Only genuine FITS cards belong here -- EPRV keywords (DATALVL)
-    # live in the registry table, KPF keywords (ORIGID) are registered to their
-    # home extension.
+    # FITS structural cards permitted on any extension (never registered keywords) --
+    # the validator's allowlist. Exact matches here; enumerated families in
+    # _STRUCTURAL_PREFIXES.
     _STRUCTURAL = {
         "SIMPLE",
         "BITPIX",
@@ -167,9 +152,7 @@ class KeywordRegistry:
         "TFIELDS",
     }
 
-    # Structural card families astropy adds when serializing an extension header
-    # (array dimensions NAXIS*, binary-table column descriptors, image WCS);
-    # matched by prefix.
+    # Structural card families (NAXIS*, bintable column descriptors, WCS); by prefix.
     _STRUCTURAL_PREFIXES = (
         "NAXIS",
         "TTYPE",
@@ -189,9 +172,8 @@ class KeywordRegistry:
     )
 
     def __init__(self):
-        # Build the source table and its derived lookups, then load the header_map
-        # -- order matters: the header_map is filtered against self.registered, the
-        # allowlist the table build produces.
+        # Order matters: _load_header_map filters against the registry
+        # _build_registry produces.
         self._build_registry()
         self._load_header_map()
 
@@ -208,8 +190,6 @@ class KeywordRegistry:
         """
         eprv_rows, kpf_rows = self._build_rows()
         table = pd.DataFrame(eprv_rows + kpf_rows, columns=self._COLUMNS)
-        # None-valued overrides carry no static default (value supplied
-        # elsewhere), so skip them.
         for keyword, value in self._DEFAULT_OVERRIDES.items():
             if value is not None:
                 table.loc[table["Keyword"] == keyword, "Default"] = value
@@ -225,16 +205,11 @@ class KeywordRegistry:
             {ext: MappingProxyType(d) for ext, d in required.items()}
         )
         self.structural = frozenset(self._STRUCTURAL)
-        # QC-flag keyword sets: the full set (ISGOOD aggregate) and the per-level
-        # split (current-level checkpoint scope). See _qc_flag_sets_lookup.
         qc_all, qc_by_level = self._qc_flag_sets_lookup()
         self.qc_flag_keywords = frozenset(qc_all)
         self.qc_flag_keywords_by_level = MappingProxyType(
             {lvl: frozenset(kws) for lvl, kws in qc_by_level.items()}
         )
-        # EPRV PRIMARY skeleton: the typed Required seed (KPF1.__init__ stamps it,
-        # mirroring RV2.__init__) and the datatypes _map_header types its emitted
-        # values with. See _eprv_primary_lookup.
         seed, datatypes = self._eprv_primary_lookup()
         self.eprv_primary_seed = MappingProxyType(seed)
         self.eprv_primary_datatypes = MappingProxyType(datatypes)
@@ -300,8 +275,7 @@ class KeywordRegistry:
                 continue
             descr = str(df["Description"].iloc[i])
             dtype = str(df["DataType"].iloc[i])
-            # Default/Units feed the typed PRIMARY seed (eprv_primary_seed); kept
-            # raw (NaN-as-is) here, the seed builder normalizes them.
+            # Kept raw (NaN preserved); _eprv_primary_lookup normalizes them.
             default = df["Default"].iloc[i]
             units = df["Units"].iloc[i]
             required = bool(req.iloc[i])
@@ -369,8 +343,8 @@ class KeywordRegistry:
                     populated_by,
                     False,
                     level_of(r),
-                    "",  # Default: EPRV-only attribute, blank for KPF rows
-                    "",  # Units: EPRV-only attribute, blank for KPF rows
+                    "",  # Default (EPRV-only)
+                    "",  # Units (EPRV-only)
                 ]
             )
         return rows
@@ -407,11 +381,9 @@ class KeywordRegistry:
     @classmethod
     def _build_rows(cls):
         """Build the EPRV and KPF row lists that union into ``self.table``."""
-        # EPRV's L2 PRIMARY keywords are KPF's L1-required set: EPRV defines no L1,
-        # so KPF holds the L1 PRIMARY to the EPRV L2 PRIMARY spec, and KPF1.__init__
-        # seeds exactly this set -- so they are Required from L1 (Level 1), which is
-        # what makes KWRDPRL1 meaningful at its own level (no L1->L2 cap). The
-        # L4-only extras stay Level 4 (first populated at L4). Never both.
+        # EPRV defines no L1, so KPF holds L1 PRIMARY to the EPRV L2 PRIMARY spec:
+        # these are Required from Level 1 (what makes KWRDPRL1 meaningful). L4-only
+        # extras stay Level 4.
         l2 = cls._eprv_rows(LEVEL2_PRIMARY_KEYWORDS, "PRIMARY", 1)
         l2_keys = {r[0] for r in l2}
         l4 = [
@@ -489,8 +461,7 @@ class KeywordRegistry:
             units = None if pd.isna(row.Units) else str(row.Units).strip()
             unitstr = "" if not units or units.lower() == "n/a" else f"[{units}] "
             comment = f"{unitstr}{row.Description}"
-            # The table is already sanitized (_DEFAULT_OVERRIDES applied in __init__),
-            # so the Default is read straight, no per-keyword correction here.
+            # Default already corrected in _build_registry (_DEFAULT_OVERRIDES).
             default = None if pd.isna(row.Default) else row.Default
             seed[row.Keyword] = parse_value_to_datatype(
                 row.Keyword, row.DataType, (default, comment)

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -108,6 +108,28 @@ class KeywordRegistry:
         "JD_UTC": None,
     }
 
+    # rvdata's header_map numbers per-trace keywords CAL-first (trace 1=CAL .. 5=SKY),
+    # the stale translator convention; KPF is SKY-first (1=SKY .. 5=CAL, see
+    # EPRV_DATA_STANDARD.md and trace-map.csv). These are the fiber-indexed families
+    # whose STANDARD index _load_header_map realigns 1<->5. NOT here (also end in 1/5
+    # but not fiber-indexed): EXSNR/EXSNRW (wavelength band 452/852nm), DQLVL, T*.
+    _FIBER_INDEXED_BASES = (
+        "TRACE",
+        "CSRC",
+        "CID",
+        "CRA",
+        "CDEC",
+        "CEQNX",
+        "CEPCH",
+        "CPLX",
+        "CPMR",
+        "CPMD",
+        "CRV",
+        "CZ",
+        "CCLR",
+        "CLSRC",
+    )
+
     # Per-extension EPRV keyword CSVs (rvdata exposes no constant). RV#/CCF# share a
     # template; BARYCORR_*/BJD_TDB are per-extension.
     _EPRV_EXT_CSV = {
@@ -217,9 +239,10 @@ class KeywordRegistry:
     def _load_header_map(self):
         """Read and sanitize rvdata's WMKO-native -> EPRV-standard ``header_map``.
 
-        Keeps only genuine static native->EPRV mapping rows, so KPF0._map_header
-        applies the map with no in-loop filter or per-keyword correction. Two row
-        classes are dropped:
+        First realigns the fiber-indexed STANDARD keys from rvdata's CAL-first to
+        KPF's SKY-first numbering (see ``_FIBER_INDEXED_BASES``), then keeps only
+        genuine static native->EPRV mapping rows so KPF0._map_header applies the map
+        with no in-loop filter or per-keyword correction. Two row classes are dropped:
           - STANDARD keys absent from the registry (PARANG/PARANG2) -- warned, so
             the rvdata header_map / registry inconsistency stays visible;
           - ``_DEFAULT_OVERRIDES`` keys, whose value comes from the corrected table
@@ -228,6 +251,12 @@ class KeywordRegistry:
         Runs after ``_build_registry`` -- it filters against ``self.registered``.
         """
         raw = pd.read_csv(_rvdata_inst_cfg / "header_map.csv")
+        # Swap trace index 1<->5 for the fiber-indexed families (SKY<->CAL). A dict
+        # replace maps each value once, so the two-way exchange is atomic.
+        swap = {}
+        for base in self._FIBER_INDEXED_BASES:
+            swap[f"{base}1"], swap[f"{base}5"] = f"{base}5", f"{base}1"
+        raw["STANDARD"] = raw["STANDARD"].replace(swap)
         eprv_keys = raw["STANDARD"].astype(str).str.strip()
         unregistered = sorted(
             set(eprv_keys[raw["STANDARD"].notna()]) - self.registered - {""}

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -141,10 +141,10 @@ class KeywordRegistry:
     # extension and are never registered keywords. This is the single source of
     # truth for "structural" (see is_structural); the checkpoint validator reads
     # it rather than keeping its own list. Two parts: exact-match cards below, and
-    # the WCS / binary-table column-descriptor families in _STRUCTURAL_PREFIXES
-    # (matched by prefix because they are enumerated, e.g. NAXIS1/TTYPE3). Only
-    # genuine FITS cards belong here -- EPRV keywords (DATALVL) live in the
-    # registry table, KPF keywords (ORIGID) are registered to their home extension.
+    # the enumerated card families in _STRUCTURAL_PREFIXES (matched by prefix, e.g.
+    # NAXIS1/TTYPE3). Only genuine FITS cards belong here -- EPRV keywords (DATALVL)
+    # live in the registry table, KPF keywords (ORIGID) are registered to their
+    # home extension.
     _STRUCTURAL = {
         "SIMPLE",
         "BITPIX",
@@ -168,7 +168,8 @@ class KeywordRegistry:
     }
 
     # Structural card families astropy adds when serializing an extension header
-    # (binary-table column descriptors, image WCS); matched by prefix.
+    # (array dimensions NAXIS*, binary-table column descriptors, image WCS);
+    # matched by prefix.
     _STRUCTURAL_PREFIXES = (
         "NAXIS",
         "TTYPE",
@@ -273,8 +274,8 @@ class KeywordRegistry:
 
         The single structural test, consumed by the checkpoint header validator: a
         card is structural if it is an exact-match bookkeeping card (``structural``)
-        or belongs to a WCS / binary-table column-descriptor family
-        (``_STRUCTURAL_PREFIXES``, e.g. ``NAXIS2``/``TTYPE3``).
+        or belongs to an enumerated card family (``_STRUCTURAL_PREFIXES``, e.g.
+        ``NAXIS2``/``TTYPE3``).
         """
         k = str(key).strip()
         return k in self.structural or k.startswith(self._STRUCTURAL_PREFIXES)
@@ -297,12 +298,12 @@ class KeywordRegistry:
             name = str(kw).strip()
             if not name:
                 continue
-            descr = str(df["Description"].iloc[i]) if "Description" in df else ""
-            dtype = str(df["DataType"].iloc[i]) if "DataType" in df else ""
+            descr = str(df["Description"].iloc[i])
+            dtype = str(df["DataType"].iloc[i])
             # Default/Units feed the typed PRIMARY seed (eprv_primary_seed); kept
             # raw (NaN-as-is) here, the seed builder normalizes them.
-            default = df["Default"].iloc[i] if "Default" in df else ""
-            units = df["Units"].iloc[i] if "Units" in df else ""
+            default = df["Default"].iloc[i]
+            units = df["Units"].iloc[i]
             required = bool(req.iloc[i])
             if "..." in name:
                 # "CDEC1 ... CDEC#" -> "CDEC" (strip the trailing index).
@@ -338,66 +339,26 @@ class KeywordRegistry:
         return rows
 
     @classmethod
-    def _kpf_rows(cls):
-        """KPF-pipeline keyword rows from config/L{0,1,2,4}-headers.csv.
+    def _parse_kpf_keyword_config(cls, df, source, level_of):
+        """Expand a KPF header CSV into unified-registry rows.
 
-        ``Required`` is always False; ``PopulatedBy`` is whatever the CSV says.
-        It must NEVER be the EPRV sentinel: the derived routing/validation lookups
-        treat a ``PopulatedBy == _EPRV_TAG`` row as EPRV-sourced, so a KPF row
-        reusing that string would be silently misclassified (dropped from routing,
-        given the wrong Required/Level). Guard against it loudly here.
+        Shared by ``_kpf_rows`` and ``_masters_rows``. ``Required`` is always
+        False; ``PopulatedBy`` is whatever the CSV says, but it must NEVER be the
+        EPRV sentinel: the derived routing/validation lookups treat a
+        ``PopulatedBy == _EPRV_TAG`` row as EPRV-sourced, so a KPF row reusing that
+        string would be silently misclassified (dropped from routing, given the
+        wrong Required/Level). Guard against it loudly here. ``source`` names the
+        CSV for that error; ``level_of(row)`` yields each row's Level.
         """
         rows = []
-        for level in (0, 1, 2, 4):
-            df = pd.read_csv(_kpf_pipe_cfg / f"L{level}-headers.csv")
-            for _, r in df.iterrows():
-                descr = (
-                    "" if pd.isna(r["Description"]) else str(r["Description"]).strip()
-                )
-                populated_by = str(r.get("PopulatedBy", "")).strip()
-                if populated_by == cls._EPRV_TAG:
-                    raise ValueError(
-                        f"L{level}-headers.csv: keyword "
-                        f"{str(r['Keyword']).strip()!r} has 'PopulatedBy' == "
-                        f"{cls._EPRV_TAG!r}, which is reserved as the EPRV-row "
-                        "discriminator; use a real populating site instead"
-                    )
-                rows.append(
-                    [
-                        str(r["Keyword"]).strip(),
-                        descr,
-                        str(r["Extension"]).strip(),
-                        str(r.get("DataType", "")).strip(),
-                        populated_by,
-                        False,
-                        level,
-                        "",  # Default: EPRV-only attribute, blank for KPF rows
-                        "",  # Units: EPRV-only attribute, blank for KPF rows
-                    ]
-                )
-        return rows
-
-    @classmethod
-    def _masters_rows(cls):
-        """KPF masters keyword rows from config/Masters-headers.csv.
-
-        Masters (bias/dark/flat/WLS calibration products) are out of EPRV scope
-        but route their PRIMARY keywords (MASTYPE + the WLS metadata) through
-        ``set_keyword`` like the science models, so they are registered here. Same
-        shape and ``Required is False`` convention as ``_kpf_rows``, but the level
-        comes from the CSV's own ``Level`` column (masters span L1/L2, not one
-        per-file level). The EPRV-tag guard mirrors ``_kpf_rows``.
-        """
-        rows = []
-        df = pd.read_csv(_kpf_pipe_cfg / "Masters-headers.csv")
         for _, r in df.iterrows():
             descr = "" if pd.isna(r["Description"]) else str(r["Description"]).strip()
             populated_by = str(r.get("PopulatedBy", "")).strip()
             if populated_by == cls._EPRV_TAG:
                 raise ValueError(
-                    f"Masters-headers.csv: keyword {str(r['Keyword']).strip()!r} "
-                    f"has 'PopulatedBy' == {cls._EPRV_TAG!r}, which is reserved as "
-                    "the EPRV-row discriminator; use a real populating site instead"
+                    f"{source}: keyword {str(r['Keyword']).strip()!r} has "
+                    f"'PopulatedBy' == {cls._EPRV_TAG!r}, which is reserved as the "
+                    "EPRV-row discriminator; use a real populating site instead"
                 )
             rows.append(
                 [
@@ -407,12 +368,41 @@ class KeywordRegistry:
                     str(r.get("DataType", "")).strip(),
                     populated_by,
                     False,
-                    int(r["Level"]),
+                    level_of(r),
                     "",  # Default: EPRV-only attribute, blank for KPF rows
                     "",  # Units: EPRV-only attribute, blank for KPF rows
                 ]
             )
         return rows
+
+    @classmethod
+    def _kpf_rows(cls):
+        """KPF-pipeline keyword rows from config/L{0,1,2,4}-headers.csv.
+
+        Level is the per-file level (one CSV per data level).
+        """
+        rows = []
+        for level in (0, 1, 2, 4):
+            df = pd.read_csv(_kpf_pipe_cfg / f"L{level}-headers.csv")
+            rows += cls._parse_kpf_keyword_config(
+                df, f"L{level}-headers.csv", lambda r, lvl=level: lvl
+            )
+        return rows
+
+    @classmethod
+    def _masters_rows(cls):
+        """KPF masters keyword rows from config/Masters-headers.csv.
+
+        Masters (bias/dark/flat/WLS calibration products) are out of EPRV scope
+        but route their PRIMARY keywords (MASTYPE + the WLS metadata) through
+        ``set_keyword`` like the science models, so they are registered here. Level
+        comes from the CSV's own ``Level`` column (masters span L1/L2, not one
+        per-file level).
+        """
+        df = pd.read_csv(_kpf_pipe_cfg / "Masters-headers.csv")
+        return cls._parse_kpf_keyword_config(
+            df, "Masters-headers.csv", lambda r: int(r["Level"])
+        )
 
     @classmethod
     def _build_rows(cls):
@@ -523,8 +513,9 @@ class KeywordRegistry:
         all_flags = set()
         by_level = {}
         for row in self.table.itertuples(index=False):
-            if row.Extension != "QUALITY_CONTROL" or row.PopulatedBy not in (
-                self._QC_POPULATORS
+            if (
+                row.Extension != "QUALITY_CONTROL"
+                or row.PopulatedBy not in self._QC_POPULATORS
             ):
                 continue
             all_flags.add(row.Keyword)

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -240,6 +240,8 @@ class KPF0(KPFDataModel):
             default_val = row["DEFAULT"] if pd.notna(row["DEFAULT"]) else None
 
             if instrument_key and instrument_key in wmko_primary:
+                # Verbatim: some cards legitimately read "None" (e.g. CAL-OBJ when
+                # the cal fiber is dark -> TRACE1/CLSRC1); real data, not a sentinel.
                 raw_value = wmko_primary.get(instrument_key)
             elif default_val is not None and str(default_val).strip():
                 raw_value = default_val

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -725,6 +725,12 @@ class BarycentricCorrection:
         l2_obj.set_keyword("CCD2BKMS", float(self._ccd_kms[1]))
         l2_obj.set_keyword("CCD2BZ", float(self._ccd_z[1]))
         l2_obj.set_keyword("ASTRSRC", self._astrometry_source)
+        # CTYPE1 names the single (spectral-order) axis of these 1-D per-order
+        # arrays -- registered content, multi-homed across the three barycorr
+        # extensions, so stamped directly (set_keyword can't route a multi-home
+        # keyword). CTYPE2 is N/A: the arrays have no second axis.
+        for ext in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
+            l2_obj.headers[ext]["CTYPE1"] = ("Order-N", "Name of axis 1")
 
     # ------------------------------------------------------------------
     # Public entry point

--- a/kpfpipe/quality_control/diagnostics/level1.py
+++ b/kpfpipe/quality_control/diagnostics/level1.py
@@ -5,7 +5,7 @@ state (read noise from raw overscan, the BIASSUB flag) are still written by
 the modules that produce them — ImageAssembly, ImageProcessing. Metrics that
 can be recomputed from the finished L1 product alone live here: the master
 calibration ages, derived from the master paths CalibrationAssociation wrote
-to RECEIPT plus the observation timestamp in INSTRUMENT_HEADER.
+to RECEIPT plus the observation timestamp (DATE-OBS) on PRIMARY.
 """
 
 from datetime import datetime

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -840,6 +840,15 @@ class TestPerform:
         np.testing.assert_allclose(kms.get("CCD1BKMS"), kms.get("CCD2BKMS"))
         np.testing.assert_allclose(z.get("CCD1BZ"), z.get("CCD2BZ"))
 
+    def test_ctype1_axis_label(self, bc_monkeypatched):
+        # These are 1-D per-order arrays: CTYPE1 names the order axis (registered
+        # content). CTYPE2 is N/A (no second axis).
+        kpf2 = bc_monkeypatched.perform()
+        for ext in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
+            hdr = kpf2.headers[ext]
+            assert hdr["CTYPE1"] == "Order-N", ext
+            assert "CTYPE2" not in hdr, ext
+
     def test_receipt_entry_added(self, bc_monkeypatched):
         bc_monkeypatched.perform()
         modules = bc_monkeypatched.l2_obj.receipt["FUNCTION"].values

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -199,14 +199,36 @@ class TestKeywordRegistry:
         assert primary_required.get("INSTRUME") == 1  # required from L1
 
     def test_is_structural_only_fits_cards(self):
-        # The single structural test: true FITS bookkeeping (exact + WCS/bintable
-        # prefixes) only. Registered keywords are NOT structural -- DATALVL (EPRV)
-        # and ORIGID (KPF, now on RECEIPT) were removed from the structural set.
+        # Structural = FITS cards astropy writes from the HDU structure, never
+        # authored by the pipeline (exact + bintable/array prefixes).
         reg = KPF1.keyword_registry
-        for card in ("SIMPLE", "EXTNAME", "NAXIS2", "TTYPE1", "TFORM3", "CRVAL1"):
+        for card in ("SIMPLE", "EXTNAME", "XTENSION", "NAXIS2", "TTYPE1", "TFORM3"):
             assert reg.is_structural(card), card
-        for kw in ("DATALVL", "ORIGID", "PROGID", "DRPTAG", "RV"):
+        # Content keywords (pipeline-authored) are NOT structural -- including CTYPE
+        # (axis meaning), DATE/FILENAME, and the pruned WCS family (KPF writes no WCS).
+        for kw in (
+            "DATALVL",
+            "ORIGID",
+            "PROGID",
+            "DRPTAG",
+            "RV",
+            "CTYPE1",
+            "DATE",
+            "FILENAME",
+            "CUNIT1",
+            "CRVAL1",
+            "CDELT1",
+        ):
             assert not reg.is_structural(kw), kw
+
+    def test_registered_and_structural_are_disjoint(self):
+        # Build-time invariant: structural cards (astropy-authored) are never
+        # registered. rvdata redundantly declares XTENSION/EXTNAME as per-extension
+        # keywords; the _build_registry sanitizer drops them.
+        reg = KPF1.keyword_registry
+        assert not [k for k in reg.registered if reg.is_structural(k)]
+        assert "XTENSION" not in reg.registered
+        assert "EXTNAME" not in reg.registered
 
     def test_default_units_populated_for_eprv_blank_for_kpf(self):
         # The new table columns carry EPRV CSV values for EPRV rows, "" for KPF.

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -6,6 +6,7 @@ Uses synthetic FITS fixtures — no real KPF data needed.
 """
 
 import importlib.metadata
+import re
 
 import numpy as np
 import pytest
@@ -167,6 +168,16 @@ class TestL1PrimarySeed:
     def test_datalvl_corrected_to_l1(self):
         # The seed defaults DATALVL (EPRV Required) to "UNKNOWN"; __init__ fixes it.
         assert KPF1().headers["PRIMARY"]["DATALVL"] == "L1"
+
+    def test_compliance_tags_from_rvdata_pin(self):
+        # EPRVTAG/VOCLASS default to "UNKNOWN" in the EPRV CSV; _DEFAULT_OVERRIDES
+        # derives them from the pinned rv-data-standard release. EPRVTAG is the
+        # version ("v0.4.0"); VOCLASS encodes the release month
+        # ("EPRVSTANDARD<YYYY.MM>").
+        prim = KPF1().headers["PRIMARY"]
+        version = importlib.metadata.version("rv-data-standard")
+        assert prim["EPRVTAG"] == f"v{version}"
+        assert re.fullmatch(r"EPRVSTANDARD\d{4}\.\d{2}", prim["VOCLASS"])
 
     def test_seed_matches_registry_lookup(self):
         # The 40 seeded keys are exactly the registry's eprv_primary_seed.

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -209,6 +209,45 @@ class TestL1PrimarySeed:
         assert not (self._required_l1_primary() & prim) - {"DATALVL"}
 
 
+class TestHeaderMapFiberRealignment:
+    """rvdata's header_map numbers per-trace keywords CAL-first (1=CAL..5=SKY);
+    _load_header_map realigns them to KPF's SKY-first numbering (1=SKY..5=CAL) by
+    swapping index 1<->5 for the fiber-indexed families. Keywords that also end in
+    1/5 but are not fiber-indexed (EXSNR wavelength bands) must be left alone.
+    """
+
+    @staticmethod
+    def _source(standard):
+        # (INSTRUMENT, DEFAULT) for a STANDARD key in the sanitized header_map, or
+        # (None, None) if the row was dropped.
+        hm = KPF1.keyword_registry.header_map
+        row = hm[hm["STANDARD"].astype(str).str.strip() == standard]
+        if row.empty:
+            return None, None
+        return str(row.iloc[0]["INSTRUMENT"]).strip(), str(
+            row.iloc[0]["DEFAULT"]
+        ).strip()
+
+    def test_trace_native_cards_swapped_to_sky_first(self):
+        # SKY is trace 1, CAL is trace 5 (KPF), so their native OBJ cards land there.
+        assert self._source("TRACE1")[0] == "SKY-OBJ"
+        assert self._source("TRACE5")[0] == "CAL-OBJ"
+
+    def test_catalog_block_swapped(self):
+        # The CAL last-source card moves to index 5; the "sky" catalog defaults move
+        # from index 5 to index 1 (SKY).
+        assert self._source("CLSRC5")[0] == "CAL-OBJ"
+        assert self._source("CLSRC1")[0] != "CAL-OBJ"
+        assert self._source("CSRC1")[1] == "sky"
+        assert self._source("CID1")[1] == "sky"
+
+    def test_exposure_meter_snr_not_swapped(self):
+        # Guard: EXSNR ends in 1/5 (wavelength band 452/852nm), not a fiber index,
+        # so it must be untouched -- catches an over-broad swap.
+        assert self._source("EXSNR1")[0] == "SNRSC452"
+        assert self._source("EXSNR5")[0] == "SNRSC852"
+
+
 class TestToKpf1:
     def test_to_kpf1_creates_kpf1(self, synthetic_l0_file):
         l0 = KPF0.from_fits(synthetic_l0_file)


### PR DESCRIPTION
  # Keyword-registry cleanup + EPRV/FITS compliance sweep

  Branch `kpf-next-keyword-compliance` → **`kpf-next`**.

  Tightens KPF's header-keyword handling: streamlines the keyword registry, grounds
  the "structural keyword" definition in the FITS standard, fixes a SKY/CAL trace
  numbering mismatch inherited from rvdata, and reconciles the header-read policy
  docs with the code. Closes out the actionable items from the EPRV keyword-
  population audit. **No scientific-behavior change** — refactors, one data-labeling
  fix (trace numbering), and docs.

  ## What's in it

  ### Keyword registry refactor (`keyword_registry.py`)
  - Renamed the config-path globals for clarity (`_rvdata_inst_cfg` / `_rvdata_core_cfg` / 
  `_kpf_pipe_cfg`).
  - Merged the two overlapping override sets into a single `_DEFAULT_OVERRIDES` consumed everywhere;
  dropped single-use helpers (`_family_base`, `_load_keyword_csv`) and dead column guards.
  - Reorganized `__init__` into two focused helpers (`_build_registry`, `_load_header_map`); deduped
  the KPF/masters CSV parsing into `_parse_kpf_keyword_config`.
  - Populated `EPRVTAG`/`VOCLASS` from the pinned `rv-data-standard` release.

  ### FITS-grounded "structural" definition + build-time sanitize
  - Adopted a self-consistent rule: **structural** = a FITS card the I/O layer (astropy) writes from
  HDU structure (never registered); **content** = anything the pipeline authors (registered).
  Audited against all 53 FITS-standard reserved keywords.
  - A one-time sanitizer in `_build_registry` drops any registered keyword that is structural, so
  `registered ∩ structural == ∅` holds by construction (absorbs rvdata's redundant
  `XTENSION`/`EXTNAME` registrations).
  - Reclassified `CTYPE`/`DATE`/`FILENAME` as content (pruned the WCS family from the structural
  prefixes); `BUNIT` kept as the one documented exception. `CTYPE1='Order-N'` now stamped on the 1-D
  barycentric extensions.

  ### SKY/CAL trace realignment
  - rvdata's `header_map.csv` numbers per-trace PRIMARY keywords **CAL-first**; KPF is
  **SKY-first**. `_load_header_map` now swaps the fiber-indexed bases 1↔5 after read, yielding KPF's
  `1=SKY … 5=CAL`. Guarded against non-fiber lookalikes (e.g. `EXSNR1`/`EXSNRW5` wavelength bands).

  ### PRIMARY-first header-read policy (docs)
  - Reconciled the governing docs with the code: **read from PRIMARY whenever a keyword lands there 
  under its own name with the same value** (e.g. `DATE-OBS`, `OBJECT`); read from
  `INSTRUMENT_HEADER` only when PRIMARY can't serve the read cleanly (native not carried to PRIMARY,
  or a coherent native block where a mix / cryptic renamed keys would obscure intent — the
  astrometry block, the SCI/SKY/CAL-OBJ illumination reads, the EXPTIME-vs-ELAPSED pair). Fixed a
  stale `DiagL1` docstring to match.

  ### Documentation of native "None"
  - Documented that a native `"None"` (e.g. `CAL-OBJ` on a dark cal fiber → `TRACE1`/`CLSRC1`) is
  **real data, not a sentinel**.

  ## Review

  A 4-agent read-only audit of every header keyword read/write (~275 sites) ahead of
  this PR found **no active violations**: `registered ∩ structural == ∅` holds; every
  pipeline-set keyword is registered in its correct home (or a justified multi-home
  direct write / the BUNIT exception); no dangling reads or missing-keyword gaps; and
  the schema, aliases, units, reference frames, and filename conventions match the
  EPRV/FITS/KPF standards. The only finding was the docs↔code drift on the read
  policy, fixed here.

  ## Deferred (tracked, out of scope)
  FULLCOMP/SUMMFLAG, DQLVL0/1/2/4, CAL-fiber RV5/CCF5, KOAID/PROGID (data-dependent),
  Flat masters (not built yet), and the EPRV-optional keyword set.

  ## Testing
  Full suite green (`make test`, 1102 passed); ruff + pre-commit clean.

  ## Files
  `keyword_registry.py` (core refactor), `level0.py`, `barycentric_correction.py`,
  `diagnostics/level1.py`; docs `CLAUDE.md` / `KPF_DRP_VNEXT_STYLE_GUIDE.md` /
  `EPRV_DATA_STANDARD.md`; tests `test_data_models_base.py` / `test_data_models_l1.py`
  / `test_barycentric_correction.py`.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)