### PR TITLE
Fix the CCF photon-limited RV uncertainty

### DIFF
--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -29,7 +29,7 @@ use_gaia_astrometry = true
 use_wmko_fallback = false
 
 [MODULE_RADIAL_VELOCITY]
-ccf_mask_width = 0.5
+ccf_mask_width = 1.0
 ccf_step_size = 0.25
 ccf_window = [-100.0, 100.0]
 rv_window = [-25.0, 25.0]

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -314,7 +314,7 @@ class RadialVelocity:
         return rows[mask_name].to_numpy(dtype=float)
 
     @staticmethod
-    def _compute_ccf_1d(wave, flux, line_mask, velocity_grid, barycorr_z):
+    def _compute_ccf_1d(wave, flux, var, line_mask, velocity_grid, barycorr_z):
         """
         Cross-correlate one order's spectrum against the mask over the velocity
         grid, folding in the order's barycentric redshift z.
@@ -325,6 +325,9 @@ class RadialVelocity:
             1D wavelength solution for the order [Å].
         flux : ndarray
             1D extracted flux for the order.
+        var : ndarray
+            1D per-pixel variance for the order (TRACE_VAR); sets the CCF photon
+            variance.
         line_mask : dict
             Line mask (keys 'start', 'end', 'weight') from _build_line_mask.
         velocity_grid : ndarray
@@ -338,7 +341,7 @@ class RadialVelocity:
             CCF value at each velocity step (all zeros if the order is unusable
             or no mask lines fall fully within it).
         ccf_var : ndarray
-            Per-velocity-bin photon variance sum(w**2 * flux), where w is the
+            Per-velocity-bin photon variance sum(w**2 * var), where w is the
             per-pixel mask weight (all zeros in the same unusable cases).
 
         Raises
@@ -350,6 +353,7 @@ class RadialVelocity:
         """
         wave = np.asarray(wave, dtype=np.float64)
         flux = np.asarray(flux, dtype=np.float64)
+        var = np.asarray(var, dtype=np.float64)
         if wave[0] > wave[-1]:
             raise ValueError(
                 f"WAVE array is descending (wave[0]={wave[0]:.4f} > "
@@ -389,6 +393,7 @@ class RadialVelocity:
         # summing flux_clean * overlap_frac (overlap weights are always finite)
         # is identical but skips the per-step NaN mask.
         flux_clean = np.nan_to_num(flux)
+        var_clean = np.nan_to_num(var)
 
         # Shifted line edges and their covering-pixel indices for every velocity
         # step at once: searchsorted takes an array of any shape, so one batched
@@ -425,7 +430,7 @@ class RadialVelocity:
                 )
 
             ccf[vi] = np.sum(flux_clean * overlap_frac)
-            ccf_var[vi] = np.sum(flux_clean * overlap_frac**2)
+            ccf_var[vi] = np.sum(var_clean * overlap_frac**2)
 
         return ccf, ccf_var
 
@@ -692,6 +697,7 @@ class RadialVelocity:
 
         flux = np.asarray(self.l2_obj.data[f"{chip}_{fiber}_FLUX"], dtype=np.float64)
         wave = np.asarray(self.l2_obj.data[f"{chip}_{fiber}_WAVE"], dtype=np.float64)
+        var = np.asarray(self.l2_obj.data[f"{chip}_{fiber}_VAR"], dtype=np.float64)
 
         # Drop the blaze-faint, low-S/N pixels at each order's edges, which
         # otherwise inject noise into the CCF. clip_edge_pixels counts pixels to
@@ -711,6 +717,7 @@ class RadialVelocity:
                 cols = slice(n_long, ncol - n_short)
             flux = flux[:, cols]
             wave = wave[:, cols]
+            var = var[:, cols]
 
         norder = flux.shape[0]
 
@@ -739,7 +746,7 @@ class RadialVelocity:
             if not np.all(np.isfinite(wave[o])) or not np.any(np.isfinite(flux[o])):
                 continue
             ccf[o], ccf_var[o] = self._compute_ccf_1d(
-                wave[o], flux[o], line_mask, velocity_grid, barycorr_z[o]
+                wave[o], flux[o], var[o], line_mask, velocity_grid, barycorr_z[o]
             )
 
         # Fail loudly: an identically-zero CCF across every order means the

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -38,7 +38,7 @@ from kpfpipe.utils.validation import strictly_increasing
 
 _DEFAULTS = {
     **DEFAULTS,
-    "ccf_mask_width": 0.5,
+    "ccf_mask_width": 1.0,
     "ccf_step_size": 0.25,
     "ccf_window": [-100.0, 100.0],
     "rv_window": [-25.0, 25.0],
@@ -227,8 +227,8 @@ class RadialVelocity:
     def _build_line_mask(self, chip, fiber, mask_width=None):
         """
         Build (and cache) the orderlet's CCF line mask: vacuum line centers,
-        weights, and per-line top-hat edges at velocity -/+ mask_width about each
-        center (relativistic Doppler). The mask is selected from the orderlet's
+        weights, and per-line top-hat holes of full width `mask_width` about
+        each center (relativistic Doppler). The mask is selected from the orderlet's
         illumination source.
 
         Stellar masks load from reference/line_masks/stellar_masks/; the 'thar'
@@ -259,11 +259,12 @@ class RadialVelocity:
             )
             centers, weights = np.loadtxt(mask_path, unpack=True)  # vacuum wavelengths
 
+        half_width = mask_width / 2.0  # hole spans +/- half_width about each center
         mask = {
             "center": centers,
             "weight": weights,
-            "start": centers * (1.0 + compute_redshift(-mask_width * u.km / u.s)),
-            "end": centers * (1.0 + compute_redshift(+mask_width * u.km / u.s)),
+            "start": centers * (1.0 + compute_redshift(-half_width * u.km / u.s)),
+            "end": centers * (1.0 + compute_redshift(+half_width * u.km / u.s)),
         }
         self._line_mask[key] = mask
         return mask
@@ -325,14 +326,15 @@ class RadialVelocity:
         oversampled. That length is *not* the native pixel: the CCF is the
         spectrum seen through a mask hole, so its noise kernel is the
         cross-correlation of two top-hats -- the mask hole (full width
-        `2 * mask_width`, since the mask spans +/- mask_width about each line
-        center) and the native pixel (`vel_span_per_pixel`) -- i.e. a trapezoid.
-        The integral length of a trapezoid's autocorrelation, (integral)^2 /
-        integral-of-square, is `M**2 / (M - m/3)` with M, m the larger/smaller
-        of the two widths (reduces to 1.5*w for equal widths).
+        `mask_width`) and the native pixel (`vel_span_per_pixel`) -- i.e. a
+        trapezoid. The integral length of a trapezoid's autocorrelation,
+        (integral)^2 / integral-of-square, is `M**2 / (M - m/3)` with M, m the
+        larger/smaller of the two widths (reduces to 1.5*w for equal widths).
         """
-        w_m = 2.0 * mask_width
-        big, small = max(vel_span_per_pixel, w_m), min(vel_span_per_pixel, w_m)
+        big, small = (
+            max(vel_span_per_pixel, mask_width),
+            min(vel_span_per_pixel, mask_width),
+        )
         return big**2 / (big - small / 3.0)
 
     @staticmethod
@@ -482,9 +484,9 @@ class RadialVelocity:
             1D wavelength solution for the order [Å]; sets the native per-pixel
             velocity scale used in the error estimate.
         mask_width : float
-            CCF mask width [km/s] used to build the CCF (the mask spans
-            +/- mask_width about each line center); with `wave` it sets the
-            CCF-noise correlation length (see `_ccf_noise_corr_length`).
+            CCF mask hole full width [km/s] used to build the CCF (each top-hat
+            hole is `mask_width` wide, centered on its line); with `wave` it sets
+            the CCF-noise correlation length (see `_ccf_noise_corr_length`).
         window : list of float
             [min, max] km/s velocity window about the dip for the first pass.
         fit_nsigma : float

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -84,6 +84,7 @@ class RadialVelocity:
         self._velocity_grid = {}  # velocity grid, set by _build_velocity_grid()
         self._ccf = {}  # CCF cube, set by compute_ccfs()
         self._ccf_var = {}  # per-bin CCF variance cube, set by compute_ccfs()
+        self._ccf_mask_width = self.ccf_mask_width  # width behind the cached CCFs
         self._order_weights = (
             None  # shared order-weight table, loaded by _get_order_weights()
         )
@@ -223,10 +224,10 @@ class RadialVelocity:
             )
         return star_rv
 
-    def _build_line_mask(self, chip, fiber, width=None):
+    def _build_line_mask(self, chip, fiber, mask_width=None):
         """
         Build (and cache) the orderlet's CCF line mask: vacuum line centers,
-        weights, and per-line top-hat edges at velocity -/+ width about each
+        weights, and per-line top-hat edges at velocity -/+ mask_width about each
         center (relativistic Doppler). The mask is selected from the orderlet's
         illumination source.
 
@@ -239,8 +240,8 @@ class RadialVelocity:
             Mask with keys 'center', 'weight', 'start', 'end', each a 1D ndarray
             of length n_line; wavelengths are vacuum [Å].
         """
-        if width is None:
-            width = self.ccf_mask_width
+        if mask_width is None:
+            mask_width = self.ccf_mask_width
         key = f"{chip.upper()}_{fiber.upper()}"
         if key in self._line_mask:
             return self._line_mask[key]
@@ -261,8 +262,8 @@ class RadialVelocity:
         mask = {
             "center": centers,
             "weight": weights,
-            "start": centers * (1.0 + compute_redshift(-width * u.km / u.s)),
-            "end": centers * (1.0 + compute_redshift(+width * u.km / u.s)),
+            "start": centers * (1.0 + compute_redshift(-mask_width * u.km / u.s)),
+            "end": centers * (1.0 + compute_redshift(+mask_width * u.km / u.s)),
         }
         self._line_mask[key] = mask
         return mask
@@ -312,6 +313,27 @@ class RadialVelocity:
             )
         rows = df[df["CHIP"] == chip.upper()].sort_values("ORDER")
         return rows[mask_name].to_numpy(dtype=float)
+
+    @staticmethod
+    def _ccf_noise_corr_length(vel_span_per_pixel, mask_width):
+        """
+        Decorrelation length [km/s] of the CCF photon noise.
+
+        The Boisse (2010) N_scale factor divides the CCF velocity step by the
+        length over which CCF-noise bins are independent, correcting the
+        diagonal information sum for the fact that a finely-stepped CCF is
+        oversampled. That length is *not* the native pixel: the CCF is the
+        spectrum seen through a mask hole, so its noise kernel is the
+        cross-correlation of two top-hats -- the mask hole (full width
+        `2 * mask_width`, since the mask spans +/- mask_width about each line
+        center) and the native pixel (`vel_span_per_pixel`) -- i.e. a trapezoid.
+        The integral length of a trapezoid's autocorrelation, (integral)^2 /
+        integral-of-square, is `M**2 / (M - m/3)` with M, m the larger/smaller
+        of the two widths (reduces to 1.5*w for equal widths).
+        """
+        w_m = 2.0 * mask_width
+        big, small = max(vel_span_per_pixel, w_m), min(vel_span_per_pixel, w_m)
+        return big**2 / (big - small / 3.0)
 
     @staticmethod
     def _compute_ccf_1d(wave, flux, var, line_mask, velocity_grid, barycorr_z):
@@ -435,7 +457,9 @@ class RadialVelocity:
         return ccf, ccf_var
 
     @staticmethod
-    def _compute_rv_1d(vel, ccf, ccf_var, wave, window, fit_nsigma=3.0, min_npts=9):
+    def _compute_rv_1d(
+        vel, ccf, ccf_var, wave, mask_width, window, fit_nsigma=3.0, min_npts=9
+    ):
         """
         Two-pass Gaussian fit to a CCF dip, with a photon-limited error.
 
@@ -455,8 +479,12 @@ class RadialVelocity:
             Per-velocity-bin CCF variance sum(w**2 * var) aligned with `ccf`; sets
             the photon noise in the error estimate (Bouchy 2001).
         wave : ndarray
-            1D wavelength solution for the order [Å]; sets the per-pixel velocity
-            scale used in the error estimate.
+            1D wavelength solution for the order [Å]; sets the native per-pixel
+            velocity scale used in the error estimate.
+        mask_width : float
+            CCF mask width [km/s] used to build the CCF (the mask spans
+            +/- mask_width about each line center); with `wave` it sets the
+            CCF-noise correlation length (see `_ccf_noise_corr_length`).
         window : list of float
             [min, max] km/s velocity window about the dip for the first pass.
         fit_nsigma : float
@@ -528,20 +556,23 @@ class RadialVelocity:
                 "(zero/negative flux counts); cannot compute a photon-limited error"
             )
 
-        # nan-aware: in the combined-CCF path `wave` is the full, unclipped order
-        # row, which may carry NaN edge pixels; plain np.median would NaN the error.
+        # Boisse (2010) N_scale = CCF step / CCF-noise correlation length,
+        # decorrelating the oversampled CCF. nan-aware: in the combined-CCF path
+        # `wave` is the full, unclipped order row, which may carry NaN edge
+        # pixels; plain np.median would NaN the error.
         speed_of_light_kms = c.to("km/s").value
         vel_span_per_pixel = (
             speed_of_light_kms
             * np.nanmedian(np.abs(np.diff(wave)))
             / np.nanmedian(wave)
         )
-        n_pix_per_vel_step = dv / vel_span_per_pixel  # dv: mean velocity-grid step
+        corr_length = RadialVelocity._ccf_noise_corr_length(
+            vel_span_per_pixel, mask_width
+        )
+        n_scale = dv / corr_length  # dv: mean velocity-grid step
 
         weighted_slope = np.gradient(ccf_fit, vel_fit) ** 2 / ccf_var_fit
-        qccf = (
-            np.sum(weighted_slope) ** 0.5 / np.sum(ccf_fit) ** 0.5
-        ) * n_pix_per_vel_step**0.5
+        qccf = (np.sum(weighted_slope) ** 0.5 / np.sum(ccf_fit) ** 0.5) * n_scale**0.5
         rv_err = 1.0 / (qccf * np.sum(ccf_fit) ** 0.5)
 
         return rv, rv_err
@@ -637,7 +668,7 @@ class RadialVelocity:
         self,
         chip,
         fiber,
-        width=None,
+        mask_width=None,
         step_size=None,
         window=None,
         clip_edge_pixels=(500, 500),
@@ -651,8 +682,9 @@ class RadialVelocity:
             Chip identifier, i.e. 'GREEN' or 'RED'.
         fiber : str
             Fiber identifier, e.g. 'SCI1'.
-        width : float, optional
-            Per-line mask top-hat width [km/s]. Defaults to the configured value.
+        mask_width : float, optional
+            Per-line mask top-hat width [km/s]. Defaults to the configured
+            value.
         step_size : float, optional
             CCF velocity step size [km/s]. Defaults to the configured value.
         window : list of float, optional
@@ -680,8 +712,8 @@ class RadialVelocity:
         """
         chip = chip.upper()
         fiber = fiber.upper()
-        if width is None:
-            width = self.ccf_mask_width
+        if mask_width is None:
+            mask_width = self.ccf_mask_width
         if step_size is None:
             step_size = self.ccf_step_size
         if window is None:
@@ -692,7 +724,7 @@ class RadialVelocity:
             return None  # fiber not illuminated; caller skips
         apply_barycorr = source["apply_barycorr"]
 
-        line_mask = self._build_line_mask(chip, fiber, width)
+        line_mask = self._build_line_mask(chip, fiber, mask_width)
         velocity_grid = self._build_velocity_grid(chip, fiber, step_size, window)
 
         flux = np.asarray(self.l2_obj.data[f"{chip}_{fiber}_FLUX"], dtype=np.float64)
@@ -764,6 +796,7 @@ class RadialVelocity:
 
         self._ccf[f"{chip}_{fiber}"] = ccf
         self._ccf_var[f"{chip}_{fiber}"] = ccf_var
+        self._ccf_mask_width = mask_width
 
         return {"velocity": velocity_grid, "ccf": ccf}
 
@@ -817,13 +850,21 @@ class RadialVelocity:
 
         velocity_grid = self._velocity_grid[ext]  # the grid compute_ccfs used
         wave = np.asarray(self.l2_obj.data[f"{chip}_{fiber}_WAVE"], dtype=np.float64)
+        mask_width = self._ccf_mask_width
         rv = np.full(ccf.shape[0], np.nan)
         rv_err = np.full(ccf.shape[0], np.nan)
         for o in range(ccf.shape[0]):
             if not np.any(ccf[o]):
                 continue
             rv[o], rv_err[o] = self._compute_rv_1d(
-                velocity_grid, ccf[o], ccf_var[o], wave[o], window, fit_nsigma, min_npts
+                velocity_grid,
+                ccf[o],
+                ccf_var[o],
+                wave[o],
+                mask_width,
+                window,
+                fit_nsigma,
+                min_npts,
             )
 
         return {"rv": rv, "rv_err": rv_err}
@@ -908,6 +949,7 @@ class RadialVelocity:
 
         # Per-chip weighted RV: value from the weighted CCF, error from the
         # unweighted-sum CCF.
+        mask_width = self._ccf_mask_width
         per_chip = {}
         for chip in chips:
             grid, ccf_w, ccf_s, ccf_s_var, wave = self._combine_ccfs(chip, fibers)
@@ -915,10 +957,24 @@ class RadialVelocity:
                 per_chip[chip] = (np.nan, np.nan)
                 continue
             rv = self._compute_rv_1d(
-                grid, ccf_w, ccf_s_var, wave, window, fit_nsigma, min_npts
+                grid,
+                ccf_w,
+                ccf_s_var,
+                wave,
+                mask_width,
+                window,
+                fit_nsigma,
+                min_npts,
             )[0]
             rv_err = self._compute_rv_1d(
-                grid, ccf_s, ccf_s_var, wave, window, fit_nsigma, min_npts
+                grid,
+                ccf_s,
+                ccf_s_var,
+                wave,
+                mask_width,
+                window,
+                fit_nsigma,
+                min_npts,
             )[1]
             per_chip[chip] = (rv, rv_err)
 

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -83,6 +83,7 @@ class RadialVelocity:
         self._line_mask = {}  # line mask, set by _build_line_mask()
         self._velocity_grid = {}  # velocity grid, set by _build_velocity_grid()
         self._ccf = {}  # CCF cube, set by compute_ccfs()
+        self._ccf_var = {}  # per-bin CCF variance cube, set by compute_ccfs()
         self._order_weights = (
             None  # shared order-weight table, loaded by _get_order_weights()
         )
@@ -333,9 +334,12 @@ class RadialVelocity:
 
         Returns
         -------
-        ndarray
+        ccf : ndarray
             CCF value at each velocity step (all zeros if the order is unusable
             or no mask lines fall fully within it).
+        ccf_var : ndarray
+            Per-velocity-bin photon variance sum(w**2 * flux), where w is the
+            per-pixel mask weight (all zeros in the same unusable cases).
 
         Raises
         ------
@@ -354,9 +358,10 @@ class RadialVelocity:
             )
 
         ccf = np.zeros(velocity_grid.size)
+        ccf_var = np.zeros(velocity_grid.size)
         n_pix = wave.size
         if n_pix < 3 or not strictly_increasing(wave):
-            return ccf
+            return ccf, ccf_var
 
         # Wavelength bin edges (length n+1) and widths at the pixel midpoints.
         edges = np.empty(n_pix + 1)
@@ -376,7 +381,7 @@ class RadialVelocity:
             line_mask["end"] * smax <= wave[-1]
         )
         if not np.any(keep):
-            return ccf
+            return ccf, ccf_var
         l_start, l_end = line_mask["start"][keep], line_mask["end"][keep]
         l_weight = line_mask["weight"][keep]
 
@@ -420,11 +425,12 @@ class RadialVelocity:
                 )
 
             ccf[vi] = np.sum(flux_clean * overlap_frac)
+            ccf_var[vi] = np.sum(flux_clean * overlap_frac**2)
 
-        return ccf
+        return ccf, ccf_var
 
     @staticmethod
-    def _compute_rv_1d(vel, ccf, wave, window, fit_nsigma=3.0, min_npts=9):
+    def _compute_rv_1d(vel, ccf, ccf_var, wave, window, fit_nsigma=3.0, min_npts=9):
         """
         Two-pass Gaussian fit to a CCF dip, with a photon-limited error.
 
@@ -440,6 +446,9 @@ class RadialVelocity:
             CCF velocity steps [km/s].
         ccf : ndarray
             CCF value at each velocity step.
+        ccf_var : ndarray
+            Per-velocity-bin CCF variance sum(w**2 * var) aligned with `ccf`; sets
+            the photon noise in the error estimate (Bouchy 2001).
         wave : ndarray
             1D wavelength solution for the order [Å]; sets the per-pixel velocity
             scale used in the error estimate.
@@ -457,6 +466,12 @@ class RadialVelocity:
             Fitted radial velocity [km/s], or NaN if the fit fails.
         rv_err : float
             Photon-limited RV uncertainty [km/s], or NaN if unavailable.
+
+        Raises
+        ------
+        ValueError
+            If the CCF or its variance is non-physical (zero/negative flux
+            counts) across the fit window, so a photon error cannot be computed.
         """
         # Fail loudly on non-finite CCF values rather than masking them out.
         if ccf.size < min_npts or not np.all(np.isfinite(ccf)) or np.ptp(ccf) == 0:
@@ -499,9 +514,14 @@ class RadialVelocity:
             pass
 
         # Photon-limited RV uncertainty from the weighted CCF slope over the
-        # second-pass window.
-        if not np.any(ccf_fit) or np.any(ccf_fit < 0):
-            return rv, np.nan
+        # second-pass window; per-bin noise is the propagated CCF variance
+        # sum(w**2 * var) (Bouchy 2001).
+        ccf_var_fit = ccf_var[idx_lo:idx_hi]
+        if not np.any(ccf_fit) or np.any(ccf_fit < 0) or np.any(ccf_var_fit <= 0):
+            raise ValueError(
+                "non-physical CCF or CCF variance in the RV fit window "
+                "(zero/negative flux counts); cannot compute a photon-limited error"
+            )
 
         # nan-aware: in the combined-CCF path `wave` is the full, unclipped order
         # row, which may carry NaN edge pixels; plain np.median would NaN the error.
@@ -513,7 +533,7 @@ class RadialVelocity:
         )
         n_pix_per_vel_step = dv / vel_span_per_pixel  # dv: mean velocity-grid step
 
-        weighted_slope = np.gradient(ccf_fit, vel_fit) ** 2 / ccf_fit
+        weighted_slope = np.gradient(ccf_fit, vel_fit) ** 2 / ccf_var_fit
         qccf = (
             np.sum(weighted_slope) ** 0.5 / np.sum(ccf_fit) ** 0.5
         ) * n_pix_per_vel_step**0.5
@@ -547,11 +567,17 @@ class RadialVelocity:
 
         Returns
         -------
-        tuple
-            (velocity_grid, weighted_ccf, summed_ccf, rep_wave): the shared
-            velocity grid [km/s], the two 1D collapsed CCFs, and the WAVE row of
-            the strongest order (the photon-error velocity scale). weighted_ccf
-            is identically zero if no order carries weight.
+        velocity_grid : ndarray
+            Shared CCF velocity grid [km/s].
+        weighted_ccf : ndarray
+            Order-weighted collapsed CCF (the RV value); identically zero if no
+            order carries weight.
+        summed_ccf : ndarray
+            Unweighted order-summed collapsed CCF (the photon-error signal).
+        summed_ccf_var : ndarray
+            Per-bin photon variance of summed_ccf.
+        rep_wave : ndarray
+            WAVE row of the strongest order (the photon-error velocity scale).
 
         Raises
         ------
@@ -583,6 +609,7 @@ class RadialVelocity:
         )
         weights = self._get_order_weights(chip, fibers[0])
         ccf = np.sum([self._ccf[f"{chip}_{f}"] for f in fibers], axis=0)
+        ccf_var = np.sum([self._ccf_var[f"{chip}_{f}"] for f in fibers], axis=0)
 
         ccf_weighted = np.zeros(velocity_grid.size)
         for o in range(ccf.shape[0]):
@@ -590,11 +617,12 @@ class RadialVelocity:
             if ccf_sum > 0 and weights[o] != 0:
                 ccf_weighted += (ccf[o] / ccf_sum) * weights[o]
         ccf_summed = np.nansum(ccf, axis=0)
+        ccf_summed_var = np.nansum(ccf_var, axis=0)
 
         # The dispersion is ~uniform across the chip; use the strongest order's
         # WAVE for the photon-noise velocity scale.
         rep = int(np.argmax(np.nansum(ccf, axis=1)))
-        return velocity_grid, ccf_weighted, ccf_summed, wave[rep]
+        return velocity_grid, ccf_weighted, ccf_summed, ccf_summed_var, wave[rep]
 
     # ------------------------------------------------------------------
     # Algorithm steps
@@ -701,6 +729,7 @@ class RadialVelocity:
             barycorr_z = np.zeros(norder)
 
         ccf = np.zeros((norder, velocity_grid.size))
+        ccf_var = np.zeros((norder, velocity_grid.size))
 
         # Some orders legitimately yield a zero CCF (no mask lines fall within
         # their wavelength coverage, or the order has no usable flux); those are
@@ -709,7 +738,7 @@ class RadialVelocity:
         for o in range(norder):
             if not np.all(np.isfinite(wave[o])) or not np.any(np.isfinite(flux[o])):
                 continue
-            ccf[o] = self._compute_ccf_1d(
+            ccf[o], ccf_var[o] = self._compute_ccf_1d(
                 wave[o], flux[o], line_mask, velocity_grid, barycorr_z[o]
             )
 
@@ -727,6 +756,7 @@ class RadialVelocity:
             )
 
         self._ccf[f"{chip}_{fiber}"] = ccf
+        self._ccf_var[f"{chip}_{fiber}"] = ccf_var
 
         return {"velocity": velocity_grid, "ccf": ccf}
 
@@ -776,6 +806,7 @@ class RadialVelocity:
                 "before compute_order_by_order_rvs"
             )
         ccf = self._ccf[ext]
+        ccf_var = self._ccf_var[ext]
 
         velocity_grid = self._velocity_grid[ext]  # the grid compute_ccfs used
         wave = np.asarray(self.l2_obj.data[f"{chip}_{fiber}_WAVE"], dtype=np.float64)
@@ -785,7 +816,7 @@ class RadialVelocity:
             if not np.any(ccf[o]):
                 continue
             rv[o], rv_err[o] = self._compute_rv_1d(
-                velocity_grid, ccf[o], wave[o], window, fit_nsigma, min_npts
+                velocity_grid, ccf[o], ccf_var[o], wave[o], window, fit_nsigma, min_npts
             )
 
         return {"rv": rv, "rv_err": rv_err}
@@ -872,13 +903,15 @@ class RadialVelocity:
         # unweighted-sum CCF.
         per_chip = {}
         for chip in chips:
-            grid, ccf_w, ccf_s, wave = self._combine_ccfs(chip, fibers)
+            grid, ccf_w, ccf_s, ccf_s_var, wave = self._combine_ccfs(chip, fibers)
             if not np.any(ccf_w):
                 per_chip[chip] = (np.nan, np.nan)
                 continue
-            rv = self._compute_rv_1d(grid, ccf_w, wave, window, fit_nsigma, min_npts)[0]
+            rv = self._compute_rv_1d(
+                grid, ccf_w, ccf_s_var, wave, window, fit_nsigma, min_npts
+            )[0]
             rv_err = self._compute_rv_1d(
-                grid, ccf_s, wave, window, fit_nsigma, min_npts
+                grid, ccf_s, ccf_s_var, wave, window, fit_nsigma, min_npts
             )[1]
             per_chip[chip] = (rv, rv_err)
 

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -83,51 +83,66 @@ class TestComputeCCF:
         # Observed absorption that the CCF should align at velocity step v_dip.
         lam_obs = centers * (1.0 + v_dip / SPEED_OF_LIGHT_KMS) / (1.0 + z)
         flux = _absorption_spectrum(wave, lam_obs)
+        var = flux.copy()  # photon-noise proxy
         vel = np.arange(-402, 403) * 0.25
-        return wave, flux, mask, vel
+        return wave, flux, var, mask, vel
 
     def test_dip_at_injected_velocity(self):
-        wave, flux, mask, vel = self._order(v_dip=3.0, z=0.0)
-        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        wave, flux, var, mask, vel = self._order(v_dip=3.0, z=0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
         assert vel[np.argmin(ccf)] == pytest.approx(3.0, abs=0.3)
 
     def test_zero_velocity_dip(self):
-        wave, flux, mask, vel = self._order(v_dip=0.0, z=0.0)
-        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        wave, flux, var, mask, vel = self._order(v_dip=0.0, z=0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
         assert vel[np.argmin(ccf)] == pytest.approx(0.0, abs=0.3)
 
     def test_barycorr_z_folds_in(self):
         z = 5.0 / SPEED_OF_LIGHT_KMS
-        wave, flux, mask, vel = self._order(v_dip=2.0, z=z)
-        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, z)
+        wave, flux, var, mask, vel = self._order(v_dip=2.0, z=z)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, z)
         assert vel[np.argmin(ccf)] == pytest.approx(2.0, abs=0.3)
 
     def test_descending_wave_raises(self):
-        wave, flux, mask, vel = self._order(v_dip=0.0)
+        wave, flux, var, mask, vel = self._order(v_dip=0.0)
         with pytest.raises(ValueError, match="descending"):
-            RadialVelocity._compute_ccf_1d(wave[::-1], flux[::-1], mask, vel, 0.0)
+            RadialVelocity._compute_ccf_1d(
+                wave[::-1], flux[::-1], var[::-1], mask, vel, 0.0
+            )
 
     def test_constant_wave_returns_zeros(self):
-        wave, flux, mask, vel = self._order()
+        wave, flux, var, mask, vel = self._order()
         ccf, _ = RadialVelocity._compute_ccf_1d(
-            np.full_like(wave, 5000.0), flux, mask, vel, 0.0
+            np.full_like(wave, 5000.0), flux, var, mask, vel, 0.0
         )
         assert not np.any(ccf)
 
     def test_nan_wave_returns_zeros(self):
-        wave, flux, mask, vel = self._order()
+        wave, flux, var, mask, vel = self._order()
         wave = wave.copy()
         wave[1000] = np.nan
-        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
         assert not np.any(ccf)
 
     def test_no_lines_in_order_returns_zeros(self):
         wave = np.linspace(6000.0, 6050.0, 2000)
         flux = np.ones_like(wave)
+        var = flux.copy()  # photon-noise proxy
         mask = _make_mask(np.linspace(5008.0, 5042.0, 20))  # all outside the order
         vel = np.arange(-402, 403) * 0.25
-        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
         assert not np.any(ccf)
+
+    def test_ccf_var_propagates_var_not_flux(self):
+        # ccf_var carries the per-pixel VARIANCE, not the flux: scaling var
+        # scales ccf_var but leaves the CCF value unchanged.
+        wave, flux, var, mask, vel = self._order(v_dip=0.0)
+        ccf1, var1 = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
+        ccf2, var2 = RadialVelocity._compute_ccf_1d(
+            wave, flux, 4.0 * var, mask, vel, 0.0
+        )
+        np.testing.assert_allclose(ccf1, ccf2)
+        np.testing.assert_allclose(var2, 4.0 * var1)
 
 
 # ---------------------------------------------------------------------------
@@ -144,19 +159,20 @@ class TestDtypeProvenance:
         centers = np.linspace(5008.0, 5042.0, 20)
         mask = _make_mask(centers)
         flux = _absorption_spectrum(wave, centers)
+        var = flux.copy()  # photon-noise proxy
         vel = np.arange(-402, 403) * 0.25
-        return wave, flux, mask, vel
+        return wave, flux, var, mask, vel
 
     def test_ccf_1d_is_float64_from_float32_flux(self):
-        wave, flux, mask, vel = self._order()
+        wave, flux, var, mask, vel = self._order()
         ccf, _ = RadialVelocity._compute_ccf_1d(
-            wave, flux.astype(np.float32), mask, vel, 0.0
+            wave, flux.astype(np.float32), var, mask, vel, 0.0
         )
         assert_dtype(ccf, CCF, "CCF (_compute_ccf_1d, float32 flux in)")
 
     def test_compute_rv_1d_returns_float64(self):
-        wave, flux, mask, vel = self._order()
-        ccf, ccf_var = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        wave, flux, var, mask, vel = self._order()
+        ccf, ccf_var = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
         rv, rv_err = RadialVelocity._compute_rv_1d(
             vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
         )
@@ -527,6 +543,9 @@ def rv_kpf2():
             )
             kpf2.set_data(
                 f"{chip}_{fiber}_FLUX", np.tile(flux_1d, (n, 1)).astype(np.float64)
+            )
+            kpf2.set_data(
+                f"{chip}_{fiber}_VAR", np.tile(flux_1d, (n, 1)).astype(np.float64)
             )
     # Per-order barycentric extensions (populated together by BarycentricCorrection).
     kpf2.set_data("BARYCORR_Z", np.zeros(NORDER))

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -174,7 +174,7 @@ class TestDtypeProvenance:
         wave, flux, var, mask, vel = self._order()
         ccf, ccf_var = RadialVelocity._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert_dtype(np.asarray(rv), RV_FLOAT, "RV scalar")
         assert_dtype(np.asarray(rv_err), RV_FLOAT, "RV_ERR scalar")
@@ -196,21 +196,23 @@ class TestComputeRV:
     def test_recovers_injected_rv(self):
         vel, ccf, ccf_var, wave = self._ccf(v0=2.5)
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert rv == pytest.approx(2.5, abs=0.05)
 
     def test_error_finite_and_positive(self):
         vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
         _, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert np.isfinite(rv_err) and rv_err > 0
 
     def test_even_window_pts_allowed(self):
         # min_npts is a minimum point count, not a centered odd window.
         vel, ccf, ccf_var, wave = self._ccf(v0=1.0)
-        rv, _ = RadialVelocity._compute_rv_1d(vel, ccf, ccf_var, wave, [-50.0, 50.0], 8)
+        rv, _ = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 8
+        )
         assert rv == pytest.approx(1.0, abs=0.05)
 
     def test_nonphysical_variance_raises(self):
@@ -219,7 +221,9 @@ class TestComputeRV:
         vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
         ccf_var[402] = -1.0  # index of v = 0, inside the +/-3 sigma fit window
         with pytest.raises(ValueError, match="non-physical"):
-            RadialVelocity._compute_rv_1d(vel, ccf, ccf_var, wave, [-50.0, 50.0], 11)
+            RadialVelocity._compute_rv_1d(
+                vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
+            )
 
     def test_flat_ccf_returns_nan(self):
         vel = np.arange(-402, 403) * 0.25
@@ -227,7 +231,7 @@ class TestComputeRV:
         ccf_var = ccf
         wave = np.linspace(5000.0, 5050.0, 4000)
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert np.isnan(rv) and np.isnan(rv_err)
 
@@ -236,7 +240,7 @@ class TestComputeRV:
         vel, ccf, ccf_var, wave = self._ccf(v0=1.0)
         ccf[10] = np.nan
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert np.isnan(rv) and np.isnan(rv_err)
 
@@ -249,7 +253,7 @@ class TestComputeRV:
         ccf_var = ccf
         wave = np.linspace(5000.0, 5050.0, 4000)
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert rv == pytest.approx(v0, abs=0.1) and np.isnan(rv_err)
 
@@ -257,10 +261,10 @@ class TestComputeRV:
         # A larger min-points floor below the +/-3 sigma window doesn't shift the fit.
         vel, ccf, ccf_var, wave = self._ccf(v0=1.0)
         rv9, _ = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 9
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 9
         )
         rv21, _ = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 21
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 21
         )
         assert rv9 == pytest.approx(1.0, abs=0.05)
         assert rv21 == pytest.approx(1.0, abs=0.05)
@@ -269,7 +273,7 @@ class TestComputeRV:
         # A first-pass window narrower than min_npts grid points -> NaN, NaN.
         vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-0.1, 0.1], 11
+            vel, ccf, ccf_var, wave, 0.5, [-0.1, 0.1], 11
         )
         assert np.isnan(rv) and np.isnan(rv_err)
 
@@ -282,7 +286,7 @@ class TestComputeRV:
 
         monkeypatch.setattr("kpfpipe.modules.radial_velocity.optimize_lsq", boom)
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert np.isnan(rv) and np.isnan(rv_err)
 
@@ -295,7 +299,7 @@ class TestComputeRV:
 
         monkeypatch.setattr("kpfpipe.modules.radial_velocity.optimize_lsq", bad_fit)
         rv, rv_err = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert np.isnan(rv) and np.isnan(rv_err)
 
@@ -312,9 +316,45 @@ class TestComputeRV:
 
         monkeypatch.setattr("kpfpipe.modules.radial_velocity.optimize_lsq", flaky)
         rv, _ = RadialVelocity._compute_rv_1d(
-            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
         )
         assert np.isfinite(rv) and rv == pytest.approx(0.0, abs=1e-9)
+
+    def test_error_scales_with_correlation_length(self):
+        # The photon error is 1/sqrt(N_scale) with N_scale = dv / corr_length,
+        # so rv_err must scale as sqrt(corr_length): widening the mask hole (via
+        # mask_width) lengthens the noise correlation and inflates the error by
+        # exactly sqrt(L2/L1). Guards the corr-length term feeding the error.
+        vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
+        velpix = c.to("km/s").value * np.median(np.abs(np.diff(wave))) / np.median(wave)
+        _, err_a = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, 0.5, [-50.0, 50.0], 11
+        )
+        _, err_b = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, 1.0, [-50.0, 50.0], 11
+        )
+        la = RadialVelocity._ccf_noise_corr_length(velpix, 0.5)
+        lb = RadialVelocity._ccf_noise_corr_length(velpix, 1.0)
+        assert err_b / err_a == pytest.approx((lb / la) ** 0.5, rel=1e-6)
+
+
+class TestCCFNoiseCorrLength:
+    def test_matches_measured_value(self):
+        # Native pixel 0.885 km/s, mask hole 2*0.5 = 1.0 km/s -> trapezoid-ACF
+        # integral length, verified against the frame's measured autocorrelation.
+        assert RadialVelocity._ccf_noise_corr_length(0.885, 0.5) == pytest.approx(
+            1.418, abs=1e-3
+        )
+
+    def test_equal_widths_give_1p5w(self):
+        # pixel width == mask-hole width == w -> 1.5 w.
+        assert RadialVelocity._ccf_noise_corr_length(0.6, 0.3) == pytest.approx(0.9)
+
+    def test_symmetric_in_the_two_widths(self):
+        # L depends only on the {pixel, mask-hole} pair, not which is larger.
+        a = RadialVelocity._ccf_noise_corr_length(1.0, 0.4)  # widths {1.0, 0.8}
+        b = RadialVelocity._ccf_noise_corr_length(0.8, 0.5)  # widths {0.8, 1.0}
+        assert a == pytest.approx(b)
 
 
 # ---------------------------------------------------------------------------
@@ -592,7 +632,7 @@ class TestComputeCCFPublic:
         monkeypatch.setattr(
             RadialVelocity,
             "_build_line_mask",
-            lambda self, chip, fiber, width=None: _make_mask(_MASK_CENTERS),
+            lambda self, chip, fiber, mask_width=None: _make_mask(_MASK_CENTERS),
         )
         rv_kpf2.set_data("BARYCORR_Z", np.array([]))
         rv = RadialVelocity(rv_kpf2, config={"ccf_window": _RANGE_KMS})

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -88,18 +88,18 @@ class TestComputeCCF:
 
     def test_dip_at_injected_velocity(self):
         wave, flux, mask, vel = self._order(v_dip=3.0, z=0.0)
-        ccf = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
         assert vel[np.argmin(ccf)] == pytest.approx(3.0, abs=0.3)
 
     def test_zero_velocity_dip(self):
         wave, flux, mask, vel = self._order(v_dip=0.0, z=0.0)
-        ccf = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
         assert vel[np.argmin(ccf)] == pytest.approx(0.0, abs=0.3)
 
     def test_barycorr_z_folds_in(self):
         z = 5.0 / SPEED_OF_LIGHT_KMS
         wave, flux, mask, vel = self._order(v_dip=2.0, z=z)
-        ccf = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, z)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, z)
         assert vel[np.argmin(ccf)] == pytest.approx(2.0, abs=0.3)
 
     def test_descending_wave_raises(self):
@@ -109,7 +109,7 @@ class TestComputeCCF:
 
     def test_constant_wave_returns_zeros(self):
         wave, flux, mask, vel = self._order()
-        ccf = RadialVelocity._compute_ccf_1d(
+        ccf, _ = RadialVelocity._compute_ccf_1d(
             np.full_like(wave, 5000.0), flux, mask, vel, 0.0
         )
         assert not np.any(ccf)
@@ -118,7 +118,7 @@ class TestComputeCCF:
         wave, flux, mask, vel = self._order()
         wave = wave.copy()
         wave[1000] = np.nan
-        ccf = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
         assert not np.any(ccf)
 
     def test_no_lines_in_order_returns_zeros(self):
@@ -126,7 +126,7 @@ class TestComputeCCF:
         flux = np.ones_like(wave)
         mask = _make_mask(np.linspace(5008.0, 5042.0, 20))  # all outside the order
         vel = np.arange(-402, 403) * 0.25
-        ccf = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        ccf, _ = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
         assert not np.any(ccf)
 
 
@@ -149,15 +149,17 @@ class TestDtypeProvenance:
 
     def test_ccf_1d_is_float64_from_float32_flux(self):
         wave, flux, mask, vel = self._order()
-        ccf = RadialVelocity._compute_ccf_1d(
+        ccf, _ = RadialVelocity._compute_ccf_1d(
             wave, flux.astype(np.float32), mask, vel, 0.0
         )
         assert_dtype(ccf, CCF, "CCF (_compute_ccf_1d, float32 flux in)")
 
     def test_compute_rv_1d_returns_float64(self):
         wave, flux, mask, vel = self._order()
-        ccf = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        ccf, ccf_var = RadialVelocity._compute_ccf_1d(wave, flux, mask, vel, 0.0)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert_dtype(np.asarray(rv), RV_FLOAT, "RV scalar")
         assert_dtype(np.asarray(rv_err), RV_FLOAT, "RV_ERR scalar")
 
@@ -171,37 +173,55 @@ class TestComputeRV:
     def _ccf(self, v0=0.0, sigma=4.0, baseline=100.0, depth=30.0):
         vel = np.arange(-402, 403) * 0.25
         ccf = baseline - depth * np.exp(-0.5 * ((vel - v0) / sigma) ** 2)
+        ccf_var = ccf.copy()  # photon-noise proxy at the CCF count scale
         wave = np.linspace(5000.0, 5050.0, 4000)
-        return vel, ccf, wave
+        return vel, ccf, ccf_var, wave
 
     def test_recovers_injected_rv(self):
-        vel, ccf, wave = self._ccf(v0=2.5)
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        vel, ccf, ccf_var, wave = self._ccf(v0=2.5)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert rv == pytest.approx(2.5, abs=0.05)
 
     def test_error_finite_and_positive(self):
-        vel, ccf, wave = self._ccf(v0=0.0)
-        _, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
+        _, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert np.isfinite(rv_err) and rv_err > 0
 
     def test_even_window_pts_allowed(self):
         # min_npts is a minimum point count, not a centered odd window.
-        vel, ccf, wave = self._ccf(v0=1.0)
-        rv, _ = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 8)
+        vel, ccf, ccf_var, wave = self._ccf(v0=1.0)
+        rv, _ = RadialVelocity._compute_rv_1d(vel, ccf, ccf_var, wave, [-50.0, 50.0], 8)
         assert rv == pytest.approx(1.0, abs=0.05)
+
+    def test_nonphysical_variance_raises(self):
+        # A non-positive CCF variance in the fit window is corrupt flux, not a
+        # recoverable "no error" case -> fail loudly rather than return NaN.
+        vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
+        ccf_var[402] = -1.0  # index of v = 0, inside the +/-3 sigma fit window
+        with pytest.raises(ValueError, match="non-physical"):
+            RadialVelocity._compute_rv_1d(vel, ccf, ccf_var, wave, [-50.0, 50.0], 11)
 
     def test_flat_ccf_returns_nan(self):
         vel = np.arange(-402, 403) * 0.25
         ccf = np.full_like(vel, 100.0)
+        ccf_var = ccf
         wave = np.linspace(5000.0, 5050.0, 4000)
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_nonfinite_ccf_returns_nan(self):
         # Non-finite CCF values fail loudly (NaN) rather than being masked out.
-        vel, ccf, wave = self._ccf(v0=1.0)
+        vel, ccf, ccf_var, wave = self._ccf(v0=1.0)
         ccf[10] = np.nan
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_second_pass_off_grid_returns_first_pass_rv(self):
@@ -210,49 +230,62 @@ class TestComputeRV:
         vel = np.arange(-402, 403) * 0.25
         v0 = vel[20]
         ccf = 100.0 - 30.0 * np.exp(-0.5 * ((vel - v0) / 4.0) ** 2)
+        ccf_var = ccf
         wave = np.linspace(5000.0, 5050.0, 4000)
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert rv == pytest.approx(v0, abs=0.1) and np.isnan(rv_err)
 
     def test_min_points_floor_does_not_change_result(self):
         # A larger min-points floor below the +/-3 sigma window doesn't shift the fit.
-        vel, ccf, wave = self._ccf(v0=1.0)
-        rv9, _ = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 9)
-        rv21, _ = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 21)
+        vel, ccf, ccf_var, wave = self._ccf(v0=1.0)
+        rv9, _ = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 9
+        )
+        rv21, _ = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 21
+        )
         assert rv9 == pytest.approx(1.0, abs=0.05)
         assert rv21 == pytest.approx(1.0, abs=0.05)
 
     def test_narrow_window_returns_nan(self):
         # A first-pass window narrower than min_npts grid points -> NaN, NaN.
-        vel, ccf, wave = self._ccf(v0=0.0)
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-0.1, 0.1], 11)
+        vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-0.1, 0.1], 11
+        )
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_first_pass_fit_failure_returns_nan(self, monkeypatch):
         # optimize_lsq raising on the first pass fails loudly as NaN, not a crash.
-        vel, ccf, wave = self._ccf(v0=0.0)
+        vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
 
         def boom(*args, **kwargs):
             raise RuntimeError("singular matrix")
 
         monkeypatch.setattr("kpfpipe.modules.radial_velocity.optimize_lsq", boom)
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_nonfinite_fit_params_return_nan(self, monkeypatch):
         # A fit returning a non-finite mean/sigma is rejected as NaN.
-        vel, ccf, wave = self._ccf(v0=0.0)
+        vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
 
         def bad_fit(*args, **kwargs):
             return np.array([100.0, 30.0, np.nan, 4.0]), None
 
         monkeypatch.setattr("kpfpipe.modules.radial_velocity.optimize_lsq", bad_fit)
-        rv, rv_err = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        rv, rv_err = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_second_pass_fit_failure_keeps_first_pass_rv(self, monkeypatch):
         # If the refinement (second) fit raises, the first-pass mean is retained.
-        vel, ccf, wave = self._ccf(v0=0.0)
+        vel, ccf, ccf_var, wave = self._ccf(v0=0.0)
         calls = []
 
         def flaky(*args, **kwargs):
@@ -262,7 +295,9 @@ class TestComputeRV:
             raise RuntimeError("refinement failed")
 
         monkeypatch.setattr("kpfpipe.modules.radial_velocity.optimize_lsq", flaky)
-        rv, _ = RadialVelocity._compute_rv_1d(vel, ccf, wave, [-50.0, 50.0], 11)
+        rv, _ = RadialVelocity._compute_rv_1d(
+            vel, ccf, ccf_var, wave, [-50.0, 50.0], 11
+        )
         assert np.isfinite(rv) and rv == pytest.approx(0.0, abs=1e-9)
 
 

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -41,12 +41,12 @@ NCOL = 2000
 # ---------------------------------------------------------------------------
 
 
-def _make_mask(centers, weights=None, width=0.5):
+def _make_mask(centers, weights=None, width=1.0):
     """Build a line-mask dict matching _build_line_mask's structure."""
     centers = np.asarray(centers, dtype=np.float64)
     if weights is None:
         weights = np.ones_like(centers)
-    half_width = centers * (width / SPEED_OF_LIGHT_KMS)
+    half_width = centers * (width / 2.0 / SPEED_OF_LIGHT_KMS)
     return {
         "center": centers,
         "weight": np.asarray(weights, dtype=np.float64),
@@ -340,20 +340,20 @@ class TestComputeRV:
 
 class TestCCFNoiseCorrLength:
     def test_matches_measured_value(self):
-        # Native pixel 0.885 km/s, mask hole 2*0.5 = 1.0 km/s -> trapezoid-ACF
+        # Native pixel 0.885 km/s, mask hole full width 1.0 km/s -> trapezoid-ACF
         # integral length, verified against the frame's measured autocorrelation.
-        assert RadialVelocity._ccf_noise_corr_length(0.885, 0.5) == pytest.approx(
+        assert RadialVelocity._ccf_noise_corr_length(0.885, 1.0) == pytest.approx(
             1.418, abs=1e-3
         )
 
     def test_equal_widths_give_1p5w(self):
         # pixel width == mask-hole width == w -> 1.5 w.
-        assert RadialVelocity._ccf_noise_corr_length(0.6, 0.3) == pytest.approx(0.9)
+        assert RadialVelocity._ccf_noise_corr_length(0.6, 0.6) == pytest.approx(0.9)
 
     def test_symmetric_in_the_two_widths(self):
         # L depends only on the {pixel, mask-hole} pair, not which is larger.
-        a = RadialVelocity._ccf_noise_corr_length(1.0, 0.4)  # widths {1.0, 0.8}
-        b = RadialVelocity._ccf_noise_corr_length(0.8, 0.5)  # widths {0.8, 1.0}
+        a = RadialVelocity._ccf_noise_corr_length(1.0, 0.8)  # widths {1.0, 0.8}
+        b = RadialVelocity._ccf_noise_corr_length(0.8, 1.0)  # widths {0.8, 1.0}
         assert a == pytest.approx(b)
 
 
@@ -1044,10 +1044,10 @@ class TestConstructor:
             RadialVelocity(header_kpf2, config="not-a-config")
 
     def test_dict_config_overrides_default(self, header_kpf2):
-        rv = RadialVelocity(header_kpf2, config={"ccf_mask_width": 1.0})
-        assert rv.ccf_mask_width == 1.0
+        rv = RadialVelocity(header_kpf2, config={"ccf_mask_width": 2.0})
+        assert rv.ccf_mask_width == 2.0
 
     def test_defaults_applied(self, header_kpf2):
         rv = RadialVelocity(header_kpf2)
-        assert rv.ccf_mask_width == 0.5
+        assert rv.ccf_mask_width == 1.0
         assert rv.ccf_step_size == 0.25


### PR DESCRIPTION
  # Fix the CCF photon-limited RV uncertainty

  ## Summary

  The photon-limited RV error returned by `RadialVelocity` was computed from a
  noise model and an oversampling factor that were both incorrect for KPF's
  depth-weighted CCF. This PR reworks the error term end to end so it follows the
  Boisse (2010, A.2/A.3) and Bouchy (2001) formulation and matches an independent
  Monte-Carlo ground truth. The **RV values are unchanged** — only the reported
  uncertainty is corrected — and the CCF construction now propagates the real
  per-pixel variance.

  Net collapse used for the error:
  `σ_RV = 1 / sqrt(N_scale · Σ_win (∂CCF/∂V)² / CCF_noise²)`

  Two independent corrections were needed; each is a separate commit.

  ## 1. Per-bin CCF noise: propagate `Σ w²·VAR`, not `√CCF`

  `_compute_rv_1d` divided the squared CCF slope by `ccf_fit` itself — i.e. it
  modeled the per-bin CCF noise as `√CCF`. That approximation is exact only for a
  **binary** (0/1) mask. KPF uses a depth-weighted mask, so the correct per-bin
  photon variance is the mask-weighted quadratic sum `Σ w²·VAR` (Bouchy 2001),
  which `√CCF` underestimates by ~1/√w̄.

  - `_compute_ccf_1d` now also accepts the order's per-pixel variance and returns
    `ccf_var[vi] = Σ (var · overlap_frac²)` alongside the CCF.
  - `compute_ccfs` reads `{chip}_{fiber}_VAR` (TRACE_VAR), applies the same edge
    clip as flux, and caches a per-fiber `ccf_var` cube.
  - `_combine_ccfs` sums the per-fiber `ccf_var` and returns the combined
    `summed_ccf_var` (now a 5-tuple).
  - `_compute_rv_1d` takes `ccf_var` and uses `∂CCF/∂V)² / ccf_var` as the
    weighted slope.

  The variance is the *real* `TRACE_VAR` extension, not a flux proxy, so detector
  noise and non-photon terms are carried correctly.

  ## 2. `N_scale`: divide by the CCF-noise correlation length, not the pixel span

  `N_scale` corrects the diagonal information sum for the fact that the CCF is
  sampled finer than its own noise correlation, so adjacent bins are not
  independent. The code used `N_scale = dv / vel_span_per_pixel`, i.e. it assumed
  the CCF noise decorrelates over one native pixel (~0.885 km/s). It does not: the
  CCF is the spectrum seen through a mask hole, so its noise kernel is the
  cross-correlation of two top-hats — the mask hole and the native pixel — a
  trapezoid whose autocorrelation integral length is

  `L = M² / (M − m/3)`, with `M, m` = larger/smaller of {pixel width, mask-hole width}

  giving `L ≈ 1.42 km/s` for the default mask. Using the pixel instead over-counted
  the independent information and made the error ~23% too small.

  - New static helper `_ccf_noise_corr_length(vel_span_per_pixel, mask_width)`
    returns that closed form.
  - `_compute_rv_1d` uses `n_scale = dv / corr_length`.

  `L` is a deterministic instrument-level constant (mask-hole width from config,
  pixel dispersion from the WLS); its only star-dependent input, per-pixel
  variance, moves it <2% under a ±10× per-pixel swing, so it is stable
  star-to-star and night-to-night.

  ## Naming change: `ccf_mask_width` is now the full mask-hole width

  `ccf_mask_width` was applied as ± the value about each line center, so `0.5`
  silently meant a 1.0 km/s hole (legacy convention). The new correlation length
  reasons about the full hole width, so the config is redefined to *be* that full
  width for clarity:

  - Default and `configs/kpf_drp_science.toml`: `0.5 → 1.0`.
  - `_build_line_mask` derives a local `half_width = mask_width / 2` for the ±
    top-hat edges (the one place a half is needed); the arg `width` is renamed
    `mask_width`.

  This is a naming/units change only — the physical mask hole is still 1.0 km/s.

  ## Behavioral change: fail loudly on a non-physical fit window

  Where `_compute_rv_1d` previously returned `(rv, NaN)` on a zero/negative CCF or
  variance inside the fit window, it now raises `ValueError`. A non-physical CCF in
  the RV window indicates upstream corruption, not a recoverable no-measurement
  case; the deliberate NaN returns (fit failure, window off-grid) are unchanged.

  ## Validation

  - **Monte-Carlo ground truth** on the real 47 UMa GREEN L2 frame (inject
    per-pixel photon noise, propagate through the real mask weights, refit the
    combined CCF): MC truth **0.168 m/s**. The corrected pipeline reports
    **0.165 m/s (0.98×)**; RV unchanged at 11.2917 km/s. Fixing the noise term
    alone (leaving `N_scale` on the native pixel) gives 0.130 m/s (0.77×), which
    is why both corrections are required together.
  - **New unit tests**: `TestCCFNoiseCorrLength` (closed-form value vs the frame's
    measured autocorrelation, the equal-width `1.5·w` case, and width symmetry);
    `test_error_scales_with_correlation_length` (rv_err ∝ √L guard);
    `test_ccf_var_propagates_var_not_flux`; `test_nonphysical_variance_raises`.
    All `_compute_rv_1d` / `_compute_ccf_1d` call sites updated for the new
    `ccf_var` / `mask_width` signatures.
  - **Full suite**: 1114 passed; ruff format + lint clean.

  ## Files changed

  | File | Change |
  |---|---|
  | `kpfpipe/modules/radial_velocity.py` | CCF variance propagation, `_ccf_noise_corr_length`,
  `N_scale` fix, full-width `mask_width`, loud-fail on bad window |
  | `configs/kpf_drp_science.toml` | `ccf_mask_width = 1.0` |
  | `tests/regression/test_radial_velocity.py` | new tests + signature updates |