### PR TITLE
Kpf next pointing qc

### DIFF
--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -9,4 +9,7 @@ KWRDPRL0,QC: required L0 PRIMARY keywords present,QUALITY_CONTROL,int,QCL0
 EXPTIMOK,"QC: EXPTIME present, finite, non-negative",QUALITY_CONTROL,int,QCL0
 DATTIMOK,QC: Dates/times consistent (DATE-BEG/MID/END/ELAPSED),QUALITY_CONTROL,int,QCL0
 NOTJUNK,QC: obs_id not in junk list,QUALITY_CONTROL,int,QCL0
+TARGOFF,Pointing offset from DCS target (arcsec),QUALITY_CONTROL,float,DiagL0
+OBJOFF,Pointing offset from OBJECT (SIMBAD) position (arcsec),QUALITY_CONTROL,float,DiagL0
+GAIAOFF,Pointing offset from GAIAID position (arcsec),QUALITY_CONTROL,float,DiagL0
 ISGOOD,QC: aggregate pass/fail,QUALITY_CONTROL,int,QC

--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -8,8 +8,9 @@ DATAPRL0,QC: GREEN/RED amp extensions present/non-empty,QUALITY_CONTROL,int,QCL0
 KWRDPRL0,QC: required L0 PRIMARY keywords present,QUALITY_CONTROL,int,QCL0
 EXPTIMOK,"QC: EXPTIME present, finite, non-negative",QUALITY_CONTROL,int,QCL0
 DATTIMOK,QC: Dates/times consistent (DATE-BEG/MID/END/ELAPSED),QUALITY_CONTROL,int,QCL0
-NOTJUNK,QC: obs_id not in junk list,QUALITY_CONTROL,int,QCL0
+RADECOK,QC: pointing consistent with target/catalog RA/DEC,QUALITY_CONTROL,int,QCL0
 TARGOFF,Pointing offset from DCS target (arcsec),QUALITY_CONTROL,float,DiagL0
 OBJOFF,Pointing offset from OBJECT (SIMBAD) position (arcsec),QUALITY_CONTROL,float,DiagL0
 GAIAOFF,Pointing offset from GAIAID position (arcsec),QUALITY_CONTROL,float,DiagL0
+NOTJUNK,QC: obs_id not in junk list,QUALITY_CONTROL,int,QCL0
 ISGOOD,QC: aggregate pass/fail,QUALITY_CONTROL,int,QC

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -1,14 +1,213 @@
 """Diagnostics for KPF Level 0 (raw CCD) data products.
 
-Currently a placeholder. Most L0 metrics computable from the raw product
-alone are header pass-throughs from the telescope and don't need
-re-computation here. Diagnostics that read the overscan region (read
-noise, non-Gaussian RN) are owned by ImageAssembly because they need
-to run before gain conversion modifies the amp data.
+Pointing/identity checks that cross-match the telescope pointing (RA/DEC) against
+three reference positions: the loaded DCS target (TARGRA/DEC), the Gaia DR3
+catalog position of GAIAID, and the SIMBAD position of the OBJECT name. All three
+metrics are fail-soft: a frame with no pointing/target (e.g. a calibration frame)
+skips them, and a Gaia/SIMBAD lookup failure warns and skips rather than failing
+the L0 checkpoint. Diagnostics that read the overscan region (read noise,
+non-Gaussian RN) are owned by ImageAssembly because they need to run before gain
+conversion modifies the amp data.
 """
+
+import re
+import warnings
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.time import Time
+from astroquery.gaia import Gaia
+from astroquery.simbad import Simbad
 
 from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 
 class DiagL0(Diagnostics):
     LEVEL = "L0"
+
+    # Keys each metric needs; absent -> metric is N/A for that frame (skip).
+    _POINTING_KEYS = ("RA", "DEC", "MJD-OBS")
+    _TARGET_KEYS = (
+        "TARGRA",
+        "TARGDEC",
+        "TARGPMRA",
+        "TARGPMDC",
+        "TARGPLAX",
+        "TARGFRAM",
+        "TARGEPOC",
+    )
+
+    @staticmethod
+    def _present(hdr, keys):
+        """True if every key in `keys` is present and non-None in `hdr`."""
+        return all(hdr.get(k) is not None for k in keys)
+
+    # Astrometry helpers reproduced from BarycentricCorrection._gaia_astrometry /
+    # ._wmko_astrometry (there they read INSTRUMENT_HEADER; at L0 the natives are
+    # on PRIMARY). The shared copies move to utils/astro.py in a follow-up -- keep
+    # the two in sync until then.
+
+    def _gaia_source_id(self):
+        """Digit-only Gaia DR3 id from L0 GAIAID, or None if absent/malformed."""
+        raw = self.kpf_obj.headers["PRIMARY"].get("GAIAID")
+        if raw is None:
+            return None
+        token = re.split(r"\s+", str(raw).strip())[-1]
+        return token if token.isdigit() else None
+
+    def _gaia_astrometry(self):
+        """Gaia DR3 SkyCoord (ICRS, PM+distance, Gaia epoch) for the L0 GAIAID."""
+        gaia_id = self._gaia_source_id()
+        if gaia_id is None:
+            raise ValueError("no usable Gaia source id in L0 PRIMARY GAIAID")
+        query = f"""
+        SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
+        FROM gaiadr3.gaia_source
+        WHERE source_id = {gaia_id}
+        """
+        result = Gaia.launch_job(query).get_results()[0]
+        return SkyCoord(
+            ra=result["ra"] * u.deg,
+            dec=result["dec"] * u.deg,
+            pm_ra_cosdec=result["pmra"] * u.mas / u.yr,
+            pm_dec=result["pmdec"] * u.mas / u.yr,
+            distance=(1e3 / result["parallax"]) * u.pc,
+            obstime=Time(result["ref_epoch"], format="jyear"),
+            frame="icrs",
+        )
+
+    def _wmko_astrometry(self):
+        """WMKO/DCS target SkyCoord from L0 PRIMARY TARG* astrometry.
+
+        TARGPMRA is s/yr (-> mas/yr via x15 cos(dec)); TARGPLAX is mas (-> pc).
+        """
+        hdr = self.kpf_obj.headers["PRIMARY"]
+        pos = SkyCoord(hdr["TARGRA"], hdr["TARGDEC"], unit=(u.hourangle, u.deg))
+        pm_ra_cosdec = float(hdr["TARGPMRA"]) * 15.0 * np.cos(pos.dec.rad) * 1e3
+        return SkyCoord(
+            ra=pos.ra,
+            dec=pos.dec,
+            pm_ra_cosdec=pm_ra_cosdec * u.mas / u.yr,
+            pm_dec=float(hdr["TARGPMDC"]) * 1e3 * u.mas / u.yr,
+            distance=(1e3 / float(hdr["TARGPLAX"])) * u.pc,
+            frame=str(hdr["TARGFRAM"]).lower(),
+            obstime=Time(float(hdr["TARGEPOC"]), format="jyear"),
+        )
+
+    def _object_name(self):
+        """SIMBAD-resolvable name from L0 PRIMARY OBJECT, or None if absent.
+
+        KPF OBJECT for standard stars is the bare HD number (e.g. '10700'),
+        which SIMBAD only resolves with an 'HD ' prefix; named targets pass
+        through unchanged.
+        """
+        obj = self.kpf_obj.headers["PRIMARY"].get("OBJECT")
+        if obj is None:
+            return None
+        obj = str(obj).strip()
+        if not obj:
+            return None
+        return f"HD {obj}" if obj.isdigit() else obj
+
+    def _simbad_astrometry(self):
+        """SIMBAD SkyCoord (ICRS J2000, PM+distance) for the L0 OBJECT name.
+
+        SIMBAD reports ICRS coordinates at epoch J2000.0; column names are the
+        astroquery 0.4.11 lowercase schema (ra/dec in deg, pmra/pmdec, plx_value).
+        """
+        name = self._object_name()
+        if name is None:
+            raise ValueError("no OBJECT name in L0 PRIMARY header")
+        simbad = Simbad()
+        simbad.add_votable_fields("pmra", "pmdec", "plx")
+        result = simbad.query_object(name)
+        if result is None or len(result) == 0:
+            raise ValueError(f"SIMBAD returned no match for {name!r}")
+        row = result[0]
+        return SkyCoord(
+            ra=row["ra"] * u.deg,
+            dec=row["dec"] * u.deg,
+            pm_ra_cosdec=row["pmra"] * u.mas / u.yr,
+            pm_dec=row["pmdec"] * u.mas / u.yr,
+            distance=(1e3 / row["plx_value"]) * u.pc,
+            obstime=Time(2000.0, format="jyear"),
+            frame="icrs",
+        )
+
+    def _pointing(self):
+        """Telescope pointing SkyCoord from L0 PRIMARY RA/DEC (sexagesimal h/deg)."""
+        hdr = self.kpf_obj.headers["PRIMARY"]
+        return SkyCoord(hdr["RA"], hdr["DEC"], unit=(u.hourangle, u.deg))
+
+    def _obs_time(self):
+        """Observation epoch (Time) from L0 PRIMARY MJD-OBS, for PM propagation."""
+        return Time(float(self.kpf_obj.headers["PRIMARY"]["MJD-OBS"]), format="mjd")
+
+    def gaia_ra_dec_offset(self):
+        """GAIAOFF: arcsec, RA/DEC pointing vs GAIAID position at obs epoch.
+
+        Skipped when the frame has no pointing or no usable GAIAID; a Gaia
+        network/lookup failure warns and skips (fail-soft).
+        """
+        hdr = self.kpf_obj.headers["PRIMARY"]
+        if (
+            not self._present(hdr, self._POINTING_KEYS)
+            or self._gaia_source_id() is None
+        ):
+            return {}
+        try:
+            gaia = self._gaia_astrometry().apply_space_motion(
+                new_obstime=self._obs_time()
+            )
+        except Exception as e:
+            warnings.warn(
+                f"GAIAOFF skipped: Gaia lookup failed ({type(e).__name__}: {e})",
+                stacklevel=2,
+            )
+            return {}
+        sep = float(self._pointing().separation(gaia).arcsec)
+        return self._tag(GAIAOFF=round(sep, 4))
+
+    gaia_ra_dec_offset._diag_name = "gaia_ra_dec_offset"
+
+    def target_ra_dec_offset(self):
+        """TARGOFF: arcsec, RA/DEC pointing vs TARGRA/DEC target at obs epoch.
+
+        Skipped when the frame has no pointing or no DCS target (e.g. a
+        calibration frame).
+        """
+        hdr = self.kpf_obj.headers["PRIMARY"]
+        if not self._present(hdr, self._POINTING_KEYS + self._TARGET_KEYS):
+            return {}
+        target = self._wmko_astrometry().apply_space_motion(
+            new_obstime=self._obs_time()
+        )
+        sep = float(self._pointing().separation(target).arcsec)
+        return self._tag(TARGOFF=round(sep, 4))
+
+    target_ra_dec_offset._diag_name = "target_ra_dec_offset"
+
+    def object_ra_dec_offset(self):
+        """OBJOFF: arcsec, RA/DEC pointing vs SIMBAD(OBJECT) position at obs epoch.
+
+        Skipped when the frame has no pointing or no OBJECT name; a SIMBAD
+        network/lookup failure (or an unresolvable name) warns and skips.
+        """
+        hdr = self.kpf_obj.headers["PRIMARY"]
+        if not self._present(hdr, self._POINTING_KEYS) or self._object_name() is None:
+            return {}
+        try:
+            obj = self._simbad_astrometry().apply_space_motion(
+                new_obstime=self._obs_time()
+            )
+        except Exception as e:
+            warnings.warn(
+                f"OBJOFF skipped: SIMBAD lookup failed ({type(e).__name__}: {e})",
+                stacklevel=2,
+            )
+            return {}
+        sep = float(self._pointing().separation(obj).arcsec)
+        return self._tag(OBJOFF=round(sep, 4))
+
+    object_ra_dec_offset._diag_name = "object_ra_dec_offset"

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -138,3 +138,21 @@ class QCL0(QC):
         return obs_id not in load_junk_obs_ids(data_input)
 
     not_junk._qc_key = "NOTJUNK"
+
+    def radec_consistent(self):
+        """Pointing agrees with the target and catalog positions.
+
+        Thresholds the DiagL0 offsets on QUALITY_CONTROL: TARGOFF < 1", and the
+        catalog cross-matches OBJOFF/GAIAOFF < 5" (a loose bound, since the loaded
+        pointing coordinates are not Gaia/SIMBAD-derived). Each offset is checked
+        only when present, so a frame with no pointing (e.g. a calibration frame)
+        or a skipped catalog lookup passes.
+        """
+        hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
+        for key, limit in (("TARGOFF", 1.0), ("OBJOFF", 5.0), ("GAIAOFF", 5.0)):
+            val = _hdr_float(hdr, key)
+            if val is not None and val >= limit:
+                return False
+        return True
+
+    radec_consistent._qc_key = "RADECOK"

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -1,11 +1,17 @@
 """Tests for the Diagnostics framework and per-level subclasses."""
 
+import warnings
+from unittest.mock import MagicMock, patch
+
 import numpy as np
 import pytest
+from astropy import units as u
+from astropy.coordinates import SkyCoord
 from astropy.io import fits
 from astropy.table import Table
 
 from kpfpipe import DETECTOR
+from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.quality_control.diagnostics import (
@@ -123,7 +129,8 @@ class TestDiagnosticsBase:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 — empty placeholder; DiagL1 with no calibrations is a clean no-op
+# DiagL0 with no pointing (e.g. a calibration frame) and DiagL1 with no
+# calibrations are each a clean no-op
 # ---------------------------------------------------------------------------
 
 
@@ -136,6 +143,7 @@ class TestEmptyLevels:
         return _FakeObj()
 
     def test_diag_l0_runs_cleanly(self):
+        # No RA/DEC/GAIAID -> GAIAOFF/TARGOFF both skip (fail-soft), no crash.
         results = DiagL0(self._make_obj()).run()
         assert results == {}
 
@@ -143,6 +151,182 @@ class TestEmptyLevels:
         # No RECEIPT/INSTRUMENT_HEADER -> calibration_ages returns {} (no crash).
         results = DiagL1(self._make_obj()).run()
         assert results == {}
+
+
+# ---------------------------------------------------------------------------
+# DiagL0 — pointing / identity offsets (GAIAOFF, TARGOFF)
+# ---------------------------------------------------------------------------
+
+_PT_RA, _PT_DEC = "01:44:01.30", "-15:55:54.0"
+
+
+def _make_l0_pointing(**overrides):
+    """A KPF0 with L0 PRIMARY pointing + DCS target + GAIAID natives.
+
+    Pass ``KEY=None`` to omit a native (used to exercise the skip paths).
+    """
+    prim = {
+        "RA": _PT_RA,
+        "DEC": _PT_DEC,
+        "MJD-OBS": 60540.6,
+        "GAIAID": "DR3 12345",
+        "TARGRA": _PT_RA,
+        "TARGDEC": _PT_DEC,
+        "TARGPMRA": 0.0,
+        "TARGPMDC": 0.0,
+        "TARGPLAX": 100.0,
+        "TARGFRAM": "FK5",
+        "TARGEPOC": 2000.0,
+    }
+    prim.update(overrides)
+    l0 = KPF0()
+    for k, v in prim.items():
+        if v is not None:
+            l0.headers["PRIMARY"][k] = v
+    return l0
+
+
+def _fake_gaia_job(ra_deg, dec_deg):
+    """Stand-in for Gaia.launch_job: a one-row results Table, no network.
+
+    Zero proper motion so ``apply_space_motion`` leaves the position at
+    (ra_deg, dec_deg).
+    """
+    tbl = Table(
+        {
+            "ra": [ra_deg],
+            "dec": [dec_deg],
+            "pmra": [0.0],
+            "pmdec": [0.0],
+            "parallax": [100.0],
+            "ref_epoch": [2016.0],
+        }
+    )
+
+    class _Job:
+        def get_results(self):
+            return tbl
+
+    return _Job()
+
+
+class TestDiagL0Pointing:
+    def _gaia_at_pointing(self):
+        # Gaia source placed exactly at the pointing -> GAIAOFF ~ 0.
+        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+        return _fake_gaia_job(pt.ra.deg, pt.dec.deg)
+
+    def test_offsets_written_to_quality_control(self):
+        l0 = _make_l0_pointing()
+        with patch(
+            "kpfpipe.quality_control.diagnostics.level0.Gaia.launch_job",
+            return_value=self._gaia_at_pointing(),
+        ):
+            results = DiagL0(l0).run()
+        # Pointing == target == Gaia position, so both offsets are ~0 (TARGOFF
+        # carries the ~23 mas ICRS<->FK5 frame bias); well under the 1" budget.
+        assert results["GAIAOFF"][0] < 0.1
+        assert results["TARGOFF"][0] < 0.1
+        # set_keyword routed both to QUALITY_CONTROL.
+        assert l0.headers["QUALITY_CONTROL"]["GAIAOFF"] == results["GAIAOFF"][0]
+        assert l0.headers["QUALITY_CONTROL"]["TARGOFF"] == results["TARGOFF"][0]
+
+    def test_skip_when_no_pointing(self):
+        # A calibration-like frame with no RA/DEC/target -> both metrics N/A.
+        l0 = _make_l0_pointing(RA=None, DEC=None, TARGRA=None, GAIAID=None)
+        results = DiagL0(l0).run()
+        assert "GAIAOFF" not in results
+        assert "TARGOFF" not in results
+
+    def test_skip_gaiaoff_when_no_gaiaid(self):
+        # Pointing + target present, GAIAID absent -> TARGOFF only, no warning.
+        l0 = _make_l0_pointing(GAIAID=None)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            results = DiagL0(l0).run()
+        assert "GAIAOFF" not in results
+        assert "TARGOFF" in results
+        assert not any("GAIAOFF skipped" in str(c.message) for c in caught)
+
+    def test_gaia_failure_warns_and_skips(self):
+        # Gaia unreachable -> GAIAOFF warns and skips; the network-free TARGOFF
+        # still computes (fail-soft, so the L0 checkpoint does not fail).
+        l0 = _make_l0_pointing()
+        with (
+            patch(
+                "kpfpipe.quality_control.diagnostics.level0.Gaia.launch_job",
+                side_effect=ConnectionError("gaia down"),
+            ),
+            pytest.warns(UserWarning, match="GAIAOFF skipped"),
+        ):
+            results = DiagL0(l0).run()
+        assert "GAIAOFF" not in results
+        assert "TARGOFF" in results
+
+
+# ---------------------------------------------------------------------------
+# DiagL0 — OBJECT-name offset via SIMBAD (OBJOFF)
+# ---------------------------------------------------------------------------
+
+
+def _fake_simbad(ra_deg=None, dec_deg=None, no_match=False):
+    """Stand-in for the Simbad class: Simbad() -> instance whose query_object
+    returns a one-row Table (astroquery 0.4.11 schema), or None for no match."""
+    instance = MagicMock()
+    if no_match:
+        instance.query_object.return_value = None
+    else:
+        instance.query_object.return_value = Table(
+            {
+                "ra": [ra_deg],
+                "dec": [dec_deg],
+                "pmra": [0.0],
+                "pmdec": [0.0],
+                "plx_value": [100.0],
+            }
+        )
+    return instance
+
+
+class TestDiagL0Object:
+    def test_object_offset_routed_to_quality_control(self):
+        # GAIAID absent -> GAIAOFF skips silently (no Gaia network); OBJECT set,
+        # SIMBAD placed at the pointing -> OBJOFF ~ 0, routed to QUALITY_CONTROL.
+        l0 = _make_l0_pointing(GAIAID=None)
+        l0.headers["PRIMARY"]["OBJECT"] = "10700"
+        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+        with patch(
+            "kpfpipe.quality_control.diagnostics.level0.Simbad",
+            return_value=_fake_simbad(pt.ra.deg, pt.dec.deg),
+        ):
+            results = DiagL0(l0).run()
+        assert results["OBJOFF"][0] < 0.1
+        assert l0.headers["QUALITY_CONTROL"]["OBJOFF"] == results["OBJOFF"][0]
+
+    def test_object_name_hd_prefix(self):
+        # Bare-numeric OBJECT gets an 'HD ' prefix; named targets pass through.
+        l0 = _make_l0_pointing()
+        l0.headers["PRIMARY"]["OBJECT"] = "10700"
+        assert DiagL0(l0)._object_name() == "HD 10700"
+        l0.headers["PRIMARY"]["OBJECT"] = "tau Cet"
+        assert DiagL0(l0)._object_name() == "tau Cet"
+
+    def test_skip_when_no_object(self):
+        # No OBJECT native -> metric N/A, skip silently (no SIMBAD call).
+        l0 = _make_l0_pointing()  # helper sets no OBJECT
+        assert DiagL0(l0).object_ra_dec_offset() == {}
+
+    def test_simbad_no_match_warns_and_skips(self):
+        l0 = _make_l0_pointing()
+        l0.headers["PRIMARY"]["OBJECT"] = "NotARealStar"
+        with (
+            patch(
+                "kpfpipe.quality_control.diagnostics.level0.Simbad",
+                return_value=_fake_simbad(no_match=True),
+            ),
+            pytest.warns(UserWarning, match="OBJOFF skipped"),
+        ):
+            assert DiagL0(l0).object_ra_dec_offset() == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -509,6 +509,37 @@ class TestQCL0:
         qc = QCL0.__dict__["not_junk"]
         assert qc._qc_key == "NOTJUNK"
 
+    def test_radec_consistent_pass(self, tmp_path):
+        l0 = _make_kpf0(tmp_path)
+        for k, v in (("TARGOFF", 0.02), ("OBJOFF", 2.3), ("GAIAOFF", 2.3)):
+            l0.set_keyword(k, v)  # routes to QUALITY_CONTROL
+        assert QCL0(l0).radec_consistent() is True
+
+    def test_radec_gaiaoff_fail(self, tmp_path):
+        # The 20240816 signature: pointing/target/OBJECT fine, GAIAID ~25 deg off.
+        l0 = _make_kpf0(tmp_path)
+        for k, v in (("TARGOFF", 0.02), ("OBJOFF", 2.3), ("GAIAOFF", 91004.96)):
+            l0.set_keyword(k, v)
+        assert QCL0(l0).radec_consistent() is False
+
+    def test_radec_targoff_fail(self, tmp_path):
+        l0 = _make_kpf0(tmp_path)
+        l0.set_keyword("TARGOFF", 1.5)  # > 1" pointing-vs-target
+        assert QCL0(l0).radec_consistent() is False
+
+    def test_radec_objoff_fail(self, tmp_path):
+        l0 = _make_kpf0(tmp_path)
+        l0.set_keyword("OBJOFF", 6.0)  # > 5" pointing-vs-OBJECT
+        assert QCL0(l0).radec_consistent() is False
+
+    def test_radec_absent_offsets_pass(self, tmp_path):
+        # A calibration-like frame writes no offsets -> nothing to check -> pass.
+        l0 = _make_kpf0(tmp_path)
+        assert QCL0(l0).radec_consistent() is True
+
+    def test_radecok_key_present(self):
+        assert QCL0.__dict__["radec_consistent"]._qc_key == "RADECOK"
+
     def test_dataprl0_key_and_comment(self):
         fn = QCL0.__dict__["data_l0_red_green"]
         assert fn._qc_key == "DATAPRL0"


### PR DESCRIPTION
  ## Summary

  Adds L0 pointing/identity quality control: DiagL0 now cross-matches the telescope
  pointing (RA/DEC) against three independent reference positions, and a new QCL0
  flag (`RADECOK`) thresholds the resulting offsets. Motivated by the target 10700
  (Tau Ceti) night **20240816**, a ~744 m/s RV outlier: the offsets fingerprint it
  as the correct star observed with the **wrong Gaia source** attached, so
  `BarycentricCorrection` computed the BERV for the wrong sky position.

  ## What's new

  ### DiagL0 offsets (`GAIAOFF`, `TARGOFF`, `OBJOFF`)

  Three diagnostics, each written to `QUALITY_CONTROL` as an arcsec offset from the
  pointing:

  | Keyword   | Reference                                   | Notes |
  |-----------|---------------------------------------------|-------|
  | `TARGOFF` | Loaded DCS target (`TARGRA`/`TARGDEC`)      | Internal-consistency check; holds sub-arcsec. |
  | `GAIAOFF` | Gaia DR3 position of `GAIAID`               | Catalog cross-match (network). |
  | `OBJOFF`  | SIMBAD position of the `OBJECT` name        | Catalog cross-match (network); bare HD numbers get an `HD ` prefix, which SIMBAD needs. |

  All three build a full `SkyCoord` (proper motion + parallax) and propagate it to
  the observation epoch (`MJD-OBS`) before taking the separation, so the comparison
  holds at the arcsec level for high-PM standards. The Gaia/WMKO astrometry helpers
  are reproduced in-place from `BarycentricCorrection._gaia_astrometry` /
  `._wmko_astrometry` (to be lifted into `utils/astro.py` in a follow-up — kept in
  sync until then). The `GAIAOFF`/`OBJOFF` catalog cross-matches carry a ~2–3"
  floor because the loaded pointing coordinates are not themselves catalog-derived;
  `TARGOFF` does not.

  **Fail-soft.** A frame with no pointing / no target / no `OBJECT` (e.g. a
  calibration frame) skips the relevant metric, and a Gaia/SIMBAD lookup failure
  warns and skips. `CheckpointL0` — and hence the science recipe — never
  hard-fails on a network outage. Note this adds up to two network calls per L0.

  ### `RADECOK` QC flag

  `QCL0.radec_consistent` reads the three offsets and fails the frame if any
  *present* offset exceeds its bound:

  - `TARGOFF ≥ 1"` (pointing vs DCS target)
  - `OBJOFF ≥ 5"` or `GAIAOFF ≥ 5"` (the loose 5" bound clears the ~2–3" catalog floor)

  Each offset is checked only when present, so calibration frames and skipped
  lookups pass. `RADECOK` is **not** in `CheckpointL0.RAISE_FLAGS`, so a failure
  warns and folds into `ISGOOD` rather than raising.

  On the outlier night this fires via `GAIAOFF` (~25 deg) while `TARGOFF`/`OBJOFF`
  stay normal — flagging exactly the frame whose wrong Gaia source drove the RV
  outlier — while the good nights (Tau Ceti, HD 34411) pass.

  ## Files changed

  - `kpfpipe/quality_control/diagnostics/level0.py` — three offset diagnostics + astrometry helpers
  - `kpfpipe/quality_control/qc_flags/level0.py` — `radec_consistent` / `RADECOK`
  - `kpfpipe/data_models/config/L0-headers.csv` — registers `RADECOK`, `TARGOFF`, `OBJOFF`,
  `GAIAOFF`
  - `tests/regression/test_diagnostics.py` — `TestDiagL0Pointing`, `TestDiagL0Object` (Gaia/SIMBAD
  mocked, no network)
  - `tests/regression/test_qc_flags.py` — `RADECOK` pass / per-bound fail / vacuous-pass cases

  ## Testing

  - Fast suite green (`make test-fast`, 1117 passed).
  - Gaia and SIMBAD are mocked in the unit tests — the suite makes no network calls.

  ## Follow-ups (not in this PR)

  - Move the reproduced `_gaia_astrometry` / `_wmko_astrometry` (and `_simbad_astrometry`) helpers
  to `utils/astro.py` to de-duplicate with `BarycentricCorrection`.
  - Mock Gaia/SIMBAD in the slow real-data recipe test so `make test` stays offline-safe
  (`CheckpointL0` now makes up to two network calls per L0).