### PR TITLE
Masters, mini-database, and processing-script cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,9 +233,10 @@ see the style guide §11.)* The architecture invariants:
   the native (a) never reaches PRIMARY, or (b) is one of a **coherent block of natives** where mixing
   PRIMARY + INSTRUMENT reads (or the cryptic renamed keys) would obscure intent — the WMKO astrometry/
   catalog block (`TARGRA`/`DEC`/`PM*`/`PLAX`/`TARGFRAM`/`TARGEPOC`/`TARGRADV`/`GAIAID`) in
-  `barycentric_correction`, the per-fiber illumination source (`SCI-OBJ`/`SKY-OBJ`/`CAL-OBJ`) in
-  `radial_velocity`, and the `EXPTIME`-vs-`ELAPSED` pair in masters (which name **different** quantities —
-  requested vs. elapsed — that only coexist as distinct cards on INSTRUMENT_HEADER).
+  `barycentric_correction` and the per-fiber illumination source (`SCI-OBJ`/`SKY-OBJ`/`CAL-OBJ`) in
+  `radial_velocity`. (Masters no longer read INSTRUMENT_HEADER at all: the former masters
+  `EXPTIME`-vs-`ELAPSED` load check is now `QCL0.exptime_sane`/`EXPTIMOK`, which reads the raw L0
+  PRIMARY — where both natives coexist before `to_kpf1` renames `ELAPSED`→`EXPTIME`.)
 - **Each registered keyword has one home extension** (the registry `Extension` column), which
   `set_keyword` routes to: **PRIMARY** (EPRV keywords, plus the L4 final-RV exception
   `CCD{1,2}RV`/`CCD{1,2}ERV` above), **QUALITY_CONTROL** (QC flags + `ISGOOD`, read-noise,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -329,9 +329,13 @@ up:** `kpfpipe/` (scientist-facing building blocks) ← `recipes/` (compose modu
 `scripts/` (run a recipe many times) ← `tools/` (the CLI interface). So `tools/cli.py`
 imports `scripts.processing.*`, but **the scripts must never import `tools`** — shared
 orchestration helpers live in `scripts/processing/_dispatch.py` (the process-pool
-engine) and `_argparse.py` (the shared argparse parent-parser factories `recipe_and_config_parser`
-[`-r`/`-c`], `data_dirs_parser`, `logging_parser`, `pool_parser`, composed via
-`parents=[…]` so each shared flag is declared once), both `tools`-free. `data_dirs_parser`
+engine), `_argparse.py` (the shared argparse parent-parser factories `recipe_and_config_parser`
+[`-r`/`-c`], `data_dirs_parser`, `logging_parser`, `pool_parser`, `cache_parser` [`--cache`],
+composed via `parents=[…]` so each shared flag is declared once), and `_scan.py` (the
+up-front, parallel-by-datecode L0 mini-db cache **pre-scan** the orchestrators run before
+fan-out — `warm_mini_db_caches`/`scan_datecodes`/`scan_night_to_cache`, gated by `--cache`).
+`_scan.py` is deliberately where the lone `kpfpipe.utils.io` (`FileHandler`) import lives, so
+`_dispatch.py` stays io-free; all three are `tools`-free. `data_dirs_parser`
 also carries two convenience shortcuts each of the four processing scripts (reduce/masters/
 science/timeseries) accepts: **`--input_dir`** is a plain argparse alias of `--kpf_data_input`,
 and **`--output_dir`** is a fan-out — `_argparse.resolve_dir_shortcuts(args)` (called post-parse

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -280,11 +280,13 @@ class StageName:
   `FileHandler.build_mini_database` caches the night's DataFrame on `self._mini_db`,
   which `build_calibration_stacks` reads by default (an explicit `mini_db=` arg overrides
   it, per the "`None` means use `self`" rule), so the recipe passes a datecode once
-  and the mini database is never surfaced. Its `cache=True` flag adds an on-disk tier
-  keyed by the same `datecode`: it loads `{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv`
-  when present (skipping the header scan) and writes it after a scan otherwise — a
-  read/write-through cache under one flag, not two. Callers that reduce a night repeatedly
-  (the masters recipe, `select_master_cals.py`, `timeseries.py` discovery) pass it.
+  and the mini database is never surfaced. Its `cache` flag adds an on-disk tier
+  keyed by the same `datecode`, whose read and write sides are selected independently by a
+  mode string (`False` default / `"r"` / `"w"` / `"rw"`): read loads
+  `{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv` when present (skipping the header
+  scan), write writes it after a scan, and `"rw"` is the read/write-through cache. Callers
+  that reduce a night repeatedly (the masters recipe, `select_master_cals.py`,
+  `timeseries.py` discovery) pass `"rw"`.
 - **Defaults live in the module, not the config file.** Resolution is a three-tier
   override chain, lowest precedence first: `_DEFAULTS` (the in-module default) → config
   (TOML values applied on top via `params.get(k, v)` in the loop above) → a direct keyword

--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -270,10 +270,11 @@ class StageName:
   Tunable params become instance attributes via the `_DEFAULTS` setattr loop.
 - **`_DEFAULTS` merges the global defaults**: `_DEFAULTS = {**DEFAULTS, "key": ...}`
   (use the `{**DEFAULTS, ...}` spread form, not `dict(DEFAULTS)`).
-- **Utility handlers in `utils/` are a lighter variant.** A config-carrying
-  discovery/IO handler (e.g. `io.FileHandler`) has no data-model object and often no
-  per-call tunables: it takes `config=None` alone, resolves only the roots it needs
-  (`config.get_params(["DATA_DIRS"])`), stores them as private attributes, and
+- **Utility handlers in `utils/` are a lighter variant.** A discovery/IO handler
+  (e.g. `io.FileHandler`) has no data-model object and often no per-call tunables: it
+  takes the already-extracted **`[DATA_DIRS]` dict** (required; the caller does the
+  `config.get_params(["DATA_DIRS"])` — the handler deliberately does not import or
+  accept `ConfigHandler`), stores the roots it needs as private attributes, and
   **omits the `_DEFAULTS` setattr loop** when there is nothing tunable to surface
   (every clustering knob stays a per-call method argument). Such a handler may also
   carry loaded working state so callers never thread an intermediate product:
@@ -282,11 +283,14 @@ class StageName:
   it, per the "`None` means use `self`" rule), so the recipe passes a datecode once
   and the mini database is never surfaced. Its `cache` flag adds an on-disk tier
   keyed by the same `datecode`, whose read and write sides are selected independently by a
-  mode string (`False` default / `"r"` / `"w"` / `"rw"`): read loads
+  mode string (`False` default / `"r"` / `"w"` / `"rw"`/`"wr"`, order-insensitive): read loads
   `{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv` when present (skipping the header
-  scan), write writes it after a scan, and `"rw"` is the read/write-through cache. Callers
-  that reduce a night repeatedly (the masters recipe, `select_master_cals.py`,
-  `timeseries.py` discovery) pass `"rw"`.
+  scan), write writes it (atomically, temp file + `os.replace`) after a scan, and `"rw"` is
+  the read/write-through cache. Cache **writing is owned by the scripts/orchestrator layer**:
+  the batch orchestrators warm each night once up front (the `_scan.py` pre-scan,
+  `cache="rw"`) and `timeseries.py` discovery writes with `"rw"`, while the readers — the
+  reduce leaf (masters recipe) and `select_master_cals.py` — pass `"r"`. Recipes/modules
+  read the cache but never write it.
 - **Defaults live in the module, not the config file.** Resolution is a three-tier
   override chain, lowest precedence first: `_DEFAULTS` (the in-module default) → config
   (TOML values applied on top via `params.get(k, v)` in the loop above) → a direct keyword

--- a/configs/kpf_drp_masters.toml
+++ b/configs/kpf_drp_masters.toml
@@ -13,12 +13,18 @@ chips = ["GREEN", "RED"]
 fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 
 [BIAS]
+min_stack_size = 5
+max_stack_size = 20
 stack_sigma = 5.0
 
 [DARK]
+min_stack_size = 3
+max_stack_size = 20
 stack_sigma = 5.0
 
 [FLAT]
+min_stack_size = 5
+max_stack_size = 20
 stack_sigma = 5.0
 
 [WLS]

--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -6,7 +6,7 @@ DRPVERNO,Pipeline version (DRP-RUN-11; EPRV equivalent is DRPTAG),RECEIPT,str,KP
 DRPSTATU,DRP reduction status (DRP-RUN-20),RECEIPT,str,KPF0.from_fits
 DATAPRL0,QC: GREEN/RED amp extensions present/non-empty,QUALITY_CONTROL,int,QCL0
 KWRDPRL0,QC: required L0 PRIMARY keywords present,QUALITY_CONTROL,int,QCL0
-EXPTIMOK,"QC: EXPTIME present, finite, non-negative",QUALITY_CONTROL,int,QCL0
+EXPTIMOK,"QC: EXPTIME finite/non-neg, matches ELAPSED",QUALITY_CONTROL,int,QCL0
 DATTIMOK,QC: Dates/times consistent (DATE-BEG/MID/END/ELAPSED),QUALITY_CONTROL,int,QCL0
 RADECOK,QC: pointing consistent with target/catalog RA/DEC,QUALITY_CONTROL,int,QCL0
 TARGOFF,Pointing offset from DCS target (arcsec),QUALITY_CONTROL,float,DiagL0

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -93,9 +93,7 @@ class CalibrationAssociation:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _find_master_files(
-        self, cal_type, date_obs, masters_search_window_days=None, verbose=True
-    ):
+    def _find_master_files(self, cal_type, date_obs, masters_search_window_days=None):
         """
         Return a list of (filepath, timestamp) tuples for all available
         masters of the given calibration type within the search window.
@@ -110,10 +108,6 @@ class CalibrationAssociation:
         masters_search_window_days : [int, int], optional
             Search window as [days_before, days_after]. Defaults to
             self.masters_search_window_days.
-        verbose : bool, optional
-            If True (default), emit a UserWarning when a candidate master is
-            dropped because its filename has no parseable KPF timestamp
-            (a silent drop could invisibly shift which master is selected).
 
         Returns
         -------
@@ -145,12 +139,11 @@ class CalibrationAssociation:
                 try:
                     ts = get_timestamp(filepath)
                 except ValueError as e:
-                    if verbose:
-                        warnings.warn(
-                            f"dropping master with unparseable timestamp: "
-                            f"{filepath!r} ({e})",
-                            stacklevel=2,
-                        )
+                    warnings.warn(
+                        f"dropping master with unparseable timestamp: "
+                        f"{filepath!r} ({e})",
+                        stacklevel=2,
+                    )
                     continue
                 master_files.append((filepath, ts))
 
@@ -222,7 +215,7 @@ class CalibrationAssociation:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, cal_types, *, masters_search_window_days=None, verbose=True):
+    def perform(self, cal_types, *, masters_search_window_days=None):
         """
         Run calibration association for the given calibration types.
 
@@ -233,9 +226,6 @@ class CalibrationAssociation:
         masters_search_window_days : [int, int], optional
             Search window as [days_before, days_after]. Defaults to
             self.masters_search_window_days.
-        verbose : bool, optional
-            If True (default), warn when a candidate master is dropped for an
-            unparseable timestamp (passed through to _find_master_files).
 
         Returns
         -------
@@ -263,7 +253,7 @@ class CalibrationAssociation:
         self._calibrations = {}
         for cal_type in cal_types:
             master_files = self._find_master_files(
-                cal_type, date_obs, masters_search_window_days, verbose=verbose
+                cal_type, date_obs, masters_search_window_days
             )
             filepath = self._select_nearest(date_obs, master_files)
             if filepath is None:

--- a/kpfpipe/modules/masters/__init__.py
+++ b/kpfpipe/modules/masters/__init__.py
@@ -1,1 +1,8 @@
 """Masters modules: stack L0 frames into bias, dark, flat, and WLS products."""
+
+from kpfpipe.modules.masters.bias import Bias
+from kpfpipe.modules.masters.dark import Dark
+from kpfpipe.modules.masters.flat import Flat
+from kpfpipe.modules.masters.wls import WLS
+
+__all__ = ["Bias", "Dark", "Flat", "WLS"]

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -71,6 +71,11 @@ class BaseMasterModule:
     # any is dropped in `_load_frame` and counted as a load failure.
     _REQUIRED_L0_QC_FLAGS = ("DATAPRL0", "KWRDPRL0", "EXPTIMOK", "NOTJUNK")
 
+    # Exposure-time threshold (seconds) for the bias/zero-exposure decision in
+    # the stats methods: a frame whose exposure is <= this counts as zero
+    # (a bias, stacked with T=1), else as a real exposure (T=exptime).
+    _ZERO_EXPTIME_TOL_SECONDS = 0.1
+
     def __init__(self, l0_file_list, config=None):
         if l0_file_list != sorted(l0_file_list):
             raise ValueError("l0_file_list must be sorted in ascending order")
@@ -201,7 +206,7 @@ class BaseMasterModule:
             self._master_paths[cal_type] = path
         return self._master_ml1[cal_type]
 
-    def _load_frame(self, fn, cache=False, exptime_tolerance=0.1):
+    def _load_frame(self, fn, cache=False):
         """
         Load an L0 file and perform image assembly to produce an L1 object.
 
@@ -214,17 +219,15 @@ class BaseMasterModule:
             The caller decides which frames are worth caching (see the streaming
             stats path). A frame already cached is returned from the cache
             regardless of this flag.
-        exptime_tolerance : float
-            Maximum allowed excess of elapsed time over requested exposure time,
-            in seconds (default = 0.1).
 
         Returns
         -------
         l1_obj : KPF1 or None
             The assembled L1 object, or None on failure. Failure means the
-            frame could not be read/assembled, failed a required QCL0 flag
-            (`_REQUIRED_L0_QC_FLAGS`), or failed the exptime check; a warning
-            names the cause. Callers detect failure via `l1_obj is None`.
+            frame could not be read/assembled or failed a required QCL0 flag
+            (`_REQUIRED_L0_QC_FLAGS`, which includes the EXPTIME/ELAPSED
+            consistency check); a warning names the cause. Callers detect
+            failure via `l1_obj is None`.
 
         Notes
         -----
@@ -233,33 +236,24 @@ class BaseMasterModule:
         its approximation-pass frames so the exact pass reuses them.
         """
         if fn in self._l1_obj_cache:
-            l1_obj = self._l1_obj_cache[fn]
-
-        else:
-            try:
-                l0_obj = KPF0.from_fits(fn)
-
-                qc = QCL0(l0_obj).run()
-                failed = [kw for kw in self._REQUIRED_L0_QC_FLAGS if not qc[kw][0]]
-                if failed:
-                    warnings.warn(
-                        f"QC failed for {fn}: {', '.join(failed)}", stacklevel=2
-                    )
-                    return None
-
-                l1_obj = ImageAssembly(l0_obj).perform()
-
-                if cache:
-                    self._l1_obj_cache[fn] = l1_obj
-
-            except (FileNotFoundError, OSError) as e:
-                warnings.warn(f"Failed to load {fn}: {e}", stacklevel=2)
-                return None
+            return self._l1_obj_cache[fn]
 
         try:
-            self._check_exptime_vs_elapsed(l1_obj, exptime_tolerance)
-        except ValueError as e:
-            warnings.warn(f"Exptime check failed for {fn}: {e}", stacklevel=2)
+            l0_obj = KPF0.from_fits(fn)
+
+            qc = QCL0(l0_obj).run()
+            failed = [kw for kw in self._REQUIRED_L0_QC_FLAGS if not qc[kw][0]]
+            if failed:
+                warnings.warn(f"QC failed for {fn}: {', '.join(failed)}", stacklevel=2)
+                return None
+
+            l1_obj = ImageAssembly(l0_obj).perform()
+
+            if cache:
+                self._l1_obj_cache[fn] = l1_obj
+
+        except (FileNotFoundError, OSError) as e:
+            warnings.warn(f"Failed to load {fn}: {e}", stacklevel=2)
             return None
 
         return l1_obj
@@ -340,34 +334,6 @@ class BaseMasterModule:
         spectral_extraction = SpectralExtraction(l1_obj)
         return spectral_extraction.perform()
 
-    @staticmethod
-    def _check_exptime_vs_elapsed(l1_obj, exptime_tolerance):
-        """
-        Validate that elapsed readout time is consistent with requested exposure time.
-
-        Parameters
-        ----------
-        l1_obj : KPF1
-            Assembled L1 object whose INSTRUMENT_HEADER contains EXPTIME and ELAPSED.
-        exptime_tolerance : float
-            Maximum allowed excess of elapsed time over requested exposure time,
-            in seconds.
-
-        Raises
-        ------
-        ValueError
-            If elapsed time is less than requested (premature readout), or if the
-            excess exceeds exptime_tolerance.
-        """
-        exptime = l1_obj.headers["INSTRUMENT_HEADER"]["EXPTIME"]
-        elapsed = l1_obj.headers["INSTRUMENT_HEADER"]["ELAPSED"]
-
-        delta = elapsed - exptime
-        if delta < 0:
-            raise ValueError("premature frame readout detected")
-        if delta > exptime_tolerance:
-            raise ValueError(f"elapsed time - requested time > {exptime_tolerance}")
-
     # ------------------------------------------------------------------
     # Private helpers for frame stacking.
     # ------------------------------------------------------------------
@@ -409,7 +375,6 @@ class BaseMasterModule:
         cache=False,
         max_fail_fraction=0.2,
         max_fail_number=2,
-        exptime_tolerance=0.1,
     ):
         """
         Compute stacked statistics using an in-memory data cube.
@@ -433,10 +398,6 @@ class BaseMasterModule:
             Maximum absolute number of frames allowed to fail loading before
             raising. Defaults to 2. Stacking raises when either limit is
             exceeded.
-        exptime_tolerance : float, optional
-            Exposure-time tolerance in seconds (default 0.1): the per-frame
-            elapsed-vs-requested bound in `_load_frame`, and the threshold at or
-            below which a frame's exposure counts as zero (a bias).
 
         Returns
         -------
@@ -454,8 +415,8 @@ class BaseMasterModule:
                               bias stack, where T = 1)
         zero_exptime : bool
             True if this is a bias stack (all frames have exposure at or below
-            exptime_tolerance), used by the streaming path to validate per-frame
-            exposure consistency.
+            `_ZERO_EXPTIME_TOL_SECONDS`), used by the streaming path to validate
+            per-frame exposure consistency.
 
         Notes
         -----
@@ -464,8 +425,8 @@ class BaseMasterModule:
         requested EXPTIME. Outlier rejection is performed on the CCD rate (VAR =
         |CCD| + RN adds no independent information); rates are used so frames of
         differing exposure are comparable, and VAR is still summed for the SNR.
-        Exposure times must be either all zero (≤ tolerance) or all above
-        tolerance. Raises an error if more than `max_fail_fraction` of frames
+        Exposure times must be either all zero (≤ `_ZERO_EXPTIME_TOL_SECONDS`) or
+        all above it. Raises an error if more than `max_fail_fraction` of frames
         fail to load.
         """
         if l0_file_list is None:
@@ -492,9 +453,7 @@ class BaseMasterModule:
         failure_count = 0
 
         for fn in l0_file_list:
-            l1_obj = self._load_frame(
-                fn, cache=cache, exptime_tolerance=exptime_tolerance
-            )
+            l1_obj = self._load_frame(fn, cache=cache)
 
             if l1_obj is None:
                 failure_count += 1
@@ -521,10 +480,10 @@ class BaseMasterModule:
         if np.any(exptime < 0):
             raise ValueError(f"Exposure times cannot be negative; exptime = {exptime}")
 
-        if np.all(exptime > exptime_tolerance):
+        if np.all(exptime > self._ZERO_EXPTIME_TOL_SECONDS):
             zero_exptime = False
             T = exptime[:, None, None]
-        elif np.all(exptime <= exptime_tolerance):
+        elif np.all(exptime <= self._ZERO_EXPTIME_TOL_SECONDS):
             zero_exptime = True
             T = np.ones_like(exptime)[:, None, None]
         else:
@@ -585,7 +544,6 @@ class BaseMasterModule:
         sigma=None,
         max_fail_fraction=0.2,
         max_fail_number=2,
-        exptime_tolerance=0.1,
     ):
         """
         Compute stacked statistics with a single streaming pass over the frames.
@@ -606,10 +564,6 @@ class BaseMasterModule:
             Maximum absolute number of frames allowed to fail loading before
             raising. Defaults to 2. Stacking raises when either limit is
             exceeded.
-        exptime_tolerance : float, optional
-            Exposure-time tolerance in seconds (default 0.1): the per-frame
-            elapsed-vs-requested bound in `_load_frame`, and the threshold at or
-            below which a frame's exposure counts as zero (a bias).
 
         Returns
         -------
@@ -624,7 +578,7 @@ class BaseMasterModule:
             approximation below, and the master IMG is counts_sum / exptime_sum.)
         zero_exptime : bool
             True if this is a bias stack (all frames have exposure at or below
-            exptime_tolerance).
+            `_ZERO_EXPTIME_TOL_SECONDS`).
 
         Notes
         -----
@@ -652,7 +606,6 @@ class BaseMasterModule:
             cache=True,
             max_fail_fraction=max_fail_fraction,
             max_fail_number=max_fail_number,
-            exptime_tolerance=exptime_tolerance,
         )
 
         if len(l0_file_list) <= ndirect:
@@ -692,9 +645,7 @@ class BaseMasterModule:
         for fn in l0_file_list:
             # The first `ndirect` frames are cache hits from the approximation
             # pass above; the rest are read once here and not worth caching.
-            l1_obj = self._load_frame(
-                fn, cache=False, exptime_tolerance=exptime_tolerance
-            )
+            l1_obj = self._load_frame(fn, cache=False)
 
             if l1_obj is None:
                 failure += 1
@@ -710,7 +661,7 @@ class BaseMasterModule:
             if exptime < 0:
                 raise ValueError("Exposure times cannot be negative")
 
-            is_zero = exptime <= exptime_tolerance
+            is_zero = exptime <= self._ZERO_EXPTIME_TOL_SECONDS
             if zero_exptime != is_zero:
                 raise ValueError("Exposure times must be all zero or all non-zero")
 
@@ -866,7 +817,6 @@ class BaseMasterModule:
         cal_type=None,
         max_fail_fraction=0.2,
         max_fail_number=2,
-        exptime_tolerance=0.1,
     ):
         """
         Stack full-frame images to produce masters L1.
@@ -892,11 +842,6 @@ class BaseMasterModule:
             Maximum absolute number of frames allowed to fail loading before
             raising. Defaults to 2. Stacking raises when either limit is
             exceeded.
-        exptime_tolerance : float, optional
-            Exposure-time tolerance in seconds (default 0.1), threaded to the
-            stats sub-methods. It bounds the allowed excess of elapsed over
-            requested time in `_check_exptime_vs_elapsed`, and is the threshold
-            at or below which a frame's exposure counts as zero (a bias).
 
         Returns
         -------
@@ -933,7 +878,6 @@ class BaseMasterModule:
                 sigma=sigma,
                 max_fail_fraction=max_fail_fraction,
                 max_fail_number=max_fail_number,
-                exptime_tolerance=exptime_tolerance,
             )
         else:
             stats, _ = self._compute_stats_from_stream(
@@ -942,7 +886,6 @@ class BaseMasterModule:
                 sigma=sigma,
                 max_fail_fraction=max_fail_fraction,
                 max_fail_number=max_fail_number,
-                exptime_tolerance=exptime_tolerance,
             )
 
         for chip in self.chips:

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -195,7 +195,7 @@ class BaseMasterModule:
             self._master_paths[cal_type] = path
         return self._master_ml1[cal_type]
 
-    def _load_frame(self, fn, cache=False, exptime_tolerance=0.1, verbose=True):
+    def _load_frame(self, fn, cache=False, exptime_tolerance=0.1):
         """
         Load an L0 file and perform image assembly to produce an L1 object.
 
@@ -211,11 +211,6 @@ class BaseMasterModule:
         exptime_tolerance : float
             Maximum allowed excess of elapsed time over requested exposure time,
             in seconds (default = 0.1).
-        verbose : bool, optional
-            If True (default), emit a progress print and propagate load /
-            exptime-check failures as UserWarnings. If False, all such
-            output is suppressed; the (None, False) failure return value
-            still signals the caller.
 
         Returns
         -------
@@ -245,15 +240,13 @@ class BaseMasterModule:
                     self._l1_obj_cache[fn] = l1_obj
 
             except (FileNotFoundError, OSError) as e:
-                if verbose:
-                    warnings.warn(f"Failed to load {fn}: {e}", stacklevel=2)
+                warnings.warn(f"Failed to load {fn}: {e}", stacklevel=2)
                 return None, failure
 
         try:
             self._check_exptime_vs_elapsed(l1_obj, exptime_tolerance)
         except ValueError as e:
-            if verbose:
-                warnings.warn(f"Exptime check failed for {fn}: {e}", stacklevel=2)
+            warnings.warn(f"Exptime check failed for {fn}: {e}", stacklevel=2)
             return None, failure
 
         return l1_obj, success
@@ -313,7 +306,7 @@ class BaseMasterModule:
 
         return l1_obj
 
-    def _extract_frame(self, l1_obj, verbose=True):
+    def _extract_frame(self, l1_obj):
         """
         Extract an assembled frame to L2 (for spectral masters, e.g. WLS).
 
@@ -325,8 +318,6 @@ class BaseMasterModule:
         ----------
         l1_obj : KPF1
             Assembled (and, where needed, already calibrated) L1 frame.
-        verbose : bool, optional
-            If True (default), emit progress prints during extraction.
 
         Returns
         -------
@@ -334,7 +325,7 @@ class BaseMasterModule:
             The extracted L2 spectra.
         """
         spectral_extraction = SpectralExtraction(l1_obj)
-        return spectral_extraction.perform(verbose=verbose)
+        return spectral_extraction.perform()
 
     @staticmethod
     def _check_exptime_vs_elapsed(l1_obj, exptime_tolerance):
@@ -402,7 +393,6 @@ class BaseMasterModule:
         l0_file_list=None,
         *,
         sigma=None,
-        verbose=True,
         cache=False,
         max_fail_fraction=0.2,
         max_fail_number=2,
@@ -419,9 +409,6 @@ class BaseMasterModule:
             streaming path passes only its approximation-pass frames).
         sigma : float, optional
             Sigma threshold for outlier rejection across frames.
-        verbose : bool, optional
-            If True (default), emit per-frame progress prints and load
-            failure warnings from `_load_frame`.
         cache : bool, optional
             If True, cache each loaded frame so a later pass (the streaming
             exact pass) can reuse it without re-reading from disk. Defaults to
@@ -493,7 +480,7 @@ class BaseMasterModule:
 
         for fn in l0_file_list:
             l1_obj, success = self._load_frame(
-                fn, cache=cache, exptime_tolerance=exptime_tolerance, verbose=verbose
+                fn, cache=cache, exptime_tolerance=exptime_tolerance
             )
 
             if not success:
@@ -583,7 +570,6 @@ class BaseMasterModule:
         *,
         nstream,
         sigma=None,
-        verbose=True,
         max_fail_fraction=0.2,
         max_fail_number=2,
         exptime_tolerance=0.1,
@@ -600,9 +586,6 @@ class BaseMasterModule:
             approximation pass that estimates the per-pixel clipping bounds.
         sigma : float, optional
             Sigma threshold for outlier rejection.
-        verbose : bool, optional
-            If True (default), emit per-frame progress prints and load
-            failure warnings from `_load_frame`.
         max_fail_fraction : float, optional
             Maximum fraction of frames allowed to fail loading before raising.
             Defaults to 0.2.
@@ -653,7 +636,6 @@ class BaseMasterModule:
         approx_stats, zero_exptime = self._compute_stats_from_datacube(
             l0_file_list=l0_file_list[:ndirect],
             sigma=sigma,
-            verbose=verbose,
             cache=True,
             max_fail_fraction=max_fail_fraction,
             max_fail_number=max_fail_number,
@@ -698,7 +680,7 @@ class BaseMasterModule:
             # The first `ndirect` frames are cache hits from the approximation
             # pass above; the rest are read once here and not worth caching.
             l1_obj, success = self._load_frame(
-                fn, cache=False, exptime_tolerance=exptime_tolerance, verbose=verbose
+                fn, cache=False, exptime_tolerance=exptime_tolerance
             )
 
             if not success:
@@ -868,7 +850,6 @@ class BaseMasterModule:
         l0_file_list=None,
         nstream=6,
         sigma=None,
-        verbose=True,
         cal_type=None,
         max_fail_fraction=0.2,
         max_fail_number=2,
@@ -887,9 +868,6 @@ class BaseMasterModule:
             Defaults to 6.
         sigma : float, optional
             Sigma threshold for frame-to-frame outlier rejection.
-        verbose : bool, optional
-            If True (default), emit per-frame progress prints and load
-            failure warnings during stacking.
         cal_type : {'bias', 'dark', 'flat', None}, optional
             Calibration type, forwarded to `_clean_l1_arrays` to select the
             final outlier-flagging mode. Defaults to the conservative
@@ -940,7 +918,6 @@ class BaseMasterModule:
             stats, _ = self._compute_stats_from_datacube(
                 l0_file_list,
                 sigma=sigma,
-                verbose=verbose,
                 max_fail_fraction=max_fail_fraction,
                 max_fail_number=max_fail_number,
                 exptime_tolerance=exptime_tolerance,
@@ -950,7 +927,6 @@ class BaseMasterModule:
                 l0_file_list,
                 nstream=nstream,
                 sigma=sigma,
-                verbose=verbose,
                 max_fail_fraction=max_fail_fraction,
                 max_fail_number=max_fail_number,
                 exptime_tolerance=exptime_tolerance,

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -14,6 +14,7 @@ from kpfpipe.modules.calibration_association import CalibrationAssociation
 from kpfpipe.modules.image_assembly import ImageAssembly
 from kpfpipe.modules.image_processing import ImageProcessing
 from kpfpipe.modules.spectral_extraction import SpectralExtraction
+from kpfpipe.quality_control.qc_flags.level0 import QCL0
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.stats import flag_outliers, interpolate_bad_pixels
 
@@ -64,6 +65,11 @@ class BaseMasterModule:
         "dark": "electrons/sec",
         "flat": None,
     }
+
+    # QCL0 flags a frame must pass to enter a stack: data present, required
+    # keywords present, sane exptime, and not observer-junk. A frame failing
+    # any is dropped in `_load_frame` and counted as a load failure.
+    _REQUIRED_L0_QC_FLAGS = ("DATAPRL0", "KWRDPRL0", "EXPTIMOK", "NOTJUNK")
 
     def __init__(self, l0_file_list, config=None):
         if l0_file_list != sorted(l0_file_list):
@@ -215,9 +221,10 @@ class BaseMasterModule:
         Returns
         -------
         l1_obj : KPF1 or None
-            Assembled L1 data object if successful, otherwise None.
-        success : bool
-            True if file was successfully loaded and processed, False otherwise.
+            The assembled L1 object, or None on failure. Failure means the
+            frame could not be read/assembled, failed a required QCL0 flag
+            (`_REQUIRED_L0_QC_FLAGS`), or failed the exptime check; a warning
+            names the cause. Callers detect failure via `l1_obj is None`.
 
         Notes
         -----
@@ -225,15 +232,21 @@ class BaseMasterModule:
         reduce redundant I/O and recomputation. The streaming stats path caches
         its approximation-pass frames so the exact pass reuses them.
         """
-        success = True
-        failure = False
-
         if fn in self._l1_obj_cache:
             l1_obj = self._l1_obj_cache[fn]
 
         else:
             try:
                 l0_obj = KPF0.from_fits(fn)
+
+                qc = QCL0(l0_obj).run()
+                failed = [kw for kw in self._REQUIRED_L0_QC_FLAGS if not qc[kw][0]]
+                if failed:
+                    warnings.warn(
+                        f"QC failed for {fn}: {', '.join(failed)}", stacklevel=2
+                    )
+                    return None
+
                 l1_obj = ImageAssembly(l0_obj).perform()
 
                 if cache:
@@ -241,15 +254,15 @@ class BaseMasterModule:
 
             except (FileNotFoundError, OSError) as e:
                 warnings.warn(f"Failed to load {fn}: {e}", stacklevel=2)
-                return None, failure
+                return None
 
         try:
             self._check_exptime_vs_elapsed(l1_obj, exptime_tolerance)
         except ValueError as e:
             warnings.warn(f"Exptime check failed for {fn}: {e}", stacklevel=2)
-            return None, failure
+            return None
 
-        return l1_obj, success
+        return l1_obj
 
     def _process_frame(self, l1_obj):
         """
@@ -476,17 +489,17 @@ class BaseMasterModule:
             data_cube[f"{chip}_VAR"] = np.zeros((nframe, nrow, ncol), dtype=np.float32)
 
         i = 0
-        failure = 0
+        failure_count = 0
 
         for fn in l0_file_list:
-            l1_obj, success = self._load_frame(
+            l1_obj = self._load_frame(
                 fn, cache=cache, exptime_tolerance=exptime_tolerance
             )
 
-            if not success:
-                failure += 1
+            if l1_obj is None:
+                failure_count += 1
                 self._check_load_failures(
-                    failure, len(l0_file_list), max_fail_fraction, max_fail_number
+                    failure_count, len(l0_file_list), max_fail_fraction, max_fail_number
                 )
                 continue
 
@@ -679,11 +692,11 @@ class BaseMasterModule:
         for fn in l0_file_list:
             # The first `ndirect` frames are cache hits from the approximation
             # pass above; the rest are read once here and not worth caching.
-            l1_obj, success = self._load_frame(
+            l1_obj = self._load_frame(
                 fn, cache=False, exptime_tolerance=exptime_tolerance
             )
 
-            if not success:
+            if l1_obj is None:
                 failure += 1
                 self._check_load_failures(
                     failure, len(l0_file_list), max_fail_fraction, max_fail_number

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -46,6 +46,7 @@ class BaseMasterModule:
     _DEFAULTS = {
         **DEFAULTS,
         "stack_sigma": 5.0,
+        "min_stack_size": 5,
         "bias": True,
         "dark": True,
         "flat": False,

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -26,8 +26,7 @@ class Bias(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: stack_sigma,
-        exptime_tolerance, chips.
+        Module configuration. Recognized keys: stack_sigma, chips.
     """
 
     def __init__(self, l0_file_list, config=None):

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -56,7 +56,6 @@ class Bias(BaseMasterModule):
         nstream=6,
         sigma=None,
         filepath=None,
-        verbose=True,
     ):
         """
         Build master bias from stack.
@@ -79,8 +78,6 @@ class Bias(BaseMasterModule):
         filepath : str, optional
             If provided, calls `self.save_master('L1', filepath)` at
             the end to persist the master L1 to a FITS file at this filepath.
-        verbose : bool, optional
-            If True (default), emit per-frame progress prints during stacking.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -91,7 +88,6 @@ class Bias(BaseMasterModule):
             l0_file_list=l0_file_list,
             nstream=nstream,
             sigma=sigma,
-            verbose=verbose,
             cal_type="bias",
         )
 

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -26,8 +26,7 @@ class Dark(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: stack_sigma,
-        exptime_tolerance, chips.
+        Module configuration. Recognized keys: stack_sigma, chips.
     """
 
     _STANDARD_CALIBRATIONS = ("bias",)

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -65,7 +65,6 @@ class Dark(BaseMasterModule):
         sigma=None,
         bias=None,
         filepath=None,
-        verbose=True,
     ):
         """
         Build master dark from stack.
@@ -91,8 +90,6 @@ class Dark(BaseMasterModule):
         filepath : str, optional
             If provided, calls `self.save_master('L1', filepath)` at
             the end to persist the master L1 to a FITS file at this filepath.
-        verbose : bool, optional
-            If True (default), emit per-frame progress prints during stacking.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -105,7 +102,6 @@ class Dark(BaseMasterModule):
             l0_file_list=l0_file_list,
             nstream=nstream,
             sigma=sigma,
-            verbose=verbose,
             cal_type="dark",
         )
 

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -16,8 +16,7 @@ class Flat(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: stack_sigma,
-        exptime_tolerance, chips.
+        Module configuration. Recognized keys: stack_sigma, chips.
     """
 
     _STANDARD_CALIBRATIONS = ("bias", "dark")

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -225,9 +225,9 @@ class WLS(BaseMasterModule):
         failure = 0
 
         for fn in l0_file_list:
-            l1_obj, success = self._load_frame(fn, cache=False)
+            l1_obj = self._load_frame(fn, cache=False)
 
-            if not success:
+            if l1_obj is None:
                 failure += 1
                 self._check_load_failures(
                     failure, len(l0_file_list), max_fail_fraction, max_fail_number

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -188,7 +188,6 @@ class WLS(BaseMasterModule):
     def _process_stack_l0_to_l2(
         self,
         l0_file_list=None,
-        verbose=True,
         max_fail_fraction=0.2,
         max_fail_number=2,
     ):
@@ -199,9 +198,6 @@ class WLS(BaseMasterModule):
         ----------
         l0_file_list : list of str, optional
             L0 files to process. Defaults to self.l0_file_list.
-        verbose : bool, optional
-            If True (default), emit progress prints and per-frame warnings
-            from the underlying L0 → L1 → L2 calls.
         max_fail_fraction : float, optional
             Maximum fraction of frames allowed to fail loading before raising.
             Defaults to 0.2.
@@ -229,7 +225,7 @@ class WLS(BaseMasterModule):
         failure = 0
 
         for fn in l0_file_list:
-            l1_obj, success = self._load_frame(fn, cache=False, verbose=verbose)
+            l1_obj, success = self._load_frame(fn, cache=False)
 
             if not success:
                 failure += 1
@@ -239,7 +235,7 @@ class WLS(BaseMasterModule):
                 continue
 
             l1_obj = self._process_frame(l1_obj)
-            l2_obj = self._extract_frame(l1_obj, verbose=verbose)
+            l2_obj = self._extract_frame(l1_obj)
             self._l2_obj_cache.append(l2_obj)
 
         return self._l2_obj_cache
@@ -366,7 +362,6 @@ class WLS(BaseMasterModule):
         linelist=None,
         lineprofile=None,
         window=5,
-        verbose=True,
     ):
         """
         Fit line positions across all orders and fibers of one chip.
@@ -393,8 +388,6 @@ class WLS(BaseMasterModule):
             Line profile model name. See kpfpipe.utils.stats._FUNCTIONS.
         window : int, optional
             Half-width of the per-line fit window, in pixels.
-        verbose : bool, optional
-            If True, print a progress line for each fiber.
 
         Returns
         -------
@@ -446,7 +439,7 @@ class WLS(BaseMasterModule):
                 )
 
                 nlines = len(line_dict["wav"])
-                if nlines == 0 and verbose:
+                if nlines == 0:
                     warnings.warn(
                         f"{chip} {fiber} order {o}: orderlet skipped "
                         f"(no fittable lines; flux likely NaN-filled)",
@@ -464,7 +457,7 @@ class WLS(BaseMasterModule):
             n_total = len(lines["wav"][i])
             n_good = int(np.sum(~lines["bad"][i]))
             logger.info("%s %s: %d/%d good lines", chip, fiber, n_good, n_total)
-            if n_good == 0 and verbose:
+            if n_good == 0:
                 warnings.warn(
                     f"{chip} {fiber}: no good lines retained "
                     f"({n_total} attempted; all rejected or NaN-filled)",
@@ -651,7 +644,6 @@ class WLS(BaseMasterModule):
         window=5,
         qc_sigma=2.5,
         max_bad_frac=0.05,
-        verbose=True,
     ):
         """
         Compute a master wavelength solution from a stack of extracted L2 frames.
@@ -690,8 +682,6 @@ class WLS(BaseMasterModule):
             Maximum fraction of per-line fits allowed to fail QC before a
             frame is rejected from the stack. Frames exceeding this are
             dropped; if more than one frame is rejected, an error is raised.
-        verbose : bool, optional
-            If True, print progress for each frame and fiber.
 
         Returns
         -------
@@ -744,7 +734,6 @@ class WLS(BaseMasterModule):
                 linelist=linelist,
                 lineprofile=lineprofile,
                 window=window,
-                verbose=verbose,
             )
 
             nlines = len(lines_stack[i]["bad"])
@@ -758,12 +747,11 @@ class WLS(BaseMasterModule):
                         f"{chip}: more than one frame rejected from stack "
                         f"(> {max_bad_frac:.0%} of line fits failed QC)"
                     )
-                if verbose:
-                    warnings.warn(
-                        f"{chip} frame {i + 1}: {bad_frac:.1%} of line fits failed QC "
-                        f"(> {max_bad_frac:.0%}); frame rejected from stack",
-                        stacklevel=2,
-                    )
+                warnings.warn(
+                    f"{chip} frame {i + 1}: {bad_frac:.1%} of line fits failed QC "
+                    f"(> {max_bad_frac:.0%}); frame rejected from stack",
+                    stacklevel=2,
+                )
                 continue
 
             coeffs_stack[i] = self._calculate_wls_coeffs(
@@ -827,7 +815,6 @@ class WLS(BaseMasterModule):
         flat=None,
         master_path=None,
         diagnostics_path=None,
-        verbose=True,
     ):
         """
         Build a master wavelength solution from a stack of L0 frames.
@@ -871,10 +858,6 @@ class WLS(BaseMasterModule):
             If provided, calls `self.save_diagnostics(diagnostics_path)`
             at the end to persist the per-frame coefficient and line stacks
             to an HDF5 file at this path.
-        verbose : bool, optional
-            If True (default), emit progress prints and informational
-            warnings from frame loading, spectral extraction, and the
-            per-frame WLS fit. Hard failures still raise.
 
         Returns
         -------
@@ -906,7 +889,7 @@ class WLS(BaseMasterModule):
         self._load_linelist(linelist)
 
         # _process_stack_l0_to_l2 resets self._l2_obj_cache at entry.
-        self._process_stack_l0_to_l2(l0_file_list=l0_file_list, verbose=verbose)
+        self._process_stack_l0_to_l2(l0_file_list=l0_file_list)
 
         self.ml2_obj = KPFMasterL2(kind="wls")
 
@@ -922,7 +905,6 @@ class WLS(BaseMasterModule):
                 polyorder_x=polyorder_x,
                 polyorder_m=polyorder_m,
                 polyorder_f=polyorder_f,
-                verbose=verbose,
             )
             W, coeffs_mean, coeffs_stack, lines_stack = result
 

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -317,9 +317,7 @@ class SpectralExtraction:
     # Algorithm steps
     # ------------------------------------------------------------------
 
-    def extract_orderlet(
-        self, chip, fiber, order, extraction_method=None, verbose=True
-    ):
+    def extract_orderlet(self, chip, fiber, order, extraction_method=None):
         """
         Extract a single orderlet as a 1D spectrum.
 
@@ -333,10 +331,6 @@ class SpectralExtraction:
             Spectral order number.
         extraction_method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
-        verbose : bool, optional
-            If True (default), emit warnings from per-orderlet array
-            validation (NaN / negative / non-finite flux). If False,
-            those warnings are suppressed.
 
         Returns
         -------
@@ -366,20 +360,19 @@ class SpectralExtraction:
 
         flux_1d, var_1d = extraction_fxn(D, V, W=W)
 
-        if verbose:
-            for arr, name in ((flux_1d, "flux_1d"), (var_1d, "var_1d")):
-                n_bad = int(np.sum(~np.isfinite(arr)))
-                n_neg = int(np.sum(arr < 0))
-                if n_bad or n_neg:
-                    warnings.warn(
-                        f"{name} array: {chip} {fiber} {order} has "
-                        f"{n_bad} non-finite, {n_neg} negative values",
-                        stacklevel=2,
-                    )
+        for arr, name in ((flux_1d, "flux_1d"), (var_1d, "var_1d")):
+            n_bad = int(np.sum(~np.isfinite(arr)))
+            n_neg = int(np.sum(arr < 0))
+            if n_bad or n_neg:
+                warnings.warn(
+                    f"{name} array: {chip} {fiber} {order} has "
+                    f"{n_bad} non-finite, {n_neg} negative values",
+                    stacklevel=2,
+                )
 
         return flux_1d, var_1d
 
-    def extract_ffi(self, chip, fibers=None, extraction_method=None, verbose=True):
+    def extract_ffi(self, chip, fibers=None, extraction_method=None):
         """
         Extract all spectral orders from a full-frame image (FFI).
 
@@ -391,10 +384,6 @@ class SpectralExtraction:
             Fibers identifiers, e.g. 'SCI2'
         extraction_method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
-        verbose : bool, optional
-            If True (default), emit informational warnings (per-orderlet
-            validation, expected single-orderlet failure). Hard failures
-            (>1 orderlet missing) still raise regardless.
 
         Returns
         -------
@@ -433,7 +422,7 @@ class SpectralExtraction:
             for fiber in fibers:
                 try:
                     flux_1d, var_1d = self.extract_orderlet(
-                        chip, fiber, order, extraction_method, verbose=verbose
+                        chip, fiber, order, extraction_method
                     )
                 except LookupError:
                     failure += 1
@@ -447,7 +436,7 @@ class SpectralExtraction:
         # In this case a single failure is expected from this method. Allowing
         # the loop to continue through all orders provides useful diagnostic
         # information for cases where the algorithm truly fails.
-        if failure == 1 and verbose:
+        if failure == 1:
             warnings.warn(
                 f"1 orderlet failed to extract from the {chip} CCD; filled with NaN.",
                 UserWarning,
@@ -490,7 +479,7 @@ class SpectralExtraction:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, chips=None, fibers=None, *, extraction_method=None, verbose=True):
+    def perform(self, chips=None, fibers=None, *, extraction_method=None):
         """
         Execute spectral extraction. Optional keyword arguments
         default to config settings.
@@ -503,10 +492,6 @@ class SpectralExtraction:
             Fiber identifiers, e.g. 'SCI2'
         extraction_method : str, optional
             Extraction method ('box', 'optimal', or 'flat_relative').
-        verbose : bool, optional
-            If True (default), emit informational warnings during
-            extraction (per-orderlet array validation, expected
-            single-orderlet failure). Hard errors still raise.
 
         Returns
         -------
@@ -528,9 +513,7 @@ class SpectralExtraction:
         l2_obj = self.l1_obj.to_kpf2()
 
         for chip in chips:
-            l2_arrays = self.extract_ffi(
-                chip, fibers, extraction_method, verbose=verbose
-            )
+            l2_arrays = self.extract_ffi(chip, fibers, extraction_method)
             for fiber in fibers:
                 l2_obj.set_data(
                     f"{chip}_{fiber}_FLUX", l2_arrays[f"{chip}_{fiber}_FLUX"]

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -102,20 +102,28 @@ class QCL0(QC):
     times_consistent._qc_key = "DATTIMOK"
 
     def exptime_sane(self):
-        """EXPTIME is present, finite, and non-negative.
+        """EXPTIME present, finite, non-negative, and consistent with ELAPSED.
 
         Bias frames legitimately have EXPTIME=0, so we don't require strictly
-        positive. Tightening this requires frame-type-aware filtering, which
-        is deferred until QC gains spectrum-type gating.
+        positive. When the raw ELAPSED readout time is present, it must not fall
+        short of the requested EXPTIME (premature readout) or exceed it by more
+        than ``_TIME_TOL_S`` (the elapsed-vs-requested check formerly done in the
+        masters frame loader); an absent ELAPSED skips only that comparison.
         """
         hdr = self.kpf_obj.headers["PRIMARY"]
         if "EXPTIME" not in hdr:
             return False
         try:
-            f = float(hdr.get("EXPTIME"))
+            exptime = float(hdr.get("EXPTIME"))
         except (TypeError, ValueError):
             return False
-        return np.isfinite(f) and f >= 0
+        if not (np.isfinite(exptime) and exptime >= 0):
+            return False
+
+        elapsed = _hdr_float(hdr, "ELAPSED")
+        if elapsed is not None and not (0 <= elapsed - exptime <= _TIME_TOL_S):
+            return False
+        return True
 
     exptime_sane._qc_key = "EXPTIMOK"
 

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -126,7 +126,8 @@ class FileHandler:
     def __init__(self, data_dirs):
         self._data_input = data_dirs.get("KPF_DATA_INPUT")
         self._masters_output = data_dirs.get("KPF_MASTERS_OUTPUT")
-        self._mini_db = None  # the loaded night, set by build_mini_database
+        self._mini_db = None  # loaded night's readable frames (build_mini_database)
+        self._full_scan_mini_db = None  # full scan of every file, written to the cache
 
     def _mini_db_cache_path(self, datecode):
         """On-disk mini-database cache path for one night:
@@ -145,9 +146,9 @@ class FileHandler:
 
         * **Count** -- the cache's row count must equal the number of FITS files
           on disk, so a frame added or removed since the cache was written
-          invalidates it. (An unreadable frame is dropped from the scan but still
-          counts on disk, so a persistently-corrupt frame defeats the cache -- an
-          acceptable, rare edge that errs toward rescanning.)
+          invalidates it. The cache records *every* file, including unreadable ones
+          (as header-null rows), so a persistently-corrupt frame no longer skews the
+          count and defeats the cache.
         * **Freshness** -- the cache must be at least as new as every input's
           timestamp: for each file the later of its modification time
           (``st_mtime``, when its contents were written) and its change time
@@ -189,8 +190,12 @@ class FileHandler:
         return cached
 
     def _write_mini_db_cache(self, datecode):
-        """Atomically write the carried mini database (``self._mini_db``) to the
-        on-disk cache CSV for `datecode`, creating the cache directory as needed.
+        """Atomically write the full scan (``self._full_scan_mini_db`` -- one row
+        per file, including unreadable frames) to the on-disk cache CSV for
+        `datecode`, creating the cache directory as needed. Writing the full scan
+        (not the cleaned ``self._mini_db``) keeps the cache a faithful mirror of the
+        L0 directory, so the row-count guardrail in ``_read_mini_db_cache`` stays
+        honest.
 
         pandas' ``to_csv`` truncates the target in place, so a concurrent reader
         could observe an empty, partial, or half-written CSV. Fill a same-dir temp
@@ -204,13 +209,23 @@ class FileHandler:
         fd, tmp = tempfile.mkstemp(dir=cache_dir, suffix=".tmp")
         os.close(fd)
         try:
-            self._mini_db.to_csv(tmp, index=False)
+            self._full_scan_mini_db.to_csv(tmp, index=False)
             os.replace(tmp, cache_path)
         except BaseException:
             if os.path.exists(tmp):
                 os.remove(tmp)
             raise
         logger.info("wrote mini database cache to %s", cache_path)
+
+    @staticmethod
+    def _clean_mini_db(full_scan_mini_db):
+        """The readable-frame subset of a full scan: drop rows whose header could not
+        be read (every header column null). Such frames belong in the on-disk cache
+        -- which mirrors the L0 directory -- but are useless for stacking/discovery,
+        so the in-memory ``self._mini_db`` excludes them. Re-indexes the survivors."""
+        return full_scan_mini_db.dropna(
+            subset=_MINI_DB_KEYS[1:], how="all"
+        ).reset_index(drop=True)
 
     def build_mini_database(self, datecode, cache=False):
         """
@@ -250,8 +265,10 @@ class FileHandler:
             (absolute path), TARGNAME, IMTYPE, OBJECT, EXPTIME, ELAPSED; plus
             derived UTC and HST (KPF-format timestamps from the filename, HST =
             UTC-10) and ISJUNK (frame is on the observer junk list -- flagged,
-            not dropped). A missing header key gives None for that column; an
-            unreadable frame is skipped; both warn.
+            not dropped). A missing header key gives None for that column. An
+            unreadable frame is warned and omitted from this DataFrame (useless
+            for stacking), but is still recorded -- with null header columns -- in
+            the on-disk cache, so the cache mirrors the L0 directory exactly.
 
         Raises
         ------
@@ -276,7 +293,8 @@ class FileHandler:
                     "loaded mini database cache from %s",
                     self._mini_db_cache_path(datecode),
                 )
-                self._mini_db = cached
+                self._full_scan_mini_db = cached
+                self._mini_db = self._clean_mini_db(cached)
                 return self._mini_db
 
         data_dir = os.path.join(self._data_input, "L0", datecode)
@@ -295,12 +313,12 @@ class FileHandler:
                 header = fits.getheader(fn, ext=0)
             except Exception as e:
                 warnings.warn(f"Could not read header from {fn}: {e}", stacklevel=2)
-                continue
+                header = None
 
             mini_db["FILENAME"].append(fn)
 
             for k in _MINI_DB_KEYS[1:]:
-                mini_db[k].append(header.get(k, None))
+                mini_db[k].append(header.get(k, None) if header is not None else None)
 
             # UTC is the KPF timestamp; HST is that converted to Hawaii time.
             utc = get_timestamp(fn)
@@ -308,7 +326,8 @@ class FileHandler:
             mini_db["HST"].append(utc_to_hst(utc))
             mini_db["ISJUNK"].append(get_obs_id(fn) in junk)
 
-        self._mini_db = pd.DataFrame(mini_db)
+        self._full_scan_mini_db = pd.DataFrame(mini_db)
+        self._mini_db = self._clean_mini_db(self._full_scan_mini_db)
 
         if write_cache:
             self._write_mini_db_cache(datecode)

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -289,31 +289,57 @@ class FileHandler:
         dt = kpf_timestamp_to_datetime(get_timestamp(s))
         return int((dt - _J2000_EPOCH).total_seconds())
 
-    def _identify_clusters(self, cal_df, *, cluster_gap_seconds):
+    def _select_frames(self, cal_type, *, exclude_junk=True):
         """
-        Group calibration frames into observing-session clusters by time gaps.
+        The junk-excluded, OBJECT-filtered frames of `cal_type` from the carried
+        mini database (``self._mini_db``).
 
-        Infers the morn/midday/eve/night/midnight sessions purely from the frame
-        timestamps: the OBJECT morn/eve/night suffix is only a label and does not
-        partition the result, so a mislabeled frame clusters with its true session
-        instead of splitting off. Consecutive time-sorted frames start a new
-        cluster wherever they are more than `cluster_gap_seconds` apart; for the
-        allowlisted cal types the morn and eve sessions sit hours apart, so the gap
-        alone separates them.
+        The single frame-selection entry point the grouping paths share. Raises
+        ``ValueError`` if no mini database is loaded (call ``build_mini_database``
+        first) or if the type has no frames; a mini database lacking the ISJUNK
+        column raises ``KeyError`` under ``exclude_junk=True`` (a fail-loud guard
+        against a database built before junk tracking existed).
+        """
+        mini_db = self._mini_db
+        if mini_db is None:
+            raise ValueError(
+                "no mini database available; call build_mini_database(datecode) first"
+            )
+        if exclude_junk:
+            mini_db = mini_db[~mini_db["ISJUNK"].astype(bool)]
+        cal_df = mini_db[mini_db["OBJECT"].isin(_OBJECT_MAP[cal_type])]
+        if cal_df.empty:
+            raise ValueError(f"No '{cal_type}' calibration frames found")
+        return cal_df
+
+    def _identify_clusters(self, cal_type, *, cluster_gap_seconds, exclude_junk=True):
+        """
+        Group `cal_type` frames into observing-session clusters by time gaps.
+
+        Reads the carried mini database (``self._mini_db``) via `_select_frames`
+        and infers the morn/midday/eve/night/midnight sessions purely from the
+        frame timestamps: the OBJECT morn/eve/night suffix is only a label and
+        does not partition the result, so a mislabeled frame clusters with its
+        true session instead of splitting off. Consecutive time-sorted frames
+        start a new cluster wherever they are more than `cluster_gap_seconds`
+        apart; for the allowlisted cal types the morn and eve sessions sit hours
+        apart, so the gap alone separates them.
 
         Parameters
         ----------
-        cal_df : pandas.DataFrame
-            OBJECT-filtered, junk-excluded frames for one cal_type; must be
-            non-empty and carry a FILENAME column.
+        cal_type : str
+            Calibration frame type (a key of `_OBJECT_MAP`).
         cluster_gap_seconds : int
             Gap [s] between consecutive frames that starts a new cluster.
+        exclude_junk : bool, default True
+            Drop observer-flagged junk frames before clustering.
 
         Returns
         -------
         clusters : list of list of str
             Chronologically-sorted filename lists, one per detected session.
         """
+        cal_df = self._select_frames(cal_type, exclude_junk=exclude_junk)
         timed = sorted((self._seconds_since_j2000(fn), fn) for fn in cal_df["FILENAME"])
         clusters = []
         cluster = [timed[0][1]]
@@ -333,7 +359,6 @@ class FileHandler:
         self,
         cal_type,
         *,
-        mini_db=None,
         min_file_count=5,
         cluster_gap_seconds=7200,
         groupby="time_of_day",
@@ -341,7 +366,8 @@ class FileHandler:
     ):
         """
         Return sorted file lists for all calibration stacks of the requested
-        type, grouped from the loaded mini database.
+        type, grouped from the mini database carried on the instance
+        (``self._mini_db``, set by `build_mini_database`).
 
         Drops observer-flagged junk frames (unless `exclude_junk=False`), filters
         by OBJECT, then groups the surviving frames into stacks according to
@@ -358,17 +384,14 @@ class FileHandler:
           routinely straddle HST midnight and belong in a single nightly stack.
 
         Every returned stack has at least `min_file_count` files; undersized
-        stacks are dropped, and it raises when none meets the threshold. Clusters
-        the mini database carried on the instance, so the recipe never handles the
-        DataFrame itself.
+        stacks are dropped, and it raises when none meets the threshold. Reads the
+        mini database off the instance, so the recipe never handles the DataFrame
+        itself.
 
         Parameters
         ----------
         cal_type : str
             Calibration frame type. One of 'bias', 'dark', 'flat', 'thar'.
-        mini_db : pandas.DataFrame, optional
-            DataFrame to cluster; defaults to ``self._mini_db``. Pass one only to
-            cluster a database the handler did not build.
         min_file_count : int, default 5
             Minimum number of files required per stack.
         cluster_gap_seconds : int, default 7200
@@ -389,8 +412,8 @@ class FileHandler:
         ------
         ValueError
             If `groupby` or `cal_type` is not recognized, if no mini database is
-            available (none loaded and none passed), if no calibration frames of
-            the requested type are found, or if no stack meets `min_file_count`.
+            loaded on the instance, if no calibration frames of the requested type
+            are found, or if no stack meets `min_file_count`.
         """
         if groupby not in _GROUPBY_MODES:
             raise ValueError(
@@ -401,37 +424,25 @@ class FileHandler:
                 f"cal_type must be one of {list(_OBJECT_MAP.keys())}; got '{cal_type}'"
             )
 
-        if mini_db is None:
-            mini_db = self._mini_db
-        if mini_db is None:
-            raise ValueError(
-                "no mini database available; call build_mini_database(datecode) "
-                "first (or pass mini_db=)"
-            )
-
-        if exclude_junk:
-            mini_db = mini_db[~mini_db["ISJUNK"].astype(bool)]
-
-        cal_df = mini_db[mini_db["OBJECT"].isin(_OBJECT_MAP[cal_type])]
-
-        if cal_df.empty:
-            raise ValueError(f"No '{cal_type}' calibration frames found")
-
         if groupby == "time_of_day":
             clusters = self._identify_clusters(
-                cal_df, cluster_gap_seconds=cluster_gap_seconds
+                cal_type,
+                cluster_gap_seconds=cluster_gap_seconds,
+                exclude_junk=exclude_junk,
             )
-        elif groupby == "hst_day":
-            # One stack per HST calendar day (the 'YYYYMMDD' HST-timestamp prefix).
-            by_day = {}
-            for fn, hst in zip(cal_df["FILENAME"], cal_df["HST"], strict=True):
-                by_day.setdefault(str(hst).split(".")[0], []).append(fn)
-            clusters = [
-                sorted(v, key=self._seconds_since_j2000)
-                for _, v in sorted(by_day.items())
-            ]
-        else:  # obs_night -- the whole loaded night, one stack spanning HST midnight
-            clusters = [sorted(cal_df["FILENAME"], key=self._seconds_since_j2000)]
+        else:
+            cal_df = self._select_frames(cal_type, exclude_junk=exclude_junk)
+            if groupby == "hst_day":
+                # One stack per HST calendar day (the 'YYYYMMDD' HST-timestamp prefix).
+                by_day = {}
+                for fn, hst in zip(cal_df["FILENAME"], cal_df["HST"], strict=True):
+                    by_day.setdefault(str(hst).split(".")[0], []).append(fn)
+                clusters = [
+                    sorted(v, key=self._seconds_since_j2000)
+                    for _, v in sorted(by_day.items())
+                ]
+            else:  # obs_night -- the whole loaded night, one stack spanning midnight
+                clusters = [sorted(cal_df["FILENAME"], key=self._seconds_since_j2000)]
 
         clusters = [c for c in clusters if len(c) >= min_file_count]
 

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -2,7 +2,6 @@
 
 import glob
 import logging
-import math
 import os
 import warnings
 from datetime import datetime
@@ -51,6 +50,11 @@ _OBJECT_MAP = {
 # (build_calibration_stacks) and master-product filenames (kpf_filename) validate
 # against the same set and cannot drift.
 _CAL_TYPES = tuple(_OBJECT_MAP)
+
+# How build_calibration_stacks groups a cal_type's frames into stacks:
+# 'time_of_day' (per observing session, gap-split), 'hst_day' (per HST calendar
+# day), or 'obs_night' (the whole loaded night, one stack spanning HST midnight).
+_GROUPBY_MODES = ("time_of_day", "hst_day", "obs_night")
 
 
 def load_junk_obs_ids(data_input):
@@ -285,55 +289,43 @@ class FileHandler:
         dt = kpf_timestamp_to_datetime(get_timestamp(s))
         return int((dt - _J2000_EPOCH).total_seconds())
 
-    def _merge_undersized_clusters(
-        self, clusters, hst_day, min_file_count, enforce_hst_midnight_boundary
-    ):
+    def _identify_clusters(self, cal_df, *, cluster_gap_seconds):
         """
-        Fold each undersized cluster into its nearer chronological neighbor.
+        Group calibration frames into observing-session clusters by time gaps.
 
-        Repeatedly takes the smallest cluster below `min_file_count` and merges
-        it into whichever adjacent cluster is nearer in time, until every
-        remaining cluster meets the threshold (or none can grow). When the
-        HST-midnight boundary is enforced the neighbor must share the cluster's
-        HST day (so a master never spans HST midnight), and a cluster with no
-        same-day neighbor is dropped; otherwise any adjacent cluster is eligible.
+        Infers the morn/midday/eve/night/midnight sessions purely from the frame
+        timestamps: the OBJECT morn/eve/night suffix is only a label and does not
+        partition the result, so a mislabeled frame clusters with its true session
+        instead of splitting off. Consecutive time-sorted frames start a new
+        cluster wherever they are more than `cluster_gap_seconds` apart; for the
+        allowlisted cal types the morn and eve sessions sit hours apart, so the gap
+        alone separates them.
 
-        `clusters` is a chronologically-sorted list of filename lists and
-        `hst_day` maps each filename to its HST calendar day ('YYYYMMDD'); the
-        input is not modified and the merged clusters are returned
-        chronologically sorted.
+        Parameters
+        ----------
+        cal_df : pandas.DataFrame
+            OBJECT-filtered, junk-excluded frames for one cal_type; must be
+            non-empty and carry a FILENAME column.
+        cluster_gap_seconds : int
+            Gap [s] between consecutive frames that starts a new cluster.
+
+        Returns
+        -------
+        clusters : list of list of str
+            Chronologically-sorted filename lists, one per detected session.
         """
-        clusters = list(clusters)
-
-        def gap_to(i, j):
-            # Chronological gap [s] from cluster i to neighbor j (i - 1 or i + 1);
-            # inf when j is out of range or -- boundary enforced -- on a different
-            # HST day, marking it ineligible to merge into.
-            if not 0 <= j < len(clusters) or (
-                enforce_hst_midnight_boundary
-                and hst_day[clusters[j][0]] != hst_day[clusters[i][0]]
-            ):
-                return math.inf
-            earlier, later = sorted((i, j))
-            return self._seconds_since_j2000(
-                clusters[later][0]
-            ) - self._seconds_since_j2000(clusters[earlier][-1])
-
-        while len(clusters) > 1 and any(len(c) < min_file_count for c in clusters):
-            i = min(
-                (k for k, c in enumerate(clusters) if len(c) < min_file_count),
-                key=lambda k: len(clusters[k]),
-            )
-            prev_gap = gap_to(i, i - 1)
-            next_gap = gap_to(i, i + 1)
-            if prev_gap == next_gap == math.inf:
-                clusters.pop(i)
-                continue
-            j = i - 1 if prev_gap <= next_gap else i + 1
-            merged = sorted(clusters[i] + clusters[j], key=self._seconds_since_j2000)
-            for idx in sorted((i, j), reverse=True):
-                clusters.pop(idx)
-            clusters.append(merged)
+        timed = sorted((self._seconds_since_j2000(fn), fn) for fn in cal_df["FILENAME"])
+        clusters = []
+        cluster = [timed[0][1]]
+        prev_t = timed[0][0]
+        for t, fn in timed[1:]:
+            if t - prev_t > cluster_gap_seconds:
+                clusters.append(cluster)
+                cluster = [fn]
+            else:
+                cluster.append(fn)
+            prev_t = t
+        clusters.append(cluster)
         clusters.sort(key=lambda c: self._seconds_since_j2000(c[0]))
         return clusters
 
@@ -344,25 +336,30 @@ class FileHandler:
         mini_db=None,
         min_file_count=5,
         cluster_gap_seconds=7200,
-        merge_small_clusters=False,
-        enforce_hst_midnight_boundary=True,
+        groupby="time_of_day",
         exclude_junk=True,
     ):
         """
-        Return sorted file lists for all calibration clusters of the requested
+        Return sorted file lists for all calibration stacks of the requested
         type, grouped from the loaded mini database.
 
         Drops observer-flagged junk frames (unless `exclude_junk=False`), filters
-        by OBJECT, then groups frames into clusters by detecting gaps larger than
-        `cluster_gap_seconds` between consecutive timestamps. By default a cluster
-        never spans two HST (Hawaii) calendar days: frames on either side of HST
-        midnight are always split, even though the UTC-keyed data directory places
-        them together. Set `enforce_hst_midnight_boundary=False` to lift that split
-        (used for darks, whose sparse sequences routinely straddle HST midnight).
-        Every returned cluster has at least `min_file_count` files: undersized
-        clusters are dropped, or (with `merge_small_clusters`) folded into a
-        neighbor. Raises only when no cluster meets the threshold. Clusters the
-        mini database carried on the instance, so the recipe never handles the
+        by OBJECT, then groups the surviving frames into stacks according to
+        `groupby`:
+
+        * ``'time_of_day'`` (default) -- one stack per observing session, split
+          wherever consecutive frames are more than `cluster_gap_seconds` apart
+          (the morn/eve/night sessions). The split is purely temporal, so the
+          morn/eve/night OBJECT suffix does not partition it and a mislabeled
+          frame stacks with its true session. Used for bias and thar.
+        * ``'hst_day'`` -- one stack per HST (Hawaii) calendar day.
+        * ``'obs_night'`` -- one stack for the whole loaded night (the UTC-keyed
+          datecode), spanning HST midnight. Used for darks, whose sparse sequences
+          routinely straddle HST midnight and belong in a single nightly stack.
+
+        Every returned stack has at least `min_file_count` files; undersized
+        stacks are dropped, and it raises when none meets the threshold. Clusters
+        the mini database carried on the instance, so the recipe never handles the
         DataFrame itself.
 
         Parameters
@@ -373,34 +370,32 @@ class FileHandler:
             DataFrame to cluster; defaults to ``self._mini_db``. Pass one only to
             cluster a database the handler did not build.
         min_file_count : int, default 5
-            Minimum number of files required per cluster.
+            Minimum number of files required per stack.
         cluster_gap_seconds : int, default 7200
-            Gap [s] between consecutive frames that splits one cluster from the
-            next. The 2-hour default separates KPF morning vs. evening clusters.
-        merge_small_clusters : bool, default False
-            When False, drop clusters below `min_file_count`; when True, merge
-            each into its nearest-in-time (and, if the boundary is enforced,
-            same-HST-day) neighbor.
-        enforce_hst_midnight_boundary : bool, default True
-            Whether clusters may span HST midnight (see summary). Set False for
-            darks.
+            Gap [s] between consecutive frames that splits one session from the
+            next. The 2-hour default separates KPF morning vs. evening sessions.
+            Applies only to ``groupby='time_of_day'``; ignored otherwise.
+        groupby : {'time_of_day', 'hst_day', 'obs_night'}, default 'time_of_day'
+            How to group frames into stacks (see summary).
         exclude_junk : bool, default True
-            Drop junk frames (the ISJUNK column) before clustering. Rarely
-            disabled.
+            Drop junk frames (the ISJUNK column) before grouping. Rarely disabled.
 
         Returns
         -------
         list of list of str
-            Sorted file lists, one per cluster.
+            Sorted file lists, one per stack.
 
         Raises
         ------
         ValueError
-            If `cal_type` is not a recognized calibration type, if no mini
-            database is available (none loaded and none passed), if no calibration
-            frames of the requested type are found, or if no cluster meets
-            `min_file_count`.
+            If `groupby` or `cal_type` is not recognized, if no mini database is
+            available (none loaded and none passed), if no calibration frames of
+            the requested type are found, or if no stack meets `min_file_count`.
         """
+        if groupby not in _GROUPBY_MODES:
+            raise ValueError(
+                f"groupby must be one of {list(_GROUPBY_MODES)}; got '{groupby}'"
+            )
         if cal_type not in _OBJECT_MAP:
             raise ValueError(
                 f"cal_type must be one of {list(_OBJECT_MAP.keys())}; got '{cal_type}'"
@@ -422,45 +417,27 @@ class FileHandler:
         if cal_df.empty:
             raise ValueError(f"No '{cal_type}' calibration frames found")
 
-        # HST calendar day per file, from the mini_db HST timestamp ('YYYYMMDD...').
-        hst_day = {
-            fn: str(hst).split(".")[0]
-            for fn, hst in zip(cal_df["FILENAME"], cal_df["HST"], strict=True)
-        }
-
-        # Cluster per-OBJECT (morning vs. evening thar etc. have different OBJECT
-        # suffixes), splitting wherever consecutive frames are more than
-        # cluster_gap_seconds apart or fall on different HST days (the UTC-keyed
-        # directory can straddle HST midnight). Final list sorted chronologically.
-        clusters = []
-        for _, group in cal_df.groupby("OBJECT", dropna=False):
-            timed = sorted(
-                (self._seconds_since_j2000(fn), fn) for fn in group["FILENAME"]
+        if groupby == "time_of_day":
+            clusters = self._identify_clusters(
+                cal_df, cluster_gap_seconds=cluster_gap_seconds
             )
-            cluster = [timed[0][1]]
-            for (prev_t, prev_fn), (t, fn) in zip(timed, timed[1:], strict=False):
-                crosses_midnight = (
-                    enforce_hst_midnight_boundary and hst_day[fn] != hst_day[prev_fn]
-                )
-                if t - prev_t > cluster_gap_seconds or crosses_midnight:
-                    clusters.append(cluster)
-                    cluster = [fn]
-                else:
-                    cluster.append(fn)
-            clusters.append(cluster)
-        clusters.sort(key=lambda c: self._seconds_since_j2000(c[0]))
+        elif groupby == "hst_day":
+            # One stack per HST calendar day (the 'YYYYMMDD' HST-timestamp prefix).
+            by_day = {}
+            for fn, hst in zip(cal_df["FILENAME"], cal_df["HST"], strict=True):
+                by_day.setdefault(str(hst).split(".")[0], []).append(fn)
+            clusters = [
+                sorted(v, key=self._seconds_since_j2000)
+                for _, v in sorted(by_day.items())
+            ]
+        else:  # obs_night -- the whole loaded night, one stack spanning HST midnight
+            clusters = [sorted(cal_df["FILENAME"], key=self._seconds_since_j2000)]
 
-        if merge_small_clusters:
-            clusters = self._merge_undersized_clusters(
-                clusters, hst_day, min_file_count, enforce_hst_midnight_boundary
-            )
-        else:
-            # Drop undersized clusters; one usable cluster is enough.
-            clusters = [c for c in clusters if len(c) >= min_file_count]
+        clusters = [c for c in clusters if len(c) >= min_file_count]
 
-        if not any(len(c) >= min_file_count for c in clusters):
+        if not clusters:
             raise ValueError(
-                f"'{cal_type}' has no cluster with at least "
+                f"'{cal_type}' groupby={groupby} produced no cluster with at least "
                 f"min_file_count={min_file_count} files"
             )
         # Which frames feed each master is a decision point (DRP-RUN-08).

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -133,7 +133,7 @@ class FileHandler:
         ``{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv``."""
         return os.path.join(self._data_input, "vNext", "mini_db", f"{datecode}_L0.csv")
 
-    def _load_mini_db_cache(self, datecode):
+    def _read_mini_db_cache(self, datecode):
         """The cached mini database for `datecode` as a DataFrame if the on-disk
         cache is trustworthy for the current L0 directory, else None (the caller
         then rescans). Reads the cache CSV at most once: the loaded frame is both
@@ -188,6 +188,30 @@ class FileHandler:
 
         return cached
 
+    def _write_mini_db_cache(self, datecode):
+        """Atomically write the carried mini database (``self._mini_db``) to the
+        on-disk cache CSV for `datecode`, creating the cache directory as needed.
+
+        pandas' ``to_csv`` truncates the target in place, so a concurrent reader
+        could observe an empty, partial, or half-written CSV. Fill a same-dir temp
+        file and ``os.replace`` it into position instead (atomic on POSIX), so
+        readers always see the old or new CSV whole; clean up the temp file if the
+        write fails.
+        """
+        cache_path = self._mini_db_cache_path(datecode)
+        cache_dir = os.path.dirname(cache_path)
+        os.makedirs(cache_dir, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=cache_dir, suffix=".tmp")
+        os.close(fd)
+        try:
+            self._mini_db.to_csv(tmp, index=False)
+            os.replace(tmp, cache_path)
+        except BaseException:
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            raise
+        logger.info("wrote mini database cache to %s", cache_path)
+
     def build_mini_database(self, datecode, cache=False):
         """
         Scan the PRIMARY header of every L0 FITS file for one observing night,
@@ -197,24 +221,27 @@ class FileHandler:
         ``self._mini_db``, so a subsequent ``build_calibration_stacks`` needs
         only the calibration type; callers rarely need the return value directly.
 
-        With ``cache=True`` the on-disk CSV cache at
-        ``{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv`` is used for both
-        read and write: a *current* cache is loaded instead of re-scanning the L0
-        directory, otherwise the directory is scanned and the result written to
-        the cache (directory created as needed) for next time. A cache is current
-        only when it passes the count and freshness guardrails in
-        ``_load_mini_db_cache``; a frame added, removed, replaced, or
-        rewritten since the cache was built forces a rescan. With ``cache=False``
-        (default) the directory is always scanned and nothing is read from or
-        written to disk.
+        The on-disk CSV cache lives at
+        ``{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv``. `cache` selects which
+        side of it to use, read and write being independent:
+
+        * read (``"r"``) -- load a *current* cache instead of re-scanning the L0
+          directory. A cache is current only when it passes the count and
+          freshness guardrails in ``_read_mini_db_cache``; a frame added, removed,
+          replaced, or rewritten since the cache was built forces a rescan.
+        * write (``"w"``) -- after scanning, (re)write the cache (directory created
+          as needed) for next time. A cache hit on read short-circuits the scan, so
+          nothing is rewritten.
 
         Parameters
         ----------
         datecode : str
             Observing-night datecode 'YYYYMMDD'.
-        cache : bool, default False
-            When True, load the on-disk cache CSV if it is current, else scan and
-            (re)write it. When False, always scan fresh and never touch the cache.
+        cache : {False, "r", "w", "rw", "wr"}, default False
+            Which side(s) of the on-disk cache to use. ``False`` (default) always
+            scans fresh and never touches the cache. ``"r"`` reads a current cache
+            (else scans); ``"w"`` writes the scan result; ``"rw"``/``"wr"`` do both
+            (the read-then-write behavior a plain cache once had).
 
         Returns
         -------
@@ -229,13 +256,21 @@ class FileHandler:
         Raises
         ------
         ValueError
-            If KPF_DATA_INPUT is unset, or if the L0 directory holds no FITS files.
+            If `cache` is not one of the allowed modes, if KPF_DATA_INPUT is
+            unset, or if the L0 directory holds no FITS files.
         """
+        if cache not in (False, "r", "w", "rw", "wr"):
+            raise ValueError(
+                f"cache must be False or one of 'r'/'w'/'rw'/'wr', got {cache!r}"
+            )
+        read_cache = cache and "r" in cache
+        write_cache = cache and "w" in cache
+
         if self._data_input is None:
             raise ValueError("FileHandler has no KPF_DATA_INPUT configured")
 
-        if cache:
-            cached = self._load_mini_db_cache(datecode)
+        if read_cache:
+            cached = self._read_mini_db_cache(datecode)
             if cached is not None:
                 logger.info(
                     "loaded mini database cache from %s",
@@ -275,23 +310,8 @@ class FileHandler:
 
         self._mini_db = pd.DataFrame(mini_db)
 
-        if cache:
-            cache_path = self._mini_db_cache_path(datecode)
-            cache_dir = os.path.dirname(cache_path)
-            os.makedirs(cache_dir, exist_ok=True)
-            # Write atomically: fill a temp file, then os.replace (atomic on
-            # POSIX) so a concurrent reader sees the old or new CSV, never a
-            # truncated/half-written one -- pandas' to_csv truncates in place.
-            fd, tmp = tempfile.mkstemp(dir=cache_dir, suffix=".tmp")
-            os.close(fd)
-            try:
-                self._mini_db.to_csv(tmp, index=False)
-                os.replace(tmp, cache_path)
-            except BaseException:
-                if os.path.exists(tmp):
-                    os.remove(tmp)
-                raise
-            logger.info("wrote mini database cache to %s", cache_path)
+        if write_cache:
+            self._write_mini_db_cache(datecode)
 
         return self._mini_db
 

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -164,7 +164,7 @@ class FileHandler:
 
         cached = pd.read_csv(cache_path)
         if len(cached) != len(file_list):
-            logger.info(
+            logger.warning(
                 "mini database cache %s is stale (%d cached rows vs %d files on "
                 "disk); rescanning",
                 cache_path,
@@ -179,7 +179,7 @@ class FileHandler:
             st = os.stat(fn)
             newest_input = max(newest_input, st.st_mtime, st.st_ctime)
         if cache_mtime < newest_input:
-            logger.info(
+            logger.warning(
                 "mini database cache %s is out of date (older than an L0 input); "
                 "rescanning",
                 cache_path,

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -9,7 +9,6 @@ from datetime import datetime
 import pandas as pd
 from astropy.io import fits
 
-from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.kpf_utils import (
     get_datecode,
     get_obs_id,
@@ -111,25 +110,21 @@ class FileHandler:
 
     Parameters
     ----------
-    config : None | dict | ConfigHandler
-        Source of the ``[DATA_DIRS]`` roots ``KPF_DATA_INPUT`` (the L0 input
-        tree) and ``KPF_MASTERS_OUTPUT`` (the masters output tree). ``None``
-        leaves both unset -- fine for an instance that only calls methods needing
-        the other root; a method whose root is unset raises ``ValueError``.
+    data_dirs : dict
+        The already-extracted ``[DATA_DIRS]`` mapping, holding the roots
+        ``KPF_DATA_INPUT`` (the L0 input tree) and ``KPF_MASTERS_OUTPUT`` (the
+        masters output tree). Required: this is a util, not a pipeline module, so
+        it has no config defaults to fall back on. Callers with a
+        ``ConfigHandler`` pass ``config.get_params(["DATA_DIRS"])`` (this class
+        deliberately does not import ``ConfigHandler``, keeping construction
+        light). Either root may be absent -- fine for an instance that only calls
+        methods needing the other root; a method whose root is unset raises
+        ``ValueError``. Pass ``{}`` for an instance that touches neither root.
     """
 
-    def __init__(self, config=None):
-        if config is None:
-            params = {}
-        elif isinstance(config, dict):
-            params = config
-        elif isinstance(config, ConfigHandler):
-            params = config.get_params(["DATA_DIRS"])
-        else:
-            raise TypeError("config must be None, dict, or ConfigHandler")
-
-        self._data_input = params.get("KPF_DATA_INPUT")
-        self._masters_output = params.get("KPF_MASTERS_OUTPUT")
+    def __init__(self, data_dirs):
+        self._data_input = data_dirs.get("KPF_DATA_INPUT")
+        self._masters_output = data_dirs.get("KPF_MASTERS_OUTPUT")
         self._mini_db = None  # the loaded night, set by build_mini_database
 
     def _mini_db_cache_path(self, datecode):

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -3,6 +3,7 @@
 import glob
 import logging
 import os
+import tempfile
 import warnings
 from datetime import datetime
 
@@ -276,8 +277,20 @@ class FileHandler:
 
         if cache:
             cache_path = self._mini_db_cache_path(datecode)
-            os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-            self._mini_db.to_csv(cache_path, index=False)
+            cache_dir = os.path.dirname(cache_path)
+            os.makedirs(cache_dir, exist_ok=True)
+            # Write atomically: fill a temp file, then os.replace (atomic on
+            # POSIX) so a concurrent reader sees the old or new CSV, never a
+            # truncated/half-written one -- pandas' to_csv truncates in place.
+            fd, tmp = tempfile.mkstemp(dir=cache_dir, suffix=".tmp")
+            os.close(fd)
+            try:
+                self._mini_db.to_csv(tmp, index=False)
+                os.replace(tmp, cache_path)
+            except BaseException:
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+                raise
             logger.info("wrote mini database cache to %s", cache_path)
 
         return self._mini_db

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -132,10 +132,13 @@ class FileHandler:
         ``{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv``."""
         return os.path.join(self._data_input, "vNext", "mini_db", f"{datecode}_L0.csv")
 
-    def _validate_mini_db_cache(self, cache_path, file_list, data_dir):
-        """True if the on-disk mini-db cache is trustworthy for the current L0
-        directory, else False (the caller then rescans). Validation only -- the
-        cache is read (loaded) separately by the caller.
+    def _load_mini_db_cache(self, datecode):
+        """The cached mini database for `datecode` as a DataFrame if the on-disk
+        cache is trustworthy for the current L0 directory, else None (the caller
+        then rescans). Reads the cache CSV at most once: the loaded frame is both
+        validated and returned. The cache path, L0 directory, and its FITS file
+        list are all derived from `datecode` plus the instance's ``KPF_DATA_INPUT``
+        root.
 
         Two guardrails protect against a stale cache:
 
@@ -152,19 +155,22 @@ class FileHandler:
           own ``st_mtime`` (its entry list changes when a file is added or
           removed). A same-count swap thus still invalidates the cache.
         """
+        cache_path = self._mini_db_cache_path(datecode)
+        data_dir = os.path.join(self._data_input, "L0", datecode)
+        file_list = sorted(glob.glob(os.path.join(data_dir, "*.fits")))
         if not file_list or not os.path.isfile(cache_path):
-            return False
+            return None
 
-        n_cached = len(pd.read_csv(cache_path))
-        if n_cached != len(file_list):
+        cached = pd.read_csv(cache_path)
+        if len(cached) != len(file_list):
             logger.info(
                 "mini database cache %s is stale (%d cached rows vs %d files on "
                 "disk); rescanning",
                 cache_path,
-                n_cached,
+                len(cached),
                 len(file_list),
             )
-            return False
+            return None
 
         cache_mtime = os.stat(cache_path).st_mtime
         newest_input = os.stat(data_dir).st_mtime
@@ -177,9 +183,9 @@ class FileHandler:
                 "rescanning",
                 cache_path,
             )
-            return False
+            return None
 
-        return True
+        return cached
 
     def build_mini_database(self, datecode, cache=False):
         """
@@ -196,7 +202,7 @@ class FileHandler:
         directory, otherwise the directory is scanned and the result written to
         the cache (directory created as needed) for next time. A cache is current
         only when it passes the count and freshness guardrails in
-        ``_validate_mini_db_cache``; a frame added, removed, replaced, or
+        ``_load_mini_db_cache``; a frame added, removed, replaced, or
         rewritten since the cache was built forces a rescan. With ``cache=False``
         (default) the directory is always scanned and nothing is read from or
         written to disk.
@@ -227,15 +233,18 @@ class FileHandler:
         if self._data_input is None:
             raise ValueError("FileHandler has no KPF_DATA_INPUT configured")
 
+        if cache:
+            cached = self._load_mini_db_cache(datecode)
+            if cached is not None:
+                logger.info(
+                    "loaded mini database cache from %s",
+                    self._mini_db_cache_path(datecode),
+                )
+                self._mini_db = cached
+                return self._mini_db
+
         data_dir = os.path.join(self._data_input, "L0", datecode)
         file_list = sorted(glob.glob(os.path.join(data_dir, "*.fits")))
-
-        cache_path = self._mini_db_cache_path(datecode)
-        if cache and self._validate_mini_db_cache(cache_path, file_list, data_dir):
-            logger.info("loading mini database cache from %s", cache_path)
-            self._mini_db = pd.read_csv(cache_path)
-            return self._mini_db
-
         if not file_list:
             raise ValueError(f"No FITS files found in {data_dir}")
 
@@ -266,6 +275,7 @@ class FileHandler:
         self._mini_db = pd.DataFrame(mini_db)
 
         if cache:
+            cache_path = self._mini_db_cache_path(datecode)
             os.makedirs(os.path.dirname(cache_path), exist_ok=True)
             self._mini_db.to_csv(cache_path, index=False)
             logger.info("wrote mini database cache to %s", cache_path)

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -397,7 +397,7 @@ class FileHandler:
         self,
         cal_type,
         *,
-        min_file_count=5,
+        min_stack_size=1,
         cluster_gap_seconds=7200,
         groupby="time_of_day",
         exclude_junk=True,
@@ -421,7 +421,7 @@ class FileHandler:
           datecode), spanning HST midnight. Used for darks, whose sparse sequences
           routinely straddle HST midnight and belong in a single nightly stack.
 
-        Every returned stack has at least `min_file_count` files; undersized
+        Every returned stack has at least `min_stack_size` files; undersized
         stacks are dropped, and it raises when none meets the threshold. Reads the
         mini database off the instance, so the recipe never handles the DataFrame
         itself.
@@ -430,8 +430,10 @@ class FileHandler:
         ----------
         cal_type : str
             Calibration frame type. One of 'bias', 'dark', 'flat', 'thar'.
-        min_file_count : int, default 5
-            Minimum number of files required per stack.
+        min_stack_size : int, default 1
+            Minimum number of files required per stack; undersized stacks are
+            dropped. The default of 1 keeps every cluster (a no-op filter); the
+            masters recipe passes the configured per-cal-type value.
         cluster_gap_seconds : int, default 7200
             Gap [s] between consecutive frames that splits one session from the
             next. The 2-hour default separates KPF morning vs. evening sessions.
@@ -451,7 +453,7 @@ class FileHandler:
         ValueError
             If `groupby` or `cal_type` is not recognized, if no mini database is
             loaded on the instance, if no calibration frames of the requested type
-            are found, or if no stack meets `min_file_count`.
+            are found, or if no stack meets `min_stack_size`.
         """
         if groupby not in _GROUPBY_MODES:
             raise ValueError(
@@ -482,12 +484,12 @@ class FileHandler:
             else:  # obs_night -- the whole loaded night, one stack spanning midnight
                 clusters = [sorted(cal_df["FILENAME"], key=self._seconds_since_j2000)]
 
-        clusters = [c for c in clusters if len(c) >= min_file_count]
+        clusters = [c for c in clusters if len(c) >= min_stack_size]
 
         if not clusters:
             raise ValueError(
                 f"'{cal_type}' groupby={groupby} produced no cluster with at least "
-                f"min_file_count={min_file_count} files"
+                f"min_stack_size={min_stack_size} files"
             )
         # Which frames feed each master is a decision point (DRP-RUN-08).
         logger.info(

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -11,7 +11,6 @@ and written to the output data root via the pipeline path helpers.
 import logging
 import os
 
-from kpfpipe.modules.masters.base import BaseMasterModule
 from kpfpipe.modules.masters.bias import Bias
 from kpfpipe.modules.masters.dark import Dark
 
@@ -23,14 +22,6 @@ from kpfpipe.utils.kpf_utils import get_obs_id
 # Explicit name: the CLI execs recipes with __name__ == "recipe", so __name__
 # would not identify this module in the log (style guide section 6).
 logger = logging.getLogger("kpfpipe.recipe.masters")
-
-
-def _min_stack_size(config, cal_type):
-    """Configured minimum stack size for `cal_type`, from its ``[BIAS]``/``[DARK]``/
-    ``[FLAT]`` config section, falling back to the masters-module default when the
-    section omits it (e.g. thar, which has no dedicated section)."""
-    section = config.get_params([cal_type.upper()])
-    return section.get("min_stack_size", BaseMasterModule._DEFAULTS["min_stack_size"])
 
 
 def main(config, args):
@@ -61,7 +52,7 @@ def main(config, args):
     # Stack the bias frames into a master bias used to remove the detector
     # offset from every science and calibration frame.
     for files in file_handler.build_calibration_stacks(
-        "bias", min_stack_size=_min_stack_size(config, "bias")
+        "bias", min_stack_size=config.get_params(["BIAS"]).get("min_stack_size")
     ):
         bias_path = kpf_filepath(
             get_obs_id(files[0]), "L1", data_root=data_root_masters, master="bias"
@@ -75,7 +66,7 @@ def main(config, args):
     # bias from each dark frame (via _process_frame) before stacking.
     for files in file_handler.build_calibration_stacks(
         "dark",
-        min_stack_size=_min_stack_size(config, "dark"),
+        min_stack_size=config.get_params(["DARK"]).get("min_stack_size"),
         groupby="obs_night",
     ):
         dark_path = kpf_filepath(
@@ -94,9 +85,7 @@ def main(config, args):
 
     # Stack the ThAr exposures into a master wavelength solution, since the
     # emission-line spectrum anchors the per-order wavelength calibration.
-    for files in file_handler.build_calibration_stacks(
-        "thar", min_stack_size=_min_stack_size(config, "thar")
-    ):
+    for files in file_handler.build_calibration_stacks("thar"):
         obs_id = get_obs_id(files[0])
         wls_master_path = kpf_filepath(
             obs_id, "L2", data_root=data_root_masters, master="thar"

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -47,7 +47,7 @@ def main(config, args):
     # across the per-cal-type build_calibration_stacks calls below. cache=True
     # reuses the on-disk mini-database CSV when present, else writes it after the
     # scan so re-runs of the night skip the header scan entirely.
-    file_handler = FileHandler(config)
+    file_handler = FileHandler(data_dirs)
     file_handler.build_mini_database(datecode, cache=True)
 
     # Stack the bias frames into a master bias used to remove the detector

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -11,6 +11,7 @@ and written to the output data root via the pipeline path helpers.
 import logging
 import os
 
+from kpfpipe.modules.masters.base import BaseMasterModule
 from kpfpipe.modules.masters.bias import Bias
 from kpfpipe.modules.masters.dark import Dark
 
@@ -22,6 +23,14 @@ from kpfpipe.utils.kpf_utils import get_obs_id
 # Explicit name: the CLI execs recipes with __name__ == "recipe", so __name__
 # would not identify this module in the log (style guide section 6).
 logger = logging.getLogger("kpfpipe.recipe.masters")
+
+
+def _min_stack_size(config, cal_type):
+    """Configured minimum stack size for `cal_type`, from its ``[BIAS]``/``[DARK]``/
+    ``[FLAT]`` config section, falling back to the masters-module default when the
+    section omits it (e.g. thar, which has no dedicated section)."""
+    section = config.get_params([cal_type.upper()])
+    return section.get("min_stack_size", BaseMasterModule._DEFAULTS["min_stack_size"])
 
 
 def main(config, args):
@@ -51,7 +60,9 @@ def main(config, args):
 
     # Stack the bias frames into a master bias used to remove the detector
     # offset from every science and calibration frame.
-    for files in file_handler.build_calibration_stacks("bias"):
+    for files in file_handler.build_calibration_stacks(
+        "bias", min_stack_size=_min_stack_size(config, "bias")
+    ):
         bias_path = kpf_filepath(
             get_obs_id(files[0]), "L1", data_root=data_root_masters, master="bias"
         )
@@ -64,7 +75,7 @@ def main(config, args):
     # bias from each dark frame (via _process_frame) before stacking.
     for files in file_handler.build_calibration_stacks(
         "dark",
-        min_file_count=3,
+        min_stack_size=_min_stack_size(config, "dark"),
         groupby="obs_night",
     ):
         dark_path = kpf_filepath(
@@ -83,7 +94,9 @@ def main(config, args):
 
     # Stack the ThAr exposures into a master wavelength solution, since the
     # emission-line spectrum anchors the per-order wavelength calibration.
-    for files in file_handler.build_calibration_stacks("thar"):
+    for files in file_handler.build_calibration_stacks(
+        "thar", min_stack_size=_min_stack_size(config, "thar")
+    ):
         obs_id = get_obs_id(files[0])
         wls_master_path = kpf_filepath(
             obs_id, "L2", data_root=data_root_masters, master="thar"

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -44,11 +44,10 @@ def main(config, args):
         raise SystemExit(f"L0 data directory not found: {l0_dir}")
 
     # Scan the night's L0 headers once; the handler carries the mini database
-    # across the per-cal-type build_calibration_stacks calls below. cache="rw"
-    # reuses the on-disk mini-database CSV when present, else writes it after the
-    # scan so re-runs of the night skip the header scan entirely.
+    # across the per-cal-type build_calibration_stacks calls below. cache="r"
+    # reuses the on-disk mini-database CSV when present.
     file_handler = FileHandler(data_dirs)
-    file_handler.build_mini_database(datecode, cache="rw")
+    file_handler.build_mini_database(datecode, cache="r")
 
     # Stack the bias frames into a master bias used to remove the detector
     # offset from every science and calibration frame.

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -66,8 +66,7 @@ def main(config, args):
     for files in file_handler.build_calibration_stacks(
         "dark",
         min_file_count=3,
-        merge_small_clusters=True,
-        enforce_hst_midnight_boundary=False,
+        groupby="obs_night",
     ):
         dark_path = kpf_filepath(
             get_obs_id(files[0]), "L1", data_root=data_root_masters, master="dark"

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -44,11 +44,11 @@ def main(config, args):
         raise SystemExit(f"L0 data directory not found: {l0_dir}")
 
     # Scan the night's L0 headers once; the handler carries the mini database
-    # across the per-cal-type build_calibration_stacks calls below. cache=True
+    # across the per-cal-type build_calibration_stacks calls below. cache="rw"
     # reuses the on-disk mini-database CSV when present, else writes it after the
     # scan so re-runs of the night skip the header scan entirely.
     file_handler = FileHandler(data_dirs)
-    file_handler.build_mini_database(datecode, cache=True)
+    file_handler.build_mini_database(datecode, cache="rw")
 
     # Stack the bias frames into a master bias used to remove the detector
     # offset from every science and calibration frame.

--- a/scripts/processing/_argparse.py
+++ b/scripts/processing/_argparse.py
@@ -1,10 +1,10 @@
 """Shared argparse parent parsers for the batch processing CLI commands.
 
 Common flag groups -- recipe/config selection, data-dir overrides, logging
-overrides, and the fan-out pool controls -- factored out so the subcommand
-parsers (``reduce``/``masters``/``science``) compose them via ``parents=[...]``
-instead of each re-declaring the same flags. Every factory returns a fresh
-``add_help=False`` parser to slot in as a parent.
+overrides, the fan-out pool controls, and the mini-db ``--cache`` mode -- factored
+out so the subcommand parsers (``reduce``/``masters``/``science``) compose them via
+``parents=[...]`` instead of each re-declaring the same flags. Every factory
+returns a fresh ``add_help=False`` parser to slot in as a parent.
 
 Depends only on ``argparse`` -- never on ``tools`` -- so, like ``_dispatch.py``,
 the scripts layer stays ignorant of the CLI dispatcher above it.
@@ -106,6 +106,25 @@ def logging_parser():
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("--log_dir", help="override [LOGGER] log_dir")
     p.add_argument("--log_level", help="override [LOGGER] log_level (e.g. DEBUG)")
+    return p
+
+
+def cache_parser(default="r"):
+    """L0 mini-db ``--cache`` mode flag, shared by the batch orchestrators.
+
+    Controls how a command's up-front pre-scan warms the on-disk mini-database
+    cache. The factory default is ``"r"`` (read-only, no warm); the orchestrators
+    that own cache writing pass ``default="rw"``. The leaf ``reduce`` deliberately
+    has no such flag -- recipes read the cache but never write it.
+    """
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument(
+        "--cache",
+        choices=["r", "w", "rw", "wr"],
+        default=default,
+        help="L0 mini-db cache mode: 'r' read-only (skip the pre-scan), 'w' rescan "
+        "and write, 'rw' reuse a current cache else write (default: %(default)s)",
+    )
     return p
 
 

--- a/scripts/processing/_scan.py
+++ b/scripts/processing/_scan.py
@@ -1,0 +1,88 @@
+"""Up-front L0 mini-database cache warming for the batch orchestrators.
+
+The masters and science orchestrators warm the on-disk mini-database cache
+(``{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv``) once, up front, in parallel
+by datecode (``cache="rw"``) before fanning reductions out; every downstream
+``reduce`` then reads it read-only (``cache="r"``). Writing thus happens in one
+place, one thread per distinct cache file, so a future analysis pulling frames from
+multiple nights can never race two writers onto the same file.
+
+``FileHandler`` is not thread-safe (it carries the scanned night on
+``self._mini_db``), so each night gets its own instance; header scans are I/O-bound
+(``fits.getheader`` releases the GIL), so nights fan out across a thread pool. This
+lives apart from ``_dispatch.py`` (the subprocess engine) to keep that module free
+of a ``kpfpipe.utils.io`` import.
+"""
+
+import concurrent.futures
+import logging
+
+from kpfpipe.utils.io import FileHandler
+
+logger = logging.getLogger(__name__)
+
+
+def scan_night_to_cache(data_input, datecode):
+    """Scan one night's L0 headers and (re)write its mini-database cache.
+
+    Builds a fresh ``FileHandler`` for `datecode` and calls
+    ``build_mini_database(datecode, cache="rw")`` (reuse a current cache, else
+    rescan and write). Returns the scanned ``DataFrame``, or ``None`` for an
+    empty/absent night (which ``build_mini_database`` signals with ``ValueError`` --
+    warned and skipped, not fatal); any other error propagates.
+    """
+    file_handler = FileHandler({"KPF_DATA_INPUT": data_input})
+    try:
+        return file_handler.build_mini_database(datecode, cache="rw")
+    except ValueError as e:
+        logger.warning("  skipping night %s: %s", datecode, e)
+        return None
+
+
+def scan_datecodes(datecodes, jobs, worker, *, label="scanning"):
+    """Fan `worker(dc)` out over `datecodes` in a thread pool; return the results.
+
+    A generic parallel dispatcher for the per-night header scans (I/O bound, so a
+    thread pool overlaps the NFS latency). `worker(dc)` returns ``(result, note)``:
+    `result` is appended to the returned list, `note` is an optional string
+    appended to that night's heartbeat, logged in completion order.
+    """
+    n = len(datecodes)
+    logger.info("%s %d night(s) (%d workers)...", label, n, min(jobs, n) if n else 0)
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, jobs)) as pool:
+        futures = {pool.submit(worker, dc): dc for dc in datecodes}
+        for i, future in enumerate(concurrent.futures.as_completed(futures), 1):
+            dc = futures[future]
+            result, note = future.result()
+            results.append(result)
+            logger.info("  [%d/%d] %s%s", i, n, dc, note)
+    return results
+
+
+def warm_mini_db_caches(data_input, datecodes, jobs):
+    """Warm the mini-database cache for every datecode, up front and in parallel.
+
+    The masters/science entry point: writes each night's cache so the fan-out's
+    ``reduce`` subprocesses read it read-only. Side-effect only (DataFrames
+    discarded); returns ``(n_written, n_skipped)``. Fail-soft -- an empty night is
+    skipped and any pool-level failure is swallowed (returns ``(0, len(datecodes))``)
+    so warming never aborts the batch; each reduction falls back to an in-process
+    scan on a miss.
+    """
+
+    def _worker(dc):
+        df = scan_night_to_cache(data_input, dc)
+        return (df is not None, "" if df is not None else " (empty; skipped)")
+
+    logger.info("pre-scanning L0 mini-db caches for %d night(s)...", len(datecodes))
+    try:
+        flags = scan_datecodes(datecodes, jobs, _worker, label="pre-scanning")
+    except Exception as e:
+        logger.warning("mini-db pre-scan failed (%s); reduces will scan in-process", e)
+        return 0, len(datecodes)
+
+    n_written = sum(1 for ok in flags if ok)
+    n_skipped = len(flags) - n_written
+    logger.info("pre-scan done: %d night(s) cached, %d skipped", n_written, n_skipped)
+    return n_written, n_skipped

--- a/scripts/processing/_scan.py
+++ b/scripts/processing/_scan.py
@@ -22,18 +22,19 @@ from kpfpipe.utils.io import FileHandler
 logger = logging.getLogger(__name__)
 
 
-def scan_night_to_cache(data_input, datecode):
-    """Scan one night's L0 headers and (re)write its mini-database cache.
+def scan_night_to_cache(data_input, datecode, cache="rw"):
+    """Scan one night's L0 headers under the given mini-database `cache` mode.
 
     Builds a fresh ``FileHandler`` for `datecode` and calls
-    ``build_mini_database(datecode, cache="rw")`` (reuse a current cache, else
-    rescan and write). Returns the scanned ``DataFrame``, or ``None`` for an
-    empty/absent night (which ``build_mini_database`` signals with ``ValueError`` --
-    warned and skipped, not fatal); any other error propagates.
+    ``build_mini_database(datecode, cache=cache)`` -- with the default ``"rw"``,
+    reuse a current cache else rescan and write. Returns the scanned ``DataFrame``,
+    or ``None`` for an empty/absent night (which ``build_mini_database`` signals
+    with ``ValueError`` -- warned and skipped, not fatal); any other error
+    propagates.
     """
     file_handler = FileHandler({"KPF_DATA_INPUT": data_input})
     try:
-        return file_handler.build_mini_database(datecode, cache="rw")
+        return file_handler.build_mini_database(datecode, cache=cache)
     except ValueError as e:
         logger.warning("  skipping night %s: %s", datecode, e)
         return None
@@ -60,19 +61,24 @@ def scan_datecodes(datecodes, jobs, worker, *, label="scanning"):
     return results
 
 
-def warm_mini_db_caches(data_input, datecodes, jobs):
+def warm_mini_db_caches(data_input, datecodes, jobs, cache="rw"):
     """Warm the mini-database cache for every datecode, up front and in parallel.
 
     The masters/science entry point: writes each night's cache so the fan-out's
-    ``reduce`` subprocesses read it read-only. Side-effect only (DataFrames
-    discarded); returns ``(n_written, n_skipped)``. Fail-soft -- an empty night is
-    skipped and any pool-level failure is swallowed (returns ``(0, len(datecodes))``)
-    so warming never aborts the batch; each reduction falls back to an in-process
-    scan on a miss.
+    ``reduce`` subprocesses read it read-only. A read-only `cache` mode (no ``"w"``)
+    warms nothing, so the pre-scan is skipped entirely and ``(0, len(datecodes))``
+    is returned. Otherwise, side-effect only (DataFrames discarded); returns
+    ``(n_written, n_skipped)``. Fail-soft -- an empty night is skipped and any
+    pool-level failure is swallowed (returns ``(0, len(datecodes))``) so warming
+    never aborts the batch; each reduction falls back to an in-process scan on a
+    miss.
     """
+    if "w" not in cache:
+        logger.info("cache=%s: read-only, skipping mini-db pre-scan", cache)
+        return 0, len(datecodes)
 
     def _worker(dc):
-        df = scan_night_to_cache(data_input, dc)
+        df = scan_night_to_cache(data_input, dc, cache=cache)
         return (df is not None, "" if df is not None else " (empty; skipped)")
 
     logger.info("pre-scanning L0 mini-db caches for %d night(s)...", len(datecodes))

--- a/scripts/processing/_scan.py
+++ b/scripts/processing/_scan.py
@@ -64,14 +64,16 @@ def scan_datecodes(datecodes, jobs, worker, *, label="scanning"):
 def warm_mini_db_caches(data_input, datecodes, jobs, cache="rw"):
     """Warm the mini-database cache for every datecode, up front and in parallel.
 
-    The masters/science entry point: writes each night's cache so the fan-out's
-    ``reduce`` subprocesses read it read-only. A read-only `cache` mode (no ``"w"``)
-    warms nothing, so the pre-scan is skipped entirely and ``(0, len(datecodes))``
-    is returned. Otherwise, side-effect only (DataFrames discarded); returns
-    ``(n_written, n_skipped)``. Fail-soft -- an empty night is skipped and any
-    pool-level failure is swallowed (returns ``(0, len(datecodes))``) so warming
-    never aborts the batch; each reduction falls back to an in-process scan on a
-    miss.
+    The masters/science entry point: leaves each night with a current on-disk cache
+    the fan-out's ``reduce`` subprocesses read read-only. A read-only `cache` mode
+    (no ``"w"``) warms nothing, so the pre-scan is skipped entirely and
+    ``(0, len(datecodes))`` is returned. Otherwise, side-effect only (DataFrames
+    discarded); returns ``(n_cached, n_skipped)`` where `n_cached` counts the nights
+    left with a usable cache (freshly written *or* already current -- the per-night
+    log distinguishes "wrote" from "loaded"). Fail-soft -- an empty night is skipped
+    and any pool-level failure is swallowed (returns ``(0, len(datecodes))``) so
+    warming never aborts the batch; each reduction falls back to an in-process scan
+    on a miss.
     """
     if "w" not in cache:
         logger.info("cache=%s: read-only, skipping mini-db pre-scan", cache)
@@ -88,7 +90,7 @@ def warm_mini_db_caches(data_input, datecodes, jobs, cache="rw"):
         logger.warning("mini-db pre-scan failed (%s); reduces will scan in-process", e)
         return 0, len(datecodes)
 
-    n_written = sum(1 for ok in flags if ok)
-    n_skipped = len(flags) - n_written
-    logger.info("pre-scan done: %d night(s) cached, %d skipped", n_written, n_skipped)
-    return n_written, n_skipped
+    n_cached = sum(1 for ok in flags if ok)
+    n_skipped = len(flags) - n_cached
+    logger.info("pre-scan done: %d night(s) cached, %d skipped", n_cached, n_skipped)
+    return n_cached, n_skipped

--- a/scripts/processing/masters.py
+++ b/scripts/processing/masters.py
@@ -14,10 +14,12 @@ which nights to build, via two mutually exclusive input forms:
 The range form enumerates the datecode dirs present under ``{KPF_DATA_INPUT}/L0``
 within [START, END].
 
-Builds run in a bounded process pool: the first night runs alone as a canary to
-warm the shared on-disk caches, then the rest fan out. The run is fail-soft (a
-night that fails to build is reported and the others continue) but exits nonzero
-if any night failed.
+Builds run in a bounded process pool. The L0 mini-database caches are warmed up
+front by a parallel per-datecode pre-scan; the first night then runs alone as a
+canary to warm the *other* shared caches (barycorrpy leap-seconds, astropy IERS,
+matplotlib fonts, bytecode) before the rest fan out. The run is fail-soft (a night
+that fails to build is reported and the others continue) but exits nonzero if any
+night failed.
 """
 
 import argparse
@@ -44,6 +46,7 @@ from scripts.processing._dispatch import (
     configure_runtime,
     run_stage,
 )
+from scripts.processing._scan import warm_mini_db_caches
 
 logger = logging.getLogger(__name__)
 
@@ -230,6 +233,9 @@ def main(argv=None):
     logger.info(
         "building masters for %d night(s): %s", len(datecodes), ", ".join(datecodes)
     )
+
+    # Warm the L0 mini-db caches up front, one thread per night
+    warm_mini_db_caches(data_input, datecodes, args.jobs)
 
     tasks = [
         _cli_task(dc, forward, config=args.config, recipe=args.recipe)

--- a/scripts/processing/masters.py
+++ b/scripts/processing/masters.py
@@ -15,7 +15,9 @@ The range form enumerates the datecode dirs present under ``{KPF_DATA_INPUT}/L0`
 within [START, END].
 
 Builds run in a bounded process pool. The L0 mini-database caches are warmed up
-front by a parallel per-datecode pre-scan; the first night then runs alone as a
+front by a parallel per-datecode pre-scan (``--cache``, ``rw`` by default; ``r``
+skips the pre-scan and leaves each reduce to read-only); the first night then runs
+alone as a
 canary to warm the *other* shared caches (barycorrpy leap-seconds, astropy IERS,
 matplotlib fonts, bytecode) before the rest fan out. The run is fail-soft (a night
 that fails to build is reported and the others continue) but exits nonzero if any
@@ -34,6 +36,7 @@ from kpfpipe.utils.kpf_utils import is_datecode
 from kpfpipe.utils.logger import setup_batch_logging
 from scripts.processing import DEFAULT_MASTERS_CONFIG, DEFAULT_MASTERS_RECIPE
 from scripts.processing._argparse import (
+    cache_parser,
     data_dirs_parser,
     logging_parser,
     pool_parser,
@@ -83,6 +86,7 @@ def parse_args(argv=None):
             data_dirs_parser(science_output=False),
             logging_parser(),
             pool_parser(jobs_help=_JOBS_HELP),
+            cache_parser(default="rw"),
         ],
     )
     ap.add_argument(
@@ -234,8 +238,9 @@ def main(argv=None):
         "building masters for %d night(s): %s", len(datecodes), ", ".join(datecodes)
     )
 
-    # Warm the L0 mini-db caches up front, one thread per night
-    warm_mini_db_caches(data_input, datecodes, args.jobs)
+    # Warm the L0 mini-db caches up front, one thread per night (--cache, rw
+    # default; --cache r skips the pre-scan and leaves reduces to read-only).
+    warm_mini_db_caches(data_input, datecodes, args.jobs, cache=args.cache)
 
     tasks = [
         _cli_task(dc, forward, config=args.config, recipe=args.recipe)

--- a/scripts/processing/science.py
+++ b/scripts/processing/science.py
@@ -12,8 +12,10 @@ the orchestrator, not here), via the input form:
     kpfpipe science --obs_ids frames.txt        # a file of obs_ids
 
 Reductions run in a bounded process pool. The L0 mini-database caches for the
-nights the frames span are warmed up front by a parallel per-datecode pre-scan;
-the first frame then runs alone as a canary to warm the *other* shared caches,
+nights the frames span are warmed up front by a parallel per-datecode pre-scan
+(``--cache``, ``rw`` by default; ``r`` skips the pre-scan and leaves each reduce to
+read-only); the first frame then runs alone as a canary to warm the *other* shared
+caches,
 then the rest fan out (paced apart, since the per-frame L0 pointing QC queries
 SIMBAD/Gaia). The run is fail-soft (a frame that fails to reduce is reported and
 the others continue) but exits nonzero if any frame failed.
@@ -31,6 +33,7 @@ from kpfpipe.utils.kpf_utils import get_datecode, is_obs_id
 from kpfpipe.utils.logger import setup_batch_logging
 from scripts.processing import DEFAULT_SCIENCE_CONFIG, DEFAULT_SCIENCE_RECIPE
 from scripts.processing._argparse import (
+    cache_parser,
     data_dirs_parser,
     logging_parser,
     pool_parser,
@@ -70,6 +73,7 @@ def parse_args(argv=None):
             data_dirs_parser(science_output=True),
             logging_parser(),
             pool_parser(jobs_help=_JOBS_HELP),
+            cache_parser(default="rw"),
         ],
     )
     ap.add_argument(
@@ -180,9 +184,10 @@ def main(argv=None):
     logger.info("batch log: %s", log_path)
     logger.info("reducing %d science frame(s): %s", len(obs_ids), ", ".join(obs_ids))
 
-    # Warm the L0 mini-db caches up front, one thread per night
+    # Warm the L0 mini-db caches up front, one thread per night (--cache, rw
+    # default; --cache r skips the pre-scan and leaves reduces to read-only).
     datecodes = sorted({get_datecode(o) for o in obs_ids})
-    warm_mini_db_caches(data_input, datecodes, args.jobs)
+    warm_mini_db_caches(data_input, datecodes, args.jobs, cache=args.cache)
 
     tasks = [
         _cli_task(o, forward, config=args.config, recipe=args.recipe) for o in obs_ids

--- a/scripts/processing/science.py
+++ b/scripts/processing/science.py
@@ -11,11 +11,12 @@ the orchestrator, not here), via the input form:
     kpfpipe science --obs_ids KP.20240405.40113.57 KP.20240405.40237.36
     kpfpipe science --obs_ids frames.txt        # a file of obs_ids
 
-Reductions run in a bounded process pool: the first frame runs alone as a canary
-to warm the shared on-disk caches, then the rest fan out (paced apart, since the
-per-frame L0 pointing QC queries SIMBAD/Gaia). The run is fail-soft (a frame that
-fails to reduce is reported and the others continue) but exits nonzero if any
-frame failed.
+Reductions run in a bounded process pool. The L0 mini-database caches for the
+nights the frames span are warmed up front by a parallel per-datecode pre-scan;
+the first frame then runs alone as a canary to warm the *other* shared caches,
+then the rest fan out (paced apart, since the per-frame L0 pointing QC queries
+SIMBAD/Gaia). The run is fail-soft (a frame that fails to reduce is reported and
+the others continue) but exits nonzero if any frame failed.
 """
 
 import argparse
@@ -26,7 +27,7 @@ import sys
 import kpfpipe
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import read_token_file
-from kpfpipe.utils.kpf_utils import is_obs_id
+from kpfpipe.utils.kpf_utils import get_datecode, is_obs_id
 from kpfpipe.utils.logger import setup_batch_logging
 from scripts.processing import DEFAULT_SCIENCE_CONFIG, DEFAULT_SCIENCE_RECIPE
 from scripts.processing._argparse import (
@@ -41,6 +42,7 @@ from scripts.processing._dispatch import (
     configure_runtime,
     run_stage,
 )
+from scripts.processing._scan import warm_mini_db_caches
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +144,9 @@ def main(argv=None):
     # the log dir; subprocesses get recipe/config via -r/-c.
     config = ConfigHandler(args.config or DEFAULT_SCIENCE_CONFIG)
     logger_params = config.get_params(["LOGGER"])
+    data_input = (
+        args.kpf_data_input or config.get_params(["DATA_DIRS"])["KPF_DATA_INPUT"]
+    )
     log_dir = args.log_dir or logger_params.get("log_dir")
     if not log_dir:
         sys.exit(
@@ -174,6 +179,10 @@ def main(argv=None):
     logger.info("jobs: %s", args.jobs)
     logger.info("batch log: %s", log_path)
     logger.info("reducing %d science frame(s): %s", len(obs_ids), ", ".join(obs_ids))
+
+    # Warm the L0 mini-db caches up front, one thread per night
+    datecodes = sorted({get_datecode(o) for o in obs_ids})
+    warm_mini_db_caches(data_input, datecodes, args.jobs)
 
     tasks = [
         _cli_task(o, forward, config=args.config, recipe=args.recipe) for o in obs_ids

--- a/scripts/processing/timeseries.py
+++ b/scripts/processing/timeseries.py
@@ -194,7 +194,7 @@ def discover_science_obs_ids(data_input, target, start, end, jobs):
     """Raw science obs_ids for `target` over [start, end], from the L0 tree.
 
     Scans each night (datecode dir) under {data_input}/L0 via
-    FileHandler.build_mini_database (cache=True: reuse the night's on-disk CSV when
+    FileHandler.build_mini_database (cache="rw": reuse the night's on-disk CSV when
     present, else write it), keeping frames whose IMTYPE is 'Object' and OBJECT
     matches `target`. Non-datecode entries are skipped with a note; observer-flagged
     junk frames (the ISJUNK column) are dropped. Exits loudly when the tree is
@@ -226,7 +226,7 @@ def discover_science_obs_ids(data_input, target, start, end, jobs):
         # self._mini_db, so one instance across these pooled threads would race.
         file_handler = FileHandler({"KPF_DATA_INPUT": data_input})
         try:
-            df = file_handler.build_mini_database(dc, cache=True)
+            df = file_handler.build_mini_database(dc, cache="rw")
         except ValueError as e:
             # e.g. a datecode dir with no FITS files -- skip it, don't abort.
             logger.warning("  skipping night %s: %s", dc, e)

--- a/scripts/processing/timeseries.py
+++ b/scripts/processing/timeseries.py
@@ -29,7 +29,6 @@ it. The run exits nonzero if any stage that ran reported a failure.
 """
 
 import argparse
-import concurrent.futures
 import logging
 import os
 import subprocess
@@ -37,7 +36,7 @@ import sys
 
 import kpfpipe
 from kpfpipe.utils.config import ConfigHandler
-from kpfpipe.utils.io import FileHandler, datecode_dirs_in_range
+from kpfpipe.utils.io import datecode_dirs_in_range
 from kpfpipe.utils.kpf_utils import get_datecode, get_obs_id, is_datecode
 from kpfpipe.utils.logger import setup_batch_logging
 from scripts.processing import (
@@ -53,6 +52,7 @@ from scripts.processing._argparse import (
     resolve_dir_shortcuts,
 )
 from scripts.processing._dispatch import _default_science_jobs
+from scripts.processing._scan import scan_datecodes, scan_night_to_cache
 
 logger = logging.getLogger(__name__)
 
@@ -157,48 +157,15 @@ def parse_args(argv=None):
     return resolve_dir_shortcuts(args)
 
 
-def _scan_nights(nights, target, worker, jobs):
-    """Fan `worker(dc)` out over `nights` in a thread pool; return the pooled hits.
-
-    Scanning a night reads every PRIMARY header -- I/O bound, so a thread pool
-    overlaps the NFS latency (``getheader`` releases the GIL during I/O).
-    `worker(dc)` returns ``(hits, note)``: that night's obs_ids and an optional
-    note, logged as a per-night heartbeat in completion order.
-    """
-    logger.info(
-        "scanning %d night(s) for target %s (%d workers)...",
-        len(nights),
-        target,
-        min(jobs, len(nights)),
-    )
-    hits_all = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
-        futures = {pool.submit(worker, dc): dc for dc in nights}
-        for i, future in enumerate(concurrent.futures.as_completed(futures), 1):
-            dc = futures[future]
-            hits, note = future.result()
-            hits_all.extend(hits)
-            logger.info(
-                "  [%d/%d] %s: %d matching frame(s)%s (total %d)",
-                i,
-                len(nights),
-                dc,
-                len(hits),
-                note,
-                len(hits_all),
-            )
-    return hits_all
-
-
 def discover_science_obs_ids(data_input, target, start, end, jobs):
     """Raw science obs_ids for `target` over [start, end], from the L0 tree.
 
-    Scans each night (datecode dir) under {data_input}/L0 via
-    FileHandler.build_mini_database (cache="rw": reuse the night's on-disk CSV when
-    present, else write it), keeping frames whose IMTYPE is 'Object' and OBJECT
-    matches `target`. Non-datecode entries are skipped with a note; observer-flagged
-    junk frames (the ISJUNK column) are dropped. Exits loudly when the tree is
-    missing or nothing matches.
+    Scans each night (datecode dir) under {data_input}/L0 via the shared
+    ``scan_night_to_cache`` (cache="rw": reuse the night's on-disk CSV when present,
+    else write it), keeping frames whose IMTYPE is 'Object' and OBJECT matches
+    `target`. Non-datecode entries are skipped with a note; observer-flagged junk
+    frames (the ISJUNK column) are dropped. Exits loudly when the tree is missing or
+    nothing matches.
     """
     l0_root = os.path.join(data_input, "L0")
     if not os.path.isdir(l0_root):
@@ -222,24 +189,22 @@ def discover_science_obs_ids(data_input, target, start, end, jobs):
         sys.exit(f"error: no datecode dirs under {l0_root} in range {start}..{end}")
 
     def _scan_night(dc):
-        # A FileHandler per night (not shared): it carries the scanned night on
-        # self._mini_db, so one instance across these pooled threads would race.
-        file_handler = FileHandler({"KPF_DATA_INPUT": data_input})
-        try:
-            df = file_handler.build_mini_database(dc, cache="rw")
-        except ValueError as e:
-            # e.g. a datecode dir with no FITS files -- skip it, don't abort.
-            logger.warning("  skipping night %s: %s", dc, e)
+        df = scan_night_to_cache(data_input, dc)
+        if df is None:  # empty/absent night -- already warned, skip it
             return [], ""
         is_object = df["IMTYPE"].astype(str).str.strip() == "Object"
         is_target = df["OBJECT"].astype(str).str.strip() == str(target)
         matched = df.loc[is_object & is_target]
         good = matched.loc[~matched["ISJUNK"].astype(bool)]
         n_junk = len(matched) - len(good)
-        note = f", {n_junk} junk skipped" if n_junk else ""
-        return [get_obs_id(fn) for fn in good["FILENAME"]], note
+        hits = [get_obs_id(fn) for fn in good["FILENAME"]]
+        junk_note = f", {n_junk} junk skipped" if n_junk else ""
+        return hits, f": {len(hits)} matching frame(s){junk_note}"
 
-    obs_ids = _scan_nights(nights, target, _scan_night, jobs)
+    results = scan_datecodes(
+        nights, jobs, _scan_night, label=f"scanning for target {target},"
+    )
+    obs_ids = [oid for hits in results for oid in hits]
 
     obs_ids = sorted(set(obs_ids))
     if not obs_ids:

--- a/scripts/processing/timeseries.py
+++ b/scripts/processing/timeseries.py
@@ -17,6 +17,10 @@ one ``reduce`` per unit, and the standalone plotter), so the robust fan-out,
 timeout, and interrupt handling live in the orchestrators. The plotter is handed
 the already-discovered obs_ids, so it does no second scan.
 
+Discovery doubles as the sole L0 mini-db cache warm (``--cache``, ``rw`` by
+default); the masters and science stages it launches are told ``--cache r`` so they
+read those caches rather than redundantly re-warming them.
+
 All three stages run by default; ``--no-masters`` / ``--no-science`` / ``--no-plots``
 skip any (discovery always runs). The stages are fail-soft and independent: every
 discovered frame is handed to science regardless of the masters result (a frame
@@ -46,6 +50,7 @@ from scripts.processing import (
     DEFAULT_SCIENCE_RECIPE,
 )
 from scripts.processing._argparse import (
+    cache_parser,
     data_dirs_parser,
     logging_parser,
     pool_parser,
@@ -75,6 +80,7 @@ def parse_args(argv=None):
             data_dirs_parser(science_output=True),
             logging_parser(),
             pool_parser(jobs_help=_JOBS_HELP),
+            cache_parser(default="rw"),
         ],
     )
     ap.add_argument(
@@ -157,15 +163,17 @@ def parse_args(argv=None):
     return resolve_dir_shortcuts(args)
 
 
-def discover_science_obs_ids(data_input, target, start, end, jobs):
+def discover_science_obs_ids(data_input, target, start, end, jobs, cache="rw"):
     """Raw science obs_ids for `target` over [start, end], from the L0 tree.
 
     Scans each night (datecode dir) under {data_input}/L0 via the shared
-    ``scan_night_to_cache`` (cache="rw": reuse the night's on-disk CSV when present,
-    else write it), keeping frames whose IMTYPE is 'Object' and OBJECT matches
-    `target`. Non-datecode entries are skipped with a note; observer-flagged junk
-    frames (the ISJUNK column) are dropped. Exits loudly when the tree is missing or
-    nothing matches.
+    ``scan_night_to_cache`` under the given `cache` mode (``"rw"`` by default: reuse
+    the night's on-disk CSV when present, else write it), keeping frames whose
+    IMTYPE is 'Object' and OBJECT matches `target`. This discovery scan is the sole
+    mini-db writer in the timeseries flow -- the masters/science stages it launches
+    are told ``--cache r`` (see ``main``). Non-datecode entries are skipped with a
+    note; observer-flagged junk frames (the ISJUNK column) are dropped. Exits loudly
+    when the tree is missing or nothing matches.
     """
     l0_root = os.path.join(data_input, "L0")
     if not os.path.isdir(l0_root):
@@ -189,7 +197,7 @@ def discover_science_obs_ids(data_input, target, start, end, jobs):
         sys.exit(f"error: no datecode dirs under {l0_root} in range {start}..{end}")
 
     def _scan_night(dc):
-        df = scan_night_to_cache(data_input, dc)
+        df = scan_night_to_cache(data_input, dc, cache=cache)
         if df is None:  # empty/absent night -- already warned, skip it
             return [], ""
         is_object = df["IMTYPE"].astype(str).str.strip() == "Object"
@@ -271,6 +279,9 @@ def main(argv=None):
         if value:
             common_forward += [flag, value]
     common_forward += ["--job_timeout", str(args.job_timeout)]
+    # Discovery above is the sole mini-db writer; force both launched stages
+    # read-only so they don't redundantly re-warm the caches it just wrote.
+    common_forward += ["--cache", "r"]
 
     # --jobs sizes only the science fan-out: forwarding a large --jobs to masters
     # would defeat its fixed _MASTERS_JOBS safety cap (see _dispatch.py), so --jobs
@@ -294,7 +305,7 @@ def main(argv=None):
     # Steps 1-2: discover the target's science frames -> the nights they span.
     scan_workers = args.jobs or _default_science_jobs()
     obs_ids = discover_science_obs_ids(
-        data_input, args.target, start, end, scan_workers
+        data_input, args.target, start, end, scan_workers, cache=args.cache
     )
     datecodes = sorted({get_datecode(o) for o in obs_ids})
     logger.info(

--- a/tests/profiling/_profiling.py
+++ b/tests/profiling/_profiling.py
@@ -222,7 +222,7 @@ def masters_l0_files(imtype):
     file_handler = FileHandler({"KPF_DATA_INPUT": str(TESTDATA_DIR)})
     file_handler.build_mini_database(MASTERS_DATECODE)
     if imtype == "dark":
-        kwargs = {"min_file_count": 3, "groupby": "obs_night"}
+        kwargs = {"min_stack_size": 3, "groupby": "obs_night"}
     else:
         kwargs = {"cluster_gap_seconds": MASTERS_CLUSTER_GAP_SECONDS}
     return file_handler.build_calibration_stacks(imtype, **kwargs)[0]

--- a/tests/profiling/_profiling.py
+++ b/tests/profiling/_profiling.py
@@ -204,10 +204,9 @@ def bary_l2(config):
 
 # --- masters inputs --------------------------------------------------------
 
-# The bundled darks span two default-gap clusters, so we widen the gap to group
-# the five frames into one stack — the same accommodation the master-dark
-# regression test makes (see tests/regression/test_master_dark.py). Harmless
-# for bias/thar, which already form a single cluster.
+# Widen the time_of_day gap so bias/thar's frames form a single representative
+# stack rather than splitting morn/eve. Darks instead use groupby='obs_night'
+# (the whole night in one stack), matching recipes/kpf_drp_masters.py.
 MASTERS_CLUSTER_GAP_SECONDS = 24 * 3600
 
 # Reading masters (bias/dark/flat/thar) for the dark and WLS harnesses, which
@@ -222,9 +221,11 @@ def masters_l0_files(imtype):
 
     file_handler = FileHandler({"KPF_DATA_INPUT": str(TESTDATA_DIR)})
     file_handler.build_mini_database(MASTERS_DATECODE)
-    return file_handler.build_calibration_stacks(
-        imtype, cluster_gap_seconds=MASTERS_CLUSTER_GAP_SECONDS
-    )[0]
+    if imtype == "dark":
+        kwargs = {"min_file_count": 3, "groupby": "obs_night"}
+    else:
+        kwargs = {"cluster_gap_seconds": MASTERS_CLUSTER_GAP_SECONDS}
+    return file_handler.build_calibration_stacks(imtype, **kwargs)[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/profiling/profile_master_wls.py
+++ b/tests/profiling/profile_master_wls.py
@@ -27,7 +27,7 @@ def run():
         title="Master WLS (WLS.make_master_l2)",
         report_name="master_wls",
         setup=setup,
-        call=lambda mod: mod.make_master_l2(verbose=False),
+        call=lambda mod: mod.make_master_l2(),
         candidate_modules=[m_wls, m_base],
     )
 

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -2,8 +2,6 @@
 Unit tests for CalibrationAssociation.
 """
 
-import warnings
-
 import pytest
 from astropy.io import fits
 
@@ -144,20 +142,6 @@ class TestFindMasterFiles:
 
         assert len(result) == 1
         assert result[0][0].endswith("KP.20240405.03637.74_master_bias_L1.fits")
-
-    def test_unparseable_timestamp_silent_when_verbose_false(self, tmp_path):
-        d = tmp_path / "masters" / "20240405"
-        d.mkdir(parents=True)
-        (d / "nostamp_master_bias_L1.fits").touch()
-
-        mod = _make_module(tmp_path)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
-            result = mod._find_master_files(
-                "bias", "2024-04-05T11:08:33", verbose=False
-            )
-
-        assert result == []
 
     def test_ignores_wrong_cal_type(self, tmp_path):
         d = tmp_path / "masters" / "20240405"

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -691,9 +691,9 @@ def _touch_newer(cache, l0_dir):
 
 
 class TestMiniDatabaseCache:
-    def test_cache_true_writes_csv_on_scan(self, tmp_path):
+    def test_cache_write_writes_csv_on_scan(self, tmp_path):
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
-        db = fh.build_mini_database("20240405", cache=True)
+        db = fh.build_mini_database("20240405", cache="rw")
 
         cache = tmp_path / "vNext" / "mini_db" / "20240405_L0.csv"
         assert cache.is_file()
@@ -703,7 +703,7 @@ class TestMiniDatabaseCache:
         assert len(cached) == len(db)
         assert cached["FILENAME"].tolist() == db["FILENAME"].tolist()
 
-    def test_cache_true_reads_current_cache_without_scanning(self, tmp_path):
+    def test_cache_read_reads_current_cache_without_scanning(self, tmp_path):
         # A current cache (row count matches disk, newer than every input) is
         # loaded verbatim, not rescanned. Prove it by seeding a SENTINEL FILENAME
         # a real scan would never produce, then asserting it survives.
@@ -711,8 +711,27 @@ class TestMiniDatabaseCache:
         cache = _seed_cache(tmp_path, "20240405", ["/sentinel.fits"])
         _touch_newer(cache, tmp_path / "L0" / "20240405")
 
-        db = fh.build_mini_database("20240405", cache=True)
+        db = fh.build_mini_database("20240405", cache="rw")
         assert db["FILENAME"].tolist() == ["/sentinel.fits"]
+
+    def test_cache_read_only_does_not_write(self, tmp_path):
+        # "r" reads a current cache but, on a miss, never writes one back.
+        fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
+        db = fh.build_mini_database("20240405", cache="r")
+
+        assert len(db) == 1  # scanned fresh (no cache to read)
+        assert not (tmp_path / "vNext" / "mini_db").exists()  # and none written
+
+    def test_cache_write_only_does_not_read(self, tmp_path):
+        # "w" writes the scan result but ignores an existing cache on read: the
+        # seeded sentinel is overwritten by a real scan, not loaded.
+        fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
+        cache = _seed_cache(tmp_path, "20240405", ["/sentinel.fits"])
+        _touch_newer(cache, tmp_path / "L0" / "20240405")
+
+        db = fh.build_mini_database("20240405", cache="w")
+        assert "/sentinel.fits" not in db["FILENAME"].tolist()
+        assert pd.read_csv(cache)["FILENAME"].tolist() == db["FILENAME"].tolist()
 
     def test_cache_stale_row_count_rescans(self, tmp_path):
         # Cache lists one frame but two are on disk -> count guardrail rejects it.
@@ -721,7 +740,7 @@ class TestMiniDatabaseCache:
         cache = _seed_cache(tmp_path, "20240405", ["/sentinel.fits"])
         _touch_newer(cache, tmp_path / "L0" / "20240405")
 
-        db = fh.build_mini_database("20240405", cache=True)
+        db = fh.build_mini_database("20240405", cache="rw")
         assert len(db) == 2
         assert "/sentinel.fits" not in db["FILENAME"].tolist()
 
@@ -731,7 +750,7 @@ class TestMiniDatabaseCache:
         cache = _seed_cache(tmp_path, "20240405", ["/sentinel.fits"])
         os.utime(cache, (1_000_000, 1_000_000))  # far in the past
 
-        db = fh.build_mini_database("20240405", cache=True)
+        db = fh.build_mini_database("20240405", cache="rw")
         assert "/sentinel.fits" not in db["FILENAME"].tolist()
         expected = os.path.join(
             str(tmp_path), "L0", "20240405", "KP.20240405.01000.00.fits"
@@ -742,6 +761,11 @@ class TestMiniDatabaseCache:
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
         fh.build_mini_database("20240405")  # cache defaults to False
         assert not (tmp_path / "vNext" / "mini_db").exists()
+
+    def test_invalid_cache_mode_raises(self, tmp_path):
+        fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
+        with pytest.raises(ValueError, match="cache must be False"):
+            fh.build_mini_database("20240405", cache=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -220,70 +220,32 @@ class TestBuildCalibrationStacks:
         assert len(lists) == 1
         assert lists[0] == sorted(_BIAS_A)
 
-    def test_merge_folds_small_into_neighbor(self):
-        db, small = _mixed_bias_db()
-        lists = _cluster("bias", db, merge_small_clusters=True)
-        assert len(lists) == 1
-        assert lists[0] == sorted(_BIAS_A + small)
+    def test_invalid_groupby_raises(self):
+        with pytest.raises(ValueError, match="groupby must be one of"):
+            _cluster("bias", _make_mini_db(), groupby="bogus")
 
-    def test_merge_combines_two_small_clusters(self):
-        # Two 5-file bias clusters, each below min=6; merged into one of 10.
-        lists = _cluster(
-            "bias", _make_mini_db(), min_file_count=6, merge_small_clusters=True
-        )
-        assert len(lists) == 1
-        assert len(lists[0]) == 10
-
-    def test_merge_raises_when_total_below_min(self):
-        # 7 bias files total (5 + 2); merging cannot reach min=8 → raises.
-        db, _ = _mixed_bias_db()
-        with pytest.raises(ValueError, match="no cluster with at least"):
-            _cluster("bias", db, min_file_count=8, merge_small_clusters=True)
-
-    def test_hst_midnight_splits_cluster(self):
-        # Same-OBJECT frames <gap apart but on opposite sides of HST midnight
-        # (UTC 36000) must not share a cluster.
+    def test_time_of_day_ignores_hst_boundary(self):
+        # time_of_day splits on time gaps alone: frames <gap apart but on opposite
+        # sides of HST midnight now share one cluster (there is no midnight split).
         db, before, after = _midnight_bias_db()
         lists = _cluster("bias", db, min_file_count=5)
+        assert len(lists) == 1
+        assert lists[0] == sorted(before + after)
+
+    def test_hst_day_splits_at_midnight(self):
+        # groupby='hst_day' puts each HST calendar day in its own stack, even when
+        # the frames are <gap apart across HST midnight.
+        db, before, after = _midnight_bias_db()
+        lists = _cluster("bias", db, min_file_count=5, groupby="hst_day")
         assert len(lists) == 2
         assert lists[0] == sorted(before)
         assert lists[1] == sorted(after)
 
-    def test_hst_midnight_blocks_merge(self):
-        # A small post-midnight cluster has no same-HST-day neighbor, so it is
-        # dropped rather than merged across midnight into the pre-midnight one.
-        db, before, _ = _midnight_bias_db(n_before=5, n_after=2)
-        lists = _cluster("bias", db, min_file_count=5, merge_small_clusters=True)
-        assert len(lists) == 1
-        assert lists[0] == sorted(before)
-
-    def test_no_boundary_keeps_cross_midnight_cluster(self):
-        # With enforce_hst_midnight_boundary=False, frames <gap apart across HST
-        # midnight stay in one cluster (only cluster_gap_seconds can split them).
-        db, before, after = _midnight_bias_db()
-        lists = _cluster(
-            "bias",
-            db,
-            min_file_count=5,
-            enforce_hst_midnight_boundary=False,
-        )
-        assert len(lists) == 1
-        assert lists[0] == sorted(before + after)
-
-    def test_no_boundary_merges_across_midnight(self):
-        # Two sparse dark clusters on opposite HST days (the 20240806 case): with
-        # the boundary enforced they cannot merge and both drop; with it lifted
-        # they merge into one cluster that meets the threshold.
+    def test_obs_night_single_stack_spans_midnight(self):
+        # groupby='obs_night' groups the whole loaded night into one stack,
+        # spanning both a >2 h gap and HST midnight (the 20240806 sparse-dark case).
         db, before, after = _cross_midnight_gap_db()
-        with pytest.raises(ValueError, match="no cluster with at least"):
-            _cluster("dark", db, min_file_count=3, merge_small_clusters=True)
-        lists = _cluster(
-            "dark",
-            db,
-            min_file_count=3,
-            merge_small_clusters=True,
-            enforce_hst_midnight_boundary=False,
-        )
+        lists = _cluster("dark", db, min_file_count=3, groupby="obs_night")
         assert len(lists) == 1
         assert lists[0] == sorted(before + after)
 
@@ -338,22 +300,14 @@ class TestBuildCalibrationStacksRealData:
         with pytest.raises(ValueError, match="no cluster with at least"):
             fh.build_calibration_stacks("dark")
 
-    def test_dark_merge_respects_hst_boundary(self, fh):
-        # The 5 dark frames span two HST days (2 on one, 3 on the next), so they
-        # can never merge into a single >=5 master without crossing HST midnight.
-        # With the default min=5, no same-HST-day cluster reaches the threshold →
-        # raises even with merge_small_clusters.
-        with pytest.raises(ValueError, match="no cluster with at least"):
-            fh.build_calibration_stacks("dark", merge_small_clusters=True)
-
-    def test_dark_merges_within_hst_day(self, fh):
-        # Lowering min to 3 lets the 3 same-HST-day darks merge into one cluster;
-        # the 2 frames on the other HST day are dropped (no same-day neighbor).
+    def test_dark_obs_night_single_stack(self, fh):
+        # The recipe's dark usage: the night's 5 dark frames span two HST days
+        # (2 + 3), and groupby='obs_night' groups them into one nightly stack.
         lists = fh.build_calibration_stacks(
-            "dark", min_file_count=3, merge_small_clusters=True
+            "dark", min_file_count=3, groupby="obs_night"
         )
         assert len(lists) == 1
-        assert len(lists[0]) == 3
+        assert len(lists[0]) == 5
         assert lists[0] == sorted(lists[0])
 
 

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -678,13 +678,15 @@ def _write_l0_frame(tmp_path, datecode, obs_id):
 
 
 def _seed_cache(tmp_path, datecode, filenames):
-    """Seed the on-disk mini-db cache CSV with the given FILENAME rows and return
-    its path. Only FILENAME/OBJECT are written -- enough for the guardrail
-    (row count) and cache-hit (FILENAME) assertions."""
+    """Seed the on-disk mini-db cache CSV (the full real schema, one row per
+    filename) and return its path. OBJECT is populated so the row survives the
+    readable-frame clean; the other columns are left blank -- enough for the
+    row-count / freshness / cache-hit (FILENAME) assertions."""
     cache = tmp_path / "vNext" / "mini_db" / f"{datecode}_L0.csv"
     cache.parent.mkdir(parents=True, exist_ok=True)
-    rows = "".join(f"{fn},autocal-bias\n" for fn in filenames)
-    cache.write_text("FILENAME,OBJECT\n" + rows)
+    cols = "FILENAME,TARGNAME,IMTYPE,OBJECT,EXPTIME,ELAPSED,UTC,HST,ISJUNK"
+    rows = "".join(f"{fn},,,autocal-bias,,,,,\n" for fn in filenames)
+    cache.write_text(cols + "\n" + rows)
     return cache
 
 
@@ -710,6 +712,28 @@ class TestMiniDatabaseCache:
         assert list(cached.columns) == list(db.columns)
         assert len(cached) == len(db)
         assert cached["FILENAME"].tolist() == db["FILENAME"].tolist()
+
+    def test_unreadable_frame_recorded_in_cache_not_in_memory(self, tmp_path):
+        # An unreadable frame is omitted from the in-memory db (useless for
+        # stacking) but still recorded in the on-disk cache, so the cache mirrors
+        # the directory and its row-count guardrail treats it as current, not stale.
+        fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
+        _write_l0_frame(tmp_path, "20240405", "KP.20240405.02000.00")
+        corrupt = tmp_path / "L0" / "20240405" / "KP.20240405.03000.00.fits"
+        corrupt.write_bytes(b"not a valid FITS file")
+
+        with pytest.warns(UserWarning, match="Could not read header"):
+            db = fh.build_mini_database("20240405", cache="rw")
+
+        assert len(db) == 2  # in-memory: only the two readable frames
+        cache = tmp_path / "vNext" / "mini_db" / "20240405_L0.csv"
+        assert len(pd.read_csv(cache)) == 3  # on-disk: one row per file present
+
+        # The count guardrail now sees 3 == 3, so the cache reads back as current.
+        cached = fh._read_mini_db_cache("20240405")
+        assert cached is not None and len(cached) == 3
+        # A full read-mode build is a cache hit and still cleans to the readable set.
+        assert len(fh.build_mini_database("20240405", cache="r")) == 2
 
     def test_cache_write_failure_leaves_no_partial_or_temp(self, tmp_path, monkeypatch):
         # The atomic write (temp file + os.replace) cleans up on failure: a to_csv

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -148,10 +148,13 @@ def _cross_midnight_gap_db(n_before=2, n_after=2):
 def _cluster(cal_type, mini_db, **kwargs):
     """Cluster a synthetic mini_db through the (instance-method) API.
 
-    build_calibration_stacks reads the handler's carried mini database by default;
-    these logic tests pass a synthetic one via ``mini_db=`` on a bare handler.
+    build_calibration_stacks reads the handler's carried mini database
+    (``self._mini_db``); these logic tests set a synthetic one on a bare handler
+    the same way ``build_mini_database`` would.
     """
-    return FileHandler().build_calibration_stacks(cal_type, mini_db=mini_db, **kwargs)
+    fh = FileHandler()
+    fh._mini_db = mini_db
+    return fh.build_calibration_stacks(cal_type, **kwargs)
 
 
 class TestSecondsSinceJ2000:
@@ -180,7 +183,7 @@ class TestSecondsSinceJ2000:
 
 class TestBuildCalibrationStacks:
     """Clustering depends only on the mini database, so these exercise it with
-    synthetic DataFrames (no files on disk) via the ``mini_db=`` override."""
+    synthetic DataFrames (no files on disk) set on a bare handler."""
 
     def test_two_bias_clusters_returned_separately(self):
         lists = _cluster("bias", _make_mini_db())

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -222,6 +222,15 @@ class TestBuildCalibrationStacks:
         assert len(lists) == 1
         assert lists[0] == sorted(_BIAS_A)
 
+    def test_default_min_stack_size_is_noop(self):
+        # The default min_stack_size=1 is a no-op filter: a lone 2-frame cluster
+        # survives with no explicit threshold (distinguishing it from any nonzero
+        # default that would drop it).
+        db = _mini_db(_rows(_BIAS_SMALL, "autocal-bias", "Bias"))
+        lists = _cluster("bias", db)
+        assert len(lists) == 1
+        assert lists[0] == sorted(_BIAS_SMALL)
+
     def test_invalid_groupby_raises(self):
         with pytest.raises(ValueError, match="groupby must be one of"):
             _cluster("bias", _make_mini_db(), groupby="bogus")
@@ -701,6 +710,22 @@ class TestMiniDatabaseCache:
         assert list(cached.columns) == list(db.columns)
         assert len(cached) == len(db)
         assert cached["FILENAME"].tolist() == db["FILENAME"].tolist()
+
+    def test_cache_write_failure_leaves_no_partial_or_temp(self, tmp_path, monkeypatch):
+        # The atomic write (temp file + os.replace) cleans up on failure: a to_csv
+        # error re-raises, leaving no partial cache CSV and no orphaned .tmp file.
+        fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
+
+        def _boom(self, *a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(pd.DataFrame, "to_csv", _boom)
+        with pytest.raises(OSError, match="disk full"):
+            fh.build_mini_database("20240405", cache="w")
+
+        cache_dir = tmp_path / "vNext" / "mini_db"
+        assert not (cache_dir / "20240405_L0.csv").exists()  # no partial cache
+        assert list(cache_dir.glob("*.tmp")) == []  # temp file removed
 
     def test_cache_read_reads_current_cache_without_scanning(self, tmp_path):
         # A current cache (row count matches disk, newer than every input) is

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -125,7 +125,7 @@ def _cross_midnight_gap_db(n_before=2, n_after=2):
     """Sparse dark clusters on opposite HST days, split by a >2 h gap.
 
     Mirrors a real sparse-dark night (e.g. 20240806): a pre-midnight group and a
-    post-midnight group, each below the dark min_file_count and separated by both
+    post-midnight group, each below the dark min_stack_size and separated by both
     the gap and HST midnight. Returns (df, before_files, after_files).
     """
     before = [
@@ -202,24 +202,23 @@ class TestBuildCalibrationStacks:
             assert lst == sorted(lst)
 
     def test_raises_when_no_cluster_meets_min(self):
-        # min_file_count=6: both bias clusters (5 files each) fall below and are
+        # min_stack_size=6: both bias clusters (5 files each) fall below and are
         # dropped, leaving nothing → raises.
         with pytest.raises(ValueError, match="no cluster with at least"):
-            _cluster("bias", _make_mini_db(), min_file_count=6)
+            _cluster("bias", _make_mini_db(), min_stack_size=6)
 
     def test_raises_when_no_frames_found(self):
         with pytest.raises(ValueError, match="No 'flat' calibration frames found"):
             _cluster("flat", _make_mini_db())
 
-    def test_raises_when_only_cluster_below_default_min(self):
-        # dark cluster has only 3 files; default min_file_count=5 → dropped →
-        # raises.
+    def test_raises_when_only_cluster_below_min(self):
+        # dark cluster has only 3 files; min_stack_size=5 → dropped → raises.
         with pytest.raises(ValueError, match="no cluster with at least"):
-            _cluster("dark", _make_mini_db())
+            _cluster("dark", _make_mini_db(), min_stack_size=5)
 
     def test_drops_small_cluster_keeps_large(self):
         db, _ = _mixed_bias_db()
-        lists = _cluster("bias", db)
+        lists = _cluster("bias", db, min_stack_size=5)
         assert len(lists) == 1
         assert lists[0] == sorted(_BIAS_A)
 
@@ -231,7 +230,7 @@ class TestBuildCalibrationStacks:
         # time_of_day splits on time gaps alone: frames <gap apart but on opposite
         # sides of HST midnight now share one cluster (there is no midnight split).
         db, before, after = _midnight_bias_db()
-        lists = _cluster("bias", db, min_file_count=5)
+        lists = _cluster("bias", db, min_stack_size=5)
         assert len(lists) == 1
         assert lists[0] == sorted(before + after)
 
@@ -239,7 +238,7 @@ class TestBuildCalibrationStacks:
         # groupby='hst_day' puts each HST calendar day in its own stack, even when
         # the frames are <gap apart across HST midnight.
         db, before, after = _midnight_bias_db()
-        lists = _cluster("bias", db, min_file_count=5, groupby="hst_day")
+        lists = _cluster("bias", db, min_stack_size=5, groupby="hst_day")
         assert len(lists) == 2
         assert lists[0] == sorted(before)
         assert lists[1] == sorted(after)
@@ -248,7 +247,7 @@ class TestBuildCalibrationStacks:
         # groupby='obs_night' groups the whole loaded night into one stack,
         # spanning both a >2 h gap and HST midnight (the 20240806 sparse-dark case).
         db, before, after = _cross_midnight_gap_db()
-        lists = _cluster("dark", db, min_file_count=3, groupby="obs_night")
+        lists = _cluster("dark", db, min_stack_size=3, groupby="obs_night")
         assert len(lists) == 1
         assert lists[0] == sorted(before + after)
 
@@ -299,15 +298,15 @@ class TestBuildCalibrationStacksRealData:
 
     def test_dark_raises_on_undersized_clusters(self, fh):
         # The testdata has two dark clusters of 2 and 3 frames — both below
-        # the default min_file_count=5 and dropped, leaving nothing → raises.
+        # min_stack_size=5 and dropped, leaving nothing → raises.
         with pytest.raises(ValueError, match="no cluster with at least"):
-            fh.build_calibration_stacks("dark")
+            fh.build_calibration_stacks("dark", min_stack_size=5)
 
     def test_dark_obs_night_single_stack(self, fh):
         # The recipe's dark usage: the night's 5 dark frames span two HST days
         # (2 + 3), and groupby='obs_night' groups them into one nightly stack.
         lists = fh.build_calibration_stacks(
-            "dark", min_file_count=3, groupby="obs_night"
+            "dark", min_stack_size=3, groupby="obs_night"
         )
         assert len(lists) == 1
         assert len(lists[0]) == 5
@@ -799,17 +798,17 @@ class TestJunkExclusion:
     def test_exclude_junk_default_drops_flagged_frame(self):
         junk_fn = _JUNK_BIAS[1]
         db = _mini_db(_rows(_JUNK_BIAS, "autocal-bias", "Bias"), junk=[junk_fn])
-        lists = _cluster("bias", db, min_file_count=1)
+        lists = _cluster("bias", db, min_stack_size=1)
         assert junk_fn not in [fn for cluster in lists for fn in cluster]
 
     def test_exclude_junk_false_keeps_flagged_frame(self):
         junk_fn = _JUNK_BIAS[1]
         db = _mini_db(_rows(_JUNK_BIAS, "autocal-bias", "Bias"), junk=[junk_fn])
-        lists = _cluster("bias", db, min_file_count=1, exclude_junk=False)
+        lists = _cluster("bias", db, min_stack_size=1, exclude_junk=False)
         assert junk_fn in [fn for cluster in lists for fn in cluster]
 
     def test_exclude_junk_without_column_raises(self):
         # A mini database built before ISJUNK existed must fail loudly.
         db = _mini_db(_rows(_JUNK_BIAS, "autocal-bias", "Bias")).drop(columns="ISJUNK")
         with pytest.raises(KeyError):
-            _cluster("bias", db, min_file_count=1)
+            _cluster("bias", db, min_stack_size=1)

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -152,7 +152,7 @@ def _cluster(cal_type, mini_db, **kwargs):
     (``self._mini_db``); these logic tests set a synthetic one on a bare handler
     the same way ``build_mini_database`` would.
     """
-    fh = FileHandler()
+    fh = FileHandler({})
     fh._mini_db = mini_db
     return fh.build_calibration_stacks(cal_type, **kwargs)
 
@@ -163,22 +163,22 @@ class TestSecondsSinceJ2000:
 
     def test_basic(self):
         # J2000.0 itself: 2000-01-01 12:00 UTC = '20000101.43200.00'
-        assert FileHandler()._seconds_since_j2000("20000101.43200.00") == 0
+        assert FileHandler({})._seconds_since_j2000("20000101.43200.00") == 0
 
     def test_monotonic_across_year_boundary(self):
         # Dec 31 23:59:00 -> Jan 1 00:00:00 should differ by 60s exactly.
-        fh = FileHandler()
+        fh = FileHandler({})
         end = fh._seconds_since_j2000("20231231.86340.00")
         start_next_year = fh._seconds_since_j2000("20240101.00000.00")
         assert start_next_year - end == 60
 
     def test_raises_on_invalid_timestamp(self):
         with pytest.raises(ValueError, match="Invalid KPF timestamp"):
-            FileHandler()._seconds_since_j2000("KP.20240405.99999.57.fits")
+            FileHandler({})._seconds_since_j2000("KP.20240405.99999.57.fits")
 
     def test_raises_when_no_timestamp_found(self):
         with pytest.raises(ValueError, match="No KPF timestamp found"):
-            FileHandler()._seconds_since_j2000("notimestamp.fits")
+            FileHandler({})._seconds_since_j2000("notimestamp.fits")
 
 
 class TestBuildCalibrationStacks:
@@ -512,7 +512,7 @@ class TestFindMasters:
 
     def test_raises_without_masters_output(self):
         with pytest.raises(ValueError, match="KPF_MASTERS_OUTPUT"):
-            FileHandler().find_masters("bias", "L1", "20240405")
+            FileHandler({}).find_masters("bias", "L1", "20240405")
 
     @pytest.mark.parametrize(
         "cal_type,level",
@@ -639,7 +639,7 @@ class TestBuildMiniDatabase:
 
     def test_missing_data_input_raises(self):
         with pytest.raises(ValueError, match="KPF_DATA_INPUT"):
-            FileHandler().build_mini_database("20240405")
+            FileHandler({}).build_mini_database("20240405")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -58,25 +58,12 @@ class TestMasterBaseErrors:
             l1_obj = m._load_frame(fn, cache=False)
         assert l1_obj is None
 
-    def test_load_frame_exptime_failure_warns_and_skips(self, monkeypatch):
-        # A frame failing the exptime-vs-elapsed check is warned and skipped.
-        m = Dark(FILE_LIST)
-        fn = FILE_LIST[0]
-        m._l1_obj_cache[fn] = object()  # cache hit bypasses real I/O
-
-        def bad_check(l1_obj, exptime_tolerance):
-            raise ValueError("elapsed exceeds exptime")
-
-        monkeypatch.setattr(m, "_check_exptime_vs_elapsed", bad_check)
-        with pytest.warns(UserWarning, match="Exptime check failed"):
-            l1_obj = m._load_frame(fn, cache=False)
-        assert l1_obj is None
-
     def test_load_frame_qc_failure_warns_and_skips(self, monkeypatch):
-        # A frame failing a required QCL0 flag is warned and dropped before assembly.
+        # A frame failing a required QCL0 flag (here the EXPTIME/ELAPSED
+        # consistency flag EXPTIMOK) is warned and dropped before assembly.
         m = Dark(FILE_LIST)
         fn = FILE_LIST[0]
-        qc_result = {kw: (kw != "NOTJUNK", "") for kw in Dark._REQUIRED_L0_QC_FLAGS}
+        qc_result = {kw: (kw != "EXPTIMOK", "") for kw in Dark._REQUIRED_L0_QC_FLAGS}
         monkeypatch.setattr(
             "kpfpipe.modules.masters.base.KPF0.from_fits", lambda fn: object()
         )
@@ -84,7 +71,7 @@ class TestMasterBaseErrors:
             "kpfpipe.modules.masters.base.QCL0",
             lambda l0: MagicMock(run=lambda: qc_result),
         )
-        with pytest.warns(UserWarning, match="QC failed.*NOTJUNK"):
+        with pytest.warns(UserWarning, match="QC failed.*EXPTIMOK"):
             l1_obj = m._load_frame(fn, cache=False)
         assert l1_obj is None
 

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -51,12 +51,12 @@ class TestMasterBaseErrors:
             Dark(FILE_LIST, config="not-a-config")
 
     def test_load_frame_missing_file_warns_and_skips(self):
-        # A missing/unreadable L0 frame warns and returns (None, failure), not a crash.
+        # A missing/unreadable L0 frame warns and returns None, not a crash.
         fn = "/nonexistent/KP.20240101.00001.00.fits"
         m = Dark([fn])
         with pytest.warns(UserWarning, match="Failed to load"):
-            l1_obj, success = m._load_frame(fn, cache=False)
-        assert l1_obj is None and success is False
+            l1_obj = m._load_frame(fn, cache=False)
+        assert l1_obj is None
 
     def test_load_frame_exptime_failure_warns_and_skips(self, monkeypatch):
         # A frame failing the exptime-vs-elapsed check is warned and skipped.
@@ -69,8 +69,24 @@ class TestMasterBaseErrors:
 
         monkeypatch.setattr(m, "_check_exptime_vs_elapsed", bad_check)
         with pytest.warns(UserWarning, match="Exptime check failed"):
-            l1_obj, success = m._load_frame(fn, cache=False)
-        assert l1_obj is None and success is False
+            l1_obj = m._load_frame(fn, cache=False)
+        assert l1_obj is None
+
+    def test_load_frame_qc_failure_warns_and_skips(self, monkeypatch):
+        # A frame failing a required QCL0 flag is warned and dropped before assembly.
+        m = Dark(FILE_LIST)
+        fn = FILE_LIST[0]
+        qc_result = {kw: (kw != "NOTJUNK", "") for kw in Dark._REQUIRED_L0_QC_FLAGS}
+        monkeypatch.setattr(
+            "kpfpipe.modules.masters.base.KPF0.from_fits", lambda fn: object()
+        )
+        monkeypatch.setattr(
+            "kpfpipe.modules.masters.base.QCL0",
+            lambda l0: MagicMock(run=lambda: qc_result),
+        )
+        with pytest.warns(UserWarning, match="QC failed.*NOTJUNK"):
+            l1_obj = m._load_frame(fn, cache=False)
+        assert l1_obj is None
 
 
 # ---------------------------------------------------------------------------
@@ -364,7 +380,7 @@ class TestRateEstimator:
         # the approximate (clip-bound) pass, so a frame may be loaded twice.
         by_fn = dict(zip(file_list, frames, strict=True))
         with (
-            patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
             return dark.stack_frames(nstream=nstream)["GREEN_IMG"]
@@ -433,7 +449,7 @@ class TestPerPixelRejection:
         dark.ccd = {"nrow": nrow, "ncol": ncol}
         by_fn = dict(zip(dark.l0_file_list, frames, strict=True))
         with (
-            patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
             arrays = dark.stack_frames()
@@ -466,7 +482,7 @@ class TestPerPixelRejection:
         dark.stack_sigma = 5.0
         by_fn = dict(zip(dark.l0_file_list, frames, strict=True))
         with (
-            patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
             # nstream = 3 -> ndirect = 2 -> approx from frames 0, 1
@@ -502,7 +518,7 @@ class TestDatacubeClipping:
         dark.stack_sigma = 5.0
         by_fn = dict(zip(dark.l0_file_list, frames, strict=True))
         with (
-            patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
             arrays = dark.stack_frames(nstream=10)  # > nframe, so datacube path
@@ -527,7 +543,7 @@ class TestDatacubeClipping:
         dark.stack_sigma = 5.0
         by_fn = dict(zip(dark.l0_file_list, frames, strict=True))
         with (
-            patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
             arrays = dark.stack_frames(nstream=10)  # > nframe, so datacube path
@@ -624,7 +640,7 @@ class TestStackingValidation:
         dark = self._dark(len(frames))
         by_fn = dict(zip(dark.l0_file_list, frames, strict=True))
         with (
-            patch.object(dark, "_load_frame", lambda fn, **k: (by_fn[fn], True)),
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
             return dark.stack_frames()
@@ -647,7 +663,7 @@ class TestStackingValidation:
     def test_excessive_load_failures_raises(self):
         dark = self._dark(5)
         with (
-            patch.object(dark, "_load_frame", lambda fn, **k: (None, False)),
+            patch.object(dark, "_load_frame", lambda fn, **k: None),
             patch.object(dark, "_process_frame", lambda l1: l1),
         ):
             with pytest.raises(ValueError, match="too many frames failed to load"):

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -55,7 +55,7 @@ class TestMasterBaseErrors:
         fn = "/nonexistent/KP.20240101.00001.00.fits"
         m = Dark([fn])
         with pytest.warns(UserWarning, match="Failed to load"):
-            l1_obj, success = m._load_frame(fn, cache=False, verbose=True)
+            l1_obj, success = m._load_frame(fn, cache=False)
         assert l1_obj is None and success is False
 
     def test_load_frame_exptime_failure_warns_and_skips(self, monkeypatch):
@@ -69,7 +69,7 @@ class TestMasterBaseErrors:
 
         monkeypatch.setattr(m, "_check_exptime_vs_elapsed", bad_check)
         with pytest.warns(UserWarning, match="Exptime check failed"):
-            l1_obj, success = m._load_frame(fn, cache=False, verbose=True)
+            l1_obj, success = m._load_frame(fn, cache=False)
         assert l1_obj is None and success is False
 
 

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -75,6 +75,26 @@ class TestMasterBaseErrors:
             l1_obj = m._load_frame(fn, cache=False)
         assert l1_obj is None
 
+    def test_load_frame_qc_pass_returns_assembled(self, monkeypatch):
+        # All required QCL0 flags pass -> the frame is assembled and returned
+        # (the gate's pass-through branch, otherwise only exercised in slow tests).
+        m = Dark(FILE_LIST)
+        fn = FILE_LIST[0]
+        qc_result = {kw: (True, "") for kw in Dark._REQUIRED_L0_QC_FLAGS}
+        assembled = object()
+        monkeypatch.setattr(
+            "kpfpipe.modules.masters.base.KPF0.from_fits", lambda fn: object()
+        )
+        monkeypatch.setattr(
+            "kpfpipe.modules.masters.base.QCL0",
+            lambda l0: MagicMock(run=lambda: qc_result),
+        )
+        monkeypatch.setattr(
+            "kpfpipe.modules.masters.base.ImageAssembly",
+            lambda l0: MagicMock(perform=lambda: assembled),
+        )
+        assert m._load_frame(fn, cache=False) is assembled
+
 
 # ---------------------------------------------------------------------------
 # _process_frame: bias subtraction via CalibrationAssociation + ImageProcessing

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -169,9 +169,9 @@ class TestMasterDarkSignature:
 @pytest.mark.slow
 class TestMasterDarkRegression:
     """End-to-end master dark from real L0 frames. The five bundled darks span
-    two default-gap clusters *and* HST midnight, so cluster_gap_seconds is widened
-    and the HST-midnight boundary is lifted (as the masters recipe does for darks)
-    to stack them; each frame is bias-subtracted against the bundled master bias."""
+    two default-gap clusters *and* HST midnight, so they are grouped with
+    groupby='obs_night' (the whole night in one stack, as the masters recipe does
+    for darks); each frame is bias-subtracted against the bundled master bias."""
 
     @pytest.fixture(scope="class")
     def master_dark(self):
@@ -180,8 +180,7 @@ class TestMasterDarkRegression:
         files = file_handler.build_calibration_stacks(
             "dark",
             min_file_count=5,
-            cluster_gap_seconds=24 * 3600,
-            enforce_hst_midnight_boundary=False,
+            groupby="obs_night",
         )
         assert len(files) == 1 and len(files[0]) == 5
         config = {"KPF_MASTERS_OUTPUT": str(TESTDATA_DIR)}

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -179,7 +179,7 @@ class TestMasterDarkRegression:
         file_handler.build_mini_database("20240405")
         files = file_handler.build_calibration_stacks(
             "dark",
-            min_file_count=5,
+            min_stack_size=5,
             groupby="obs_night",
         )
         assert len(files) == 1 and len(files[0]) == 5

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -152,7 +152,7 @@ class TestProcessIndividualFrames:
     def test_returns_l2_objects_for_all_frames(self, mock_pipeline, monkeypatch):
         wls = WLS(FILE_LIST)
         monkeypatch.setattr(
-            wls, "_load_frame", lambda fn, cache=False, **kwargs: (MockL1(), True)
+            wls, "_load_frame", lambda fn, cache=False, **kwargs: MockL1()
         )
         result = wls._process_stack_l0_to_l2()
         assert len(result) == len(FILE_LIST)
@@ -161,22 +161,20 @@ class TestProcessIndividualFrames:
     def test_file_list_override(self, mock_pipeline, monkeypatch):
         wls = WLS(FILE_LIST)
         monkeypatch.setattr(
-            wls, "_load_frame", lambda fn, cache=False, **kwargs: (MockL1(), True)
+            wls, "_load_frame", lambda fn, cache=False, **kwargs: MockL1()
         )
         result = wls._process_stack_l0_to_l2(l0_file_list=FILE_LIST[:3])
         assert len(result) == 3
 
     def test_raises_when_failures_exceed_threshold(self, monkeypatch):
         wls = WLS(FILE_LIST)
-        monkeypatch.setattr(
-            wls, "_load_frame", lambda fn, cache=False, **kwargs: (None, False)
-        )
+        monkeypatch.setattr(wls, "_load_frame", lambda fn, cache=False, **kwargs: None)
         with pytest.raises(ValueError, match="too many frames failed to load"):
             wls._process_stack_l0_to_l2()
 
     def test_tolerates_minority_failure(self, mock_pipeline, monkeypatch):
         # 1 failure out of 8 = 12.5%, below the 20% threshold
-        calls = iter([(None, False)] + [(MockL1(), True)] * 7)
+        calls = iter([None] + [MockL1()] * 7)
         wls = WLS(FILE_LIST)
         monkeypatch.setattr(
             wls, "_load_frame", lambda fn, cache=False, **kwargs: next(calls)
@@ -198,7 +196,7 @@ def mock_make_master_l2(monkeypatch):
     synthetic W and coefficient arrays with chip-correct shapes.
     """
     monkeypatch.setattr(
-        WLS, "_load_frame", lambda self, fn, cache=False, **kwargs: (MockL1(), True)
+        WLS, "_load_frame", lambda self, fn, cache=False, **kwargs: MockL1()
     )
     monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kwargs: l1)
     monkeypatch.setattr(WLS, "_extract_frame", lambda self, l1, **kwargs: MockL2())
@@ -268,7 +266,7 @@ class TestMakeMasterL2:
         CAL and vice versa.
         """
         monkeypatch.setattr(
-            WLS, "_load_frame", lambda self, fn, cache=False, **kw: (MockL1(), True)
+            WLS, "_load_frame", lambda self, fn, cache=False, **kw: MockL1()
         )
         monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kw: l1)
         monkeypatch.setattr(WLS, "_extract_frame", lambda self, l1, **kw: MockL2())

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -741,17 +741,13 @@ class TestComputeWlsFrameRejection:
 
     def test_all_clean_frames_kept(self, monkeypatch):
         wls = self._setup(monkeypatch, [0.01, 0.02, 0.0, 0.03, 0.01])
-        _, _, coeffs_stack, lines_stack = wls._compute_wls_from_stack(
-            "GREEN", ["SCI1"], verbose=False
-        )
+        _, _, coeffs_stack, lines_stack = wls._compute_wls_from_stack("GREEN", ["SCI1"])
         assert len(coeffs_stack) == 5
         assert len(lines_stack) == 5
 
     def test_single_bad_frame_dropped(self, monkeypatch):
         wls = self._setup(monkeypatch, [0.01, 0.22, 0.0, 0.03, 0.01])
-        _, _, coeffs_stack, lines_stack = wls._compute_wls_from_stack(
-            "GREEN", ["SCI1"], verbose=False
-        )
+        _, _, coeffs_stack, lines_stack = wls._compute_wls_from_stack("GREEN", ["SCI1"])
         # the 22%-bad frame is excluded from both stacks
         assert len(coeffs_stack) == 4
         assert len(lines_stack) == 4
@@ -759,14 +755,12 @@ class TestComputeWlsFrameRejection:
     def test_two_bad_frames_raises(self, monkeypatch):
         wls = self._setup(monkeypatch, [0.22, 0.01, 0.34, 0.01, 0.01])
         with pytest.raises(ValueError, match=r"more than one frame rejected"):
-            wls._compute_wls_from_stack("GREEN", ["SCI1"], verbose=False)
+            wls._compute_wls_from_stack("GREEN", ["SCI1"])
 
     def test_threshold_is_inclusive_at_max_bad_frac(self, monkeypatch):
         # exactly 5% bad is not > 5%, so the frame is kept
         wls = self._setup(monkeypatch, [0.05, 0.01], nlines=100)
-        _, _, coeffs_stack, _ = wls._compute_wls_from_stack(
-            "GREEN", ["SCI1"], verbose=False
-        )
+        _, _, coeffs_stack, _ = wls._compute_wls_from_stack("GREEN", ["SCI1"])
         assert len(coeffs_stack) == 2
 
     def test_nonfinite_coeffs_raise(self, monkeypatch):
@@ -786,7 +780,7 @@ class TestComputeWlsFrameRejection:
             WLS, "_evaluate_wls_coeffs", lambda self, *a, **k: np.zeros((3, 3))
         )
         with pytest.raises(ValueError, match=r"non-finite Legendre coefficients"):
-            wls._compute_wls_from_stack("GREEN", ["SCI1"], verbose=False)
+            wls._compute_wls_from_stack("GREEN", ["SCI1"])
 
 
 # ---------------------------------------------------------------------------
@@ -860,8 +854,8 @@ class TestFitLinePositions:
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0])
 
         # The fabricated all-NaN fiber makes the code warn once per synthetic order
-        # (verbose=True) plus once at the fiber level; capture them all so the
-        # per-order ones don't leak to the run summary, and assert the fiber-level one.
+        # plus once at the fiber level; capture them all so the per-order ones don't
+        # leak to the run summary, and assert the fiber-level one.
         with pytest.warns(UserWarning) as record:
             result = wls._fit_line_positions_ffi(
                 StubL2(),
@@ -871,8 +865,8 @@ class TestFitLinePositions:
         assert any("RED SCI1: no good lines retained" in str(w.message) for w in record)
         assert len(result["wav"]) == 0
 
-    def test_nan_orderlet_warning_suppressed_when_verbose_false(self, recwarn):
-        """verbose=False should silence the per-orderlet skip warning."""
+    def test_nan_orderlet_emits_skip_warning(self):
+        """A single NaN-filled orderlet emits the per-orderlet skip warning."""
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
         norder = wls.norder["RED"]
@@ -888,31 +882,10 @@ class TestFitLinePositions:
         )
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
 
-        wls._fit_line_positions_ffi(StubL2(), "RED", ["SCI1"], verbose=False)
+        with pytest.warns(UserWarning) as record:
+            wls._fit_line_positions_ffi(StubL2(), "RED", ["SCI1"])
 
-        skipped = [w for w in recwarn if "orderlet skipped" in str(w.message)]
-        assert len(skipped) == 0
-
-    def test_all_nan_fiber_warning_suppressed_when_verbose_false(self, recwarn):
-        """verbose=False should silence the fiber-level no-good-lines warning."""
-        wls = WLS(FILE_LIST)
-        ncol = wls.ccd["ncol"]
-        norder = wls.norder["RED"]
-
-        flux = np.full((norder, ncol), np.nan)
-
-        class StubL2:
-            data = {"RED_SCI1_FLUX": flux}
-
-        wls.rough_wls["RED_SCI1_WAVE"] = np.tile(
-            np.linspace(6500.0, 6510.0, ncol), (norder, 1)
-        )
-        wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0])
-
-        wls._fit_line_positions_ffi(StubL2(), "RED", ["SCI1"], verbose=False)
-
-        fiber_level = [w for w in recwarn if "no good lines retained" in str(w.message)]
-        assert len(fiber_level) == 0
+        assert any("orderlet skipped" in str(w.message) for w in record)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -32,6 +32,39 @@ def _load_masters_recipe():
 
 
 # ---------------------------------------------------------------------------
+# _min_stack_size: per-cal-type resolver (config section -> module default)
+# ---------------------------------------------------------------------------
+
+
+class TestMinStackSize:
+    """The recipe resolves min_stack_size from each cal_type's config section,
+    falling back to BaseMasterModule._DEFAULTS when the section omits it."""
+
+    @pytest.fixture(scope="class")
+    def recipe(self):
+        return _load_masters_recipe()
+
+    @pytest.fixture(scope="class")
+    def config(self):
+        return ConfigHandler(str(MASTERS_CONFIG_PATH))
+
+    def test_reads_bias_section(self, recipe, config):
+        assert recipe._min_stack_size(config, "bias") == 5
+
+    def test_reads_dark_section(self, recipe, config):
+        assert recipe._min_stack_size(config, "dark") == 3
+
+    def test_falls_back_when_section_absent(self, recipe, config):
+        # thar has no [THAR] config section -> the masters-module default.
+        from kpfpipe.modules.masters.base import BaseMasterModule
+
+        assert (
+            recipe._min_stack_size(config, "thar")
+            == BaseMasterModule._DEFAULTS["min_stack_size"]
+        )
+
+
+# ---------------------------------------------------------------------------
 # Masters recipe integration (real L0 data from tests/testdata/)
 # ---------------------------------------------------------------------------
 

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -32,39 +32,6 @@ def _load_masters_recipe():
 
 
 # ---------------------------------------------------------------------------
-# _min_stack_size: per-cal-type resolver (config section -> module default)
-# ---------------------------------------------------------------------------
-
-
-class TestMinStackSize:
-    """The recipe resolves min_stack_size from each cal_type's config section,
-    falling back to BaseMasterModule._DEFAULTS when the section omits it."""
-
-    @pytest.fixture(scope="class")
-    def recipe(self):
-        return _load_masters_recipe()
-
-    @pytest.fixture(scope="class")
-    def config(self):
-        return ConfigHandler(str(MASTERS_CONFIG_PATH))
-
-    def test_reads_bias_section(self, recipe, config):
-        assert recipe._min_stack_size(config, "bias") == 5
-
-    def test_reads_dark_section(self, recipe, config):
-        assert recipe._min_stack_size(config, "dark") == 3
-
-    def test_falls_back_when_section_absent(self, recipe, config):
-        # thar has no [THAR] config section -> the masters-module default.
-        from kpfpipe.modules.masters.base import BaseMasterModule
-
-        assert (
-            recipe._min_stack_size(config, "thar")
-            == BaseMasterModule._DEFAULTS["min_stack_size"]
-        )
-
-
-# ---------------------------------------------------------------------------
 # Masters recipe integration (real L0 data from tests/testdata/)
 # ---------------------------------------------------------------------------
 

--- a/tests/regression/test_masters_script.py
+++ b/tests/regression/test_masters_script.py
@@ -224,6 +224,7 @@ class TestMainExitCode:
         monkeypatch.setattr(m, "ConfigHandler", _FakeConfig)
         monkeypatch.setattr(m, "setup_batch_logging", lambda *a, **k: "/l/x.log")
         monkeypatch.setattr(m, "resolve_datecodes", lambda args, di: ["20240405"])
+        monkeypatch.setattr(m, "warm_mini_db_caches", lambda *a, **k: (0, 0))
 
         def _fake_run_stage(*a, **k):
             if calls is not None:
@@ -250,6 +251,27 @@ class TestMainExitCode:
         m.main(["--dates", "20240405"])
         assert calls[0]["launch_interval"] == m._LAUNCH_INTERVAL
         assert m._LAUNCH_INTERVAL > 0
+
+    def test_prescans_before_fan_out(self, m, monkeypatch):
+        # The mini-db caches are warmed up front (parallel per-datecode) before the
+        # reduces fan out, with the resolved datecodes and the pool size.
+        order = []
+        warm_args = {}
+
+        def _warm(data_input, datecodes, jobs):
+            order.append("warm")
+            warm_args.update(datecodes=datecodes, jobs=jobs)
+            return (len(datecodes), 0)
+
+        self._patch(m, monkeypatch, failed=[])
+        monkeypatch.setattr(m, "warm_mini_db_caches", _warm)
+        monkeypatch.setattr(
+            m, "run_stage", lambda *a, **k: order.append("run_stage") or set()
+        )
+        m.main(["--dates", "20240405"])
+        assert order == ["warm", "run_stage"]  # pre-scan precedes fan-out
+        assert warm_args["datecodes"] == ["20240405"]
+        assert warm_args["jobs"] == m._default_masters_jobs()
 
     def test_errors_when_log_dir_unset(self, m, monkeypatch):
         # A missing log_dir is fatal before any fan-out (DRP-RUN-07).

--- a/tests/regression/test_masters_script.py
+++ b/tests/regression/test_masters_script.py
@@ -258,9 +258,9 @@ class TestMainExitCode:
         order = []
         warm_args = {}
 
-        def _warm(data_input, datecodes, jobs):
+        def _warm(data_input, datecodes, jobs, cache="rw"):
             order.append("warm")
-            warm_args.update(datecodes=datecodes, jobs=jobs)
+            warm_args.update(datecodes=datecodes, jobs=jobs, cache=cache)
             return (len(datecodes), 0)
 
         self._patch(m, monkeypatch, failed=[])
@@ -272,6 +272,7 @@ class TestMainExitCode:
         assert order == ["warm", "run_stage"]  # pre-scan precedes fan-out
         assert warm_args["datecodes"] == ["20240405"]
         assert warm_args["jobs"] == m._default_masters_jobs()
+        assert warm_args["cache"] == "rw"  # masters default: warm up front
 
     def test_errors_when_log_dir_unset(self, m, monkeypatch):
         # A missing log_dir is fatal before any fan-out (DRP-RUN-07).

--- a/tests/regression/test_masters_script.py
+++ b/tests/regression/test_masters_script.py
@@ -260,7 +260,9 @@ class TestMainExitCode:
 
         def _warm(data_input, datecodes, jobs, cache="rw"):
             order.append("warm")
-            warm_args.update(datecodes=datecodes, jobs=jobs, cache=cache)
+            warm_args.update(
+                data_input=data_input, datecodes=datecodes, jobs=jobs, cache=cache
+            )
             return (len(datecodes), 0)
 
         self._patch(m, monkeypatch, failed=[])
@@ -270,6 +272,7 @@ class TestMainExitCode:
         )
         m.main(["--dates", "20240405"])
         assert order == ["warm", "run_stage"]  # pre-scan precedes fan-out
+        assert warm_args["data_input"] == "/in"  # resolved L0 input root
         assert warm_args["datecodes"] == ["20240405"]
         assert warm_args["jobs"] == m._default_masters_jobs()
         assert warm_args["cache"] == "rw"  # masters default: warm up front

--- a/tests/regression/test_plot_timeseries.py
+++ b/tests/regression/test_plot_timeseries.py
@@ -469,7 +469,7 @@ class TestPlot:
         paths = self._paths(str(tmp_path), spec)
         plot_dir = tmp_path / "plots"
         pt.plot_rv_timeseries("10700", paths, str(plot_dir))
-        assert (plot_dir / "10700_20240926_rv_timeseries.png").exists()
+        assert (plot_dir / "10700_rv_timeseries_20240926.png").exists()
         assert (plot_dir / "10700_rv_timeseries.png").exists()
         # The high-cadence night is one datecode with >1 obs, but it is held out of
         # the nightly panels, and the two survivors are single-obs -> no nightly PNG.
@@ -483,8 +483,8 @@ class TestPlot:
         paths = self._paths(str(tmp_path), spec)
         plot_dir = tmp_path / "plots"
         pt.plot_rv_timeseries("10700", paths, str(plot_dir))
-        assert (plot_dir / "10700_20240926_rv_timeseries.png").exists()
-        assert (plot_dir / "10700_20240927_rv_timeseries.png").exists()
+        assert (plot_dir / "10700_rv_timeseries_20240926.png").exists()
+        assert (plot_dir / "10700_rv_timeseries_20240927.png").exists()
         assert not (plot_dir / "10700_rv_timeseries.png").exists()
         assert not (plot_dir / "10700_rv_nightly.png").exists()
 

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -431,6 +431,27 @@ class TestQCL0:
         del l0.headers["PRIMARY"]["EXPTIME"]
         assert QCL0(l0).exptime_sane() is False
 
+    def test_exptime_sane_pass_elapsed_within_tol(self, tmp_path):
+        # ELAPSED may exceed the requested EXPTIME by up to the timing tolerance.
+        l0 = _make_kpf0(tmp_path, exptime=300.0, dates={"ELAPSED": 300.05})
+        assert QCL0(l0).exptime_sane() is True
+
+    def test_exptime_sane_pass_elapsed_absent(self, tmp_path):
+        # No ELAPSED card -> the consistency comparison is skipped.
+        l0 = _make_kpf0(tmp_path, exptime=300.0)
+        assert "ELAPSED" not in l0.headers["PRIMARY"]
+        assert QCL0(l0).exptime_sane() is True
+
+    def test_exptime_sane_fail_premature_readout(self, tmp_path):
+        # ELAPSED shorter than the requested EXPTIME (premature readout).
+        l0 = _make_kpf0(tmp_path, exptime=300.0, dates={"ELAPSED": 299.0})
+        assert QCL0(l0).exptime_sane() is False
+
+    def test_exptime_sane_fail_elapsed_exceeds_tol(self, tmp_path):
+        # ELAPSED over the requested EXPTIME by more than the tolerance.
+        l0 = _make_kpf0(tmp_path, exptime=300.0, dates={"ELAPSED": 301.0})
+        assert QCL0(l0).exptime_sane() is False
+
     # not_junk delegates all file I/O to io.load_junk_obs_ids, so these tests
     # monkeypatch that helper (no junk file is ever written to a data tree) and
     # verify only not_junk's own logic: the dirname -> data_input recovery, the
@@ -917,13 +938,15 @@ _REPO_ROOT = os.path.dirname(
 def _write_l0_fixture(path, *, passing=True):
     """Write a minimal L0 FITS fixture at path.
 
-    passing=True  → all QCL0 checks pass (valid header keywords, finite EXPTIME,
-                    amps present).
+    passing=True  → all QCL0 checks pass (valid header keywords, EXPTIME finite
+                    and consistent with ELAPSED, amps present).
     passing=False → inject a failure (negative EXPTIME so EXPTIMOK fails).
     """
     primary = fits.PrimaryHDU()
     primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
-    primary.header["EXPTIME"] = 60.0 if passing else -1.0
+    # Requested EXPTIME within tolerance of the elapsed time (_GOOD_DATES
+    # ELAPSED = 12.07) so EXPTIMOK's ELAPSED-consistency check passes.
+    primary.header["EXPTIME"] = 12.0 if passing else -1.0
     primary.header["OBJECT"] = "synthetic"
     primary.header["OFNAME"] = os.path.basename(path)
     primary.header["IMTYPE"] = "Object"

--- a/tests/regression/test_scan.py
+++ b/tests/regression/test_scan.py
@@ -54,6 +54,16 @@ class TestScanNightToCache:
         assert len(df) == 2
         assert _cache_path(str(tmp_path), "20240101").is_file()  # cache="rw" wrote it
 
+    def test_read_only_mode_does_not_write(self, tmp_path):
+        # cache="r" scans in-process but writes no cache CSV (recipes read the
+        # cache; only the scripts layer writes it).
+        _write_l0(str(tmp_path), "20240101", 3600)
+
+        df = _scan.scan_night_to_cache(str(tmp_path), "20240101", cache="r")
+
+        assert df is not None and len(df) == 1
+        assert not _cache_path(str(tmp_path), "20240101").exists()
+
     def test_empty_night_returns_none(self, tmp_path):
         # A datecode dir with no FITS files -> ValueError inside build_mini_database,
         # swallowed here: returns None, no cache written, no raise.
@@ -118,6 +128,21 @@ class TestWarmMiniDbCaches:
         assert (written, skipped) == (2, 0)
         for dc in nights:
             assert _cache_path(str(tmp_path), dc).is_file()
+
+    def test_read_only_mode_skips_prescan(self, tmp_path):
+        # A read-only mode warms nothing: no cache is written and every night is
+        # reported skipped, without even scanning.
+        nights = ["20240101", "20240102"]
+        for dc in nights:
+            _write_l0(str(tmp_path), dc, 3600)
+
+        written, skipped = _scan.warm_mini_db_caches(
+            str(tmp_path), nights, jobs=2, cache="r"
+        )
+
+        assert (written, skipped) == (0, 2)
+        for dc in nights:
+            assert not _cache_path(str(tmp_path), dc).exists()
 
     def test_empty_night_counted_skipped(self, tmp_path):
         _write_l0(str(tmp_path), "20240101", 3600)  # good

--- a/tests/regression/test_scan.py
+++ b/tests/regression/test_scan.py
@@ -1,0 +1,142 @@
+"""Tests for scripts/processing/_scan.py: up-front L0 mini-db cache warming.
+
+_scan owns the in-process, parallel-by-datecode header scan the masters and
+science orchestrators run before their fan-out, so the fanned-out reduces read the
+mini-db cache read-only. These cover the per-night primitive, the generic parallel
+dispatcher (including the per-thread-FileHandler no-contamination invariant), and
+the fail-soft warm entry point.
+
+Unit tests use synthetic FITS frames in temp trees -- no real testdata needed.
+"""
+
+from pathlib import Path
+
+from astropy.io import fits
+
+from scripts.processing import _scan
+
+
+def _write_l0(data_input, datecode, seconds, obj="10700", imtype="Object"):
+    """Write one L0 frame under {data_input}/L0/{datecode}; return its obs_id."""
+    l0_dir = Path(data_input) / "L0" / datecode
+    l0_dir.mkdir(parents=True, exist_ok=True)
+    obs_id = f"KP.{datecode}.{seconds:05d}.00"
+    header = fits.Header(
+        {
+            "OBJECT": obj,
+            "IMTYPE": imtype,
+            "TARGNAME": obj,
+            "EXPTIME": 60.0,
+            "ELAPSED": 60.0,
+        }
+    )
+    fits.PrimaryHDU(header=header).writeto(l0_dir / f"{obs_id}.fits")
+    return obs_id
+
+
+def _cache_path(data_input, datecode):
+    return Path(data_input) / "vNext" / "mini_db" / f"{datecode}_L0.csv"
+
+
+# ---------------------------------------------------------------------------
+# scan_night_to_cache
+# ---------------------------------------------------------------------------
+
+
+class TestScanNightToCache:
+    def test_scans_and_writes_cache(self, tmp_path):
+        _write_l0(str(tmp_path), "20240101", 3600)
+        _write_l0(str(tmp_path), "20240101", 3700)
+
+        df = _scan.scan_night_to_cache(str(tmp_path), "20240101")
+
+        assert df is not None
+        assert len(df) == 2
+        assert _cache_path(str(tmp_path), "20240101").is_file()  # cache="rw" wrote it
+
+    def test_empty_night_returns_none(self, tmp_path):
+        # A datecode dir with no FITS files -> ValueError inside build_mini_database,
+        # swallowed here: returns None, no cache written, no raise.
+        (Path(tmp_path) / "L0" / "20240101").mkdir(parents=True)
+        assert _scan.scan_night_to_cache(str(tmp_path), "20240101") is None
+        assert not _cache_path(str(tmp_path), "20240101").exists()
+
+    def test_absent_night_returns_none(self, tmp_path):
+        assert _scan.scan_night_to_cache(str(tmp_path), "20240101") is None
+
+
+# ---------------------------------------------------------------------------
+# scan_datecodes: generic parallel dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestScanDatecodes:
+    def test_returns_per_night_results(self, tmp_path):
+        datecodes = ["20240101", "20240102", "20240103"]
+        results = _scan.scan_datecodes(datecodes, jobs=3, worker=lambda dc: (dc, ""))
+        assert sorted(results) == datecodes  # one result per night, order-agnostic
+
+    def test_tolerates_jobs_exceeding_datecodes(self, tmp_path):
+        results = _scan.scan_datecodes(["20240101"], jobs=8, worker=lambda dc: (dc, ""))
+        assert results == ["20240101"]
+
+    def test_empty_datecodes(self, tmp_path):
+        assert _scan.scan_datecodes([], jobs=4, worker=lambda dc: (dc, "")) == []
+
+    def test_threaded_scan_no_contamination(self, tmp_path):
+        # Each night gets its own FileHandler inside scan_night_to_cache, so a pooled
+        # scan never collapses nights via a shared self._mini_db. Worker returns each
+        # night's obs_id set; assert every night is exact under an 8-wide pool.
+        nights = [f"202401{d:02d}" for d in range(1, 7)]  # six nights
+        expected = {}
+        for dc in nights:
+            ids = {_write_l0(str(tmp_path), dc, 3600 + j * 100) for j in range(4)}
+            expected[dc] = ids
+
+        def _worker(dc):
+            df = _scan.scan_night_to_cache(str(tmp_path), dc)
+            obs_ids = {fn.split("/")[-1][:-5] for fn in df["FILENAME"]}
+            return (frozenset(obs_ids), "")
+
+        results = _scan.scan_datecodes(nights, jobs=8, worker=_worker)
+        assert set(results) == {frozenset(v) for v in expected.values()}
+
+
+# ---------------------------------------------------------------------------
+# warm_mini_db_caches: side-effect entry point, fail-soft
+# ---------------------------------------------------------------------------
+
+
+class TestWarmMiniDbCaches:
+    def test_writes_all_and_counts(self, tmp_path):
+        nights = ["20240101", "20240102"]
+        for dc in nights:
+            _write_l0(str(tmp_path), dc, 3600)
+
+        written, skipped = _scan.warm_mini_db_caches(str(tmp_path), nights, jobs=2)
+
+        assert (written, skipped) == (2, 0)
+        for dc in nights:
+            assert _cache_path(str(tmp_path), dc).is_file()
+
+    def test_empty_night_counted_skipped(self, tmp_path):
+        _write_l0(str(tmp_path), "20240101", 3600)  # good
+        (Path(tmp_path) / "L0" / "20240102").mkdir(parents=True)  # empty
+
+        written, skipped = _scan.warm_mini_db_caches(
+            str(tmp_path), ["20240101", "20240102"], jobs=2
+        )
+
+        assert (written, skipped) == (1, 1)
+
+    def test_fail_soft_on_pool_error(self, tmp_path, monkeypatch):
+        # A pool-level surprise must never abort the batch: warm swallows it and
+        # reports every night as skipped so the reduces fall back to in-process scans.
+        def _boom(datecodes, jobs, worker, *, label="scanning"):
+            raise RuntimeError("pool exploded")
+
+        monkeypatch.setattr(_scan, "scan_datecodes", _boom)
+        written, skipped = _scan.warm_mini_db_caches(
+            str(tmp_path), ["20240101", "20240102"], jobs=2
+        )
+        assert (written, skipped) == (0, 2)

--- a/tests/regression/test_science_script.py
+++ b/tests/regression/test_science_script.py
@@ -200,10 +200,11 @@ class TestMainExitCode:
             s,
             "warm_mini_db_caches",
             lambda di, dcs, jobs, cache="rw": (
-                warm_args.update(datecodes=dcs, cache=cache) or (0, 0)
+                warm_args.update(data_input=di, datecodes=dcs, cache=cache) or (0, 0)
             ),
         )
         s.main(["--obs_ids", _OID1, _OID2])
+        assert warm_args["data_input"] == "/in"  # resolved from config DATA_DIRS
         assert warm_args["datecodes"] == ["20240405"]
         assert warm_args["cache"] == "rw"
 

--- a/tests/regression/test_science_script.py
+++ b/tests/regression/test_science_script.py
@@ -25,14 +25,14 @@ class _FakeConfig:
         pass
 
     def get_params(self, keys):
-        return {"log_dir": "/l"}
+        return {"KPF_DATA_INPUT": "/in", "log_dir": "/l"}
 
 
 class _NoLogDirConfig(_FakeConfig):
-    """A config with no configured log_dir."""
+    """A config with a resolvable data input but no configured log_dir."""
 
     def get_params(self, keys):
-        return {}  # no log_dir
+        return {"KPF_DATA_INPUT": "/in"}  # no log_dir
 
 
 @pytest.fixture(scope="module")
@@ -187,7 +187,21 @@ class TestMainExitCode:
         monkeypatch.setattr(s, "configure_runtime", lambda: None)
         monkeypatch.setattr(s, "ConfigHandler", _FakeConfig)
         monkeypatch.setattr(s, "setup_batch_logging", lambda *a, **k: "/l/x.log")
+        monkeypatch.setattr(s, "warm_mini_db_caches", lambda *a, **k: (0, 0))
         monkeypatch.setattr(s, "run_stage", lambda *a, **k: set(failed))
+
+    def test_derives_datecodes_for_prescan(self, s, monkeypatch):
+        # The pre-scan gets the unique-sorted nights the frames span, not the raw
+        # obs_ids: two 20240405 frames collapse to one datecode.
+        warm_args = {}
+        self._patch(s, monkeypatch, failed=[])
+        monkeypatch.setattr(
+            s,
+            "warm_mini_db_caches",
+            lambda di, dcs, jobs: warm_args.update(datecodes=dcs) or (0, 0),
+        )
+        s.main(["--obs_ids", _OID1, _OID2])
+        assert warm_args["datecodes"] == ["20240405"]
 
     def test_exits_zero_when_all_reduced(self, s, monkeypatch):
         self._patch(s, monkeypatch, failed=[])

--- a/tests/regression/test_science_script.py
+++ b/tests/regression/test_science_script.py
@@ -192,16 +192,20 @@ class TestMainExitCode:
 
     def test_derives_datecodes_for_prescan(self, s, monkeypatch):
         # The pre-scan gets the unique-sorted nights the frames span, not the raw
-        # obs_ids: two 20240405 frames collapse to one datecode.
+        # obs_ids: two 20240405 frames collapse to one datecode. It warms up front
+        # (the science default cache="rw").
         warm_args = {}
         self._patch(s, monkeypatch, failed=[])
         monkeypatch.setattr(
             s,
             "warm_mini_db_caches",
-            lambda di, dcs, jobs: warm_args.update(datecodes=dcs) or (0, 0),
+            lambda di, dcs, jobs, cache="rw": (
+                warm_args.update(datecodes=dcs, cache=cache) or (0, 0)
+            ),
         )
         s.main(["--obs_ids", _OID1, _OID2])
         assert warm_args["datecodes"] == ["20240405"]
+        assert warm_args["cache"] == "rw"
 
     def test_exits_zero_when_all_reduced(self, s, monkeypatch):
         self._patch(s, monkeypatch, failed=[])

--- a/tests/regression/test_timeseries.py
+++ b/tests/regression/test_timeseries.py
@@ -347,6 +347,10 @@ class TestMainDispatch:
         assert ts.DEFAULT_MASTERS_CONFIG in calls[0]
         assert ts.DEFAULT_SCIENCE_RECIPE in calls[1]
         assert ts.DEFAULT_SCIENCE_CONFIG in calls[1]
+        # Discovery is the sole mini-db writer; both launched stages are forced
+        # read-only (--cache r) so they don't redundantly re-warm the caches.
+        for stage in (calls[0], calls[1]):
+            assert stage[stage.index("--cache") + 1] == "r"
         # Plot stage: the discovered frames (no rescan), reading from the science
         # output root, writing to its default {KPF_SCIENCE_OUTPUT}/QLP/timeseries.
         assert "scripts.plots.plot_timeseries" in calls[2]

--- a/tests/regression/test_timeseries.py
+++ b/tests/regression/test_timeseries.py
@@ -233,6 +233,16 @@ class TestDiscoverScienceObsIds:
         assert got == sorted(expected)
         assert len(got) == len(set(got)) == 24  # no duplicates, none dropped
 
+    def test_discovery_writes_mini_db_cache(self, ts, tmp_path):
+        # Discovery scans cache="rw" through the shared primitive, so it still
+        # writes each night's on-disk CSV as a side effect.
+        self._build_tree(str(tmp_path), ["20240101"], per_night=2)
+        ts.discover_science_obs_ids(
+            str(tmp_path), "10700", "20240101", "20240131", jobs=2
+        )
+        cache = Path(tmp_path) / "vNext" / "mini_db" / "20240101_L0.csv"
+        assert cache.is_file()
+
     def test_matches_serial_result(self, ts, tmp_path):
         # The discovery is deterministic: jobs=8 equals jobs=1.
         nights = ["20240101", "20240102", "20240103", "20240104"]

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -346,7 +346,7 @@ class TestSpectrumOrientation:
             ["bias", "dark", "flat", "thar"]
         )
         l1 = ImageProcessing(l1, config).perform()
-        l2 = SpectralExtraction(l1, config).perform(verbose=False)
+        l2 = SpectralExtraction(l1, config).perform()
         return WavelengthCalibration(l2, config).perform()
 
     def _anchor_cases(self, l2):

--- a/tools/select_master_cals.py
+++ b/tools/select_master_cals.py
@@ -103,7 +103,7 @@ def main():
     all_ids = []
     for dc in datecodes:
         try:
-            db = file_handler.build_mini_database(dc, cache=True)
+            db = file_handler.build_mini_database(dc, cache="rw")
         except ValueError as e:
             print(f"{dc}: {e} -- skipped", file=sys.stderr)
             continue

--- a/tools/select_master_cals.py
+++ b/tools/select_master_cals.py
@@ -103,7 +103,7 @@ def main():
     all_ids = []
     for dc in datecodes:
         try:
-            db = file_handler.build_mini_database(dc, cache="rw")
+            db = file_handler.build_mini_database(dc, cache="r")
         except ValueError as e:
             print(f"{dc}: {e} -- skipped", file=sys.stderr)
             continue

--- a/tools/select_master_cals.py
+++ b/tools/select_master_cals.py
@@ -38,14 +38,11 @@ from kpfpipe.utils.kpf_utils import get_datecode, get_obs_id, get_timestamp, is_
 
 # Per-type kwargs for build_calibration_stacks, matching recipes/kpf_drp_masters.py.
 # Darks are sparse long exposures whose sequences straddle HST midnight, so they
-# drop the threshold to 3, merge undersized clusters, and lift the midnight split.
+# drop the threshold to 3 and group the whole night into one stack (obs_night);
+# bias/thar use the default time_of_day (one stack per morn/eve session).
 _TYPE_KWARGS = {
     "bias": {},
-    "dark": {
-        "min_file_count": 3,
-        "merge_small_clusters": True,
-        "enforce_hst_midnight_boundary": False,
-    },
+    "dark": {"min_file_count": 3, "groupby": "obs_night"},
     "flat": {},
     "thar": {},
 }

--- a/tools/select_master_cals.py
+++ b/tools/select_master_cals.py
@@ -42,7 +42,7 @@ from kpfpipe.utils.kpf_utils import get_datecode, get_obs_id, get_timestamp, is_
 # bias/thar use the default time_of_day (one stack per morn/eve session).
 _TYPE_KWARGS = {
     "bias": {},
-    "dark": {"min_file_count": 3, "groupby": "obs_night"},
+    "dark": {"min_stack_size": 3, "groupby": "obs_night"},
     "flat": {},
     "thar": {},
 }


### PR DESCRIPTION
  ## Summary

  A cross-cutting cleanup of the masters pipeline, the FileHandler/mini-database layer in
  kpfpipe/utils/io.py, and the batch-processing scripts. Three threads:

  1. Masters frame-loading simplified and its exposure-time validation folded into the QC layer.
  2. The L0 "mini-database" is reworked — FileHandler is built from a plain data_dirs dict, cache
  reads/writes are split into explicit modes with atomic writes, calibration frames are sourced
  by type from the loaded scan, and cluster grouping is expressed as a groupby mode.
  3. The batch orchestrators warm the mini-db cache up front in parallel, gated by a new shared
  --cache flag that stops timeseries from triple-warming it.

  No scientific-array behavior changes; the changes are to frame selection, I/O, provenance of
  the exptime check, and orchestration.

  ### Masters: frame loading & stacking

  - Frame loads are gated on QCL0. BaseMasterModule._load_frame now runs QCL0(l0_obj).run() and
  drops any frame failing _REQUIRED_L0_QC_FLAGS (DATAPRL0, KWRDPRL0, EXPTIMOK, NOTJUNK), each
  named in a warning.
  - The EXPTIME/ELAPSED consistency check moved out of the masters loader into QCL0.exptime_sane
  (EXPTIMOK): the flag now also checks that ELAPSED neither falls short of nor exceeds EXPTIME
  beyond tolerance (premature/over-long readout). The standalone _check_exptime_vs_elapsed helper
  is deleted. config/L0-headers.csv comment updated to match.
  - Load-failure signaling simplified: _load_frame returns KPF1 | None instead of a (obj, 
  success) tuple; callers test is None.
  - verbose flags removed throughout the masters modules, SpectralExtraction, and
  CalibrationAssociation (dead progress-print plumbing).
  - Magic numbers named as class constants: _ZERO_EXPTIME_TOL_SECONDS (bias/zero-exposure
  threshold)
  - Bias/Dark/Flat/WLS are exported from kpfpipe.modules.masters.__init__.

  ### io.py / FileHandler & the mini-database

  - FileHandler(data_dirs) — constructed from the already-extracted [DATA_DIRS] mapping; the
  ConfigHandler dependency is gone.
  - Cache split into explicit modes ("r"/"w"/"rw"/"wr"/False) via _read_mini_db_cache /
  _write_mini_db_cache, replacing the old _validate_mini_db_cache. Writes are atomic (mkstemp →
  to_csv → os.replace). An invalid/stale cache now logs at warning level.
  - The cache mirrors the L0 directory. build_mini_database records every file, including frames
  with unreadable headers (as header-null rows), so the row-count freshness guardrail isn't
  tripped by a corrupt frame. _clean_mini_db drops those rows for the in-memory self._mini_db, so
  stacking still sees only readable frames.
  - Calibration frames are sourced by cal_type from self._mini_db (_select_frames), and
  clustering is expressed as a groupby mode (time_of_day / hst_day / obs_night), replacing
  _merge_undersized_clusters.
  - min_file_count → min_stack_size everywhere, and it's now configurable per cal type via the
  [BIAS]/[DARK]/[FLAT] config sections (build_calibration_stacks default is 1, a no-op filter).

 ### Masters recipe / config

  - recipes/kpf_drp_masters.py reads min_stack_size from each cal type's config section
  - configs/kpf_drp_masters.toml gains min_stack_size (5/3/5 for bias/dark/flat) and a
  currently-dormant max_stack_size.

 ### Processing scripts

  - New scripts/processing/_scan.py — up-front, parallel-by-datecode mini-db cache pre-scan
  (warm_mini_db_caches / scan_datecodes / scan_night_to_cache), kept apart from _dispatch.py so
  that module stays free of a kpfpipe.utils.io import.
  - Shared --cache flag (_argparse.cache_parser): masters/science/timeseries default "rw" (warm
  then read); a read-only mode skips the pre-scan. timeseries warms once in discovery and forces
  --cache r on the masters/science subprocesses it launches, collapsing the previous triple-warm
  to one.


 ### Docs

  CLAUDE.md and KPF_DRP_VNEXT_STYLE_GUIDE.md updated for the data_dirs-based FileHandler, the
  cache-mode/ownership model, _scan.py, and the atomic write.

 ### Tests

  New tests/regression/test_scan.py; updates across test_io.py, test_master_base.py,
  test_master_dark.py, test_master_wls.py, test_masters_script.py, test_science_script.py,
  test_timeseries.py, test_qc_flags.py, test_calibration_association.py, plus profiling helpers.
  Fast suite (make test-fast): 1312 passed.