### PR TITLE
docs: repo-wide docstring & comment cleanup + style-guide alignment

### DIFF
--- a/KPF_DRP_VNEXT_STYLE_GUIDE.md
+++ b/KPF_DRP_VNEXT_STYLE_GUIDE.md
@@ -587,6 +587,11 @@ consumes what the prior wrote (metrics → 0/1 flags → warn/raise):
   save as `f"{obs_id}_L{N}_{plotname}_{chip}_zoomable.png"` with `plt.close(fig)` after
   each. Unimplemented plots are stubbed with a docstring citing the v2.12 source and
   `raise NotImplementedError(...)`.
+- **Quicklook `run()` contract** (shared by every `PlotL{N}.run`): when `output_dir` is set,
+  each figure is saved there and closed to free memory; when `output_dir` is `None`, the
+  figures are returned **open** so a caller (e.g. an interactive notebook) can render them.
+  State this once here -- a per-level `run()` docstring should reference the contract, not
+  restate it.
 
 ---
 
@@ -833,14 +838,14 @@ class attribute (and uses `.routing` in `set_keyword`); the checkpoints validato
 
 ## 13. Docstrings & comments
 
-- **NumPy/numpydoc is the docstring standard.** Opening `"""` on its own line, summary
-  on the next line, `Parameters`/`Returns`/`Raises`/`Notes` sections with the
-  `name : type` form. Wrap referenced identifiers in backticks. The codebase is uniformly
-  numpydoc — no Google `Args:` style remains.
+- **NumPy/numpydoc is the docstring standard.** The summary **begins on the same line as
+  the opening `"""`** (never on its own line); the `Parameters`/`Returns`/`Raises`/`Notes`
+  sections follow after a blank line, in the `name : type` form. A short docstring is a
+  single line, `"""Summary."""`. The codebase is uniformly numpydoc — no Google `Args:`
+  style remains.
   ```python
   def compute_doppler_factor(v):
-      """
-      Relativistic Doppler factor f = lambda_obs / lambda_rest …
+      """Relativistic Doppler factor ``f = lambda_obs / lambda_rest`` …
 
       Parameters
       ----------
@@ -853,17 +858,23 @@ class attribute (and uses `.routing` in `set_keyword`); the checkpoints validato
           Dimensionless Doppler factor.
       """
   ```
+- **Wrap code identifiers in double backticks** (``` ``set_keyword`` ```, ``` ``obs_id`` ```):
+  in RST/Sphinx double backticks render as inline-code literals, whereas single backticks are
+  the default interpreted-text role and render as *italic*, not code.
 - **Module docstrings on every module.** One-liner for thin files
   (`"""KPF <Stage> module."""`); a rich multi-paragraph block for science modules,
   listing output HDUs with shapes/units and ending with a `Notes` section citing papers
-  (`Author (Year) — reason`). No author tags, dates, or `__author__`.
+  (`Author (Year) -- reason`). No author tags, dates, or `__author__`.
 - **Class docstrings document the `__init__` args at the class level** (in a `Parameters`
   section) — *not* on `__init__` itself. The `Attributes` section is **not** used; instead
   document instance attributes with the trailing `# populated by …` comment on the
   assignment in `__init__` (see §4).
 - **Document public methods and most private helpers.** Trivial math primitives may skip
   docstrings; short helpers may use a one-line summary, but anything with more than one
-  non-obvious argument should get full `Parameters`/`Returns` sections.
+  non-obvious argument should get full `Parameters`/`Returns` sections. On public methods,
+  document `Returns` as a section (not woven into the summary prose), and give **every
+  exception a caller can trigger** its own `Raises` entry -- do not omit one, understate its
+  cause, or bury it in `Notes`.
 - **`Examples` sections are not used.** Worked examples, where helpful, go in the prose of
   the summary (and double as test oracles for pure utils).
 - **Types are documented in the docstring, not the signature** (see §5). Array
@@ -877,6 +888,25 @@ class attribute (and uses `.routing` in `set_keyword`); the checkpoints validato
   docstrings/comments — not encoded in variable names (except unit-suffixed names like
   `..._KMS`). State the **air/vacuum convention** wherever wavelengths appear;
   use astropy `Quantity` for in-code units.
+- **Use ASCII `--`, not the em-dash `—`, inside docstrings and inline comments** (the Python
+  source is kept ASCII-only; `--` renders as an en-dash in Sphinx). This Markdown guide may
+  use `—` freely -- the rule is about `.py` docstrings/comments.
+- **State shared docstring content once, the same way everywhere.** A few descriptions recur
+  across many methods; use the canonical wording rather than re-deriving it per site:
+  - `chip : str` -- CCD identifier, e.g. `'GREEN'` or `'RED'`; `fiber : str` -- fiber
+    identifier, e.g. `'SCI1'`/…/`'CAL'`/`'SKY'`.
+  - **Calibration-source override forms** (`perform`/`make_master_*` args such as `bias`,
+    `master_wls`): `True` → resolve the path from the header; a `str` → load that path; a
+    `KPFMasterL{N}` → use in-memory. Define the meaning once (`ImageProcessing.perform`) and
+    reference it ("same forms as ``ImageProcessing.perform``") instead of re-enumerating.
+  - **Gaussian `optimize_lsq` parameters** are `theta = [b, a, mu, sigma]` (baseline,
+    amplitude, center, positive width).
+  - **Materializing memmapped FITS HDUs**: copy with `np.array(hdu.data)` (not `np.asarray`)
+    before the source file closes, so the array does not alias a freed memmap. Comment the
+    reason **once** at a canonical site; other sites just follow the idiom.
+  - **`to_fits` single-filepath shim**: KPF keeps one positional filepath; rvdata `>=0.4.0`
+    renamed the parameter to `out_filename`, so the KPF override forwards it. Explain once,
+    not per level.
 - **`TODO` is the only task marker** (`# TODO: <imperative or open question>`); no
   `FIXME`/`XXX`/`HACK`/`NOTE:`. No issue/ticket linkage is the current norm.
 - **Provenance**: legacy v2.12 compatibility choices are generally **not** annotated in

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -3,8 +3,7 @@ API
 ===
 
 Auto-generated reference for the ``kpfpipe`` package, built from the source
-docstrings. The entries below are the top-level subpackages; each recurses
-automatically through its own modules.
+docstrings.
 
 .. autosummary::
    :toctree: _generated

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,14 +87,6 @@ autosummary_context = {
     # Subpackages that keep their own page even when the parent package is
     # curated (has __all__) and its leaf submodules are collapsed inline.
     "subpackages": _find_subpackages(_repo_root),
-    # Sidebar/page-title overrides. The default title is the stemless leaf name
-    # (e.g. "barycentric_correction", "level0"); an entry here replaces it for
-    # that exact module (e.g. show both masters subpackages simply as "Masters").
-    # Keyed by full dotted name.
-    "title_overrides": {
-        "kpfpipe.modules.masters": "Masters",
-        "kpfpipe.data_models.masters": "Masters",
-    },
 }
 
 autodoc_default_options = {

--- a/kpfpipe/__init__.py
+++ b/kpfpipe/__init__.py
@@ -1,12 +1,15 @@
+"""KPF pipeline package root: version, detector config, and shared defaults."""
+
 import importlib.metadata
 import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
-# Installed package version (WMKO DRP-RUN-11); stamped onto PRIMARY as DRPTAG/
-# DRPVERNO. Falls back to "unknown" if the package metadata is unavailable
-# (e.g. running from a source tree that was never installed).
+# Installed package version (WMKO DRP-RUN-11); stamped onto RECEIPT as DRPVERNO
+# (the EPRV equivalent DRPTAG is the value carried on PRIMARY). Falls back to
+# "unknown" if the package metadata is unavailable (e.g. running from a source
+# tree that was never installed).
 try:
     __version__ = importlib.metadata.version("kpfpipe")
 except importlib.metadata.PackageNotFoundError:

--- a/kpfpipe/data_models/__init__.py
+++ b/kpfpipe/data_models/__init__.py
@@ -2,7 +2,7 @@
 KPF data models.
 
 KPF0 -- Raw CCD data (Level 0)
-KPF1 -- Assembled 2D frames (Level 1)
+KPF1 -- Assembled FFIs (Level 1)
 KPF2 -- Extracted spectra (Level 2, extends RV2 with KPF aliases)
 KPF4 -- RVs and CCFs (Level 4, extends RV4 with KPF aliases)
 """

--- a/kpfpipe/data_models/aliased_dict.py
+++ b/kpfpipe/data_models/aliased_dict.py
@@ -12,12 +12,12 @@ class AliasedOrderedDict(OrderedDict):
     """
     OrderedDict with transparent name aliases.
 
-    Register an alias with `register_alias(alias, canonical)`. After that,
-    `__getitem__`, `__setitem__`, `__contains__`, and `get()` all resolve the
-    alias to the canonical key before performing the lookup. For example, once
+    Register an alias with ``register_alias(alias, canonical)``. After that,
+    ``__getitem__``, ``__setitem__``, ``__contains__``, and ``get()`` all resolve
+    the alias to the canonical key before performing the lookup. For example, once
     "SCI2_FLUX" is registered as an alias for "TRACE3_FLUX", reading
-    `d["SCI2_FLUX"]` returns the same object stored under "TRACE3_FLUX" and
-    `"SCI2_FLUX" in d` is True.
+    ``d["SCI2_FLUX"]`` returns the same object stored under "TRACE3_FLUX" and
+    ``"SCI2_FLUX" in d`` is True.
     """
 
     def __init__(self, *args, **kwargs):

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -14,12 +14,9 @@ from astropy.io import fits
 from astropy.table import Table
 from rvdata.core.models.base import RVDataModel
 
-# The header/extension keyword registry lives in its own module as a single
-# KeywordRegistry instance; base.py is its only importer. The instance is
-# surfaced as a KPFDataModel class attribute (below) so consumers handed a
-# kpf_obj (the checkpoints validator, level0's WMKO->EPRV mapping, tests) reach
-# it through kpf.keyword_registry, and re-exported so sibling data_models files
-# (level2/4) import the same singleton from base.
+# The keyword registry lives in its own module as a single KeywordRegistry
+# instance; base.py is its only importer, and re-exports it (below) so sibling
+# data_models files (level2/4) import the same singleton from base.
 from kpfpipe.data_models.keyword_registry import keyword_registry
 from kpfpipe.utils.kpf_utils import is_obs_id
 
@@ -47,11 +44,8 @@ class KPFDataModel(RVDataModel):
     """Shared base for every KPF data model (L0, L1, L2, L4)."""
 
     # The keyword registry singleton, surfaced as a class attribute so anything
-    # handed a KPF data model (the checkpoints header validator, level0's
-    # WMKO->EPRV mapping, tests) reaches it via kpf.keyword_registry — keeping
-    # data_models/keyword_registry imported only by base.py. set_keyword uses
-    # .routing; the validator uses .allowed / .required / .structural; .table is
-    # the source table and .registered the allowlist.
+    # handed a KPF data model (the checkpoints validator, level0's WMKO->EPRV
+    # mapping, tests) reaches it via kpf.keyword_registry.
     keyword_registry = keyword_registry
 
     def __init__(self):
@@ -81,14 +75,9 @@ class KPFDataModel(RVDataModel):
         return obj
 
     def _obs_id_from_receipt(self):
-        """Recover the obs_id from the ORIGID provenance card on RECEIPT.
-
-        ORIGID is the original L0 obs_id, stamped by ``KPF0`` and forwarded on the
-        RECEIPT header through every level, so it is the obs_id source for a
-        from_fits'd L1/L2/L4 product (whose own filename does not embed it).
-        Returns ``None`` when RECEIPT/ORIGID is absent or not a valid obs_id
-        (e.g. masters, which carry no ORIGID).
-        """
+        """Recover the obs_id from the ORIGID card on RECEIPT (``None`` if absent
+        or invalid, e.g. masters). ORIGID is stamped at L0 and forwarded on the
+        RECEIPT header, so it is the obs_id source for a from_fits'd L1/L2/L4."""
         receipt = self.headers.get("RECEIPT")
         origid = receipt.get("ORIGID") if receipt is not None else None
         return origid if is_obs_id(origid) else None
@@ -99,13 +88,10 @@ class KPFDataModel(RVDataModel):
 
         KPF stores every extension header as a ``fits.Header`` so reads and writes
         go through astropy natively, with no value-vs-``(value, comment)``
-        ambiguity. This is the single bridge from the two legacy in-memory forms:
-
-        - a ``fits.Header`` (e.g. from ``from_fits``) is returned as a copy, so a
-          caller can rebuild an HDU without aliasing the stored header;
-        - a plain mapping (RVData seeds PRIMARY defaults as an ``OrderedDict`` whose
-          entries are ``(value, comment)`` tuples) is rebuilt card by card —
-          ``head[kw] = (value, comment)`` sets the value and comment together.
+        ambiguity. A ``fits.Header`` is returned as a copy (so callers can rebuild
+        an HDU without aliasing the stored header); a plain mapping — RVData seeds
+        PRIMARY defaults as an ``OrderedDict`` of ``(value, comment)`` tuples — is
+        rebuilt card by card, setting each value and comment together.
         """
         if isinstance(src, fits.Header):
             return src.copy()
@@ -212,12 +198,9 @@ class KPFDataModel(RVDataModel):
 
     def _coerce_to_min_bit_depth(self, canonical_ext, data, label):
         """Upcast ``data`` to satisfy ``canonical_ext``'s MinBitDepth, mirroring
-        rvdata's base ``set_data`` enforcement (incl. its warning) for the
-        chip-prefix write path that bypasses it. ``canonical_ext`` is the resolved
-        extension whose requirement applies (e.g. ``TRACE3_WAVE``); ``label`` is
-        the name shown in the warning (the chip-prefix key the caller passed).
-        A no-op when there is no requirement, the array is empty, or it already
-        meets the depth (and for KPF4, whose ``_get_min_bit_depth`` returns None).
+        rvdata's ``set_data`` enforcement (and its warning) for the chip-prefix
+        write path that bypasses it. A no-op with no requirement, an empty array,
+        or data already at depth (and for KPF4, whose MinBitDepth is None).
         """
         min_depth = self._get_min_bit_depth(canonical_ext)
         if (
@@ -252,15 +235,11 @@ class KPFDataModel(RVDataModel):
     def _forward_headers(self, target, ext_names):
         """Forward governed extension headers onto ``target``, card by card.
 
-        The single home for the header carry-over shared by the
-        ``to_kpf{1,2,4}`` level-up conversions. For each name present on both
-        sides, every card is copied with its FITS comment (iterating
-        ``.items()`` would drop comments). Copying *overlays* onto the target's
-        existing header rather than replacing it, so a PRIMARY pre-seeded with
-        the EPRV skeleton keeps cards the source lacks (native values win), and
-        INSTRUMENT_HEADER / QUALITY_CONTROL / RECEIPT — created empty on the
-        target — receive a verbatim, comment-preserving copy. An extension
-        absent on either side is skipped.
+        Shared by the ``to_kpf{1,2,4}`` conversions: for each name present on both
+        sides, copy every card with its FITS comment (``.items()`` would drop
+        comments). Copying overlays onto the target's header rather than replacing
+        it, so a PRIMARY pre-seeded with the EPRV skeleton keeps cards the source
+        lacks (native values win). An extension absent on either side is skipped.
         """
         for ext in ext_names:
             if ext in self.headers and ext in target.headers:
@@ -293,12 +272,10 @@ class KPFDataModel(RVDataModel):
         self.set_keyword("DRPSTATU", f"{label} module complete")
 
     def _create_hdul(self):
-        """Sync ``self.receipt`` into the RECEIPT extension before writing; rvdata
-        serializes ``self.data["RECEIPT"]``, not ``self.receipt``. L0/L1 omit
-        RECEIPT from their default extensions, so create it if absent. PRIMARY
-        keyword comments are preserved by rvdata's own ``_create_hdul`` (it copies
-        a ``fits.Header`` directly) as of rvdata >=0.4.0, so no PRIMARY rebuild is
-        needed here."""
+        """Sync ``self.receipt`` into the RECEIPT extension before writing (rvdata
+        serializes ``self.data["RECEIPT"]``, not ``self.receipt``), creating the
+        extension if L0/L1 omitted it. PRIMARY comments are preserved by rvdata's
+        own ``_create_hdul``, so no PRIMARY rebuild is needed."""
         if self.receipt is not None and not self.receipt.empty:
             if "RECEIPT" not in self.extensions:
                 self.create_extension("RECEIPT", "BinTableHDU")

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -21,7 +21,7 @@ from kpfpipe.data_models.keyword_registry import keyword_registry
 from kpfpipe.utils.kpf_utils import is_obs_id
 
 # Receipt names that are data-model conversions / serialization rather than
-# pipeline modules — excluded from DRPSTATU so it names the last real stage.
+# pipeline modules -- excluded from DRPSTATU so it names the last real stage.
 # ``read``/``from_fits`` are here too: reading a product back must not clobber
 # the status the writer stamped (rvdata >=0.4.0 logs a ``read`` receipt via its
 # ``@receipt_logged`` decorator on ``RVDataModel.read``).
@@ -89,8 +89,8 @@ class KPFDataModel(RVDataModel):
         KPF stores every extension header as a ``fits.Header`` so reads and writes
         go through astropy natively, with no value-vs-``(value, comment)``
         ambiguity. A ``fits.Header`` is returned as a copy (so callers can rebuild
-        an HDU without aliasing the stored header); a plain mapping — RVData seeds
-        PRIMARY defaults as an ``OrderedDict`` of ``(value, comment)`` tuples — is
+        an HDU without aliasing the stored header); a plain mapping -- RVData seeds
+        PRIMARY defaults as an ``OrderedDict`` of ``(value, comment)`` tuples -- is
         rebuilt card by card, setting each value and comment together.
         """
         if isinstance(src, fits.Header):
@@ -117,7 +117,7 @@ class KPFDataModel(RVDataModel):
         writes ``value`` to the extension named there, with the registry
         Description as the FITS comment. This is the single write path for
         registered keywords, so a keyword always lands on the same extension with
-        the same comment — callers never name a comment.
+        the same comment -- callers never name a comment.
 
         ``ext`` targets a specific extension for EPRV per-extension cards that
         have no single routed home because they recur on every orderlet's
@@ -134,7 +134,7 @@ class KPFDataModel(RVDataModel):
             ``config/L{level}-headers.csv`` before writing it.
         ValueError
             If the target extension does not exist on this object (a config
-            error — the extension must be created before the write).
+            error -- the extension must be created before the write).
         """
         name = str(key).strip()
         if ext is None:
@@ -285,7 +285,7 @@ class KPFDataModel(RVDataModel):
     def generate_standard_filename(self):
         """Abstract: every concrete KPF model builds its own standard filename.
 
-        KPFDataModel is never instantiated directly — only inherited — so reaching
+        KPFDataModel is never instantiated directly -- only inherited -- so reaching
         this means a subclass failed to define the method.
         """
         raise NotImplementedError(
@@ -295,7 +295,7 @@ class KPFDataModel(RVDataModel):
     def check_filename_convention(self, filename):
         """Abstract: every concrete KPF model declares its own filename convention.
 
-        KPFDataModel is never instantiated directly — only inherited — so reaching
+        KPFDataModel is never instantiated directly -- only inherited -- so reaching
         this means a subclass failed to define the method.
         """
         raise NotImplementedError(

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -1,12 +1,9 @@
 """
 KPF base data model.
 
-Thin layer on top of RVDataModel that adds KPF-specific attributes and the
-behaviour shared by every KPF data model: fits.Header storage, the DRPSTATU
-receipt stamp, alias-aware set_data/set_header, and lossless PRIMARY
-serialization. All four KPF models inherit it — L0/L1 directly, and L2/L4 via
-multiple inheritance alongside rvdata's RV2/RV4 (KPFDataModel listed first so
-its overrides win while RV2/RV4 remain reachable through ``super()``).
+Shared base for every KPF data model (L0, L1, L2, L4). Extends the EPRV
+``RVDataModel`` with the behaviour common to all KPF products: FITS-header
+storage, provenance receipts, and alias-aware data and header access.
 """
 
 import logging
@@ -47,8 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 class KPFDataModel(RVDataModel):
-    """Shared base for every KPF data model (L0, L1, and — multiply-inherited
-    with RV2/RV4 — L2, L4)."""
+    """Shared base for every KPF data model (L0, L1, L2, L4)."""
 
     # The keyword registry singleton, surfaced as a class attribute so anything
     # handed a KPF data model (the checkpoints header validator, level0's

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -1,5 +1,5 @@
 """
-KPF-specific base data model.
+KPF base data model.
 
 Thin layer on top of RVDataModel that adds KPF-specific attributes and the
 behaviour shared by every KPF data model: fits.Header storage, the DRPSTATU

--- a/kpfpipe/data_models/config/__init__.py
+++ b/kpfpipe/data_models/config/__init__.py
@@ -1,1 +1,1 @@
-# Makes this directory a package for importlib.resources.
+"""Makes this directory a package for importlib.resources."""

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -21,15 +21,15 @@ KPF rows). The ``routing``/``allowed``/``required``/``eprv_primary_*`` lookups a
 derived from this table.
 
 The three use-cases:
-  (1) Mapping  — ``header_map`` (WMKO->EPRV), consumed by ``KPF0._map_header``;
+  (1) Mapping  -- ``header_map`` (WMKO->EPRV), consumed by ``KPF0._map_header``;
       ``eprv_primary_datatypes`` types the values it emits. ``header_map`` is
       **sanitized on load** so it holds only genuine static native->EPRV mappings:
       rows whose key is unregistered (PARANG/PARANG2) or handled elsewhere
       (``_DEFAULT_OVERRIDES``) are dropped, so ``_map_header`` needs no
       in-loop filter or per-keyword correction.
-  (2) Validation — ``allowed`` / ``required`` (per-extension, from the table)
+  (2) Validation -- ``allowed`` / ``required`` (per-extension, from the table)
       plus ``structural`` (FITS bookkeeping cards).
-  (3) Routing — ``routing`` (keyword -> (extension, comment)) for the default
+  (3) Routing -- ``routing`` (keyword -> (extension, comment)) for the default
       home-extension write, plus ``comment_for`` ((extension, keyword) ->
       comment) for ``set_keyword``'s targeted (``ext=``) write of EPRV
       per-extension cards. Both consumed by ``KPFDataModel.set_keyword``.
@@ -299,7 +299,7 @@ class KeywordRegistry:
     def comment_for(self, keyword, extension):
         """FITS comment (registry Description) for ``keyword`` on ``extension``.
 
-        Returns None when the keyword is not registered for that extension — the
+        Returns None when the keyword is not registered for that extension -- the
         membership test set_keyword's targeted (``ext=``) path uses; a registered
         keyword with an empty Description returns ``""``, distinct from None.
         """
@@ -314,7 +314,7 @@ class KeywordRegistry:
         EPRV CSVs encode per-key/per-telescope families as a "BASE1 ... BASE#"
         template; expand each to literal rows BASE1-9 (only index 1 inherits the
         Required flag, mirroring rvdata's seed). EPRV rows carry ``"EPRV"`` in the
-        ``PopulatedBy`` column — the discriminator the derived lookups use to
+        ``PopulatedBy`` column -- the discriminator the derived lookups use to
         tell EPRV rows from KPF rows.
         """
         rows = []
@@ -496,10 +496,10 @@ class KeywordRegistry:
 
         Returns ``(seed, datatypes)``:
 
-        - ``seed`` — ``{keyword: (typed_default, comment)}`` for the EPRV Required
+        - ``seed`` -- ``{keyword: (typed_default, comment)}`` for the EPRV Required
           PRIMARY keywords at Level <= 1 (the skeleton ``KPF1.__init__`` stamps),
           typed via ``parse_value_to_datatype`` like ``RV2.__init__``.
-        - ``datatypes`` — ``{keyword: DataType}`` for *all* EPRV PRIMARY keywords,
+        - ``datatypes`` -- ``{keyword: DataType}`` for *all* EPRV PRIMARY keywords,
           so ``_map_header`` can type the values it overlays. Scoped to EPRV PRIMARY
           so it never feeds KPF's ``int``/``str`` to ``parse_value_to_datatype``.
         """
@@ -529,10 +529,11 @@ class KeywordRegistry:
         tuple
             ``(all_flags, by_level)``. ``all_flags`` is every QUALITY_CONTROL row
             tagged by a QC populator (used for the cross-level ISGOOD aggregate).
-            ``by_level`` maps a LEVEL tag ("L0"/"L1"/"L2") to that level's own
-            ``QCL{n}`` flags (used by the per-level checkpoint). The generic "QC"
-            aggregate keyword (ISGOOD) is in ``all_flags`` only — in no per-level
-            set, so the checkpoint never warns/raises on the aggregate itself.
+            ``by_level`` maps a LEVEL tag (one per registered level, e.g.
+            "L0"/"L1"/"L2"/"L4") to that level's own ``QCL{n}`` flags (used by the
+            per-level checkpoint). The generic "QC" aggregate keyword (ISGOOD) is
+            in ``all_flags`` only -- in no per-level set, so the checkpoint never
+            warns/raises on the aggregate itself.
         """
         all_flags = set()
         by_level = {}
@@ -543,7 +544,7 @@ class KeywordRegistry:
             ):
                 continue
             all_flags.add(row.Keyword)
-            if row.PopulatedBy != "QC":  # "QCL0"/"QCL1"/"QCL2" -> "L0"/"L1"/"L2"
+            if row.PopulatedBy != "QC":  # "QCL{n}" -> "L{n}", for each registered level
                 by_level.setdefault(row.PopulatedBy[2:], set()).add(row.Keyword)
         return all_flags, by_level
 
@@ -557,7 +558,7 @@ class KeywordRegistry:
         ``LEVELn_EXTENSIONS`` DataFrame; a KPF-only extension (e.g. QUALITY_CONTROL)
         is absent there, so reading an Ln product that contains it raises ``KeyError``.
         This appends the row in-memory (idempotent). ``Required`` is False so rvdata
-        neither auto-creates it nor lists it in EXT_DESCRIPT — the KPF model
+        neither auto-creates it nor lists it in EXT_DESCRIPT -- the KPF model
         ``__init__`` creates the (empty) extension explicitly.
         """
         if name in set(level_extensions["Name"]):
@@ -574,5 +575,5 @@ class KeywordRegistry:
         level_extensions.loc[len(level_extensions)] = row
 
 
-# Module singleton — the one registry instance every consumer reaches through.
+# Module singleton -- the one registry instance every consumer reaches through.
 keyword_registry = KeywordRegistry()

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -205,15 +205,13 @@ class KeywordRegistry:
         self._load_header_map()
 
     def _build_registry(self):
-        """Build ``self.table`` and every lookup derived from it.
+        """Build ``self.table`` and every read-only lookup derived from it.
 
-        Assembles the unified table (EPRV rows first, then KPF rows; KPF wins a
-        collision), corrects the Defaults header_map.csv gets wrong (NUMORDER
-        65 -> 67) or that are runtime (DRPTAG -> version), drops structural cards
-        rvdata redundantly registers, then derives the read-only lookups. All are
-        shared process-wide via the singleton, so they are frozen (frozenset /
-        MappingProxyType) against a stray consumer mutation; ``self.table`` is
-        only ever read.
+        Unions the EPRV and KPF rows (KPF wins a collision), applies the
+        ``_DEFAULT_OVERRIDES`` corrections, drops structural cards rvdata
+        redundantly registers, then derives the lookups. All are frozen (frozenset
+        / MappingProxyType) against stray mutation, since the singleton shares them
+        process-wide.
         """
         eprv_rows, kpf_rows = self._build_rows()
         table = pd.DataFrame(eprv_rows + kpf_rows, columns=self._COLUMNS)
@@ -221,9 +219,8 @@ class KeywordRegistry:
             if value is not None:
                 table.loc[table["Keyword"] == keyword, "Default"] = value
         # Structural cards are written by astropy, never registered: drop any that
-        # rvdata redundantly declares as keywords (e.g. XTENSION/EXTNAME), so
-        # registered & structural stay disjoint. (structural is derived first so
-        # is_structural is available here.)
+        # rvdata redundantly declares as keywords, so registered & structural stay
+        # disjoint. (structural is derived first so is_structural is available here.)
         self.structural = frozenset(self._STRUCTURAL)
         table = table[~table["Keyword"].map(self.is_structural)].reset_index(drop=True)
         self.table = table
@@ -258,16 +255,12 @@ class KeywordRegistry:
     def _load_header_map(self):
         """Read and sanitize rvdata's WMKO-native -> EPRV-standard ``header_map``.
 
-        First realigns the fiber-indexed STANDARD keys from rvdata's CAL-first to
-        KPF's SKY-first numbering (see ``_FIBER_INDEXED_BASES``), then keeps only
-        genuine static native->EPRV mapping rows so KPF0._map_header applies the map
-        with no in-loop filter or per-keyword correction. Two row classes are dropped:
-          - STANDARD keys absent from the registry (PARANG/PARANG2) -- warned, so
-            the rvdata header_map / registry inconsistency stays visible;
-          - ``_DEFAULT_OVERRIDES`` keys, whose value comes from the corrected table
-            default, the model level, or the _map_header epoch transform, not a
-            static map row.
-        Runs after ``_build_registry`` -- it filters against ``self.registered``.
+        Realigns the fiber-indexed STANDARD keys from rvdata's CAL-first to KPF's
+        SKY-first numbering (see ``_FIBER_INDEXED_BASES``), then keeps only genuine
+        static native->EPRV rows so ``KPF0._map_header`` needs no in-loop filter.
+        Drops STANDARD keys absent from the registry (PARANG/PARANG2, warned) and
+        ``_DEFAULT_OVERRIDES`` keys (valued elsewhere). Runs after
+        ``_build_registry`` -- it filters against ``self.registered``.
         """
         raw = pd.read_csv(_rvdata_inst_cfg / "header_map.csv")
         # Swap trace index 1<->5 for the fiber-indexed families (SKY<->CAL). A dict
@@ -374,12 +367,10 @@ class KeywordRegistry:
         """Expand a KPF header CSV into unified-registry rows.
 
         Shared by ``_kpf_rows`` and ``_masters_rows``. ``Required`` is always
-        False; ``PopulatedBy`` is whatever the CSV says, but it must NEVER be the
-        EPRV sentinel: the derived routing/validation lookups treat a
-        ``PopulatedBy == _EPRV_TAG`` row as EPRV-sourced, so a KPF row reusing that
-        string would be silently misclassified (dropped from routing, given the
-        wrong Required/Level). Guard against it loudly here. ``source`` names the
-        CSV for that error; ``level_of(row)`` yields each row's Level.
+        False; ``PopulatedBy`` must never be the EPRV sentinel (the derived lookups
+        treat such a row as EPRV-sourced and would misclassify it), so guard against
+        it loudly. ``source`` names the CSV for that error; ``level_of(row)`` yields
+        each row's Level.
         """
         rows = []
         for _, r in df.iterrows():
@@ -425,13 +416,10 @@ class KeywordRegistry:
         """KPF masters keyword rows from the per-master-type registries
         config/{ML1,ML2-flat,ML2-wls}-headers.csv.
 
-        Masters (bias/dark/flat/WLS calibration products) are out of EPRV scope
-        but route their PRIMARY keywords (MASTYPE + the WLS metadata) through
-        ``set_keyword`` like the science models, so they are registered here. One
-        file per master type (mirroring the per-type ``ML*-extensions.csv`` manifests);
-        Level is derived from the filename like ``_kpf_rows`` (ML1 -> 1, ML2 -> 2).
-        MASTYPE appears in every file (harmless: it dedups in ``registered`` and has a
-        single PRIMARY home). All three union into the one global table.
+        Masters are out of EPRV scope but route their PRIMARY keywords (MASTYPE +
+        WLS metadata) through ``set_keyword`` like the science models, so they are
+        registered here. Level is derived from the filename (ML1 -> 1, ML2 -> 2);
+        MASTYPE recurs harmlessly across files (it dedups in ``registered``).
         """
         rows = []
         for fname, level in (
@@ -509,15 +497,11 @@ class KeywordRegistry:
         Returns ``(seed, datatypes)``:
 
         - ``seed`` — ``{keyword: (typed_default, comment)}`` for the EPRV Required
-          PRIMARY keywords at Level <= 1 (the skeleton ``KPF1.__init__`` stamps;
-          these are tagged Level 1 in the table -- see ``_build_rows``).
-          Built exactly like ``RV2.__init__``: format the unit/description comment,
-          then type the default via ``parse_value_to_datatype`` so consumers assign
-          it straight into a header. Insertion order follows the EPRV standard's.
-        - ``datatypes`` — ``{keyword: DataType}`` for *all* EPRV PRIMARY keywords
-          (required + optional), so ``_map_header`` can type the native/default
-          values it overlays. Scoped to EPRV PRIMARY (rvdata-vocab datatypes), so
-          it never feeds KPF's ``int``/``str`` to ``parse_value_to_datatype``.
+          PRIMARY keywords at Level <= 1 (the skeleton ``KPF1.__init__`` stamps),
+          typed via ``parse_value_to_datatype`` like ``RV2.__init__``.
+        - ``datatypes`` — ``{keyword: DataType}`` for *all* EPRV PRIMARY keywords,
+          so ``_map_header`` can type the values it overlays. Scoped to EPRV PRIMARY
+          so it never feeds KPF's ``int``/``str`` to ``parse_value_to_datatype``.
         """
         seed = {}
         datatypes = {}

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -78,18 +78,11 @@ class KPF0(KPFDataModel):
     def _stamp_wmko_tracking(self):
         """Stamp WMKO DRP-RUN provenance onto the L0 RECEIPT at read time.
 
-        This is the single population site for the provenance cards (their
-        `PopulatedBy` in config/L0-headers.csv is `KPF0.from_fits`):
-        DRPVERNO (DRP-RUN-11), PROGID/KOAID (DRP-RUN-19), DRPSTATU (DRP-RUN-20),
-        and ORIGID (the original L0 obs_id). They are written to their registry
-        home, RECEIPT, via `set_keyword`, and ride the RECEIPT-header forward onto
-        L1/L2/L4 (see `to_kpf1`). The raw PRIMARY and its INSTRUMENT_HEADER
-        snapshot are left untouched.
-
-        DRPVERNO and DRPSTATU are always (re)stamped. PROGID/KOAID are read from
-        the WMKO-native PRIMARY; an absent (or empty) value is defaulted to UNKNOWN
-        with a warning, so the cards are always present downstream. ORIGID is
-        stamped only when the obs_id was resolved (e.g. from the filename).
+        The single population site for DRPVERNO, PROGID/KOAID, DRPSTATU, and ORIGID
+        (the original L0 obs_id), written to their registry home (RECEIPT) via
+        ``set_keyword`` and ridden forward onto L1/L2/L4 (see ``to_kpf1``).
+        DRPVERNO/DRPSTATU are always (re)stamped; a missing PROGID/KOAID defaults
+        to UNKNOWN with a warning; ORIGID is stamped only when the obs_id resolved.
         """
         self.set_keyword("DRPVERNO", __version__)
         self.set_keyword("DRPSTATU", _DRPSTATU_DEFAULT)
@@ -215,17 +208,9 @@ class KPF0(KPFDataModel):
         """Map this L0's raw WMKO PRIMARY to an EPRV-standard PRIMARY dict.
 
         A pure tabular application of the registry's (sanitized) header_map: for
-        each row, take the instrument (WMKO) value when present, else the row
-        default, and type it to the EPRV DataType. The registry already dropped
-        non-mapping rows (unregistered targets like PARANG, and keywords sourced
-        elsewhere -- NUMORDER/DRPTAG seeded, DATALVL the model level), so there is
-        no filter or per-keyword correction here.
-
-        The sole exception is ``JD_UTC``: it is a per-frame value transform of the
-        native ``MJD-OBS`` (+ epoch offset), not a static default, so header_map
-        cannot carry it; it is computed below. DRP-RUN provenance
-        (DRPVERNO/PROGID/KOAID/DRPSTATU) lives on RECEIPT (see
-        ``_stamp_wmko_tracking``), not here.
+        each row take the instrument value if present, else the row default, and
+        type it to the EPRV DataType. ``JD_UTC`` is the sole exception — a
+        per-frame transform of the native ``MJD-OBS``, computed below.
 
         Returns
         -------
@@ -249,18 +234,16 @@ class KPF0(KPFDataModel):
                 raw_value = default_val
             else:
                 continue
-            # Type the value to its EPRV DataType (rvdata-vocab) so the L1 overlay
-            # matches L2's typing (e.g. NUMTRACE '5' -> 5), for both native values
-            # and CSV-string defaults. Emit the bare value so to_kpf1's assignment
-            # preserves the comment KPF1.__init__ seeded onto the PRIMARY card.
+            # Type to the EPRV DataType so the L1 overlay matches L2's typing (e.g.
+            # NUMTRACE '5' -> 5). Emit the bare value so to_kpf1's assignment keeps
+            # the comment KPF1.__init__ seeded onto the PRIMARY card.
             dt = self.keyword_registry.eprv_primary_datatypes.get(eprv_key)
             out[eprv_key] = (
                 parse_value_to_datatype(eprv_key, dt, raw_value)[0] if dt else raw_value
             )
 
-        # JD_UTC: KPF's canonical exposure time is the native MJD-OBS; convert it to
-        # a full Julian date (+ 2400000.5). The one value transform header_map can't
-        # express, so it lives here rather than as a static map default.
+        # JD_UTC: convert the native MJD-OBS to a full Julian date. The one value
+        # transform header_map can't express, so it lives here, not as a default.
         mjd = wmko_primary.get("MJD-OBS")
         if mjd not in (None, "", "UNKNOWN"):
             out["JD_UTC"] = (
@@ -270,30 +253,23 @@ class KPF0(KPFDataModel):
         return out
 
     def to_kpf1(self):
-        """
-        Create a KPF1 scaffold from this L0, carrying over headers and
+        """Create a KPF1 scaffold from this L0, carrying over headers and
         pass-through extensions.
 
-        The raw WMKO PRIMARY header is converted to EPRV-standard keyword names
-        and values here (the single conversion site; see `_map_header`), so the
-        L1 PRIMARY is already EPRV-standard (EPRV-registered keywords only). The
-        DRP-RUN provenance cards (DRPVERNO/PROGID/KOAID/DRPSTATU) live on RECEIPT
-        (stamped at read) and reach L1 via the RECEIPT-header forward below. The
-        L0 PRIMARY as ingested is preserved in the immutable INSTRUMENT_HEADER
-        extension. Downstream stages read raw instrument keywords from
-        INSTRUMENT_HEADER and write EPRV/registered KPF keywords to PRIMARY.
+        The raw WMKO PRIMARY is converted to EPRV-standard names/values here (the
+        single conversion site; see ``_map_header``), and preserved verbatim in the
+        immutable INSTRUMENT_HEADER. DRP-RUN provenance lives on RECEIPT (stamped
+        at read) and reaches L1 via the header forward below.
 
-        Returns a KPF1 with EPRV PRIMARY header, INSTRUMENT_HEADER, pass-through
+        Returns a KPF1 with EPRV PRIMARY, INSTRUMENT_HEADER, pass-through
         extensions (CA_HK, EXPMETER_SCI/SKY, TELEMETRY, DRP_CONFIG), receipt, and
         obs_id copied over. GREEN_CCD, GREEN_VAR, RED_CCD, RED_VAR are created
-        but empty — the caller (image assembly) fills those in.
+        empty — the caller (image assembly) fills those in.
         """
         kpf1 = KPF1()
 
-        # Convert the raw WMKO PRIMARY to EPRV-standard names/values, and preserve
-        # the raw L0 PRIMARY verbatim (values + comments, via as_fits_header) in the
-        # immutable INSTRUMENT_HEADER -- only the raw instrument cards (DRP-RUN
-        # provenance lives on RECEIPT), and nothing else ever writes to it.
+        # Convert the raw WMKO PRIMARY to EPRV names/values, and snapshot the raw
+        # L0 PRIMARY verbatim into the immutable INSTRUMENT_HEADER.
         if "PRIMARY" in self.headers:
             for key, value in self._map_header().items():
                 kpf1.headers["PRIMARY"][key] = value
@@ -304,7 +280,6 @@ class KPF0(KPFDataModel):
                 "INSTRUMENT_HEADER", self.as_fits_header(self.headers["PRIMARY"])
             )
 
-        # Copy pass-through extensions (data + header)
         for ext_name in self._L0_TO_L1_PASSTHROUGH:
             if ext_name in self.extensions:
                 ext_type = self.extensions[ext_name]
@@ -315,23 +290,16 @@ class KPF0(KPFDataModel):
                 if ext_name in self.headers:
                     kpf1.set_header(ext_name, self.headers[ext_name])
 
-        # Forward the L0 QUALITY_CONTROL and RECEIPT *headers* onto L1 (value +
-        # comment), mirroring to_kpf2/to_kpf4 so all three conversions share one
-        # invariant. QUALITY_CONTROL carries the QCL0 booleans + ISGOOD; RECEIPT
-        # carries the four DRP-RUN provenance cards stamped at read. Downstream L1
-        # stages append to both. (PRIMARY/INSTRUMENT_HEADER are not forwarded
-        # here -- L0 PRIMARY is converted via _map_header above, not copied.)
+        # Forward the L0 QUALITY_CONTROL and RECEIPT headers onto L1, mirroring
+        # to_kpf2/to_kpf4. (PRIMARY is converted via _map_header above, not copied.)
         self._forward_headers(kpf1, ("QUALITY_CONTROL", "RECEIPT"))
 
-        # Carry forward receipt
         if self.receipt is not None and not self.receipt.empty:
             kpf1.receipt = self.receipt.copy()
-
-        # Copy obs_id
         kpf1.obs_id = self.obs_id
 
-        # DATALVL is set by KPF1.__init__ (= KPF1._DATALVL) and _map_header no
-        # longer emits it (dropped from header_map), so no fixup is needed here.
+        # DATALVL is set by KPF1.__init__; _map_header no longer emits it, so no
+        # fixup is needed here.
         kpf1.receipt_add_entry("to_kpf1", "", "PASS")
         return kpf1
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -58,11 +58,12 @@ class KPF0(KPFDataModel):
                 self.create_extension(row["Name"], row["DataType"])
 
     def read(self, hdul, instrument=None, overwrite=False, **kwargs):
-        """
-        Route L0 FITS reads to `KPF0._read`, then stamp DRP provenance.
+        """Route L0 FITS reads to ``KPF0._read``, then stamp DRP provenance.
 
-        `RVDataModel.read` has no lvl==0 dispatch branch, so the inherited
-        `from_fits` would never call into `_read` without this override.
+        ``RVDataModel.read`` has no lvl==0 dispatch branch, so the inherited
+        ``from_fits`` would never call into ``_read`` without this override.
+        (This is the canonical statement of the read-override rationale; the
+        L1 and Masters-L2 overrides refer back here.)
         """
         self._read(hdul)
         # Derive obs_id before stamping: _stamp_wmko_tracking writes it as the
@@ -101,11 +102,10 @@ class KPF0(KPFDataModel):
             self.set_keyword(key, value)
 
     def _read(self, hdul):
-        """
-        Read all extensions from an L0 FITS HDUList.
+        """Read all extensions from an L0 FITS HDUList.
 
         Iterates through all HDUs and creates extensions dynamically
-        based on what is present. CompImageHDU is transparently
+        based on what is present. ``CompImageHDU`` is transparently
         decompressed by astropy.
         """
         for hdu in hdul:
@@ -166,8 +166,10 @@ class KPF0(KPFDataModel):
     def generate_standard_filename(self):
         """KPF L0 filenames follow the KP.YYYYMMDD.NNNNN.NN.fits pattern.
 
-        Delegates to `kpf_filename` (the single source for the KPF-native naming
-        rule), which raises a `ValueError` if `obs_id` is unset or invalid.
+        Raises
+        ------
+        ValueError
+            If ``obs_id`` is unset or invalid.
         """
         return kpf_filename(self.obs_id, "L0")
 
@@ -209,7 +211,7 @@ class KPF0(KPFDataModel):
 
         A pure tabular application of the registry's (sanitized) header_map: for
         each row take the instrument value if present, else the row default, and
-        type it to the EPRV DataType. ``JD_UTC`` is the sole exception — a
+        type it to the EPRV DataType. ``JD_UTC`` is the sole exception -- a
         per-frame transform of the native ``MJD-OBS``, computed below.
 
         Returns
@@ -264,7 +266,7 @@ class KPF0(KPFDataModel):
         Returns a KPF1 with EPRV PRIMARY, INSTRUMENT_HEADER, pass-through
         extensions (CA_HK, EXPMETER_SCI/SKY, TELEMETRY, DRP_CONFIG), receipt, and
         obs_id copied over. GREEN_CCD, GREEN_VAR, RED_CCD, RED_VAR are created
-        empty — the caller (image assembly) fills those in.
+        empty -- the caller (image assembly) fills those in.
         """
         kpf1 = KPF1()
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -1,12 +1,9 @@
 """
 KPF Level 0 (raw CCD) data model.
 
-Reads raw FITS files from the KPF instrument at Keck Observatory.
-L0 files contain amplifier readouts, exposure meter tables, guide camera,
-telemetry, and telescope metadata. Extensions vary between observations.
-
-Subclasses RVDataModel (via KPFDataModel) to reuse its extension/header/data
-infrastructure and receipt system.
+Raw FITS readout from the KPF instrument: amplifier arrays plus exposure
+meter, guide camera, telemetry, and telescope metadata. The extensions
+present vary between observations.
 """
 
 import importlib.resources
@@ -46,12 +43,10 @@ class KPF0(KPFDataModel):
     """
     KPF Level 0 raw data model.
 
-    Represents a raw CCD readout from the KPF instrument. Extensions
-    vary between observations; the reader accepts whatever is present
-    in the FITS file. Construct from a FITS file with
-    `KPF0.from_fits(path)`, then read amplifier arrays from `data`
-    (e.g. `data["GREEN_AMP1"]`) and header dicts from `headers`
-    (e.g. `headers["PRIMARY"]`).
+    Represents a raw CCD readout from the KPF instrument. Construct from a
+    FITS file with ``KPF0.from_fits(path)``, then read amplifier arrays from
+    ``data`` (e.g. ``data["GREEN_AMP1"]``) and header dicts from ``headers``
+    (e.g. ``headers["PRIMARY"]``).
     """
 
     def __init__(self):

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -56,10 +56,9 @@ class KPF1(KPFDataModel):
                 self.create_extension(row["Name"], row["DataType"])
 
         # Seed PRIMARY with the EPRV Required keyword skeleton (typed defaults +
-        # comments), mirroring how rvdata's RV2.__init__ seeds KPF2. L1 is not an
-        # EPRV level, so KPF1 has no RV1 to inherit this from; we stamp it from the
-        # registry's eprv_primary_seed (the single source of truth) so KWRDPRL1 is
-        # meaningful and native values (overlaid in KPF0.to_kpf1) win over defaults.
+        # comments). L1 is not an EPRV level, so KPF1 has no RV1 to inherit this
+        # from; stamp it from the registry so KWRDPRL1 is meaningful and native
+        # values (overlaid in KPF0.to_kpf1) win over defaults.
         for kw, value in self.keyword_registry.eprv_primary_seed.items():
             self.headers["PRIMARY"][kw] = value
         # DATALVL is EPRV-Required, so the seed defaults it to "UNKNOWN"; correct it
@@ -183,31 +182,23 @@ class KPF1(KPFDataModel):
     }
 
     def to_kpf2(self):
-        """
-        Create a KPF2 scaffold from this L1, carrying over headers and
+        """Create a KPF2 scaffold from this L1, carrying over headers and
         pass-through extensions.
 
-        The L1 PRIMARY is already EPRV-standard (converted upstream in
-        KPF0.to_kpf1), so headers are a pure pass-through: the EPRV PRIMARY and
-        the immutable INSTRUMENT_HEADER are forwarded unchanged (value + comment).
-        Header validation no longer runs here — it moved to the checkpoints
-        layer (quality_control/checkpoints, Checkpoint.unregistered_keywords).
-        Pass-through extensions (TELEMETRY,
-        EXPMETER_SCI→EXPMETER, CA_HK→ANCILLARY_SPECTRUM) and KPF-friendly
-        aliases (e.g., SCI2_FLUX → TRACE3_FLUX) are handled below. Trace data
-        arrays are created but empty — the caller (spectral extraction) fills
-        those in.
+        The L1 PRIMARY is already EPRV-standard (converted in KPF0.to_kpf1), so
+        the PRIMARY and INSTRUMENT_HEADER headers are a pure pass-through. Pass-
+        through extensions (TELEMETRY, EXPMETER_SCI->EXPMETER,
+        CA_HK->ANCILLARY_SPECTRUM) and KPF-friendly aliases (e.g. SCI2_FLUX ->
+        TRACE3_FLUX) are handled below. Trace arrays are created empty — the
+        caller (spectral extraction) fills those in.
         """
         kpf2 = KPF2()
 
-        # Headers are a pure pass-through; the native→EPRV conversion and the
-        # INSTRUMENT_HEADER snapshot were done once in KPF0.to_kpf1. Forward
-        # PRIMARY + INSTRUMENT_HEADER (and QC/RECEIPT below) card-by-card,
-        # preserving comments; PRIMARY overlays onto kpf2's EPRV seed (native
-        # wins), INSTRUMENT_HEADER stays a verbatim copy.
+        # Forward PRIMARY + INSTRUMENT_HEADER card-by-card (the native->EPRV
+        # conversion happened once in KPF0.to_kpf1); PRIMARY overlays onto kpf2's
+        # EPRV seed (native wins), INSTRUMENT_HEADER stays a verbatim copy.
         self._forward_headers(kpf2, ("PRIMARY", "INSTRUMENT_HEADER"))
 
-        # Pass-through extensions with renaming
         for kpf1_ext, kpf2_ext in self._L1_TO_L2_PASSTHROUGH.items():
             if kpf1_ext in self.extensions:
                 kpf1_type = self.extensions[kpf1_ext]
@@ -221,21 +212,16 @@ class KPF1(KPFDataModel):
                 if kpf1_ext in self.headers:
                     kpf2.set_header(kpf2_ext, self.headers[kpf1_ext])
 
-        # Forward the L1 QUALITY_CONTROL and RECEIPT *headers* onto L2, with
-        # comments. The receipt *table* propagates via the receipt copy below, but
-        # the RECEIPT header cards (OSCANSUB / *FILE applied by ImageAssembly /
-        # CalibrationAssociation) and the QUALITY_CONTROL cards (RN*, *AGE, QC
-        # booleans) are separate and must be carried explicitly; downstream L2
-        # stages (BarycentricCorrection, DiagL2, QCL2) append to them.
+        # Forward the L1 QUALITY_CONTROL and RECEIPT headers onto L2. The receipt
+        # *table* propagates via the copy below, but the header cards are separate
+        # and must be carried explicitly; downstream L2 stages append to them.
         self._forward_headers(kpf2, ("QUALITY_CONTROL", "RECEIPT"))
 
-        # Carry forward receipt
         if self.receipt is not None and not self.receipt.empty:
             kpf2.receipt = self.receipt.copy()
 
-        # Carry the obs_id model attribute through. The ORIGID provenance card is
-        # stamped once at L0 (KPF0.from_fits) and rides forward on the RECEIPT
-        # header forwarded above, so it is not (re)written here.
+        # Carry the obs_id through; ORIGID (stamped at L0) rides forward on the
+        # RECEIPT header above, so it is not rewritten here.
         kpf2.obs_id = self.obs_id
 
         kpf2.set_keyword("DATALVL", "L2")

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -66,17 +66,16 @@ class KPF1(KPFDataModel):
         self.set_keyword("DATALVL", self._DATALVL)
 
     def read(self, hdul, instrument=None, overwrite=False, **kwargs):
-        """
-        Route L1 FITS reads to `KPF1._read`.
+        """Route L1 FITS reads to ``KPF1._read``.
 
-        `RVDataModel.read` has no lvl==1 dispatch branch, so the inherited
-        `from_fits` would never call into `_read` without this override.
+        Needed for the same reason as the L0 override; see ``KPF0.read`` for the
+        canonical rationale (``RVDataModel.read`` has no lvl==1 dispatch branch,
+        so the inherited ``from_fits`` would never call into ``_read``).
         """
         self._read(hdul)
 
     def _read(self, hdul):
-        """
-        Read all extensions from an L1 FITS HDUList.
+        """Read all extensions from an L1 FITS HDUList.
 
         Handles known extensions from the CSV definition and also
         accepts unknown extensions (with a warning).
@@ -116,8 +115,8 @@ class KPF1(KPFDataModel):
                     df = df.reindex(columns=all_cols).fillna("")
                 self.receipt = df
             elif fits_type == "ImageHDU":
-                # np.array (not asarray) materializes the memmapped HDU into RAM
-                # before from_fits closes the file; a view would dangle afterward.
+                # Materialize the memmap before from_fits closes the file
+                # (np.array, not asarray); see KPF0._read for the full rationale.
                 self.set_data(ext_name, np.array(hdu.data))
             elif fits_type == "BinTableHDU":
                 self.set_data(ext_name, Table.read(hdu))
@@ -140,13 +139,12 @@ class KPF1(KPFDataModel):
         return True
 
     def generate_standard_filename(self):
-        """
-        KPF L1 filenames follow the kpf_L1_YYYYMMDDThhmmss.fits convention.
+        """KPF L1 filenames follow the kpf_L1_YYYYMMDDThhmmss.fits convention.
 
-        Delegates to `kpf_filename` (the single source for the KPF-native naming
-        rule), deriving the timestamp from `obs_id` so the fallback name matches
-        where the recipe writes (`kpf_filepath(obs_id, "L1")`). Raises a
-        `ValueError` if `obs_id` is unset or invalid.
+        Raises
+        ------
+        ValueError
+            If ``obs_id`` is unset or invalid.
         """
         return kpf_filename(self.obs_id, "L1")
 
@@ -187,10 +185,9 @@ class KPF1(KPFDataModel):
 
         The L1 PRIMARY is already EPRV-standard (converted in KPF0.to_kpf1), so
         the PRIMARY and INSTRUMENT_HEADER headers are a pure pass-through. Pass-
-        through extensions (TELEMETRY, EXPMETER_SCI->EXPMETER,
-        CA_HK->ANCILLARY_SPECTRUM) and KPF-friendly aliases (e.g. SCI2_FLUX ->
-        TRACE3_FLUX) are handled below. Trace arrays are created empty — the
-        caller (spectral extraction) fills those in.
+        through extensions (TELEMETRY, EXPMETER_SCI->EXPMETER) and KPF-friendly
+        aliases (e.g. SCI2_FLUX -> TRACE3_FLUX) are handled below. Trace arrays
+        are created empty -- the caller (spectral extraction) fills those in.
         """
         kpf2 = KPF2()
 

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -1,5 +1,5 @@
 """
-KPF Level 1 (assembled 2D frame) data model.
+KPF Level 1 (assembled FFI) data model.
 
 Represents an assembled CCD frame after combining amplifier readouts.
 Also used for master calibration products (bias, dark, flat) which
@@ -38,7 +38,7 @@ _L1_FILENAME_PATTERN = re.compile(r"kpf_L1_\d{8}T\d{6}\.fits")
 
 class KPF1(KPFDataModel):
     """
-    KPF Level 1 assembled 2D frame data model.
+    KPF Level 1 assembled FFI data model.
 
     After image assembly, the L1 product contains assembled GREEN_CCD
     and RED_CCD frames with corresponding variance frames, plus

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -1,12 +1,9 @@
 """
 KPF Level 1 (assembled FFI) data model.
 
-Represents an assembled CCD frame after combining amplifier readouts.
-Also used for master calibration products (bias, dark, flat) which
-share the same structure (mean + variance frames for GREEN and RED).
-
-Subclasses RVDataModel (via KPFDataModel) to reuse its extension/header/data
-infrastructure and receipt system.
+Assembled CCD frames (GREEN and RED, with variance) built by combining the
+L0 amplifier readouts. Also used for 2D master calibrations (bias, dark,
+flat), which share the same structure.
 """
 
 import importlib.resources
@@ -40,14 +37,11 @@ class KPF1(KPFDataModel):
     """
     KPF Level 1 assembled FFI data model.
 
-    After image assembly, the L1 product contains assembled GREEN_CCD
-    and RED_CCD frames with corresponding variance frames, plus
-    pass-through extensions from L0 (CA_HK, exposure meter, telemetry).
-
-    Also used for master calibration products (bias, dark, flat).
-    Construct from a FITS file with `KPF1.from_fits(path)`, then read the
-    assembled 4080x4080 frames from `data` (e.g. `data["GREEN_CCD"]`,
-    `data["RED_CCD"]`).
+    Contains the assembled GREEN_CCD and RED_CCD frames with their variance
+    frames, plus pass-through extensions from L0 (CA_HK, exposure meter,
+    telemetry). Construct from a FITS file with ``KPF1.from_fits(path)``, then
+    read the assembled frames from ``data`` (e.g. ``data["GREEN_CCD"]``,
+    ``data["RED_CCD"]``).
     """
 
     _DATALVL = "L1"

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -1,16 +1,10 @@
 """
 KPF Level 2 (extracted spectra) data model.
 
-Inherits from RV2 (EPRV standard) and adds KPF-friendly extension aliases
-so pipeline code can use either EPRV names (TRACE3_FLUX) or KPF names
-(SCI2_FLUX). Per-chip access (GREEN_SCI2_FLUX, RED_SCI2_FLUX) is handled
-transparently — these return numpy views into the concatenated trace arrays.
-
-Each trace stores green+red orders concatenated (green first), matching the
-EPRV standard. The chip prefix dynamically slices using NORDER_GREEN.
-
-The alias mechanism (AliasedOrderedDict) is generic and could be
-upstreamed into the EPRV standard (which rvdata implements).
+Extracted, wavelength-calibrated spectra. Extends the EPRV RV2 model with
+KPF-friendly extension aliases, so data can be accessed by either EPRV name
+(``TRACE3_FLUX``) or KPF name (``SCI2_FLUX``), including per-chip views
+(``GREEN_SCI2_FLUX``, ``RED_SCI2_FLUX``).
 """
 
 import importlib.resources
@@ -155,18 +149,12 @@ class KPF2(KPFDataModel, RV2):
     """
     KPF Level 2 extracted spectra data model.
 
-    Extends RV2 with KPF-friendly extension aliases and per-chip
-    access. EPRV-standard extension names remain canonical;
-    aliases are transparent synonyms.
-
-    Each trace contains green+red orders concatenated (35 green + 32 red
-    = 67 orders total). Per-chip access via GREEN_/RED_ prefix returns
-    numpy views into the concatenated array. As examples of the aliasing,
-    `data["SCI2_FLUX"]` is `data["TRACE3_FLUX"]`, `data["CAL_WAVE"]` is
-    `data["TRACE1_WAVE"]`, and `data["CA_HK"]` is
-    `data["ANCILLARY_SPECTRUM"]`; per-chip, `data["GREEN_SCI2_FLUX"]`
-    returns `TRACE3_FLUX[:35]` (the green orders) and
-    `data["RED_SCI2_FLUX"]` returns `TRACE3_FLUX[35:]` (the red orders).
+    Extends RV2 with KPF-friendly extension aliases and per-chip access;
+    EPRV-standard names remain canonical and aliases are transparent
+    synonyms. Each trace holds the green and red orders concatenated (green
+    first); a GREEN_/RED_ prefix returns a numpy view of that chip's orders.
+    For example, ``data["SCI2_FLUX"]`` is ``data["TRACE3_FLUX"]`` and
+    ``data["GREEN_SCI2_FLUX"]`` returns its green orders.
     """
 
     def __init__(self):

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -66,7 +66,7 @@ class _KPF2DataDict(AliasedOrderedDict):
     """
     Data dict that supports GREEN_/RED_ chip-prefix access.
 
-    Accessing `d["GREEN_SCI2_FLUX"]` returns `d["SCI2_FLUX"][:NORDER_GREEN]`,
+    Accessing ``d["GREEN_SCI2_FLUX"]`` returns ``d["SCI2_FLUX"][:NORDER_GREEN]``,
     a numpy view into the first 35 orders of TRACE3_FLUX.
     """
 
@@ -219,10 +219,10 @@ class KPF2(KPFDataModel, RV2):
     def generate_standard_filename(self):
         """KPF L2 standard filename (EPRV-standard SL2 name).
 
-        Delegates to `kpf_filename` (the single source for KPF product naming, so
-        generation lives in one place across all levels), deriving the name from
-        `obs_id`. `check_filename_convention` still defers to rvdata's EPRV
-        validator. Raises a `ValueError` if `obs_id` is unset or invalid.
+        Raises
+        ------
+        ValueError
+            If ``obs_id`` is unset or invalid.
         """
         return kpf_filename(self.obs_id, "L2")
 
@@ -240,7 +240,7 @@ class KPF2(KPFDataModel, RV2):
 
         Returns a KPF4 with PRIMARY header keywords forwarded from L2,
         and the receipt chain preserved. RV and CCF data extensions are
-        created but empty — the caller (RV computation) fills those in.
+        created but empty -- the caller (RV computation) fills those in.
         """
         kpf4 = KPF4()
 

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -117,7 +117,6 @@ class _KPF2DataDict(AliasedOrderedDict):
 
     def __contains__(self, key):
         if self._chip_split(key) is not None:
-            # Valid chip-prefix key — check that the underlying trace exists
             fiber_alias, _ = self._chip_split(key)
             return super().__contains__(self._resolve(fiber_alias))
         return super().__contains__(self._resolve(key))
@@ -167,15 +166,13 @@ class KPF2(KPFDataModel, RV2):
                 if ext not in self.extensions:
                     self.create_extension(ext, "ImageHDU")
 
-        # Pass-through extensions not in RV2 base. NB: the EPRV standard defines
+        # Pass-through extensions not in the RV2 base. NB: the EPRV standard defines
         # ANCILLARY_SPECTRUM (Ca H&K) as an ImageHDU, but we keep it a BinTableHDU
-        # placeholder for now -- Ca H&K extraction is still WIP and existing master/
-        # L2 products (incl. the truth dataset) encode it as BinTableHDU, so flipping
-        # the type breaks reading them back. Switch to ImageHDU when Ca H&K is built
-        # and products are regenerated. See EPRV_DATA_STANDARD.md §8 (deviations).
-        # QUALITY_CONTROL holds the KPF QC booleans + DiagL2 metrics (the L0/L1
-        # extensions CSVs create it on those models; L2 has no CSV so create it
-        # here). RECEIPT and the barycentric/RV# extensions already exist via RV2.
+        # placeholder for now -- Ca H&K extraction is WIP and existing L2/master
+        # products encode it as BinTableHDU, so flipping the type breaks reading
+        # them back. See EPRV_DATA_STANDARD.md §8 (deviations). QUALITY_CONTROL is
+        # created here (L2 has no extensions CSV); RECEIPT and barycentric/RV#
+        # already exist via RV2.
         for ext, ext_type in [
             ("ANCILLARY_SPECTRUM", "BinTableHDU"),
             ("EXPMETER", "BinTableHDU"),
@@ -248,18 +245,13 @@ class KPF2(KPFDataModel, RV2):
         kpf4 = KPF4()
 
         # Forward PRIMARY, INSTRUMENT_HEADER, QUALITY_CONTROL, and RECEIPT
-        # card-by-card (value + comment), mirroring to_kpf2. PRIMARY overlays
-        # onto kpf4's EPRV seed (native wins); INSTRUMENT_HEADER (TARGTEFF,
-        # TARGRADV, GAIAID, CCD*BJD, ...) stays a verbatim copy; QUALITY_CONTROL
-        # carries the accumulated L0/L1/L2 diagnostics + QC flags (append-only
-        # history, like RECEIPT) and the RECEIPT cards (applied-step flags,
-        # calibration paths) ride along. The receipt *table* propagates
-        # separately via the copy below.
+        # card-by-card, mirroring to_kpf2: PRIMARY overlays onto kpf4's EPRV seed
+        # (native wins), the rest are verbatim copies. The receipt *table*
+        # propagates separately via the copy below.
         self._forward_headers(
             kpf4, ("PRIMARY", "INSTRUMENT_HEADER", "QUALITY_CONTROL", "RECEIPT")
         )
 
-        # Carry forward receipt and obs_id
         if self.receipt is not None and not self.receipt.empty:
             kpf4.receipt = self.receipt.copy()
         kpf4.obs_id = self.obs_id

--- a/kpfpipe/data_models/level4.py
+++ b/kpfpipe/data_models/level4.py
@@ -3,7 +3,7 @@ KPF Level 4 (RVs and CCFs) data model.
 
 Radial velocities and cross-correlation functions. Extends the EPRV RV4
 model with KPF-friendly extension aliases for the CCF and RV data, following
-the same pattern as KPF2 — data can be accessed by either EPRV name
+the same pattern as KPF2 -- data can be accessed by either EPRV name
 (``CCF3``, ``RV3``) or KPF name (``SCI2_CCF``, ``SCI2_RV``), with per-chip
 views for the CCF cubes (``GREEN_SCI2_CCF``, ``RED_SCI2_CCF``).
 """
@@ -50,7 +50,7 @@ _ALIASES = pd.read_csv(_config_path / "aliases.csv")
 # Each maps a chip-prefixed key -> (fiber_alias, chip). CCF and CCF_VAR cubes are
 # sliced on their order axis (axis 0) and support chip-prefix read and write; RV
 # tables are row-sliced (green = rows 0:NORDER_GREEN, red the rest) and support
-# read only — each is written whole (one BinTable per orderlet), so a chip-prefix
+# read only -- each is written whole (one BinTable per orderlet), so a chip-prefix
 # write raises.
 _CHIP_PREFIX_KEYS = {}  # chip-prefixed key → (fiber_alias, chip)
 for _, _row in _TRACE_MAP.iterrows():
@@ -66,9 +66,9 @@ class _KPF4DataDict(AliasedOrderedDict):
     Data dict supporting GREEN_/RED_ chip-prefix access for CCF cubes and
     RV tables.
 
-    Accessing `d["GREEN_SCI2_CCF"]` returns `d["SCI2_CCF"][:NORDER_GREEN]`, a
+    Accessing ``d["GREEN_SCI2_CCF"]`` returns ``d["SCI2_CCF"][:NORDER_GREEN]``, a
     numpy view into the first 35 orders of CCF3 (order axis is axis 0, like the
-    trace flux arrays). `d["GREEN_SCI2_RV"]` returns the green rows of the
+    trace flux arrays). ``d["GREEN_SCI2_RV"]`` returns the green rows of the
     SCI2_RV table (rows 0:NORDER_GREEN); RV chip-prefix access is read-only,
     since each RV table is written whole.
     """
@@ -219,17 +219,16 @@ class KPF4(KPFDataModel, RV4):
     def generate_standard_filename(self):
         """KPF L4 standard filename (EPRV-standard SL4 name).
 
-        Delegates to `kpf_filename` (the single source for KPF product naming, so
-        generation lives in one place across all levels), deriving the name from
-        `obs_id`. `check_filename_convention` still defers to rvdata's EPRV
-        validator. Raises a `ValueError` if `obs_id` is unset or invalid.
+        Raises
+        ------
+        ValueError
+            If ``obs_id`` is unset or invalid.
         """
         return kpf_filename(self.obs_id, "L4")
 
     def to_fits(self, fn=None):
-        """KPF keeps a single-filepath ``to_fits``; rvdata >=0.4.0 renamed the
-        parameter to ``out_filename``. Delegate so all our call sites can keep
-        passing one path (``to_fits(fn)``)."""
+        """Single-filepath ``to_fits`` shim; see ``KPF2.to_fits`` for the
+        rationale (rvdata >=0.4.0 renamed the parameter to ``out_filename``)."""
         out_path = super().to_fits(out_filename=fn)
         logger.info("wrote %s to %s", type(self).__name__, out_path)
         return out_path

--- a/kpfpipe/data_models/level4.py
+++ b/kpfpipe/data_models/level4.py
@@ -1,27 +1,11 @@
 """
 KPF Level 4 (RVs and CCFs) data model.
 
-Inherits from RV4 (EPRV standard) and adds KPF-friendly extension aliases
-for CCF and RV data, following the same AliasedOrderedDict pattern as KPF2.
-
-The EPRV standard defines CCF1...N (ImageHDU) and RV1...N (BinTableHDU), one
-per orderlet. KPF numbers both to match the L2 traces (CCF{n}/RV{n} hold the
-CCF/RV for the orderlet on TRACE{n}): n=1 SKY, 2 SCI1, 3 SCI2, 4 SCI3, 5 CAL.
-The KPF name → extension mapping is therefore derived from the shared trace map
-(trace-map.csv), exactly like the L2 TRACE*_FLUX aliases — not from aliases.csv.
-
-KPF adds a parallel CCF_VAR1...N ImageHDU (a KPF extension, not EPRV) holding
-the per-velocity-bin CCF photon variance for each CCF{n}, numbered and aliased
-the same way (CCF_VAR{n} ↔ TRACE{n}). It persists what the RV photon-error step
-needs, which the value-only EPRV CCF{n} does not carry.
-
-Each CCF (and CCF_VAR) stores green+red orders concatenated (green first), like
-TRACE*_FLUX, so per-chip access mirrors KPF2. RV tables hold one row per order
-(no chip prefix — slice by ORDER_INDEX instead). As examples, `data["SCI2_CCF"]`
-is `data["CCF3"]` (alias), `data["SCI2_CCF_VAR"]` is `data["CCF_VAR3"]`, and
-`data["SCI2_RV"]` is `data["RV3"]` (alias), while `data["GREEN_SCI2_CCF"]`
-returns `CCF3[:NORDER_GREEN]` (the green orders, a view) and
-`data["RED_SCI2_CCF"]` returns `CCF3[NORDER_GREEN:]` (the red orders, a view).
+Radial velocities and cross-correlation functions. Extends the EPRV RV4
+model with KPF-friendly extension aliases for the CCF and RV data, following
+the same pattern as KPF2 — data can be accessed by either EPRV name
+(``CCF3``, ``RV3``) or KPF name (``SCI2_CCF``, ``SCI2_RV``), with per-chip
+views for the CCF cubes (``GREEN_SCI2_CCF``, ``RED_SCI2_CCF``).
 """
 
 import importlib.resources
@@ -164,21 +148,13 @@ class KPF4(KPFDataModel, RV4):
     """
     KPF Level 4 RV and CCF data model.
 
-    Extends RV4 with KPF-friendly extension aliases and per-chip access for the
-    CCF cubes. EPRV-standard extension names (CCF1...N, RV1...N) remain
-    canonical; aliases are transparent synonyms. KPF also adds a parallel
-    CCF_VAR1...N ImageHDU (per-bin CCF variance) that behaves exactly like
-    CCF1...N (same shape, concatenation, and per-chip access).
-
-    Each CCF (and CCF_VAR) holds green+red orders concatenated (35 green + 32 red
-    = 67 orders total). Per-chip access via the GREEN_/RED_ prefix returns numpy
-    views into the concatenated array. RV tables hold one row per order. As
-    examples of the aliasing, `data["SCI2_CCF"]` is `data["CCF3"]`,
-    `data["SCI2_CCF_VAR"]` is `data["CCF_VAR3"]`, and `data["SCI2_RV"]` is
-    `data["RV3"]`; per-chip, `data["GREEN_SCI2_CCF"]` returns `CCF3[:35]` (green
-    orders, a numpy view), `data["RED_SCI2_CCF"]` returns `CCF3[35:]` (red
-    orders, a numpy view), and `data["GREEN_SCI2_RV"]` / `data["RED_SCI2_RV"]`
-    return the green / red rows of RV3 (read-only).
+    Extends RV4 with KPF-friendly extension aliases and per-chip access for
+    the CCF cubes; EPRV-standard names (``CCF1...N``, ``RV1...N``) remain
+    canonical and aliases are transparent synonyms. Each CCF holds the green
+    and red orders concatenated (green first); a GREEN_/RED_ prefix returns a
+    numpy view of that chip's orders, while RV tables hold one row per order.
+    For example, ``data["SCI2_CCF"]`` is ``data["CCF3"]`` and
+    ``data["SCI2_RV"]`` is ``data["RV3"]``.
     """
 
     def __init__(self):

--- a/kpfpipe/data_models/masters/__init__.py
+++ b/kpfpipe/data_models/masters/__init__.py
@@ -1,9 +1,9 @@
 """
-KPF masters calibration data models.
+KPF masters data models.
 
-KPFMasterL1 -- Stacked 2D calibration frames (bias, dark, flat)
-KPFMasterL2 -- Extracted masters spectra (stub)
-KPFMasterL4 -- Masters RV/CCF products (stub)
+KPFMasterL1 -- FFI calibrations (bias, dark, flat)
+KPFMasterL2 -- Extracted spectra (stub)
+KPFMasterL4 -- RV/CCF products (stub)
 """
 
 from kpfpipe.data_models.masters.level1 import KPFMasterL1

--- a/kpfpipe/data_models/masters/base.py
+++ b/kpfpipe/data_models/masters/base.py
@@ -58,10 +58,10 @@ class KPFMasterModel(KPFDataModel):
         """
         Record the stacked input L0 files and the master calibration type.
 
-        `master_type` is the WMKO filename token ('bias', 'dark', 'flat', or
+        ``master_type`` is the WMKO filename token ('bias', 'dark', 'flat', or
         'thar'); it is stored in the PRIMARY ``MASTYPE`` header so that
-        `generate_standard_filename()` can always build a DRP-RUN-05-compliant
-        name, including after a `from_fits()` round-trip.
+        ``generate_standard_filename()`` can always build a DRP-RUN-05-compliant
+        name, including after a ``from_fits()`` round-trip.
         """
         self.set_data("INPUT_FILES", pd.DataFrame({"FILENAME": file_list}))
         # MASTYPE is out of EPRV scope but registered so it routes through
@@ -74,9 +74,9 @@ class KPFMasterModel(KPFDataModel):
         ``{KOAID-of-first-input}_master_{type}_L{level}.fits``.
 
         The KOAID is read from the first recorded input file and the type from
-        the PRIMARY ``MASTYPE`` header (both set by `set_input_files()`). Raises
+        the PRIMARY ``MASTYPE`` header (both set by ``set_input_files()``). Raises
         if either is missing, so a non-compliant master name can never be
-        produced; `kpf_filename` validates the type token and level.
+        produced; ``kpf_filename`` validates the type token and level.
         """
         master_type = self.headers["PRIMARY"].get("MASTYPE")
         if not master_type:

--- a/kpfpipe/data_models/masters/base.py
+++ b/kpfpipe/data_models/masters/base.py
@@ -1,25 +1,12 @@
 """
-KPF masters base data model.
+KPF Masters base data model.
 
-Base class for all masters calibration data models. Inherits from
-KPFDataModel and initializes the data model infrastructure without
-creating any science-level extensions.
-
-Level-specific masters classes use double inheritance (e.g. KPFMasterL1
-subclasses both KPFMasterModel and KPF1). This gives the level-specific
-class access to science model methods (from_fits, to_fits, _read, info,
-etc.) while the extension setup is controlled entirely by KPFMasterModel
-and its subclasses.
+Shared base for the masters calibration products. Extends KPFDataModel
+without creating any science-level extensions, leaving each level-specific
+subclass (KPFMasterL1/L2/L4) to install its own masters extensions.
 
 Masters products differ from science products in extension naming to
-avoid confusion: units and normalization conventions differ by
-calibration type (bias, dark, flat) and are not the same as raw
-science counts (e.g., GREEN_CCD).
-
-Filename convention (WMKO DRP-RUN-05): masters are written as
-``{KOAID-of-first-input}_master_{type}_L{level}.fits`` (e.g.
-``KP.20240405.49597.71_master_bias_L1.fits``), built by
-``generate_standard_filename()``.
+avoid confusion (see KPFMasterL1/L2/L4)
 """
 
 import os
@@ -46,7 +33,6 @@ class KPFMasterModel(KPFDataModel):
     Inherits from KPFDataModel and initializes only the base data model
     infrastructure. Science-level extension setup is intentionally skipped
     so that level-specific subclasses can install masters extensions instead.
-    Normalization conventions differ by calibration type (bias, dark, flat).
     """
 
     def __init__(self):

--- a/kpfpipe/data_models/masters/base.py
+++ b/kpfpipe/data_models/masters/base.py
@@ -64,10 +64,8 @@ class KPFMasterModel(KPFDataModel):
         name, including after a `from_fits()` round-trip.
         """
         self.set_data("INPUT_FILES", pd.DataFrame({"FILENAME": file_list}))
-        # MASTYPE is out of EPRV scope but registered in every ML*-headers.csv so it
-        # routes through set_keyword (-> PRIMARY, registry comment) like every other
-        # KPF keyword. It reads back as a scalar via .get() in
-        # generate_standard_filename().
+        # MASTYPE is out of EPRV scope but registered so it routes through
+        # set_keyword (-> PRIMARY) like every other KPF keyword.
         self.set_keyword("MASTYPE", master_type)
 
     def generate_standard_filename(self):

--- a/kpfpipe/data_models/masters/level1.py
+++ b/kpfpipe/data_models/masters/level1.py
@@ -23,7 +23,8 @@ class KPFMasterL1(KPFMasterModel, KPF1):
     KPF Masters Level 1 stacked FFI calibration.
 
     Thin wrapper around KPF1 with masters-specific extension names.
-    Inherits all KPF1 methods (from_fits, to_fits, _read, info).
+    Inherits KPF1's from_fits, to_fits, and info; overrides ``_read`` and
+    ``_create_hdul`` to cast the MASK extensions (bool <-> uint8) across I/O.
 
     Extensions:
         GREEN_IMG   -- stacked mean image, green chip
@@ -31,8 +32,8 @@ class KPFMasterL1(KPFMasterModel, KPF1):
         GREEN_MASK  -- bad pixel mask, green chip (1=good, 0=bad)
         RED_IMG, RED_SNR, RED_MASK -- same for red chip
 
-    Construct empty with `KPFMasterL1()`, or load a stacked product from
-    disk with `KPFMasterL1.from_fits(path)`.
+    Construct empty with ``KPFMasterL1()``, or load a stacked product from
+    disk with ``KPFMasterL1.from_fits(path)``.
     """
 
     _DATALVL = "ML1"

--- a/kpfpipe/data_models/masters/level1.py
+++ b/kpfpipe/data_models/masters/level1.py
@@ -47,8 +47,7 @@ class KPFMasterL1(KPFMasterModel, KPF1):
                 self.create_extension(row["Name"], row["DataType"])
 
         # Masters carry their own minimal PRIMARY (no EPRV science skeleton); stamp
-        # DATALVL so it is present in-memory, not only at to_fits (DRP-RUN data
-        # level). Routed via set_keyword like the science models.
+        # DATALVL so it is present in-memory, not only at to_fits.
         self.set_keyword("DATALVL", self._DATALVL)
 
     def _create_hdul(self):

--- a/kpfpipe/data_models/masters/level1.py
+++ b/kpfpipe/data_models/masters/level1.py
@@ -1,21 +1,9 @@
 """
 KPF Masters Level 1 data model.
 
-Stacked 2D calibration frame product (bias, dark, flat).
-
-Inherits from KPFMasterModel and KPF1. All KPF1 methods (from_fits,
-to_fits, _read, info, to_kpf2) are inherited unchanged. Extension names
-differ from science L1 to reflect masters-specific normalization:
-
-    GREEN_IMG  -- stacked mean image
-    GREEN_SNR  -- signal-to-noise ratio
-    GREEN_MASK -- boolean bad pixel mask (1=good, 0=bad)
-    RED_IMG, RED_SNR, RED_MASK -- same for red chip
-
-Filename convention (WMKO DRP-RUN-05): masters are written as
-{KOAID-of-first-input}_master_{type}_L1.fits (e.g.
-KP.20240405.49597.71_master_bias_L1.fits), built by
-KPFMasterModel.generate_standard_filename().
+Stacked FFI calibration (bias, dark, flat). Extends KPF1 with
+masters-specific extension names (GREEN_IMG, GREEN_SNR, GREEN_MASK and the
+red-chip equivalents) that reflect the calibration normalization.
 """
 
 import importlib.resources
@@ -32,7 +20,7 @@ _ML1_EXTENSIONS = pd.read_csv(_config_path / "ML1-extensions.csv")
 
 class KPFMasterL1(KPFMasterModel, KPF1):
     """
-    KPF Masters Level 1 stacked calibration frame.
+    KPF Masters Level 1 stacked FFI calibration.
 
     Thin wrapper around KPF1 with masters-specific extension names.
     Inherits all KPF1 methods (from_fits, to_fits, _read, info).

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -1,26 +1,9 @@
 """
 KPF Masters Level 2 data model.
 
-Extracted-spectrum-level masters calibration product (e.g., master
-wavelength solutions, master flats).
-
-Inherits from KPFMasterModel and KPF2. The full L2 schema and the KPF
-alias system are inherited from KPF2 (see aliases.csv and
-trace-map.csv for the mapping between KPF-internal fiber names like
-SCI2_WAVE and the EPRV standard names like TRACE3_WAVE).
-
-An L2 master carries a different extension set per *type*: a WLS master
-holds wavelength solutions (TRACE*_WAVE) and fit coefficients
-(*_WLS_COEFFS); a flat master holds extracted spectra (TRACE*_FLUX/VAR/
-BLAZE). Each type has its own authoritative manifest -- ML2-wls-extensions.csv
-and ML2-flat-extensions.csv -- selected by the required `kind` argument
-(see __init__). Construction is explicit; from_fits infers `kind` from the
-file's PRIMARY MASTYPE.
-
-Filename convention (WMKO DRP-RUN-05): masters are written as
-{KOAID-of-first-input}_master_{type}_L2.fits (e.g.
-KP.20240405.49597.71_master_thar_L2.fits), built by
-KPFMasterModel.generate_standard_filename().
+Extracted-spectrum-level calibration (wavelength solution, flat). Extends
+KPF2 with a per-type extension set: a WLS master (kind="wls") holds wavelength
+solutions, while a flat master (kind="flat") holds extracted spectra.
 """
 
 import importlib.resources
@@ -48,16 +31,16 @@ _ML2_MANIFESTS = {"wls": _ML2_WLS_EXTENSIONS, "flat": _ML2_FLAT_EXTENSIONS}
 
 class KPFMasterL2(KPFMasterModel, KPF2):
     """
-    KPF Masters Level 2 extracted-spectrum calibration product.
+    KPF Masters Level 2 extracted-spectrum calibration.
 
-    Thin wrapper around KPF2 with masters-specific DATALVL, filename
-    prefix, and INPUT_FILES extension. Inherits the full L2 schema and
-    the KPF2 alias system (e.g., SCI2_WAVE -> TRACE3_WAVE, with chip-
-    prefix access GREEN_SCI2_WAVE / RED_SCI2_WAVE).
+    Thin wrapper around KPF2 with masters-specific extension names.
+    Inherits the full L2 schema and the KPF2 alias system (e.g.
+    SCI2_WAVE -> TRACE3_WAVE, with chip-prefix access GREEN_SCI2_WAVE /
+    RED_SCI2_WAVE).
 
-    Construct with an explicit type, `KPFMasterL2(kind="wls")` or
-    `kind="flat"`, or load a product from disk with
-    `KPFMasterL2.from_fits(path)` (which infers the kind from MASTYPE).
+    Construct with an explicit type, e.g. `KPFMasterL2(kind="wls")`, or
+    load a product from disk with `KPFMasterL2.from_fits(path)`, which
+    infers the kind from header keyword MASTYPE.
     """
 
     _DATALVL = "ML2"

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -64,23 +64,17 @@ class KPFMasterL2(KPFMasterModel, KPF2):
             )
         self.kind = kind
         KPF2.__init__(self)
-        # KPF2.__init__ runs RV2.__init__ (via super()), which seeds the EPRV L2
-        # science PRIMARY skeleton. Masters are out of EPRV scope and carry their
-        # own minimal PRIMARY, so drop that skeleton and stamp DATALVL ("ML2")
-        # ourselves -- rvdata's to_fits never re-stamps DATALVL, so without this it
-        # would ship the RV2 placeholder "UNKNOWN".
+        # KPF2.__init__ seeds the EPRV L2 science PRIMARY skeleton. Masters are out
+        # of EPRV scope and carry their own minimal PRIMARY, so drop it and stamp
+        # DATALVL ("ML2") ourselves (rvdata's to_fits never re-stamps DATALVL).
         self.headers["PRIMARY"].clear()
         self.level = 2
 
         # ML2-{kind}-extensions.csv is the authoritative manifest for this master
         # type. KPF2.__init__ builds the full science L2 schema (needed for the
-        # alias system); anything it created that the manifest omits is dropped --
-        # the observation-specific extensions (INSTRUMENT_HEADER, BARYCORR_*,
-        # BJD_TDB, EXPMETER, TELEMETRY, ANCILLARY_SPECTRUM) void for a stacked
-        # master, plus the other type's trace extensions (a wls master drops
-        # FLUX/VAR/BLAZE; a flat master drops WAVE). Then create any Required row not
-        # present (e.g. INPUT_FILES); *_WLS_COEFFS are Required=False, created
-        # per-chip on demand in make_master_l2.
+        # alias system); drop anything the manifest omits, then create any Required
+        # row not present. *_WLS_COEFFS are Required=False, created per-chip on
+        # demand in make_master_l2.
         manifest_df = _ML2_MANIFESTS[kind]
         manifest = set(manifest_df["Name"])
         for ext in list(self.extensions):

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _config_path = importlib.resources.files("kpfpipe.data_models.config")
 _ML2_WLS_EXTENSIONS = pd.read_csv(_config_path / "ML2-wls-extensions.csv")
 _ML2_FLAT_EXTENSIONS = pd.read_csv(_config_path / "ML2-flat-extensions.csv")
-# Per-type authoritative extension manifests, keyed by the `kind` selector.
+# Per-type authoritative extension manifests, keyed by the ``kind`` selector.
 _ML2_MANIFESTS = {"wls": _ML2_WLS_EXTENSIONS, "flat": _ML2_FLAT_EXTENSIONS}
 
 
@@ -38,8 +38,8 @@ class KPFMasterL2(KPFMasterModel, KPF2):
     SCI2_WAVE -> TRACE3_WAVE, with chip-prefix access GREEN_SCI2_WAVE /
     RED_SCI2_WAVE).
 
-    Construct with an explicit type, e.g. `KPFMasterL2(kind="wls")`, or
-    load a product from disk with `KPFMasterL2.from_fits(path)`, which
+    Construct with an explicit type, e.g. ``KPFMasterL2(kind="wls")``, or
+    load a product from disk with ``KPFMasterL2.from_fits(path)``, which
     infers the kind from header keyword MASTYPE.
     """
 
@@ -88,13 +88,20 @@ class KPFMasterL2(KPFMasterModel, KPF2):
 
     @classmethod
     def from_fits(cls, fn, instrument=None, **kwargs):
-        """Load an L2 master, inferring `kind` from the file's PRIMARY MASTYPE.
+        """Load an L2 master, inferring ``kind`` from the file's PRIMARY MASTYPE.
 
         rvdata's RVDataModel.from_fits builds the instance via ``cls()`` with no
         args, which a required ``kind`` rejects. This override reads MASTYPE
         (always set by ``set_input_files`` on a written master), maps it to a
         schema kind, and constructs explicitly. Mirrors the base from_fits flow
         (the base also computes an unused MD5 digest, which is omitted here).
+
+        Raises
+        ------
+        OSError
+            If ``fn`` does not exist or is not a ``.fits``/``.fit`` file.
+        ValueError
+            If the PRIMARY MASTYPE is missing or maps to no known schema kind.
         """
         if not os.path.isfile(fn):
             raise OSError(f"{fn} does not exist.")
@@ -119,21 +126,21 @@ class KPFMasterL2(KPFMasterModel, KPF2):
         return obj
 
     def read(self, hdul, instrument=None, overwrite=False, **kwargs):
-        """
-        Route Masters L2 FITS reads to `KPFMasterL2._read`.
+        """Route Masters L2 FITS reads to ``KPFMasterL2._read``.
 
-        `RVDataModel.read` dispatches lvl==2 to `RV2._read`, which only knows
-        the EPRV standard L2 extensions and would KeyError on masters-specific
-        ones (INPUT_FILES, *_WLS_COEFFS).
+        Same override pattern as ``KPF0.read`` (see there for the canonical
+        rationale), but for a distinct reason: ``RVDataModel.read`` *does*
+        dispatch lvl==2, to ``RV2._read``, which only knows the EPRV standard L2
+        extensions and would KeyError on masters-specific ones (INPUT_FILES,
+        ``*_WLS_COEFFS``).
         """
         self._read(hdul)
 
     def _read(self, hdul):
-        """
-        Read all extensions from a Masters L2 FITS HDUList.
+        """Read all extensions from a Masters L2 FITS HDUList.
 
         Handles known extensions and accepts unknown extensions (with a
-        warning). Mirrors KPF1._read in style and structure.
+        warning). Mirrors ``KPF1._read`` in style and structure.
         """
         for hdu in hdul:
             ext_name = hdu.name
@@ -170,8 +177,8 @@ class KPFMasterL2(KPFMasterModel, KPF2):
                     df = df.reindex(columns=all_cols).fillna("")
                 self.receipt = df
             elif fits_type == "ImageHDU":
-                # np.array (not asarray) materializes the memmapped HDU into RAM
-                # before from_fits closes the file; a view would dangle afterward.
+                # Materialize the memmap before from_fits closes the file
+                # (np.array, not asarray); see KPF0._read for the full rationale.
                 self.set_data(ext_name, np.array(hdu.data))
             elif fits_type == "BinTableHDU":
                 self.set_data(ext_name, Table.read(hdu))

--- a/kpfpipe/data_models/masters/level4.py
+++ b/kpfpipe/data_models/masters/level4.py
@@ -2,10 +2,6 @@
 KPF Masters Level 4 data model.
 
 Masters RV/CCF calibration products. Not yet implemented.
-
-Filename convention (WMKO DRP-RUN-05): masters are written as
-{KOAID-of-first-input}_master_{type}_L4.fits, built by
-KPFMasterModel.generate_standard_filename().
 """
 
 from kpfpipe.data_models.level4 import KPF4

--- a/kpfpipe/modules/__init__.py
+++ b/kpfpipe/modules/__init__.py
@@ -1,1 +1,1 @@
-"""Transform modules operating on KPF data-model objects (L0, L1, L2)."""
+"""Core algorithms for the science and masters pipelines."""

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -95,7 +95,7 @@ class BarycentricCorrection:
         )
 
     # ------------------------------------------------------------------
-    # Private helpers — exposure-meter handling
+    # Private helpers -- exposure-meter handling
     # ------------------------------------------------------------------
 
     def _get_timestamps(self):
@@ -144,7 +144,7 @@ class BarycentricCorrection:
 
         Numeric-named columns are wavelength channels; non-numeric columns (e.g.
         timestamps) are skipped. Column labels are in Å on L1+ (converted from
-        native L0 nm by ImageAssembly), so `w` is returned in Å.
+        native L0 nm by ImageAssembly), so ``w`` is returned in Å.
         """
         expmeter = self.l2_obj.data["EXPMETER_SCI"]
 
@@ -167,10 +167,10 @@ class BarycentricCorrection:
     @staticmethod
     def _fix_expmeter_outliers(f, kernel_size=5, k=3.0):
         """
-        Return a copy of `f` with outlier pixels interpolated (shape unchanged).
+        Return a copy of ``f`` with outlier pixels interpolated (shape unchanged).
 
         Threshold is adaptive (Chauvenet-like criterion on array size), scaled
-        by `k` (larger rejects fewer). Replacement is griddata linear, falling
+        by ``k`` (larger rejects fewer). Replacement is griddata linear, falling
         back to nearest for residual NaNs.
         """
         f_smooth = gaussian_filter(
@@ -229,7 +229,7 @@ class BarycentricCorrection:
         """
         Estimate flux for a gap before the first or after the last reading.
 
-        Same rate-based model as `_interpolate`. Returns (t_ext, f_ext)
+        Same rate-based model as ``_interpolate``. Returns (t_ext, f_ext)
         for the single gap defined by t0 vs t_beg/t_end.
         """
         dt_exp = (t_end - t_beg).jd
@@ -253,9 +253,9 @@ class BarycentricCorrection:
         """
         Flux-weighted midpoint time per expmeter channel -> (w_em [Å], t_em [JD-UTC]).
 
-        Optionally fills gaps between readings (`interpolate`), before/after the
-        shutter window (`extrapolate`, using DATE-BEG/DATE-END), and replaces
-        outlier readings (`fix_expmeter_outliers`) before collapsing the time
+        Optionally fills gaps between readings (``interpolate``), before/after the
+        shutter window (``extrapolate``, using DATE-BEG/DATE-END), and replaces
+        outlier readings (``fix_expmeter_outliers``) before collapsing the time
         axis to a flux-weighted mean per channel.
         """
         t_beg, t_mid, t_end = self._get_timestamps()
@@ -308,7 +308,7 @@ class BarycentricCorrection:
         return w_em, t_em
 
     # ------------------------------------------------------------------
-    # Private helpers — barycorr handoffs
+    # Private helpers -- barycorr handoffs
     # ------------------------------------------------------------------
 
     def _gaia_astrometry(self):
@@ -403,7 +403,7 @@ class BarycentricCorrection:
         """
         barycorrpy handoff -> (bc_vel_mps, bjd_tdb), each shape (n,).
 
-        `rv_mps` is the target's systemic RV so the BJD_TDB light-travel
+        ``rv_mps`` is the target's systemic RV so the BJD_TDB light-travel
         correction accounts for stellar motion.
         """
         icrs = skycoord.icrs
@@ -471,18 +471,18 @@ class BarycentricCorrection:
         """
         Compute the flux-weighted midpoint observation time.
 
-        The per-channel midpoint is always derived internally; `output`
+        The per-channel midpoint is always derived internally; ``output``
         controls how it is projected.
 
         Parameters
         ----------
         output : {'expmeter', 'orders', 'ccds'}
-            'expmeter' — per-channel times, shape (nwave,).
-            'orders'   — per spectral order: mean of the per-channel times for
+            'expmeter' -- per-channel times, shape (nwave,).
+            'orders'   -- per spectral order: mean of the per-channel times for
                          the expmeter channels within the order's wavelength
                          range, shape (NORDER,). Orders outside expmeter
                          coverage fall back to the nearest channel.
-            'ccds'     — per chip: the SCI2-flux-weighted mean of the per-order
+            'ccds'     -- per chip: the SCI2-flux-weighted mean of the per-order
                          values, shape (2,); [GREEN, RED].
         interpolate : bool, optional
             If True, estimate flux during gaps between expmeter readings.
@@ -502,6 +502,16 @@ class BarycentricCorrection:
             Wavelengths corresponding to each output bin [Å].
         t_fwm : Time
             Flux-weighted midpoint time (JD-UTC) per output bin.
+
+        Raises
+        ------
+        ValueError
+            If ``output`` is not one of the allowed values; if the EXPMETER_SCI
+            timestamps are not strictly increasing; if an exposure meter channel
+            has non-positive total flux; or (for ``output='ccds'``) if all SCI2
+            order weights are zero for a CCD.
+        KeyError
+            If SCI2_WAVE is missing or empty (run WavelengthCalibration first).
         """
         if output not in ("expmeter", "orders", "ccds"):
             raise ValueError(
@@ -546,7 +556,7 @@ class BarycentricCorrection:
         if output == "orders":
             return w_orders, t_orders
 
-        # Weight each order by its SCI2 brightness (`weight_percentile`, robust
+        # Weight each order by its SCI2 brightness (``weight_percentile``, robust
         # to cosmics); NaN/failed orders get zero weight, uniform if SCI2_FLUX
         # absent.
         norder_green = self.norder["GREEN"]
@@ -594,7 +604,7 @@ class BarycentricCorrection:
         Compute the barycentric correction at the flux-weighted photon-midpoint
         time for each output bin.
 
-        Mirrors compute_flux_weighted_midpoint_times: `output` selects the
+        Mirrors compute_flux_weighted_midpoint_times: ``output`` selects the
         binning. The per-channel integration and the Gaia astrometry are both
         cached, so calling this for 'orders' then 'ccds' does the heavy work
         once.
@@ -667,7 +677,7 @@ class BarycentricCorrection:
         self._info = "\n".join(lines)
 
     def _set_headers(self, l2_obj):
-        """Write the per-CCD summary keywords (the module's only summary writes).
+        """Write the per-CCD summary keywords.
 
         Reads self._ccd_bjd/_ccd_kms/_ccd_z and self._astrometry_source
         (populated by perform()); set_keyword routes each to its registry home.

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -2,32 +2,12 @@
 KPF Barycentric Correction module.
 
 Computes per-order barycentric corrections from the EXPMETER_SCI flux-weighted
-midpoint times and stores them on the L2. WAVE arrays are not modified.
+midpoint times and stores them on the L2 as BJD_TDB, BARYCORR_KMS, and
+BARYCORR_Z (per spectral order), plus per-CCD scalar summaries in the
+barycentric extension headers. Wavelength arrays are not modified.
 
-Outputs (EPRV-standard ImageHDUs, shape (NORDER,)):
-  - BJD_TDB       photon-weighted midpoint in BJD_TDB per spectral order
-  - BARYCORR_KMS  barycentric velocity per spectral order [km/s]
-  - BARYCORR_Z    barycentric redshift per spectral order
-
-Per-CCD scalar summaries (at each chip's flux-weighted photon-midpoint time)
-written to the per-CCD barycentric extension headers (BJD_TDB / BARYCORR_KMS /
-BARYCORR_Z) as registered KPF-pipeline keywords (config/L2-headers.csv):
-  - CCD1BJD       GREEN photon-weighted mid-time (BJD_TDB)
-  - CCD1BKMS      GREEN barycentric velocity [km/s]
-  - CCD1BZ        GREEN barycentric redshift
-  - CCD2BJD       RED   photon-weighted mid-time (BJD_TDB)
-  - CCD2BKMS      RED   barycentric velocity [km/s]
-  - CCD2BZ        RED   barycentric redshift
-
-CCD1BJD/CCD2BJD match the legacy keyword names and semantics; the *BKMS/*BZ
-companions follow the same CCD{n} naming pattern. INSTRUMENT_HEADER is an
-immutable pure pass-through of the raw instrument header and is never written.
-
-Notes
------
-Follows the barycentric correction approach described in:
-- Wright & Eastman (2014) — velocity calculation (barycorrpy)
-- Butler et al. (1996)    — flux-weighted midpoint time
+Follows the barycentric-correction approach of Wright & Eastman (2014,
+barycorrpy) with the flux-weighted midpoint time of Butler et al. (1996).
 """
 
 import logging

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -100,21 +100,10 @@ class BarycentricCorrection:
 
     def _get_timestamps(self):
         """
-        Read start and end timestamps from EXPMETER_SCI.
+        Read EXPMETER_SCI start/mid/end timestamps (t_beg, t_mid, t_end).
 
-        Returns
-        -------
-        t_beg : Time
-            Array of exposure start times.
-        t_mid : Time
-            Array of exposure midpoint times (unweighted).
-        t_end : Time
-            Array of exposure end times.
-
-        Notes
-        -----
-        Prefers corrected timestamps (Date-Beg-Corr / Date-End-Corr) when
-        available, falling back to uncorrected values.
+        Prefers the corrected columns (Date-Beg-Corr / Date-End-Corr), falling
+        back to uncorrected; t_mid is the unweighted (t_beg + t_end) / 2.
         """
         expmeter = self.l2_obj.data["EXPMETER_SCI"]
 
@@ -151,20 +140,11 @@ class BarycentricCorrection:
 
     def _get_normalized_flux(self):
         """
-        Read EXPMETER_SCI flux and normalize by gain and wavelength dispersion.
+        Read EXPMETER_SCI flux, gain- and dispersion-normalized -> (w [Å], f [e-/Å]).
 
-        Columns with numeric names are wavelength channels; non-numeric
-        columns (e.g. timestamps) are skipped.
-
-        EXPMETER_SCI column labels are in Å on L1+ data (converted from the
+        Numeric-named columns are wavelength channels; non-numeric columns (e.g.
+        timestamps) are skipped. Column labels are in Å on L1+ (converted from
         native L0 nm by ImageAssembly), so `w` is returned in Å.
-
-        Returns
-        -------
-        w : ndarray, shape (nwave,)
-            Wavelength of each expmeter channel [Å].
-        f : ndarray, shape (ntime, nwave)
-            Dispersion-normalized flux [e- / Å].
         """
         expmeter = self.l2_obj.data["EXPMETER_SCI"]
 
@@ -187,14 +167,11 @@ class BarycentricCorrection:
     @staticmethod
     def _fix_expmeter_outliers(f, kernel_size=5, k=3.0):
         """
-        Detect and interpolate outlier pixels in an expmeter flux array.
+        Return a copy of `f` with outlier pixels interpolated (shape unchanged).
 
-        Outlier threshold is adaptive (Chauvenet-like criterion based on array
-        size), scaled by the coefficient `k` (larger rejects fewer points).
-        Replacement uses scipy.griddata linear interpolation, falling back to
-        nearest for any remaining NaNs.
-
-        Returns a copy of f with outliers replaced; shape unchanged.
+        Threshold is adaptive (Chauvenet-like criterion on array size), scaled
+        by `k` (larger rejects fewer). Replacement is griddata linear, falling
+        back to nearest for residual NaNs.
         """
         f_smooth = gaussian_filter(
             median_filter(f, size=kernel_size), sigma=kernel_size
@@ -274,20 +251,12 @@ class BarycentricCorrection:
         self, interpolate=True, extrapolate=True, fix_expmeter_outliers=True
     ):
         """
-        Compute the flux-weighted midpoint time for each expmeter channel.
+        Flux-weighted midpoint time per expmeter channel -> (w_em [Å], t_em [JD-UTC]).
 
-        Reads EXPMETER_SCI, optionally fills gaps between readings
-        (`interpolate`), gaps before/after the shutter window (`extrapolate`,
-        using DATE-BEG/DATE-END), and replaces outlier readings
-        (`fix_expmeter_outliers`), then collapses the time axis to a single
-        flux-weighted mean time per channel.
-
-        Returns
-        -------
-        w_em : ndarray, shape (nwave,)
-            Wavelength of each expmeter channel [Å].
-        t_em : Time, shape (nwave,)
-            Flux-weighted midpoint time (JD-UTC) per channel.
+        Optionally fills gaps between readings (`interpolate`), before/after the
+        shutter window (`extrapolate`, using DATE-BEG/DATE-END), and replaces
+        outlier readings (`fix_expmeter_outliers`) before collapsing the time
+        axis to a flux-weighted mean per channel.
         """
         t_beg, t_mid, t_end = self._get_timestamps()
         w_em, f = self._get_normalized_flux()
@@ -344,12 +313,11 @@ class BarycentricCorrection:
 
     def _gaia_astrometry(self):
         """
-        Query Gaia DR3 for the target's ICRS astrometry (cached).
+        Query Gaia DR3 for the target's ICRS astrometry (cached SkyCoord).
 
-        The source_id is read from GAIAID in INSTRUMENT_HEADER (preserved from
-        L1 PRIMARY by KPF1.to_kpf2()). Returns a SkyCoord with proper motion
-        and distance (from parallax) attached, at the Gaia ref_epoch. The
-        network query runs once and is reused across calls (one target/frame).
+        source_id comes from GAIAID in INSTRUMENT_HEADER. Returns a SkyCoord
+        with proper motion and distance (from parallax) at the Gaia ref_epoch;
+        the network query runs once and is reused (one target per frame).
         """
         if self._skycoord is None:
             gaia_id_raw = self.l2_obj.headers["INSTRUMENT_HEADER"]["GAIAID"]
@@ -377,12 +345,10 @@ class BarycentricCorrection:
 
     def _wmko_astrometry(self):
         """
-        Build a SkyCoord from WMKO/DCS astrometry in INSTRUMENT_HEADER.
+        Build a SkyCoord from WMKO/DCS astrometry in INSTRUMENT_HEADER (fallback).
 
-        Uses TARGRA/TARGDEC (TARGFRAM, FK5-default equinox J2000 = TARGEPOC)
-        with proper motion and parallax. TARGPMRA is in time-seconds/yr
-        (-> mas/yr via x15 cos(dec)); TARGPLAX is in mas (-> distance via
-        1e3/plax), matching the Gaia path.
+        Unit gotchas: TARGPMRA is time-seconds/yr (-> mas/yr via x15 cos(dec));
+        TARGPLAX is mas (-> distance via 1e3/plax), matching the Gaia path.
         """
         inst = self.l2_obj.headers["INSTRUMENT_HEADER"]
         pos = SkyCoord(inst["TARGRA"], inst["TARGDEC"], unit=(u.hourangle, u.deg))
@@ -402,8 +368,8 @@ class BarycentricCorrection:
         Resolve target astrometry: Gaia DR3 first, then WMKO header fallback.
 
         Each source is tried only if its config toggle is set. If neither
-        yields a SkyCoord, raises, surfacing the captured Gaia error so the
-        failure (our-side vs Gaia-server-side) is distinguishable.
+        yields a SkyCoord, raises and surfaces the captured Gaia error so an
+        our-side vs Gaia-server-side failure stays distinguishable.
         """
         gaia_error = None
         if self.use_gaia_astrometry:
@@ -435,12 +401,10 @@ class BarycentricCorrection:
     @staticmethod
     def _compute_barycorr(skycoord, obs_times, location, rv_mps=0.0):
         """
-        Compute barycentric velocity (m/s) and BJD_TDB for an array of obs_times.
+        barycorrpy handoff -> (bc_vel_mps, bjd_tdb), each shape (n,).
 
-        `rv_mps` is the target's systemic RV (m/s), passed to barycorrpy so
-        the light-travel correction in BJD_TDB accounts for stellar motion.
-
-        Returns (bc_vel_mps, bjd_tdb), each shape (n,).
+        `rv_mps` is the target's systemic RV so the BJD_TDB light-travel
+        correction accounts for stellar motion.
         """
         icrs = skycoord.icrs
         ra = icrs.ra.to(u.deg).value
@@ -703,14 +667,11 @@ class BarycentricCorrection:
         self._info = "\n".join(lines)
 
     def _set_headers(self, l2_obj):
-        """Write all summary header keywords for barycentric correction.
+        """Write the per-CCD summary keywords (the module's only summary writes).
 
         Reads self._ccd_bjd/_ccd_kms/_ccd_z and self._astrometry_source
-        (populated by perform()); the single place this module writes summary
-        keywords, called just before the receipt entry. Per-CCD keywords are
-        registered KPF-pipeline keywords (config/L2-headers.csv); set_keyword
-        routes them to their registry homes (BJD_TDB / BARYCORR_KMS / BARYCORR_Z,
-        and RECEIPT for ASTRSRC). CCD1=GREEN, CCD2=RED.
+        (populated by perform()); set_keyword routes each to its registry home.
+        CCD1=GREEN, CCD2=RED.
         """
         l2_obj.set_keyword("CCD1BJD", float(self._ccd_bjd[0]))
         l2_obj.set_keyword("CCD1BKMS", float(self._ccd_kms[0]))

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -89,29 +89,9 @@ class CalibrationAssociation:
 
     def _find_master_files(self, cal_type, date_obs, masters_search_window_days=None):
         """
-        Return a list of (filepath, timestamp) tuples for all available
-        masters of the given calibration type within the search window.
-
-        Parameters
-        ----------
-        cal_type : str
-            One of 'bias', 'dark', 'flat', 'thar'.
-        date_obs : str
-            ISO-format observation datetime from the frame's PRIMARY header
-            (e.g. '2024-04-05T11:08:33').
-        masters_search_window_days : [int, int], optional
-            Search window as [days_before, days_after]. Defaults to
-            self.masters_search_window_days.
-
-        Returns
-        -------
-        list of (str, str)
-            Sorted list of (filepath, kpf_timestamp) tuples.
-
-        Raises
-        ------
-        ValueError
-            If `cal_type` is not a key of `_LEVEL_BY_CAL_TYPE`.
+        Return sorted (filepath, kpf_timestamp) tuples for all masters of
+        `cal_type` within the [days_before, days_after] window around
+        `date_obs`. Raises ValueError for an unsupported `cal_type`.
         """
         if cal_type not in _LEVEL_BY_CAL_TYPE:
             raise ValueError(
@@ -145,21 +125,8 @@ class CalibrationAssociation:
 
     def _select_nearest(self, date_obs, master_files):
         """
-        Select the candidate whose timestamp is nearest to date_obs.
-
-        Parameters
-        ----------
-        date_obs : str
-            ISO-format observation datetime from the frame's PRIMARY header
-            (e.g. '2024-04-05T11:08:33').
-        master_files : list of (str, str)
-            (filepath, kpf_timestamp) pairs from _find_master_files.
-
-        Returns
-        -------
-        str or None
-            Filepath of the selected master, or None if master_files is empty.
-            Callers should treat None as a failure.
+        Return the filepath of the candidate nearest in time to `date_obs`,
+        or None if `master_files` is empty (callers treat None as a failure).
         """
         if not master_files:
             return None
@@ -194,12 +161,10 @@ class CalibrationAssociation:
     def _set_headers(self, l1_obj):
         """Write the master-path keyword for each associated calibration.
 
-        Reads self._calibrations (populated by perform()); the single place this
-        module writes header keywords, called just before the receipt entry. Each
-        cal type contributes {PREFIX}FILE (full master path), which set_keyword
-        routes to RECEIPT. The signed (master - obs) age ({PREFIX}AGE) is
-        recomputed downstream by DiagL1 from this path plus PRIMARY DATE-OBS,
-        so this module no longer computes or writes it.
+        Reads self._calibrations (from perform()); each cal type contributes
+        {PREFIX}FILE (full master path), which set_keyword routes to RECEIPT.
+        The signed age {PREFIX}AGE is recomputed downstream by DiagL1 from this
+        path plus PRIMARY DATE-OBS, not written here.
         """
         for cal_type, cal in self._calibrations.items():
             prefix = _HEADER_PREFIX[cal_type]

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -52,19 +52,13 @@ class CalibrationAssociation:
     Parameters
     ----------
     l1_obj : KPF1
-        KPF observation frame. For now this is always an L1 frame. The
-        observation timestamp is read from its PRIMARY header (DATE-OBS).
+        KPF observation frame. The observation timestamp is read from its
+        PRIMARY header (DATE-OBS).
     config : None | dict | ConfigHandler
-        Module configuration. Recognised keys:
-            KPF_MASTERS_OUTPUT : str
-                Root directory under which master calibration files live
-                (searched as {root}/masters/{datecode}/). This is where the
-                masters recipe writes its products.
-            masters_search_window_days : [int, int]
-                Search window as [days_before, days_after] relative to the
-                science frame's observation date. Negative values are in the
-                past, positive in the future. Default: [-1, 0] (search up to
-                1 day before and same day only).
+        Module configuration. Recognized keys: KPF_MASTERS_OUTPUT (root
+        directory holding the master calibration files) and
+        masters_search_window_days ([days_before, days_after] search window
+        relative to the frame's observation date; default [-1, 0]).
     """
 
     def __init__(self, l1_obj, config=None):

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -90,8 +90,8 @@ class CalibrationAssociation:
     def _find_master_files(self, cal_type, date_obs, masters_search_window_days=None):
         """
         Return sorted (filepath, kpf_timestamp) tuples for all masters of
-        `cal_type` within the [days_before, days_after] window around
-        `date_obs`. Raises ValueError for an unsupported `cal_type`.
+        ``cal_type`` within the [days_before, days_after] window around
+        ``date_obs``. Raises ValueError for an unsupported ``cal_type``.
         """
         if cal_type not in _LEVEL_BY_CAL_TYPE:
             raise ValueError(
@@ -125,8 +125,8 @@ class CalibrationAssociation:
 
     def _select_nearest(self, date_obs, master_files):
         """
-        Return the filepath of the candidate nearest in time to `date_obs`,
-        or None if `master_files` is empty (callers treat None as a failure).
+        Return the filepath of the candidate nearest in time to ``date_obs``,
+        or None if ``master_files`` is empty (callers treat None as a failure).
         """
         if not master_files:
             return None
@@ -194,6 +194,8 @@ class CalibrationAssociation:
 
         Raises
         ------
+        ValueError
+            If any requested ``cal_type`` is unsupported.
         FileNotFoundError
             If no master file is found for any requested calibration type.
         """

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -206,7 +206,7 @@ class CrossCorrelation:
         return row["DEFAULT_MASK"].iloc[0]
 
     def _get_systemic_rv(self):
-        """Target systemic RV (TARGRADV) [km/s] — the stellar CCF grid center."""
+        """Target systemic RV (TARGRADV) [km/s] -- the stellar CCF grid center."""
         inst = self.l2_obj.headers.get("INSTRUMENT_HEADER", {})
         try:
             star_rv = float(inst.get("TARGRADV"))
@@ -222,7 +222,7 @@ class CrossCorrelation:
     def _build_line_mask(self, chip, fiber, mask_width=None):
         """
         Build (and cache) the orderlet's CCF line mask (dict of vacuum 'center',
-        'weight', and per-line top-hat 'start'/'end' at full width `mask_width`
+        'weight', and per-line top-hat 'start'/'end' at full width ``mask_width``
         about each center via relativistic Doppler). Stellar masks load from
         reference/line_masks/stellar_masks/; 'thar' is built from the ThAr line
         list with uniform weights.
@@ -261,8 +261,8 @@ class CrossCorrelation:
 
     def _build_velocity_grid(self, chip, fiber, step_size=None, window=None):
         """
-        Build (and cache) the orderlet's CCF velocity grid: `window` [min, max]
-        rounded to an integer number of exact `step_size` steps, then shifted by
+        Build (and cache) the orderlet's CCF velocity grid: ``window`` [min, max]
+        rounded to an integer number of exact ``step_size`` steps, then shifted by
         the grid center (systemic RV for stellar fibers, 0 for sky/cal).
         """
         if step_size is None:
@@ -441,9 +441,13 @@ class CrossCorrelation:
         Raises
         ------
         ValueError
-            If BARYCORR_Z is required (astronomical source) but not populated.
-        NotImplementedError
-            If the fiber's illumination source has no CCF path yet (etalon, lfc).
+            For a range of malformed or unusable inputs: an unrecognized or
+            missing illumination keyword; a missing target effective temperature
+            (``TARGTEFF``) or radial velocity (``TARGRADV``) for a stellar fiber;
+            a required but unpopulated ``BARYCORR_Z``; a descending ``WAVE``
+            array; or a ``clip_edge_pixels`` that removes every pixel of the order.
+        RuntimeError
+            If the CCF is identically zero across all orders (no usable signal).
         """
         chip = chip.upper()
         fiber = fiber.upper()
@@ -487,7 +491,7 @@ class CrossCorrelation:
 
         norder = flux.shape[0]
 
-        # Per-order barycentric redshift — only for astronomical sources (target,
+        # Per-order barycentric redshift -- only for astronomical sources (target,
         # sky). Calibration sources (thar) stay in the instrument frame (z = 0).
         if apply_barycorr:
             if np.size(self.l2_obj.data.get("BARYCORR_Z", np.array([]))) == 0:
@@ -590,10 +594,9 @@ class CrossCorrelation:
 
     def _set_headers(self, l4_obj):
         """
-        Write all CCF/RV extension headers (the module's single header-writing
-        site) from the per-orderlet caches, routing each EPRV per-extension card
-        with an explicit ext= to this orderlet's CCF{n}/RV{n}. CCF axes are
-        (velocity, order); RV axes are (columns, order).
+        Write all CCF/RV extension headers from the per-orderlet caches, routing
+        each EPRV per-extension card with an explicit ext= to this orderlet's
+        CCF{n}/RV{n}. CCF axes are (velocity, order); RV axes are (columns, order).
         """
         for fiber in self._fibers_done:
             key = f"{self._chips_done[-1]}_{fiber}"
@@ -727,10 +730,12 @@ class CrossCorrelation:
                 weight[rows] = self._get_order_weights(chip, fiber)
 
             # Per-orderlet RV table, one row per order (green then red). ORDER_ID
-            # is 1-based per chip; ECHELLE_ORDER is the physical grating order
-            # (detector.toml, blue->red); WEIGHT is the per-order CCF weight
-            # (ccf_order_weights.csv). RV/RV_ERR are NaN placeholders RadialVelocity
-            # fills from the CCFs.
+            # is a composite string label ``{CHIP}_{FIBER}_{n}`` whose ``n`` is
+            # 1-based per chip, while ORDER_INDEX holds the plain 0-based row
+            # index; ECHELLE_ORDER is the physical grating order (detector.toml,
+            # blue->red); WEIGHT is the per-order CCF weight
+            # (ccf_order_weights.csv). RV/RV_ERR are NaN placeholders
+            # RadialVelocity fills from the CCFs.
             order_id = np.array(
                 [
                     f"{chip}_{fiber}_{order}"

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -104,13 +104,10 @@ class CrossCorrelation:
 
     def _resolve_illumination_source(self, chip, fiber):
         """
-        Resolve (and cache) the illumination source and its CCF settings for one
-        orderlet, from its SCI-OBJ/SKY-OBJ/CAL-OBJ keyword in INSTRUMENT_HEADER.
-
-        Returns a dict with keys 'object' (the normalized source), 'mask_name',
-        'apply_barycorr', and 'vel_grid_center'. An unilluminated fiber ('none')
-        has None mask/barycorr/center. Sources whose CCF path is not yet built
-        (etalon, lfc) are skipped the same way, with a warning.
+        Resolve (and cache) the orderlet's illumination source and CCF settings
+        (dict: 'object', 'mask_name', 'apply_barycorr', 'vel_grid_center') from
+        its SCI-OBJ/SKY-OBJ/CAL-OBJ keyword in INSTRUMENT_HEADER. 'none' and the
+        not-yet-built sources (etalon, lfc) get None mask/barycorr/center.
         """
         key = f"{chip.upper()}_{fiber.upper()}"
         if key in self._illumination_source:
@@ -128,7 +125,7 @@ class CrossCorrelation:
                 f"cannot dispatch a mask for fiber {fiber}"
             )
 
-        # Map the raw keyword to the source object and its CCF settings (mask,
+        # Dispatch the raw keyword to source object + CCF settings (mask,
         # barycorr flag, grid center: systemic RV for a star, 0 for sky/cal).
         raw = inst.get(keyword)
         v = str(raw).strip().lower()
@@ -224,19 +221,11 @@ class CrossCorrelation:
 
     def _build_line_mask(self, chip, fiber, mask_width=None):
         """
-        Build (and cache) the orderlet's CCF line mask: vacuum line centers,
-        weights, and per-line top-hat holes of full width `mask_width` about
-        each center (relativistic Doppler). The mask is selected from the orderlet's
-        illumination source.
-
-        Stellar masks load from reference/line_masks/stellar_masks/; the 'thar'
-        mask is built from the ThAr line list with uniform weights.
-
-        Returns
-        -------
-        dict
-            Mask with keys 'center', 'weight', 'start', 'end', each a 1D ndarray
-            of length n_line; wavelengths are vacuum [Å].
+        Build (and cache) the orderlet's CCF line mask (dict of vacuum 'center',
+        'weight', and per-line top-hat 'start'/'end' at full width `mask_width`
+        about each center via relativistic Doppler). Stellar masks load from
+        reference/line_masks/stellar_masks/; 'thar' is built from the ThAr line
+        list with uniform weights.
         """
         if mask_width is None:
             mask_width = self.ccf_mask_width
@@ -272,12 +261,9 @@ class CrossCorrelation:
 
     def _build_velocity_grid(self, chip, fiber, step_size=None, window=None):
         """
-        Build (and cache) the orderlet's CCF velocity grid: evenly spaced over
-        `window` about the orderlet's grid center in `step_size` increments.
-
-        The [min, max] `window` is converted to an integer number of `step_size`
-        steps (so the step is exact), then shifted by the center — the systemic
-        RV (TARGRADV) for stellar fibers, 0 for sky/cal fibers.
+        Build (and cache) the orderlet's CCF velocity grid: `window` [min, max]
+        rounded to an integer number of exact `step_size` steps, then shifted by
+        the grid center (systemic RV for stellar fibers, 0 for sky/cal).
         """
         if step_size is None:
             step_size = self.ccf_step_size
@@ -319,40 +305,14 @@ class CrossCorrelation:
     @staticmethod
     def _compute_ccf_1d(wave, flux, var, line_mask, velocity_grid, barycorr_z):
         """
-        Cross-correlate one order's spectrum against the mask over the velocity
-        grid, folding in the order's barycentric redshift z.
+        Cross-correlate one order's spectrum (wave/flux/var) against the mask over
+        the velocity grid, folding in the order's barycentric redshift z. Returns
+        (ccf, ccf_var = sum(w**2 * var)), both all-zero when the order is unusable
+        or no mask lines fall fully within it.
 
-        Parameters
-        ----------
-        wave : ndarray
-            1D wavelength solution for the order [Å].
-        flux : ndarray
-            1D extracted flux for the order.
-        var : ndarray
-            1D per-pixel variance for the order (TRACE_VAR); sets the CCF photon
-            variance.
-        line_mask : dict
-            Line mask (keys 'start', 'end', 'weight') from _build_line_mask.
-        velocity_grid : ndarray
-            CCF velocity steps [km/s].
-        barycorr_z : float
-            Barycentric redshift for the order.
-
-        Returns
-        -------
-        ccf : ndarray
-            CCF value at each velocity step (all zeros if the order is unusable
-            or no mask lines fall fully within it).
-        ccf_var : ndarray
-            Per-velocity-bin photon variance sum(w**2 * var), where w is the
-            per-pixel mask weight (all zeros in the same unusable cases).
-
-        Raises
-        ------
-        ValueError
-            If the WAVE array is descending; an ascending (blue->red) solution
-            is expected, so a reversed order signals an upstream orientation
-            error rather than something to silently correct.
+        Raises ValueError if WAVE is descending: an ascending (blue->red) solution
+        is expected, so a reversed order signals an upstream orientation error
+        rather than something to silently correct.
         """
         wave = np.asarray(wave, dtype=np.float64)
         flux = np.asarray(flux, dtype=np.float64)
@@ -630,12 +590,10 @@ class CrossCorrelation:
 
     def _set_headers(self, l4_obj):
         """
-        Write all CCF/RV extension headers, the single place this module writes
-        headers, called just before the receipt entry. Reads the per-orderlet
-        caches populated by perform()/compute_ccfs (velocity grid, illumination
-        source, step, mask width). Each keyword is an EPRV per-extension card, so
-        it is routed with an explicit ext= to this orderlet's CCF{n}/RV{n}. CCF
-        axes are (velocity, order); RV axes are (columns, order).
+        Write all CCF/RV extension headers (the module's single header-writing
+        site) from the per-orderlet caches, routing each EPRV per-extension card
+        with an explicit ext= to this orderlet's CCF{n}/RV{n}. CCF axes are
+        (velocity, order); RV axes are (columns, order).
         """
         for fiber in self._fibers_done:
             key = f"{self._chips_done[-1]}_{fiber}"

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -14,7 +14,8 @@ its illumination source (SCI-OBJ/SKY-OBJ/CAL-OBJ in INSTRUMENT_HEADER):
   target   TARGTEFF-lookup      yes       TARGRADV (systemic)
   sky      G2_espresso (solar)  yes       0
   thar     ThAr list (unit wt)  no        0
-  etalon   / lfc                                skipped (no CCF; not implemented)
+  etalon   [NOT IMPLEMENTED]
+  lfc      [NOT IMPLEMENTED]
   none     not illuminated -> skipped (no CCF)
 
 All reference wavelengths (stellar line masks, ThAr line list) are in vacuum;

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -43,7 +43,7 @@ RN_KEYS = {
 
 class ImageAssembly:
     """
-    This class performs CCD-level processing to convert L0 data to L1.
+    Assemble a raw L0 readout into an L1 full-frame image.
 
     Operations include:
       - orienting amplifier channels

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -52,6 +52,14 @@ class ImageAssembly:
       - subtracting overscan bias
       - assembling full-frame images (FFI)
       - converting EXPMETER_SCI/SKY wavelengths from nm to Angstroms
+
+    Parameters
+    ----------
+    l0_obj : KPF0
+        Raw L0 readout to assemble. Its per-amplifier extensions
+        (``{CHIP}_AMP{n}``) are read and modified in place during assembly.
+    config : None | dict | ConfigHandler
+        Module configuration. Recognized keys: overscan_method, readnoise_sigma.
     """
 
     def __init__(self, l0_obj, config=None):
@@ -78,7 +86,8 @@ class ImageAssembly:
         self.namp = {}  # chip -> n amps; set by count_amplifiers()
         self.dims = {}  # chip -> amp shape; set by count_amplifiers()
         self.readnoise = {}  # channel ext -> RN std; set by measure_read_noise()
-        self.rn_nongauss = {}  # channel ext -> std/mad; set by measure_read_noise()
+        # channel ext -> sqrt(2/pi)*std/mad; set by measure_read_noise()
+        self.rn_nongauss = {}
         self._parse_amplifier_reference()
 
     # ------------------------------------------------------------------
@@ -140,8 +149,8 @@ class ImageAssembly:
     def _oscan_zero(self, chip, amp_no, **kwargs):
         """
         Returns overscan bias level of zero. chip/amp_no/kwargs are unused here
-        but kept for the uniform `_oscan_*` dispatch signature (see
-        subtract_overscan()); `del` marks them intentionally discarded.
+        but kept for the uniform ``_oscan_*`` dispatch signature (see
+        subtract_overscan()); ``del`` marks them intentionally discarded.
         """
         del chip, amp_no, kwargs
         return 0.0
@@ -206,8 +215,8 @@ class ImageAssembly:
         Notes
         -----
         Sets instance attributes:
-        - `self.namp[chip]` : number of amplifier regions detected.
-        - `self.dims[chip]` : shape of each amplifier channel.
+        - ``self.namp[chip]`` : number of amplifier regions detected.
+        - ``self.dims[chip]`` : shape of each amplifier channel.
         Only 2-amp and 4-amp configurations are supported.
         """
         chip = chip.upper()
@@ -244,7 +253,7 @@ class ImageAssembly:
 
         Notes
         -----
-        The transformations are flips, so each is its own inverse — calling
+        The transformations are flips, so each is its own inverse -- calling
         twice restores the input. measure_read_noise and subtract_overscan use
         this to orient to standard, do their work, then restore the original
         orientation, so a non-standard orientation never propagates between
@@ -320,8 +329,10 @@ class ImageAssembly:
         Notes
         -----
         Stores results in:
-        - `self.readnoise[channel_ext]` : standard deviation of cleaned overscan.
-        - `self.rn_nongauss[channel_ext]` : non-Gaussian factor computed as std/mad.
+        - ``self.readnoise[channel_ext]`` : standard deviation of cleaned overscan.
+        - ``self.rn_nongauss[channel_ext]`` : non-Gaussian factor, computed as
+          ``sqrt(2/pi) * std / mad`` (the ``sqrt(2/pi)`` normalization makes the
+          indicator ~1 for a Gaussian).
         """
         if sigma is None:
             sigma = self.readnoise_sigma

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -87,11 +87,10 @@ class ImageAssembly:
 
     def _parse_amplifier_reference(self):
         """
-        Load orientation mapping and gain for amplifier channels.
-
-        Orientation keys indicate how to flip/rotate each amplifier channel to
-        standard orientation (serial overscan on right, parallel overscan on bottom).
-        Cached in `self.orientation` for repeated use.
+        Cache per-channel orientation flips and gains from the amplifier
+        reference into ``self.orientation`` / ``self.gain``. Orientation maps
+        each channel to standard orientation (serial overscan right, parallel
+        overscan bottom).
         """
         for chip in self.chips:
             chip = chip.upper()
@@ -101,27 +100,8 @@ class ImageAssembly:
 
     def _get_overscan_pixels(self, chip, amp_no, buffer=(0, 0)):
         """
-        Extract overscan pixels for a given amplifier.
-
-        Parameters
-        ----------
-        chip : str
-            CCD identifier, e.g., 'GREEN' or 'RED'.
-        amp_no : int
-            Amplifier number (1-4).
-        buffer : tuple of int, optional
-            Number of pixels to ignore at edges (start, end). Defaults to (0, 0).
-
-        Returns
-        -------
-        oscan_pix_srl : ndarray
-            Serial overscan pixels (columns beyond imaging area).
-        oscan_pix_prl : ndarray
-            Parallel overscan pixels (rows beyond imaging area).
-
-        Notes
-        -----
-        Assumes image orientation has been standardized.
+        Return the (serial, parallel) overscan pixel arrays for one amplifier,
+        with optional edge-buffer trimming. Assumes standard orientation.
         """
         chip = chip.upper()
         full_amplifier = self.l0_obj.data[f"{chip}_AMP{amp_no}"]
@@ -142,23 +122,8 @@ class ImageAssembly:
 
     def _get_imaging_pixels(self, chip, amp_no):
         """
-        Extract imaging pixels (active CCD area) for a given amplifier.
-
-        Parameters
-        ----------
-        chip : str
-            CCD identifier, e.g., 'GREEN' or 'RED'.
-        amp_no : int
-            Amplifier number (1-4).
-
-        Returns
-        -------
-        ndarray
-            2D array of imaging pixels.
-
-        Notes
-        -----
-        Assumes image orientation has been standardized.
+        Return the active-imaging-area pixels for one amplifier (prescan and
+        overscan stripped). Assumes standard orientation.
         """
         chip = chip.upper()
         full_amplifier = self.l0_obj.data[f"{chip}_AMP{amp_no}"]
@@ -200,16 +165,10 @@ class ImageAssembly:
     @staticmethod
     def _convert_expmeter_wavelengths_to_angstroms(l1_obj):
         """
-        Rename EXPMETER_SCI/SKY wavelength column labels from nm to Å.
-
-        Raw L0 expmeter tables label per-channel flux columns with the
-        channel central wavelength in nanometers (e.g. '498.12'). The
-        RVData L2 standard and KPF WAVE arrays use Angstroms, so this
-        renames those columns at the L0 → L1 boundary so the entire
-        L1+ pipeline operates in a single wavelength unit.
-
-        Non-numeric columns (e.g. 'Date-Beg', 'Date-End') are skipped.
-        Underlying flux values are unchanged.
+        Rename EXPMETER_SCI/SKY wavelength column labels from nm to Å at the
+        L0 → L1 boundary, so the whole L1+ pipeline uses one wavelength unit
+        (RVData L2 and KPF WAVE arrays are in Angstroms). Non-numeric columns
+        (e.g. 'Date-Beg') are skipped; flux values are unchanged.
         """
         for ext_name in ("EXPMETER_SCI", "EXPMETER_SKY"):
             if ext_name not in l1_obj.data:
@@ -527,25 +486,8 @@ class ImageAssembly:
 
     def _set_headers(self, l1_obj):
         """
-        Populate KPF1 header keywords related to read noise measurement
-        and overscan subtraction.
-
-        Parameters
-        ----------
-        l1_obj : KPF1
-            L1 data object whose PRIMARY header will be updated with
-            read noise and overscan metadata.
-
-        Returns
-        -------
-        None
-
-        Notes
-        -----
-        Header updates:
-        1. Read noise per amplifier channel (e.g. RNGRN1)
-        2. Non-Gaussian read noise per amplifier channel (e.g. RNNGGR1)
-        3. Overscan subtraction applied (OSCANSUB)
+        Write read-noise metadata to ``l1_obj``: per-amplifier read noise
+        (RN_KEYS), the non-Gaussian factor, and the OSCANSUB flag.
         """
         for channel_ext, rn in self.readnoise.items():
             key_read, key_rnng = RN_KEYS[channel_ext]

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -69,8 +69,8 @@ class ImageProcessing:
         for k, v in _DEFAULTS.items():
             setattr(self, k, params.get(k, v))
 
-        # Resolved masters and their paths, cached per instance by
-        # _resolve_master() during perform() so a master is read at most once.
+        # Resolved masters + paths, cached by _resolve_master() so each master
+        # is read at most once.
         self._bias_ml1 = None
         self._dark_ml1 = None
         self._bias_path = None
@@ -86,25 +86,10 @@ class ImageProcessing:
     @classmethod
     def _load_master(cls, master_path):
         """
-        Load a master frame from an explicit path.
+        Load a master L1 frame from an explicit path.
 
-        The single FITS-read chokepoint for masters; `BaseMasterModule` also
-        delegates here.
-
-        Parameters
-        ----------
-        master_path : str
-            Path to the master L1 FITS file.
-
-        Returns
-        -------
-        KPFMasterL1
-            The loaded master.
-
-        Raises
-        ------
-        FileNotFoundError
-            If `master_path` does not exist on disk.
+        The single FITS-read chokepoint for masters (`BaseMasterModule` also
+        delegates here); raises FileNotFoundError if the path is absent.
         """
         if not os.path.isfile(master_path):
             raise FileNotFoundError(f"Master file not found: {master_path}")
@@ -168,25 +153,10 @@ class ImageProcessing:
         Recover the per-pixel variance of a master IMG from its stored SNR.
 
         A master stores IMG = counts / exptime and SNR = |counts| / sqrt(var),
-        so the variance of the IMG value is (IMG / SNR)**2 (= var / exptime**2).
-        This is the bias/dark uncertainty propagated into the science VAR. A
-        master is built from many frames, so this term is small relative to the
-        per-frame image variance. SNR is non-negative by construction and is
-        exactly zero only at bad / zero-flux pixels; those contribute zero
-        variance rather than inf/NaN.
-
-        Parameters
-        ----------
-        img : numpy.ndarray
-            Master IMG array ('{chip}_IMG'); electrons for bias, electrons/sec
-            for dark.
-        snr : numpy.ndarray
-            Matching master SNR array ('{chip}_SNR').
-
-        Returns
-        -------
-        numpy.ndarray
-            Per-pixel variance of the master IMG, in IMG units squared.
+        so var(IMG) = (IMG / SNR)**2 (= var / exptime**2) — the master's
+        contribution to the science VAR, small because a master averages many
+        frames. SNR is exactly zero only at bad / zero-flux pixels, which
+        contribute zero variance rather than inf/NaN.
         """
         ratio = np.zeros_like(img, dtype=np.float32)
         np.divide(img, snr, out=ratio, where=snr > 0)
@@ -278,11 +248,10 @@ class ImageProcessing:
         self._info = "\n".join(lines)
 
     def _set_headers(self, l1_obj):
-        """Write all PRIMARY-header keywords for image processing.
+        """Write the applied-flag keywords (BIASSUB/DARKSUB) for image processing.
 
-        Reads the applied-flag attributes populated by perform(); the single
-        place this module writes header keywords, called just before the receipt
-        entry. set_keyword routes BIASSUB/DARKSUB to their registry home (RECEIPT).
+        Reads the flags populated by perform(); set_keyword routes them to their
+        registry home (RECEIPT).
         """
         l1_obj.set_keyword("BIASSUB", int(self._biassub))
         l1_obj.set_keyword("DARKSUB", int(self._darksub))

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -88,7 +88,7 @@ class ImageProcessing:
         """
         Load a master L1 frame from an explicit path.
 
-        The single FITS-read chokepoint for masters (`BaseMasterModule` also
+        The single FITS-read chokepoint for masters (``BaseMasterModule`` also
         delegates here); raises FileNotFoundError if the path is absent.
         """
         if not os.path.isfile(master_path):
@@ -98,11 +98,11 @@ class ImageProcessing:
 
     def _resolve_master(self, cal_type, value):
         """
-        Resolve a `bias`/`dark` kwarg into a `KPFMasterL1` instance.
+        Resolve a ``bias``/``dark`` kwarg into a ``KPFMasterL1`` instance.
 
-        See `perform` for accepted input types. The resolved master is cached
-        on `self._{cal_type}_ml1` (with its path on `self._{cal_type}_path`) so
-        repeat calls — e.g. once per chip — reuse it instead of re-reading.
+        See ``perform`` for accepted input types. The resolved master is cached
+        on ``self._{cal_type}_ml1`` (with its path on ``self._{cal_type}_path``) so
+        repeat calls -- e.g. once per chip -- reuse it instead of re-reading.
         """
         cached = getattr(self, f"_{cal_type}_ml1")
         if cached is not None:
@@ -131,11 +131,11 @@ class ImageProcessing:
 
     def _get_master_path(self, cal_type):
         """
-        Read the master path for `cal_type` from the L1 RECEIPT header.
+        Read the master path for ``cal_type`` from the L1 RECEIPT header.
 
-        Returns the `{PREFIX}FILE` keyword (uppercase calibration name), the
+        Returns the ``{PREFIX}FILE`` keyword (uppercase calibration name), the
         master's full path written by CalibrationAssociation. Raises
-        FileNotFoundError if it is absent — a `True` calibration was requested
+        FileNotFoundError if it is absent -- a ``True`` calibration was requested
         on a frame that has not been through CalibrationAssociation.
         """
         prefix = cal_type.upper()
@@ -153,7 +153,7 @@ class ImageProcessing:
         Recover the per-pixel variance of a master IMG from its stored SNR.
 
         A master stores IMG = counts / exptime and SNR = |counts| / sqrt(var),
-        so var(IMG) = (IMG / SNR)**2 (= var / exptime**2) — the master's
+        so var(IMG) = (IMG / SNR)**2 (= var / exptime**2) -- the master's
         contribution to the science VAR, small because a master averages many
         frames. SNR is exactly zero only at bad / zero-flux pixels, which
         contribute zero variance rather than inf/NaN.
@@ -175,13 +175,13 @@ class ImageProcessing:
         chip : str
             CCD identifier, e.g. 'GREEN' or 'RED'.
         bias : bool | str | KPFMasterL1, optional
-            Master bias source, resolved via `_resolve_master` (see `perform`
+            Master bias source, resolved via ``_resolve_master`` (see ``perform``
             for the accepted input types). Defaults to self.bias.
 
         Returns
         -------
         None
-            Modifies `l1_obj.data['{chip}_CCD']` and `['{chip}_VAR']` in-place:
+            Modifies ``l1_obj.data['{chip}_CCD']`` and ``['{chip}_VAR']`` in-place:
             the bias is subtracted from CCD and its variance added to VAR.
         """
         if bias is None:
@@ -199,20 +199,20 @@ class ImageProcessing:
 
         The master dark is a rate (electrons/sec), so it is scaled by the
         frame's exposure time before subtraction. Otherwise identical to
-        `subtract_bias`.
+        ``subtract_bias``.
 
         Parameters
         ----------
         chip : str
             CCD identifier, e.g. 'GREEN' or 'RED'.
         dark : bool | str | KPFMasterL1, optional
-            Master dark source, resolved via `_resolve_master` (see `perform`
+            Master dark source, resolved via ``_resolve_master`` (see ``perform``
             for the accepted input types). Defaults to self.dark.
 
         Returns
         -------
         None
-            Modifies `l1_obj.data['{chip}_CCD']` and `['{chip}_VAR']` in-place:
+            Modifies ``l1_obj.data['{chip}_CCD']`` and ``['{chip}_VAR']`` in-place:
             the exposure-scaled dark is subtracted from CCD and its variance
             (scaled by exptime**2) added to VAR.
         """
@@ -263,11 +263,11 @@ class ImageProcessing:
     @staticmethod
     def calibration_applied(l1_obj, cal_type):
         """
-        Return True if `cal_type` is already flagged applied on `l1_obj`.
+        Return True if ``cal_type`` is already flagged applied on ``l1_obj``.
 
-        Reads the applied flag (`_CALIBRATION_HEADER_KEYS`: BIASSUB/DARKSUB/
-        FLATDIV) from the RECEIPT header — their registry home — written by a
-        prior `perform`. Lets callers — and `perform` itself — avoid applying a
+        Reads the applied flag (``_CALIBRATION_HEADER_KEYS``: BIASSUB/DARKSUB/
+        FLATDIV) from the RECEIPT header -- their registry home -- written by a
+        prior ``perform``. Lets callers -- and ``perform`` itself -- avoid applying a
         calibration twice (e.g. a cached frame revisited during stacking).
 
         Parameters
@@ -299,11 +299,11 @@ class ImageProcessing:
             treat as an explicit filepath. KPFMasterL1 → use this object
             directly (no disk I/O). Defaults to self.bias.
         dark : bool | str | KPFMasterL1, optional
-            Same shape as `bias`, sourced from DARKFILE. Applied
+            Same shape as ``bias``, sourced from DARKFILE. Applied
             after bias subtraction and scaled by the frame's exposure time.
             Defaults to self.dark.
         flat : bool | str | KPFMasterL1, optional
-            Same shape as `bias`. Any truthy value raises
+            Same shape as ``bias``. Any truthy value raises
             NotImplementedError until flat division is built out.
 
         Returns
@@ -319,7 +319,7 @@ class ImageProcessing:
         NotImplementedError
             If flat is truthy.
         TypeError
-            If `bias` or `dark` is not bool, str, or KPFMasterL1.
+            If ``bias`` or ``dark`` is not bool, str, or KPFMasterL1.
         RuntimeError
             If a requested calibration is already flagged applied on the frame
             (BIASSUB/DARKSUB), guarding against double subtraction.

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -3,10 +3,8 @@ KPF Image Processing module.
 
 Applies the standard CCD calibration sequence to an assembled L1 frame, in
 order: bias subtraction, then dark subtraction (an exposure-scaled rate), then
-flat division. Which steps run is set by the bias/dark/flat flags, resolved
-DEFAULTS < [MODULE_IMAGE_PROCESSING] config < perform() kwargs. The masters
-modules drive these same flags per file type (see kpfpipe/modules/masters);
-science applies the full sequence. Flat division is not yet implemented.
+flat division. Which steps run is set by the bias/dark/flat flags. Flat
+division is not yet implemented.
 """
 
 import logging

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -29,9 +29,18 @@ class BaseMasterModule:
     stacking/extraction following standard CCD reduction: a bias gets no
     calibration, a dark is bias-subtracted, and a flat and WLS are bias- and
     dark-subtracted.
+
+    Parameters
+    ----------
+    l0_file_list : list of str
+        Sorted list of L0 FITS file paths to stack (ascending order is
+        required).
+    config : None | dict | ConfigHandler
+        Module configuration. Recognized keys: stack_sigma, min_stack_size,
+        bias, dark, flat, masters_search_window_days, KPF_MASTERS_OUTPUT.
     """
 
-    # Module defaults; subclasses extend via `{**BaseMasterModule._DEFAULTS, ...}`.
+    # Module defaults; subclasses extend via ``{**BaseMasterModule._DEFAULTS, ...}``.
     # bias/dark/flat are the globally-enabled calibrations (the no-config
     # fallback; in practice resolved from the shared [MODULE_IMAGE_PROCESSING]
     # config and make_master kwargs). Keep in sync with the same keys in
@@ -46,12 +55,12 @@ class BaseMasterModule:
     }
 
     # The calibrations that are standard for this master type (the ceiling).
-    # `_process_frame` applies the intersection of this set with the resolved
+    # ``_process_frame`` applies the intersection of this set with the resolved
     # bias/dark/flat flags. Subclasses override (e.g. Dark -> ("bias",)).
     _STANDARD_CALIBRATIONS = ()
 
     # Physical pixel units (BUNIT) by master type, written to the IMG
-    # extensions in `_build_ml1_obj`. A bias master is a stacked count image
+    # extensions in ``_build_ml1_obj``. A bias master is a stacked count image
     # (electrons); a dark is normalized to a rate (electrons/sec); a flat is a
     # unitless relative throughput (no BUNIT). Unknown types get no BUNIT.
     _BUNIT_BY_TYPE = {
@@ -62,7 +71,7 @@ class BaseMasterModule:
 
     # QCL0 flags a frame must pass to enter a stack: data present, required
     # keywords present, sane exptime, and not observer-junk. A frame failing
-    # any is dropped in `_load_frame` and counted as a load failure.
+    # any is dropped in ``_load_frame`` and counted as a load failure.
     _REQUIRED_L0_QC_FLAGS = ("DATAPRL0", "KWRDPRL0", "EXPTIMOK", "NOTJUNK")
 
     # Exposure-time threshold (seconds) for the bias/zero-exposure decision in
@@ -90,16 +99,16 @@ class BaseMasterModule:
         self._l1_obj_cache = {}
 
         # Masters output root; CalibrationAssociation reads masters from here
-        # when `_process_frame` associates a calibration for a stacked frame.
+        # when ``_process_frame`` associates a calibration for a stacked frame.
         self._masters_output = params.get("KPF_MASTERS_OUTPUT")
 
-        # Forwarded to CalibrationAssociation in `_process_frame` so an operator's
+        # Forwarded to CalibrationAssociation in ``_process_frame`` so an operator's
         # configured search window is honored, not silently reset to the default.
         self._masters_search_window_days = params.get("masters_search_window_days")
 
         # One cached master (KPFMasterL1) and its path per calibration type.
         # Frames in a stack are taken close in time and so almost always
-        # associate the same nearest master; caching lets `_process_frame`
+        # associate the same nearest master; caching lets ``_process_frame``
         # read each master from disk once rather than once per frame.
         self._master_ml1 = {}
         self._master_paths = {}
@@ -252,7 +261,7 @@ class BaseMasterModule:
         """
         Extract an assembled frame to L2 (for spectral masters, e.g. WLS).
 
-        Spectral extraction only — calibration is not implicit; callers needing
+        Spectral extraction only -- calibration is not implicit; callers needing
         bias/dark applied must run ``_process_frame`` first.
         """
         spectral_extraction = SpectralExtraction(l1_obj)
@@ -294,7 +303,7 @@ class BaseMasterModule:
         ``max_fail_fraction`` or ``max_fail_number``.
 
         Returns ``(stats, zero_exptime)``. ``stats`` is per-extension with 'nframe',
-        'counts_sum', 'rate_mean' (equal-weight mean of per-frame rates — the clip
+        'counts_sum', 'rate_mean' (equal-weight mean of per-frame rates -- the clip
         center, not the master IMG), 'rate_rms' (frame-to-frame sample RMS), and on
         '{chip}_CCD' only 'exptime_sum' (per-pixel total exposure over valid frames;
         the exposure-weighted-rate denominator in stack_frames, = valid-frame count
@@ -435,7 +444,7 @@ class BaseMasterModule:
         ``max_fail_fraction``/``max_fail_number`` or exposures are inconsistent.
 
         Returns ``(exact_stats, zero_exptime)``. ``exact_stats`` carries only
-        'nframe', 'counts_sum', and (on '{chip}_CCD') 'exptime_sum' — no
+        'nframe', 'counts_sum', and (on '{chip}_CCD') 'exptime_sum' -- no
         'rate_mean'/'rate_rms', since clip bounds come from the approximation and
         the master IMG is counts_sum / exptime_sum.
         """
@@ -446,7 +455,7 @@ class BaseMasterModule:
 
         ndirect = nstream - 1
 
-        # The approximation pass stacks only the first `ndirect` frames; cache
+        # The approximation pass stacks only the first ``ndirect`` frames; cache
         # them so the streaming exact pass below reuses them instead of
         # re-reading and re-assembling those files from disk.
         approx_stats, zero_exptime = self._compute_stats_from_datacube(
@@ -492,7 +501,7 @@ class BaseMasterModule:
         clipping_mask = np.ones((nrow, ncol), dtype=bool)
 
         for fn in l0_file_list:
-            # The first `ndirect` frames are cache hits from the approximation
+            # The first ``ndirect`` frames are cache hits from the approximation
             # pass above; the rest are read once here and not worth caching.
             l1_obj = self._load_frame(fn, cache=False)
 
@@ -543,7 +552,7 @@ class BaseMasterModule:
         illuminated only for flats (in the assembled image dispersion runs along
         axis=1, cross-dispersion along axis=0):
 
-        - 'bias' : per-column median (axis=0) — judges each pixel against its own
+        - 'bias' : per-column median (axis=0) -- judges each pixel against its own
           cross-dispersion column, removing column-wise bias structure.
         - 'dark'/None : global median (no illumination/column structure to preserve).
         - 'flat' : residual deviation from the smooth illumination trend along
@@ -649,7 +658,7 @@ class BaseMasterModule:
         sigma : float, optional
             Sigma threshold for frame-to-frame outlier rejection.
         cal_type : {'bias', 'dark', 'flat', None}, optional
-            Calibration type, forwarded to `_clean_l1_arrays` to select the
+            Calibration type, forwarded to ``_clean_l1_arrays`` to select the
             final outlier-flagging mode. Defaults to the conservative
             global-median mode.
         max_fail_fraction : float, optional
@@ -664,14 +673,14 @@ class BaseMasterModule:
         -------
         l1_arrays : dict
             Dictionary containing per-chip stacked products, with bad pixels
-            interpolated and the bad-pixel mask recomputed (`_clean_l1_arrays`):
+            interpolated and the bad-pixel mask recomputed (``_clean_l1_arrays``):
             - '{chip}_IMG'  : mean count rate FFI
             - '{chip}_SNR'  : signal-to-noise ratio FFI
             - '{chip}_MASK' : boolean bad pixel mask (1 = good, 0 = bad)
 
         Notes
         -----
-        If number of frames is less than `nstream`, statistics are computed
+        If number of frames is less than ``nstream``, statistics are computed
         directly from a full data cube. Otherwise, a single-pass streaming
         accumulation is used to bound memory usage.
 
@@ -748,30 +757,30 @@ class BaseMasterModule:
 
     def save_master(self, level, path, *, overwrite=False):
         """
-        Write the cached master object to a FITS file at `path`.
+        Write the cached master object to a FITS file at ``path``.
 
         Parameters
         ----------
         level : str
             Data level of the master to save; selects which cached
             object to write. One of 'L1' or 'L2', matching the
-            subclass's `make_master_l1` / `make_master_l2` entry point.
+            subclass's ``make_master_l1`` / ``make_master_l2`` entry point.
         path : str
             Output FITS path. Parent directories are created as needed.
         overwrite : bool, optional
             If False (default), refuse to clobber an existing file and
             raise FileExistsError. If True, replace any existing file
-            at `path`. Defaults to False to protect against accidental
+            at ``path``. Defaults to False to protect against accidental
             overwrites when called directly; entry points that pass an
-            output path through `make_master_lN()` should set True
+            output path through ``make_master_lN()`` should set True
             explicitly.
 
         Raises
         ------
         ValueError
-            If `level` is not a recognized data level.
+            If ``level`` is not a recognized data level.
         FileExistsError
-            If `path` already exists and `overwrite` is False.
+            If ``path`` already exists and ``overwrite`` is False.
         RuntimeError
             If the corresponding make_master_lN() has not been run yet,
             or raised before constructing the master.

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -123,26 +123,14 @@ class BaseMasterModule:
 
     def _resolve_calibrations(self, *, bias=None, dark=None, flat=None):
         """
-        Resolve which calibrations to apply to each frame.
+        Resolve which calibrations apply per frame: {name: False|True|str|KPFMasterL1}.
 
-        For each calibration, the value is the per-call override (the make_master
-        kwarg if not None, else the config-resolved `self.<name>`, i.e.
-        DEFAULTS < [MODULE_IMAGE_PROCESSING]) — but only if the calibration is in
-        the per-master standard (`_STANDARD_CALIBRATIONS`); otherwise it is forced
-        off. A flag/path can only turn a standard calibration off (or aim it at a
-        specific master); it can never enable one outside the master's standard.
-
-        Parameters
-        ----------
-        bias, dark, flat : bool | str | KPFMasterL1, optional
-            Per-call overrides (same accepted forms as `ImageProcessing.perform`:
-            True → header-associated master, str → filepath, KPFMasterL1 → that
-            object). None means "use the resolved config value".
-
-        Returns
-        -------
-        dict
-            {name: False | True | str | KPFMasterL1} for name in bias/dark/flat.
+        For bias/dark/flat, take the per-call override (make_master kwarg if not
+        None, else config-resolved ``self.<name>``) only if the calibration is in
+        this master's ``_STANDARD_CALIBRATIONS``, else force it off. A flag/path can
+        only disable a standard calibration (or aim it at a specific master), never
+        enable one outside the standard. Override forms match
+        ``ImageProcessing.perform``.
         """
         overrides = {"bias": bias, "dark": dark, "flat": flat}
         resolved = {}
@@ -160,27 +148,11 @@ class BaseMasterModule:
         """
         Resolve one active calibration to a master, caching one per type.
 
-        The source comes from `self._active_calibrations[cal_type]`: True → the
-        master associated into the frame header, str → a filepath, KPFMasterL1 →
-        an in-memory master. A disk-backed master is read only when its path
-        differs from the one already cached for `cal_type`; frames in a stack
-        almost always share the same master, so each is read from disk once.
-        Falsy (inactive) values and in-memory KPFMasterL1 objects are returned
-        unchanged.
-
-        Parameters
-        ----------
-        l1_obj : KPF1
-            The frame being calibrated; its PRIMARY header supplies the
-            associated master path for a True calibration.
-        cal_type : str
-            Calibration name: 'bias', 'dark', or 'flat'.
-
-        Returns
-        -------
-        bool | str | KPFMasterL1
-            A cached KPFMasterL1 for a disk-backed calibration; otherwise the
-            source value unchanged (so ImageProcessing handles falsy/invalid).
+        Source is ``self._active_calibrations[cal_type]``: True → master associated
+        into the frame header, str → filepath, KPFMasterL1 → in-memory master. A
+        disk-backed master is read only when its path differs from the cached one
+        (frames in a stack almost always share a master, so each is read once).
+        Falsy and in-memory values are returned unchanged.
         """
         value = self._active_calibrations[cal_type]
         if not value or isinstance(value, KPFMasterL1):
@@ -202,32 +174,14 @@ class BaseMasterModule:
 
     def _load_frame(self, fn, cache=False):
         """
-        Load an L0 file and perform image assembly to produce an L1 object.
+        Load an L0 file and assemble it to an L1 object; None on failure.
 
-        Parameters
-        ----------
-        fn : str
-            Path to L0 FITS file.
-        cache : bool
-            If True, retain the assembled L1 in the internal cache for reuse.
-            The caller decides which frames are worth caching (see the streaming
-            stats path). A frame already cached is returned from the cache
-            regardless of this flag.
-
-        Returns
-        -------
-        l1_obj : KPF1 or None
-            The assembled L1 object, or None on failure. Failure means the
-            frame could not be read/assembled or failed a required QCL0 flag
-            (`_REQUIRED_L0_QC_FLAGS`, which includes the EXPTIME/ELAPSED
-            consistency check); a warning names the cause. Callers detect
-            failure via `l1_obj is None`.
-
-        Notes
-        -----
-        When `cache=True`, the successfully processed frame is retained to
-        reduce redundant I/O and recomputation. The streaming stats path caches
-        its approximation-pass frames so the exact pass reuses them.
+        Failure means the frame could not be read/assembled or failed a required
+        QCL0 flag (``_REQUIRED_L0_QC_FLAGS``, incl. the EXPTIME/ELAPSED consistency
+        check); a warning names the cause and callers detect it via ``is None``.
+        With ``cache=True`` the assembled L1 is retained for reuse (the streaming
+        stats path caches its approximation-pass frames so the exact pass reuses
+        them); an already-cached frame is returned regardless of the flag.
         """
         if fn in self._l1_obj_cache:
             return self._l1_obj_cache[fn]
@@ -254,25 +208,12 @@ class BaseMasterModule:
 
     def _process_frame(self, l1_obj):
         """
-        Apply this module's active calibrations to an assembled frame.
+        Apply this module's active calibrations to an assembled frame (in place).
 
-        Subtracts the active masters via ImageProcessing, reusing the standard
-        science-path modules rather than reimplementing the math. Calibrations
-        requested as `True` are associated first (CalibrationAssociation writes
-        their nearest-in-time master into the PRIMARY header); calibrations given
-        as an explicit filepath or KPFMasterL1 object skip association and are
-        passed straight through. Modules with no active calibrations receive the
-        frame unchanged.
-
-        Parameters
-        ----------
-        l1_obj : KPF1
-            Assembled L1 frame to calibrate, mutated in place.
-
-        Returns
-        -------
-        KPF1
-            The same frame with the active calibrations applied.
+        Subtracts active masters via ImageProcessing (reusing the science-path
+        modules). ``True`` calibrations are associated first (nearest-in-time
+        master written to PRIMARY); explicit filepath/KPFMasterL1 overrides pass
+        straight through. No active calibrations → frame returned unchanged.
         """
         calibrations = self._active_calibrations
         active = [name for name, value in calibrations.items() if value]
@@ -311,19 +252,8 @@ class BaseMasterModule:
         """
         Extract an assembled frame to L2 (for spectral masters, e.g. WLS).
 
-        Performs spectral extraction only. Calibration is not implicit here:
-        callers that need bias/dark applied must run `_process_frame` on the
-        frame first.
-
-        Parameters
-        ----------
-        l1_obj : KPF1
-            Assembled (and, where needed, already calibrated) L1 frame.
-
-        Returns
-        -------
-        KPF2
-            The extracted L2 spectra.
+        Spectral extraction only — calibration is not implicit; callers needing
+        bias/dark applied must run ``_process_frame`` first.
         """
         spectral_extraction = SpectralExtraction(l1_obj)
         return spectral_extraction.perform()
@@ -335,23 +265,8 @@ class BaseMasterModule:
     @staticmethod
     def _check_load_failures(failure, n_total, max_fail_fraction, max_fail_number):
         """
-        Raise if cumulative frame-load failures exceed either limit.
-
-        Parameters
-        ----------
-        failure : int
-            Number of frames that have failed to load so far.
-        n_total : int
-            Total number of frames in the stack.
-        max_fail_fraction : float
-            Maximum allowed fraction of failed frames.
-        max_fail_number : int
-            Maximum allowed absolute number of failed frames.
-
-        Raises
-        ------
-        ValueError
-            If either limit is exceeded.
+        Raise ValueError if cumulative frame-load failures exceed either the
+        fraction (``max_fail_fraction``) or absolute (``max_fail_number``) limit.
         """
         if failure / n_total > max_fail_fraction or failure > max_fail_number:
             raise ValueError(
@@ -373,55 +288,26 @@ class BaseMasterModule:
         """
         Compute stacked statistics using an in-memory data cube.
 
-        Parameters
-        ----------
-        l0_file_list : list of str, optional
-            List of L0 FITS filenames to process. The full list is stacked;
-            the caller is responsible for passing the desired subset (e.g. the
-            streaming path passes only its approximation-pass frames).
-        sigma : float, optional
-            Sigma threshold for outlier rejection across frames.
-        cache : bool, optional
-            If True, cache each loaded frame so a later pass (the streaming
-            exact pass) can reuse it without re-reading from disk. Defaults to
-            False, since the standalone datacube path reads each frame once.
-        max_fail_fraction : float, optional
-            Maximum fraction of frames allowed to fail loading before raising.
-            Defaults to 0.2.
-        max_fail_number : int, optional
-            Maximum absolute number of frames allowed to fail loading before
-            raising. Defaults to 2. Stacking raises when either limit is
-            exceeded.
+        Stacks the full ``l0_file_list`` (caller passes the desired subset). With
+        ``cache=True`` each loaded frame is retained so a later pass (the streaming
+        exact pass) reuses it. Raises when frame-load failures exceed
+        ``max_fail_fraction`` or ``max_fail_number``.
 
-        Returns
-        -------
-        stats : dict
-            Per-extension statistics including:
-            - 'nframe'      : number of valid frames per pixel
-            - 'counts_sum'  : summed counts across valid frames
-            - 'rate_mean'   : equal-weight mean of per-frame rates (the center
-                              used for streaming clip bounds, not the master IMG)
-            - 'rate_rms'    : frame-to-frame sample RMS of the per-frame rates
-            On the '{chip}_CCD' entry only:
-            - 'exptime_sum' : per-pixel total exposure time over valid frames
-                              (the denominator of the exposure-weighted rate in
-                              stack_frames; equals the valid-frame count for a
-                              bias stack, where T = 1)
-        zero_exptime : bool
-            True if this is a bias stack (all frames have exposure at or below
-            `_ZERO_EXPTIME_TOL_SECONDS`), used by the streaming path to validate
-            per-frame exposure consistency.
+        Returns ``(stats, zero_exptime)``. ``stats`` is per-extension with 'nframe',
+        'counts_sum', 'rate_mean' (equal-weight mean of per-frame rates — the clip
+        center, not the master IMG), 'rate_rms' (frame-to-frame sample RMS), and on
+        '{chip}_CCD' only 'exptime_sum' (per-pixel total exposure over valid frames;
+        the exposure-weighted-rate denominator in stack_frames, = valid-frame count
+        for a bias stack where T=1). ``zero_exptime`` is True for a bias stack (all
+        exposures ≤ ``_ZERO_EXPTIME_TOL_SECONDS``).
 
         Notes
         -----
-        Exposure time is read from the EPRV-standard PRIMARY EXPTIME (the actual
-        elapsed time, mapped from the native WMKO ELAPSED), not the nominal
-        requested EXPTIME. Outlier rejection is performed on the CCD rate (VAR =
-        |CCD| + RN adds no independent information); rates are used so frames of
-        differing exposure are comparable, and VAR is still summed for the SNR.
-        Exposure times must be either all zero (≤ `_ZERO_EXPTIME_TOL_SECONDS`) or
-        all above it. Raises an error if more than `max_fail_fraction` of frames
-        fail to load.
+        Exposure time is the EPRV PRIMARY EXPTIME (elapsed, mapped from native
+        ELAPSED), not the nominal requested EXPTIME. Rejection is on the CCD rate
+        (VAR = |CCD| + RN adds no independent info); rates make differing-exposure
+        frames comparable, and VAR is still summed for the SNR. Exposures must be
+        all zero (≤ ``_ZERO_EXPTIME_TOL_SECONDS``) or all above it.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -540,49 +426,18 @@ class BaseMasterModule:
         max_fail_number=2,
     ):
         """
-        Compute stacked statistics with a single streaming pass over the frames.
+        Compute stacked statistics with a single streaming pass over the frames
+        (memory-light, at the cost of compute speed).
 
-        Parameters
-        ----------
-        l0_file_list : list of str, optional
-            List of L0 FITS filenames to process.
-        nstream : int
-            Streaming threshold; the first `nstream - 1` frames form the
-            approximation pass that estimates the per-pixel clipping bounds.
-        sigma : float, optional
-            Sigma threshold for outlier rejection.
-        max_fail_fraction : float, optional
-            Maximum fraction of frames allowed to fail loading before raising.
-            Defaults to 0.2.
-        max_fail_number : int, optional
-            Maximum absolute number of frames allowed to fail loading before
-            raising. Defaults to 2. Stacking raises when either limit is
-            exceeded.
+        The first ``nstream - 1`` frames are stacked via the datacube method to
+        estimate per-pixel rate mean/RMS, which set the clipping bounds for the
+        streaming pass. Raises when load failures exceed
+        ``max_fail_fraction``/``max_fail_number`` or exposures are inconsistent.
 
-        Returns
-        -------
-        exact_stats : dict
-            Per-extension statistics needed by `stack_frames`:
-            - 'nframe'     : number of valid frames per pixel
-            - 'counts_sum' : summed counts across valid frames
-            On the '{chip}_CCD' entry only:
-            - 'exptime_sum' : per-pixel total exposure time over valid frames
-            (Unlike `_compute_stats_from_datacube`, the streaming pass does not
-            produce 'rate_mean'/'rate_rms': clip bounds come from the datacube
-            approximation below, and the master IMG is counts_sum / exptime_sum.)
-        zero_exptime : bool
-            True if this is a bias stack (all frames have exposure at or below
-            `_ZERO_EXPTIME_TOL_SECONDS`).
-
-        Notes
-        -----
-        An initial subset of frames is processed using the direct data cube
-        method to estimate approximate rate mean and RMS. These estimates define
-        the per-pixel clipping bounds for the streaming pass.
-
-        Optimized to reduce memory usage at the expense of compute speed.
-        Raises an error if frame load failures exceed `max_fail_fraction` or
-        `max_fail_number`, or if exposure times are inconsistent.
+        Returns ``(exact_stats, zero_exptime)``. ``exact_stats`` carries only
+        'nframe', 'counts_sum', and (on '{chip}_CCD') 'exptime_sum' — no
+        'rate_mean'/'rate_rms', since clip bounds come from the approximation and
+        the master IMG is counts_sum / exptime_sum.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -681,34 +536,18 @@ class BaseMasterModule:
 
     def _clean_l1_arrays(self, l1_arrays, sigma, cal_type=None):
         """
-        Interpolate bad pixels and recompute the bad-pixel mask per chip.
+        Interpolate bad pixels and recompute the per-chip bad-pixel mask
+        (True = good) on the stacked '{chip}_IMG/_SNR/_MASK' arrays.
 
-        Parameters
-        ----------
-        l1_arrays : dict
-            Per-chip '{chip}_IMG/_SNR/_MASK' arrays from `stack_frames`.
-        sigma : float
-            Sigma threshold for the final outlier pass on the combined image.
-        cal_type : {'bias', 'dark', 'flat', None}, optional
-            Selects the final outlier-flagging mode. The detector is illuminated
-            only for flats, so each cal type compares a pixel to a different
-            notion of "normal" (in the assembled image dispersion runs along
-            axis=1, cross-dispersion along axis=0):
+        ``cal_type`` selects the final outlier-flagging mode, since the detector is
+        illuminated only for flats (in the assembled image dispersion runs along
+        axis=1, cross-dispersion along axis=0):
 
-            - 'bias' : per-column median (axis=0) -- each pixel is judged against
-              its own cross-dispersion column, removing the CCD's column-wise
-              bias structure.
-            - 'dark' : global median (no illumination or column structure to
-              preserve). `None` falls back to this conservative mode.
-            - 'flat' : residual deviation from the smooth illumination trend
-              along dispersion (axis=1), tolerating the blaze while catching
-              pixels that depart from it.
-
-        Returns
-        -------
-        dict
-            The same dict with IMG/SNR interpolated over bad pixels and MASK
-            recomputed (True = good).
+        - 'bias' : per-column median (axis=0) — judges each pixel against its own
+          cross-dispersion column, removing column-wise bias structure.
+        - 'dark'/None : global median (no illumination/column structure to preserve).
+        - 'flat' : residual deviation from the smooth illumination trend along
+          dispersion (axis=1), tolerating the blaze while catching departures.
         """
         for chip in self.chips:
             img = l1_arrays[f"{chip}_IMG"]
@@ -745,24 +584,10 @@ class BaseMasterModule:
 
     def _build_ml1_obj(self, l1_arrays, l0_file_list, *, master_type):
         """
-        Assemble a KPFMasterL1 from finalized per-chip arrays.
-
-        Parameters
-        ----------
-        l1_arrays : dict
-            Finalized '{chip}_IMG/_SNR/_MASK' arrays.
-        l0_file_list : list of str
-            L0 files that went into the stack; recorded via set_input_files.
-        master_type : str
-            WMKO filename token for the product ('bias', 'dark', 'flat').
-            Recorded via set_input_files for the compliant output filename, and
-            the single source for both the receipt key (`master_{master_type}`)
-            and the BUNIT units (`_BUNIT_BY_TYPE`).
-
-        Returns
-        -------
-        KPFMasterL1
-            The populated master L1 object.
+        Assemble a KPFMasterL1 from finalized per-chip '{chip}_IMG/_SNR/_MASK'
+        arrays. ``master_type`` ('bias'/'dark'/'flat') drives the WMKO filename
+        token, the receipt key (``master_{master_type}``), and the BUNIT units
+        (``_BUNIT_BY_TYPE``).
         """
         receipt_key = f"master_{master_type}"
         bunit = self._BUNIT_BY_TYPE.get(master_type)
@@ -784,10 +609,8 @@ class BaseMasterModule:
 
     def _populate_stack_info(self, l1_arrays):
         """
-        Cache per-chip master statistics on `self._stack_info` for `_track_info()`.
-
-        Sets `self._stack_info` to a per-chip dict of
-        {'num_bad', 'pct_bad', 'median', 'rms'}.
+        Cache per-chip master statistics ({'num_bad','pct_bad','median','rms'}) on
+        ``self._stack_info`` for the subclass ``_track_info()``.
         """
         self._stack_info = {
             chip: {
@@ -921,7 +744,6 @@ class BaseMasterModule:
             l1_arrays[f"{chip}_SNR"] = snr.astype(np.float32)
             l1_arrays[f"{chip}_MASK"] = good
 
-        # Interpolate bad pixels and recompute the bad-pixel mask before return.
         return self._clean_l1_arrays(l1_arrays, sigma, cal_type=cal_type)
 
     def save_master(self, level, path, *, overwrite=False):

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -23,19 +23,12 @@ class BaseMasterModule:
     """
     Base class for KPF masters generation.
 
-    The class should not be called directly, but is used for inheritance
-    of masters subclasses: Bias, Dark, Flat, WLS. Masters modules read a
-    stack of L0 files from disk and output a masters L1 object.
-
-    Each frame is calibrated before stacking/extraction following standard CCD
-    reduction: bias gets no calibration, dark is bias-subtracted, flat is
-    bias+dark-subtracted, and WLS (like science) is bias+dark-subtracted then
-    flat-divided. Each subclass declares its standard set via
-    `_STANDARD_CALIBRATIONS`. Which of those actually run is the standard set
-    intersected with the resolved bias/dark/flat flags
-    (DEFAULTS < [MODULE_IMAGE_PROCESSING] config < make_master kwargs): a flag
-    can only turn a standard calibration off, never enable one a master type
-    does not use.
+    Not called directly; the concrete masters subclasses (Bias, Dark, Flat,
+    WLS) inherit it. A masters module reads a stack of L0 files from disk and
+    outputs a masters L1 object. Each frame is calibrated before
+    stacking/extraction following standard CCD reduction: a bias gets no
+    calibration, a dark is bias-subtracted, and a flat and WLS are bias- and
+    dark-subtracted.
     """
 
     # Module defaults; subclasses extend via `{**BaseMasterModule._DEFAULTS, ...}`.

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -26,7 +26,9 @@ class Bias(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: stack_sigma, chips.
+        Module configuration. Recognized keys: stack_sigma, min_stack_size,
+        chips. A bias takes no calibration, so the bias/dark/flat overrides are
+        ignored.
     """
 
     def __init__(self, l0_file_list, config=None):
@@ -60,8 +62,8 @@ class Bias(BaseMasterModule):
         Build master bias from stack.
 
         The constructed KPFMasterL1 is returned and cached on
-        `self.ml1_obj`; pass `master_path` to also persist it to disk
-        via `save_master('L1', ...)`.
+        ``self.ml1_obj``; pass ``master_path`` to also persist it to disk
+        via ``save_master('L1', ...)``.
 
         A bias receives no calibrations, so there are no bias/dark/
         flat overrides (unlike Dark/WLS).

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -18,8 +18,8 @@ class Bias(BaseMasterModule):
     and performs a final outlier pass on the combined image. Outputs a
     KPFMasterL1 containing per-chip IMG, SNR, and MASK extensions.
 
-    Standard reduction: a bias receives no calibration
-    (`_STANDARD_CALIBRATIONS` is empty), so raw frames are stacked as-is.
+    Standard reduction: a bias receives no calibration, so raw frames are
+    stacked as-is.
 
     Parameters
     ----------

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -75,8 +75,7 @@ class Bias(BaseMasterModule):
         sigma : float, optional
             Outlier rejection threshold passed to stack_frames.
         master_path : str, optional
-            If provided, calls `self.save_master('L1', master_path)` at
-            the end to persist the master L1 to a FITS file at this path.
+            If provided, persist the master L1 to a FITS file at this path.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -25,7 +25,9 @@ class Dark(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: stack_sigma, chips.
+        Module configuration. Recognized keys: stack_sigma, min_stack_size,
+        chips, bias (master-bias calibration override), and the calibration-
+        association keys masters_search_window_days and KPF_MASTERS_OUTPUT.
     """
 
     _STANDARD_CALIBRATIONS = ("bias",)
@@ -68,8 +70,8 @@ class Dark(BaseMasterModule):
         Build master dark from stack.
 
         The constructed KPFMasterL1 is returned and cached on
-        `self.ml1_obj`; pass `master_path` to also persist it to disk
-        via `save_master('L1', ...)`.
+        ``self.ml1_obj``; pass ``master_path`` to also persist it to disk
+        via ``save_master('L1', ...)``.
 
         Parameters
         ----------
@@ -82,8 +84,8 @@ class Dark(BaseMasterModule):
         bias : bool | str | KPFMasterL1, optional
             Per-call master-bias override (same forms as ImageProcessing.perform:
             bool, a master filepath, or a KPFMasterL1 object). A dark's standard
-            is bias-only, so `bias=False` skips bias subtraction and
-            `bias="/path/master_bias.fits"` uses a specific master. Dark/flat are
+            is bias-only, so ``bias=False`` skips bias subtraction and
+            ``bias="/path/master_bias.fits"`` uses a specific master. Dark/flat are
             never applied to a dark, so they are not accepted.
         master_path : str, optional
             If provided, persist the master L1 to a FITS file at this path.

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -14,12 +14,11 @@ class Dark(BaseMasterModule):
     """
     Construct a master dark frame from a stack of L0 dark exposures.
 
-    Standard reduction: a dark is bias-subtracted (`_STANDARD_CALIBRATIONS =
-    ("bias",)`). The associated master bias is subtracted from each frame via
-    the shared `_process_frame` hook (CalibrationAssociation + ImageProcessing)
-    before stacking with sigma-clipped statistics, interpolating bad pixels,
-    and performing a final outlier pass. Outputs a KPFMasterL1 containing
-    per-chip IMG, SNR, and MASK extensions, with IMG in electrons/sec.
+    Standard reduction: a dark is bias-subtracted. The associated master bias
+    is subtracted from each frame before stacking with sigma-clipped
+    statistics, interpolating bad pixels, and performing a final outlier pass.
+    Outputs a KPFMasterL1 containing per-chip IMG, SNR, and MASK extensions,
+    with IMG in electrons/sec.
 
     Parameters
     ----------

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -86,8 +86,7 @@ class Dark(BaseMasterModule):
             `bias="/path/master_bias.fits"` uses a specific master. Dark/flat are
             never applied to a dark, so they are not accepted.
         master_path : str, optional
-            If provided, calls `self.save_master('L1', master_path)` at
-            the end to persist the master L1 to a FITS file at this path.
+            If provided, persist the master L1 to a FITS file at this path.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -8,8 +8,8 @@ class Flat(BaseMasterModule):
     """
     Construct a master flat frame from a stack of L0 flat exposures.
 
-    Standard reduction: a flat is bias- and dark-subtracted
-    (`_STANDARD_CALIBRATIONS = ("bias", "dark")`). Not yet implemented.
+    Standard reduction: a flat is bias- and dark-subtracted. Not yet
+    implemented.
 
     Parameters
     ----------

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -16,7 +16,10 @@ class Flat(BaseMasterModule):
     l0_file_list : list of str
         Sorted list of L0 FITS file paths to stack.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: stack_sigma, chips.
+        Module configuration. Recognized keys: stack_sigma, min_stack_size,
+        chips, bias and dark (master-calibration overrides), and the
+        calibration-association keys masters_search_window_days and
+        KPF_MASTERS_OUTPUT.
     """
 
     _STANDARD_CALIBRATIONS = ("bias", "dark")

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -104,12 +104,11 @@ class WLS(BaseMasterModule):
 
     def _load_linelist(self, linelist=None):
         """
-        Return the cached line list DataFrame, loading or reloading if needed.
+        Return the cached line list DataFrame, loading/reloading if `linelist`
+        differs from the cached path.
 
         Columns: CHIP, INDEX (0-based row), ECHELLE (physical order), WAVE
-        [Å, vacuum]. Loads from disk when nothing is cached, or when `linelist`
-        (a file path) differs from the cached `self.linelist`; otherwise returns
-        the cache unchanged.
+        [Å, vacuum].
         """
         needs_load = not hasattr(self, "_linelist_df")
         if linelist is not None and linelist != self.linelist:
@@ -122,13 +121,8 @@ class WLS(BaseMasterModule):
 
     def _load_rough_wls(self, rough_wls_file=None):
         """
-        Return the cached rough WLS dict, loading or reloading if needed.
-
-        Loads from disk when no rough WLS is cached yet, or when
-        `rough_wls_file` (a file path) differs from the cached
-        `self.rough_wls_file`. Otherwise returns the cache unchanged. The
-        cache is transparently kept in sync with the most recently
-        passed-in file path.
+        Return the cached rough WLS dict, loading/reloading if `rough_wls_file`
+        differs from the cached path. The cache tracks the most recent path.
         """
         needs_load = not hasattr(self, "rough_wls")
         if rough_wls_file is not None and rough_wls_file != self.rough_wls_file:
@@ -163,13 +157,12 @@ class WLS(BaseMasterModule):
 
     def _line_fit_qc(self, lines, lineprofile, window, loc, amp_max=1.5e6, std_min=0.5):
         """
-        Quality-control the per-line fits and return a boolean flag array
-        (True = line passed QC), aligned with the per-line arrays in `lines`.
+        QC the per-line fits; return a boolean flag array aligned with `lines`
+        (True = passed).
 
-        `loc` is the per-line window-center pixel; a centroid more than
-        `window` pixels from it is flagged as a runaway fit. Fitted amplitudes
-        outside [0, `amp_max`] (default 1.5e6, ~10x single-pixel saturation)
-        and Gaussian sigmas outside [`std_min`, `window`] px are also flagged.
+        Flags runaway centroids (>`window` px from the window-center `loc`),
+        amplitudes outside [0, `amp_max`] (~10x single-pixel saturation), and
+        Gaussian sigmas outside [`std_min`, `window`] px.
         """
         if lineprofile != "gaussian":
             raise ValueError(f"Unsupported lineprofile: {lineprofile}")
@@ -191,28 +184,10 @@ class WLS(BaseMasterModule):
         max_fail_number=2,
     ):
         """
-        Run each L0 frame in the stack through the L0→L2 pipeline.
-
-        Parameters
-        ----------
-        l0_file_list : list of str, optional
-            L0 files to process. Defaults to self.l0_file_list.
-        max_fail_fraction : float, optional
-            Maximum fraction of frames allowed to fail loading before raising.
-            Defaults to 0.2.
-        max_fail_number : int, optional
-            Maximum absolute number of frames allowed to fail loading before
-            raising. Defaults to 2. Raises when either limit is exceeded.
-
-        Returns
-        -------
-        list of KPF2
-            Extracted L2 objects for all successfully processed frames.
-
-        Notes
-        -----
-        Resets self._l2_obj_cache at entry. Raises ValueError if frame load
-        failures exceed `max_fail_fraction` or `max_fail_number`.
+        Run each L0 frame in the stack through the L0->L2 pipeline, returning the
+        extracted KPF2 objects (also cached on `self._l2_obj_cache`, reset at
+        entry). Raises if load failures exceed `max_fail_fraction` or
+        `max_fail_number`.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -248,43 +223,18 @@ class WLS(BaseMasterModule):
         window=5,
     ):
         """
-        Fit line positions (in pixel space) along a 1D extracted order.
+        Fit line positions (pixel space) along one 1D extracted order.
 
-        Fits a 1D line model over a ±`window` pixel neighborhood around each
-        reference line in `line_waves` (the lines pre-selected for this order),
-        then quality-controls the fits via `_line_fit_qc`. The rough WLS span
-        of `wave1d` is a guardrail: a reference line outside it raises.
+        Fits a 1D line model over a +/-`window` px neighborhood around each
+        reference line in `line_waves`, then QCs the fits via `_line_fit_qc`.
+        A reference line outside the rough WLS span of `wave1d` raises (a
+        CHIP/ORDER labeling-inconsistency guardrail).
 
-        Parameters
-        ----------
-        flux1d : ndarray
-            1D extracted flux for a single order.
-        wave1d : ndarray
-            1D rough wavelength grid for the same order.
-        line_waves : ndarray
-            Reference line wavelengths to fit in this order [Å], already
-            selected for the order by the caller.
-        lineprofile : str, optional
-            Line profile model name. See kpfpipe.utils.stats._FUNCTIONS
-            for supported values.
-        window : int, optional
-            Half-width of the fit window, in pixels.
-
-        Returns
-        -------
-        lines : dict of ndarray
-            Per-line arrays of equal length. All entries are retained
-            regardless of QC status; the caller is responsible for
-            filtering on 'isgood' before downstream use. Lines whose fit
-            window contains any non-finite flux are dropped silently
-            before fitting. If the input order is entirely non-finite
-            (e.g. an extraction-failed orderlet filled with NaN), all
-            arrays are returned empty. Keys:
-              'wav' - reference line wavelength
-              'pix' - fitted pixel position
-              'std' - fitted line sigma (Gaussian width)
-              'amp' - fitted line amplitude
-              'isgood' - boolean QC flag (True = line passed QC)
+        Returns a dict of equal-length per-line arrays; all lines are retained
+        regardless of QC (caller filters on 'isgood'). Lines whose fit window
+        contains any non-finite flux are dropped before fitting; an all-NaN
+        order returns empty arrays. Keys: 'wav' (reference wavelength), 'pix'
+        (fitted pixel), 'std' (Gaussian sigma), 'amp' (amplitude), 'isgood'.
         """
         # Fit in float64 (wavelength solutions are float64).
         flux1d = np.asarray(flux1d, dtype=np.float64)
@@ -365,46 +315,11 @@ class WLS(BaseMasterModule):
         """
         Fit line positions across all orders and fibers of one chip.
 
-        Loops over the requested fibers, calling `_fit_line_positions_1d`
-        on each (order, fiber) extracted spectrum, and concatenates the
-        surviving lines into flat arrays tagged with their chip, fiber,
-        order index, and echelle order.
-
-        Parameters
-        ----------
-        l2_obj : KPF2
-            Extracted L2 object containing per-fiber FLUX arrays of shape
-            (norder, ncol).
-        chip : str
-            Chip identifier ('GREEN' or 'RED').
-        fibers : list of str
-            Fiber identifiers (e.g. ['SCI1', 'SCI2', 'SCI3']).
-        linelist : str, optional
-            Path to a CSV line list. If different from the currently
-            cached `self.linelist`, the file is reloaded and the cache
-            is updated. Defaults to `self.linelist` (no reload).
-        lineprofile : str, optional
-            Line profile model name. See kpfpipe.utils.stats._FUNCTIONS.
-        window : int, optional
-            Half-width of the per-line fit window, in pixels.
-
-        Returns
-        -------
-        lines : dict of ndarray
-            Flat 1D arrays, all of equal length. All lines are retained
-            regardless of QC status; the caller is responsible for
-            filtering on 'isgood' before downstream use. All per-line keys
-            produced by `_fit_line_positions_1d` are carried through, plus
-            provenance tags identifying each line's source. Keys:
-              'chip' - chip identifier ('GREEN' or 'RED')
-              'fiber' - fiber name
-              'index' - KPF order index (0-based row)
-              'echelle' - physical echelle order
-              'wav' - reference line wavelength
-              'pix' - fitted pixel position
-              'std' - fitted line sigma (Gaussian width)
-              'amp' - fitted line amplitude
-              'isgood' - boolean QC flag (True = line passed QC)
+        Loops the requested fibers, calling `_fit_line_positions_1d` per
+        (order, fiber) and concatenating survivors into flat arrays. Returns the
+        per-line dict from `_fit_line_positions_1d` plus provenance tags 'chip',
+        'fiber', 'index' (0-based row), and 'echelle' (physical order); all lines
+        retained regardless of QC.
         """
         linelist_df = self._load_linelist(linelist)
 
@@ -490,40 +405,16 @@ class WLS(BaseMasterModule):
         polyorder_f=None,
     ):
         """
-        Fit a multivariate Legendre polynomial wavelength solution to
-        fitted line positions.
+        Fit a multivariate Legendre wavelength solution to fitted line positions.
 
         Treats the grating invariant m*lambda (echelle order x wavelength) as a
-        smooth function of pixel position (x), order (m), and (optionally) fiber
-        index (f). All variables are rescaled to [-1, 1] before fitting.
-
-        Parameters
-        ----------
-        lines : dict of ndarray
-            Flat 1D arrays as produced by `_fit_line_positions_ffi`. Lines
-            without `lines['isgood']` set are excluded from the fit. Required
-            keys: 'wav', 'pix', 'echelle', 'fiber', 'isgood'.
-        orders : ndarray of int
-            Physical echelle order per row (bluest first), used to rescale
-            the order axis to [-1, 1].
-        polyorder_x : int, optional
-            Polynomial degree along the pixel axis.
-        polyorder_m : int, optional
-            Polynomial degree along the order axis.
-        polyorder_f : int, optional
-            Polynomial degree along the fiber axis (only used for 3-fiber fits).
-
-        Returns
-        -------
-        coeffs : ndarray
-            Legendre coefficient array. Shape is
-            (polyorder_x+1, polyorder_m+1) for a single-fiber fit, or
-            (polyorder_x+1, polyorder_m+1, polyorder_f+1) for a 3-fiber fit.
-
-        Notes
-        -----
-        Raises ValueError if `lines['fiber']` contains anything other than
-        one fiber, all five fibers, or three SCI fibers (SCI1, SCI2, SCI3).
+        smooth function of pixel (x), order (m), and optionally fiber (f); all
+        variables are rescaled to [-1, 1] before fitting. Only lines with
+        `lines['isgood']` set are used. Returns the Legendre coefficient array,
+        shape (polyorder_x+1, polyorder_m+1) for a single-fiber fit or with a
+        trailing (polyorder_f+1) axis for a multi-fiber fit. Raises for a fiber
+        set other than 1, the 3 SCI fibers, or all 5 fibers, or when the fit is
+        underconstrained.
         """
         if polyorder_x is None:
             polyorder_x = self.polyorder_x
@@ -605,23 +496,10 @@ class WLS(BaseMasterModule):
 
         The coefficients describe the grating-invariant m*lambda surface, so the
         evaluated surface is divided by the physical order to recover wavelength.
-
-        Parameters
-        ----------
-        coeffs : ndarray
-            Legendre coefficient array from `_calculate_wls_coeffs`. Either
-            2D (single-fiber) or 3D (three-fiber).
-        orders : ndarray of int
-            Physical echelle order per row (bluest first); sets the number of
-            orders and the [-1, 1] rescaling (must match `_calculate_wls_coeffs`).
-        nfiber : int
-            Number of fibers at which to evaluate. Ignored for 2D `coeffs`.
-
-        Returns
-        -------
-        W : ndarray
-            Wavelength array of shape (norder, ncol) for 2D `coeffs`, or
-            (norder, ncol, nfiber) for 3D `coeffs`.
+        `orders` sets the [-1, 1] order rescaling (must match
+        `_calculate_wls_coeffs`). Returns W of shape (norder, ncol) for 2D
+        `coeffs` or (norder, ncol, nfiber) for 3D `coeffs` (`nfiber` ignored for
+        2D).
         """
         blue, red = orders[0], orders[-1]
         x = np.linspace(-1, 1, self.ccd["ncol"])
@@ -658,47 +536,17 @@ class WLS(BaseMasterModule):
     ):
         """
         Fit line positions and a per-frame Legendre WLS for every frame in
-        `self._l2_obj_cache`. Every frame is reported; a frame is flagged
-        `rejected` (warned, never raised) and kept out of the combined solution
-        when its line-fit QC failure fraction exceeds `max_bad_frac`, or when its
-        per-frame fit fails (too few good lines, a dropped fiber, or non-finite
-        coefficients). Survivors are gated against `min_stack_size` in
-        `make_master_l2`.
+        `self._l2_obj_cache`.
 
-        Parameters
-        ----------
-        chip : str
-            Chip identifier, i.e. 'GREEN' or 'RED'.
-        fibers : list of str
-            Fiber identifiers, e.g. ['SCI1', 'SCI2', 'SCI3'] or a single fiber.
-        linelist : str, optional
-            Path to a CSV line list. If different from the currently
-            cached `self.linelist`, the file is reloaded and the cache
-            is updated. Defaults to `self.linelist` (no reload).
-        lineprofile : str, optional
-            Line profile model name. Defaults to self.lineprofile.
-        polyorder_x, polyorder_m, polyorder_f : int, optional
-            Polynomial degrees along the pixel / order / fiber axes.
-        window : int, optional
-            Half-width of the per-line fit window, in pixels.
-        max_bad_frac : float, optional
-            Maximum fraction of per-line fits allowed to fail QC before a
-            frame is rejected from the stack.
+        Every frame is reported; a frame is flagged `rejected` (warned, never
+        raised) and kept out of the combined solution when its line-fit QC
+        failure fraction exceeds `max_bad_frac`, or when its per-frame fit fails
+        (too few good lines, a dropped fiber, or non-finite coefficients).
+        Survivors are gated against `min_stack_size` in `make_master_l2`.
 
-        Returns
-        -------
-        frames : list of dict
-            Per-frame diagnostics, one entry per input frame in original
-            order. Keys: 'obs_id', 'lines' (the `_fit_line_positions_ffi`
-            dict), 'coeffs' (per-frame Legendre coefficients, or None if
-            rejected), and 'rejected' (bool). Only non-rejected frames feed
-            the combined solution.
-
-        Notes
-        -----
-        Raises ValueError only if `self._l2_obj_cache` is empty (i.e.,
-        `_process_stack_l0_to_l2` has not been run). Per-frame QC/fit problems
-        warn and reject the frame; they never raise.
+        Returns a list of per-frame dicts (original order) with keys 'obs_id',
+        'lines' (the `_fit_line_positions_ffi` dict), 'coeffs' (None if
+        rejected), and 'rejected'. Raises only if `self._l2_obj_cache` is empty.
         """
         self._load_linelist(linelist)
         if lineprofile is None:
@@ -785,38 +633,13 @@ class WLS(BaseMasterModule):
         """
         Combine surviving per-frame coefficients into a master WLS.
 
-        Stacks the Legendre coefficients of the non-rejected `frames`, combines
-        them via per-coefficient outlier-rejected averaging (median +/- `qc_sigma`
-        MAD), and evaluates the mean coefficients to a master wavelength array.
-        Assumes at least one surviving frame -- callers gate the surviving-frame
-        count against `min_stack_size` first.
-
-        Parameters
-        ----------
-        frames : list of dict
-            Per-frame diagnostics from `_fit_and_qc_lines_stack`; only entries with
-            `rejected` False (and a non-None `coeffs`) contribute.
-        chip : str
-            Chip identifier, i.e. 'GREEN' or 'RED'.
-        nfibers : int
-            Number of fibers in the fit (sets the W fiber axis).
-        qc_sigma : float, optional
-            Outlier rejection threshold applied to the per-frame Legendre
-            coefficients when combining them.
-
-        Returns
-        -------
-        W : ndarray
-            Master wavelength array, shape (norder, ncol) or
-            (norder, ncol, nfiber).
-        coeffs_mean : ndarray
-            Outlier-rejected mean Legendre coefficient array.
-
-        Notes
-        -----
-        Raises ValueError if every surviving frame is rejected as an outlier for
-        at least one Legendre coefficient (a cross-frame degeneracy that leaves
-        the stack uncombinable).
+        Stacks the non-rejected frames' Legendre coefficients, combines them by
+        per-coefficient outlier-rejected averaging (median +/- `qc_sigma` MAD),
+        and evaluates the mean to a master wavelength array. Assumes at least one
+        survivor (callers gate against `min_stack_size` first). Returns
+        (W, coeffs_mean). Raises if every survivor is rejected as an outlier for
+        some coefficient (a cross-frame degeneracy that leaves the stack
+        uncombinable).
         """
         coeffs_stack = np.array([fr["coeffs"] for fr in frames if not fr["rejected"]])
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -34,8 +34,8 @@ class WLS(BaseMasterModule):
     wavelength solutions.
 
     Standard reduction: like science, a WLS frame is bias- and dark-subtracted
-    before extraction (`_STANDARD_CALIBRATIONS = ("bias", "dark")`); flat
-    division is part of the standard reduction but stays off until it is implemented.
+    before extraction; flat division is part of the standard reduction but
+    stays off until it is implemented.
 
     Parameters
     ----------

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -56,8 +56,8 @@ class WLS(BaseMasterModule):
         "polyorder_f": 2,
     }
 
-    # Bias+dark subtraction is standard for WLS; `_process_frame` (run before
-    # `_extract_frame`) applies whichever of these the config has enabled.
+    # Bias+dark subtraction is standard for WLS; ``_process_frame`` (run before
+    # ``_extract_frame``) applies whichever of these the config has enabled.
     _STANDARD_CALIBRATIONS = ("bias", "dark")
 
     def __init__(self, l0_file_list, config=None):
@@ -104,7 +104,7 @@ class WLS(BaseMasterModule):
 
     def _load_linelist(self, linelist=None):
         """
-        Return the cached line list DataFrame, loading/reloading if `linelist`
+        Return the cached line list DataFrame, loading/reloading if ``linelist``
         differs from the cached path.
 
         Columns: CHIP, INDEX (0-based row), ECHELLE (physical order), WAVE
@@ -121,7 +121,7 @@ class WLS(BaseMasterModule):
 
     def _load_rough_wls(self, rough_wls_file=None):
         """
-        Return the cached rough WLS dict, loading/reloading if `rough_wls_file`
+        Return the cached rough WLS dict, loading/reloading if ``rough_wls_file``
         differs from the cached path. The cache tracks the most recent path.
         """
         needs_load = not hasattr(self, "rough_wls")
@@ -157,12 +157,12 @@ class WLS(BaseMasterModule):
 
     def _line_fit_qc(self, lines, lineprofile, window, loc, amp_max=1.5e6, std_min=0.5):
         """
-        QC the per-line fits; return a boolean flag array aligned with `lines`
+        QC the per-line fits; return a boolean flag array aligned with ``lines``
         (True = passed).
 
-        Flags runaway centroids (>`window` px from the window-center `loc`),
-        amplitudes outside [0, `amp_max`] (~10x single-pixel saturation), and
-        Gaussian sigmas outside [`std_min`, `window`] px.
+        Flags runaway centroids (>``window`` px from the window-center ``loc``),
+        amplitudes outside [0, ``amp_max``] (~10x single-pixel saturation), and
+        Gaussian sigmas outside [``std_min``, ``window``] px.
         """
         if lineprofile != "gaussian":
             raise ValueError(f"Unsupported lineprofile: {lineprofile}")
@@ -185,9 +185,9 @@ class WLS(BaseMasterModule):
     ):
         """
         Run each L0 frame in the stack through the L0->L2 pipeline, returning the
-        extracted KPF2 objects (also cached on `self._l2_obj_cache`, reset at
-        entry). Raises if load failures exceed `max_fail_fraction` or
-        `max_fail_number`.
+        extracted KPF2 objects (also cached on ``self._l2_obj_cache``, reset at
+        entry). Raises if load failures exceed ``max_fail_fraction`` or
+        ``max_fail_number``.
         """
         if l0_file_list is None:
             l0_file_list = self.l0_file_list
@@ -225,9 +225,9 @@ class WLS(BaseMasterModule):
         """
         Fit line positions (pixel space) along one 1D extracted order.
 
-        Fits a 1D line model over a +/-`window` px neighborhood around each
-        reference line in `line_waves`, then QCs the fits via `_line_fit_qc`.
-        A reference line outside the rough WLS span of `wave1d` raises (a
+        Fits a 1D line model over a +/-``window`` px neighborhood around each
+        reference line in ``line_waves``, then QCs the fits via ``_line_fit_qc``.
+        A reference line outside the rough WLS span of ``wave1d`` raises (a
         CHIP/ORDER labeling-inconsistency guardrail).
 
         Returns a dict of equal-length per-line arrays; all lines are retained
@@ -315,9 +315,9 @@ class WLS(BaseMasterModule):
         """
         Fit line positions across all orders and fibers of one chip.
 
-        Loops the requested fibers, calling `_fit_line_positions_1d` per
+        Loops the requested fibers, calling ``_fit_line_positions_1d`` per
         (order, fiber) and concatenating survivors into flat arrays. Returns the
-        per-line dict from `_fit_line_positions_1d` plus provenance tags 'chip',
+        per-line dict from ``_fit_line_positions_1d`` plus provenance tags 'chip',
         'fiber', 'index' (0-based row), and 'echelle' (physical order); all lines
         retained regardless of QC.
         """
@@ -410,7 +410,7 @@ class WLS(BaseMasterModule):
         Treats the grating invariant m*lambda (echelle order x wavelength) as a
         smooth function of pixel (x), order (m), and optionally fiber (f); all
         variables are rescaled to [-1, 1] before fitting. Only lines with
-        `lines['isgood']` set are used. Returns the Legendre coefficient array,
+        ``lines['isgood']`` set are used. Returns the Legendre coefficient array,
         shape (polyorder_x+1, polyorder_m+1) for a single-fiber fit or with a
         trailing (polyorder_f+1) axis for a multi-fiber fit. Raises for a fiber
         set other than 1, the 3 SCI fibers, or all 5 fibers, or when the fit is
@@ -496,9 +496,9 @@ class WLS(BaseMasterModule):
 
         The coefficients describe the grating-invariant m*lambda surface, so the
         evaluated surface is divided by the physical order to recover wavelength.
-        `orders` sets the [-1, 1] order rescaling (must match
-        `_calculate_wls_coeffs`). Returns W of shape (norder, ncol) for 2D
-        `coeffs` or (norder, ncol, nfiber) for 3D `coeffs` (`nfiber` ignored for
+        ``orders`` sets the [-1, 1] order rescaling (must match
+        ``_calculate_wls_coeffs``). Returns W of shape (norder, ncol) for 2D
+        ``coeffs`` or (norder, ncol, nfiber) for 3D ``coeffs`` (``nfiber`` ignored for
         2D).
         """
         blue, red = orders[0], orders[-1]
@@ -536,17 +536,17 @@ class WLS(BaseMasterModule):
     ):
         """
         Fit line positions and a per-frame Legendre WLS for every frame in
-        `self._l2_obj_cache`.
+        ``self._l2_obj_cache``.
 
-        Every frame is reported; a frame is flagged `rejected` (warned, never
+        Every frame is reported; a frame is flagged ``rejected`` (warned, never
         raised) and kept out of the combined solution when its line-fit QC
-        failure fraction exceeds `max_bad_frac`, or when its per-frame fit fails
+        failure fraction exceeds ``max_bad_frac``, or when its per-frame fit fails
         (too few good lines, a dropped fiber, or non-finite coefficients).
-        Survivors are gated against `min_stack_size` in `make_master_l2`.
+        Survivors are gated against ``min_stack_size`` in ``make_master_l2``.
 
         Returns a list of per-frame dicts (original order) with keys 'obs_id',
-        'lines' (the `_fit_line_positions_ffi` dict), 'coeffs' (None if
-        rejected), and 'rejected'. Raises only if `self._l2_obj_cache` is empty.
+        'lines' (the ``_fit_line_positions_ffi`` dict), 'coeffs' (None if
+        rejected), and 'rejected'. Raises only if ``self._l2_obj_cache`` is empty.
         """
         self._load_linelist(linelist)
         if lineprofile is None:
@@ -634,9 +634,9 @@ class WLS(BaseMasterModule):
         Combine surviving per-frame coefficients into a master WLS.
 
         Stacks the non-rejected frames' Legendre coefficients, combines them by
-        per-coefficient outlier-rejected averaging (median +/- `qc_sigma` MAD),
+        per-coefficient outlier-rejected averaging (median +/- ``qc_sigma`` MAD),
         and evaluates the mean to a master wavelength array. Assumes at least one
-        survivor (callers gate against `min_stack_size` first). Returns
+        survivor (callers gate against ``min_stack_size`` first). Returns
         (W, coeffs_mean). Raises if every survivor is rejected as an outlier for
         some coefficient (a cross-frame degeneracy that leaves the stack
         uncombinable).
@@ -680,13 +680,13 @@ class WLS(BaseMasterModule):
         Build a master wavelength solution from a stack of L0 frames.
 
         Processes each input L0 frame through the L0-to-L2 pipeline, fits
-        per-frame line positions and WLS coefficients (`_fit_and_qc_lines_stack`),
+        per-frame line positions and WLS coefficients (``_fit_and_qc_lines_stack``),
         then combines the surviving frames into per-chip Legendre wavelength
-        solutions (`_combine_coeffs_stack`). The resulting wavelength arrays are
+        solutions (``_combine_coeffs_stack``). The resulting wavelength arrays are
         written to the per-fiber _WAVE extensions of a KPFMasterL2 object,
-        which is returned and cached on `self.ml2_obj`. Per-frame diagnostics
-        are always stashed on `self._frame_diagnostics`; pass `master_path`
-        to persist the master and, into the `thar_L2/` subdirectory
+        which is returned and cached on ``self.ml2_obj``. Per-frame diagnostics
+        are always stashed on ``self._frame_diagnostics``; pass ``master_path``
+        to persist the master and, into the ``thar_L2/`` subdirectory
         beside it, the per-frame L2s and the diagnostics HDF5.
 
         Parameters
@@ -695,8 +695,8 @@ class WLS(BaseMasterModule):
             L0 files to process. Defaults to self.l0_file_list.
         linelist : str, optional
             Path to a CSV line list. If different from the currently
-            cached `self.linelist`, the file is reloaded and the cache
-            is updated. Defaults to `self.linelist` (no reload).
+            cached ``self.linelist``, the file is reloaded and the cache
+            is updated. Defaults to ``self.linelist`` (no reload).
         lineprofile : str, optional
             Line profile model name. Defaults to self.lineprofile.
         polyorder_x : int, optional
@@ -709,14 +709,14 @@ class WLS(BaseMasterModule):
         bias, dark, flat : bool | str | KPFMasterL1, optional
             Per-call calibration overrides (same forms as ImageProcessing.perform:
             bool, a master filepath, or a KPFMasterL1 object), clamped by the WLS
-            standard of bias+dark. E.g. `dark=False` extracts with bias only, and
-            `dark="/path/master_dark.fits"` uses a specific master.
+            standard of bias+dark. E.g. ``dark=False`` extracts with bias only, and
+            ``dark="/path/master_dark.fits"`` uses a specific master.
         master_path : str, optional
             If provided, persists the master L2 to this FITS path via
-            `save_master('L2', ...)` and, into a `thar_L2/` subdirectory
+            ``save_master('L2', ...)`` and, into a ``thar_L2/`` subdirectory
             beside it, each processed ThAr frame's L2
-            (`save_reduced_frames()`) and the per-frame diagnostics HDF5
-            (`save_diagnostics()`).
+            (``save_reduced_frames()``) and the per-frame diagnostics HDF5
+            (``save_diagnostics()``).
 
         Returns
         -------
@@ -734,7 +734,7 @@ class WLS(BaseMasterModule):
         QC or per-frame fit fails is warned and dropped, never raised. The
         per-frame L2s and diagnostics HDF5 are written before the survivor gate,
         so they persist even on gate failure. Raises ValueError if any chip has
-        fewer than `self.min_stack_size` frames passing line-fit QC (the master
+        fewer than ``self.min_stack_size`` frames passing line-fit QC (the master
         is then not written).
         """
         if l0_file_list is None:
@@ -839,21 +839,21 @@ class WLS(BaseMasterModule):
     def save_diagnostics(self, master_path, *, overwrite=False):
         """
         Write the per-frame WLS diagnostics to an HDF5 file in the
-        `thar_L2/` subdirectory beside `master_path`, named
-        `{obs_id}_master_thar_diagnostics.h5` (obs_id from `master_path`).
+        ``thar_L2/`` subdirectory beside ``master_path``, named
+        ``{obs_id}_master_thar_diagnostics.h5`` (obs_id from ``master_path``).
 
         Layout: /<obs_id>/<chip>/ per input frame and chip, each holding a
-        `coeffs` dataset (per-frame Legendre coefficients; omitted for a
-        rejected frame), a `lines/` group with every key from the per-frame
+        ``coeffs`` dataset (per-frame Legendre coefficients; omitted for a
+        rejected frame), a ``lines/`` group with every key from the per-frame
         line dict (chip, fiber, index, echelle, wav, pix, std, amp, isgood), and
-        a `rejected` group attribute flagging whole-frame QC rejection for
+        a ``rejected`` group attribute flagging whole-frame QC rejection for
         that chip.
 
         Parameters
         ----------
         master_path : str
             The master L2 output path; its directory anchors the
-            `thar_L2/` subdirectory and its obs_id names the file.
+            ``thar_L2/`` subdirectory and its obs_id names the file.
         overwrite : bool, optional
             If False (default), refuse to clobber an existing file and raise
             FileExistsError. If True, replace any existing file.
@@ -864,7 +864,7 @@ class WLS(BaseMasterModule):
             If make_master_l2() has not been run yet, or raised before
             populating any chip.
         FileExistsError
-            If the file already exists and `overwrite` is False.
+            If the file already exists and ``overwrite`` is False.
         """
         if not self._frame_diagnostics:
             raise RuntimeError("No diagnostics available; run make_master_l2() first")
@@ -901,8 +901,8 @@ class WLS(BaseMasterModule):
 
     def save_reduced_frames(self, master_path, *, overwrite=False):
         """
-        Write each processed ThAr frame's L2 to a `thar_L2/` subdirectory
-        beside `master_path`, as `{obs_id}_thar_L2.fits`.
+        Write each processed ThAr frame's L2 to a ``thar_L2/`` subdirectory
+        beside ``master_path``, as ``{obs_id}_thar_L2.fits``.
 
         Persists the per-frame L2 objects cached by make_master_l2() (every
         frame that loaded, processed, and extracted), for follow-up ThAr
@@ -912,7 +912,7 @@ class WLS(BaseMasterModule):
         ----------
         master_path : str
             The master L2 output path; its directory anchors the
-            `thar_L2/` subdirectory.
+            ``thar_L2/`` subdirectory.
         overwrite : bool, optional
             If False (default), refuse to clobber an existing per-frame file
             and raise FileExistsError. If True, replace any existing file.
@@ -923,7 +923,7 @@ class WLS(BaseMasterModule):
             If make_master_l2() has not been run yet, or raised before
             extracting any frame.
         FileExistsError
-            If a per-frame file already exists and `overwrite` is False.
+            If a per-frame file already exists and ``overwrite`` is False.
         """
         if not self._l2_obj_cache:
             raise RuntimeError("No frames available; run make_master_l2() first")

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -83,12 +83,10 @@ class RadialVelocity:
 
     def _load_ccfs(self, chips, fibers):
         """
-        Load the CCF cubes, per-bin variances, velocity grids, and mask width from
-        the (CrossCorrelation-produced) L4 into the caches the RV methods read.
-
-        Only illuminated fibers (non-empty CCF) are loaded; the velocity grid is
-        reconstructed from the CCF header (VELSTART/VELSTEP/VELNSTEP) and the mask
-        width from VELMASK.
+        Load the CCF cubes/variances, velocity grids, and mask width from the
+        (CrossCorrelation-produced) L4 into the caches the RV methods read. Only
+        illuminated fibers (non-empty CCF) are loaded; the grid is reconstructed
+        from the CCF header (VELSTART/VELSTEP/VELNSTEP) and the width from VELMASK.
         """
         for fiber in fibers:
             if self.l4_obj.data[f"{fiber}_CCF"].size == 0:
@@ -108,10 +106,10 @@ class RadialVelocity:
 
     def _get_order_weights(self, chip, fiber):
         """
-        Per-order CCF-combination weights for one orderlet, read from the WEIGHT
-        column of the L4 RVn table (written by CrossCorrelation). Returns a 1D
-        ndarray of length norder_chip, ordered by ORDER (green-then-red rows; the
-        chip-prefixed read returns this chip's rows).
+        Per-order CCF-combination weights for one orderlet, from the WEIGHT column
+        of the L4 RVn table (written by CrossCorrelation). Returns a length-
+        norder_chip ndarray ordered by ORDER (the chip-prefixed read slices to
+        this chip's rows).
         """
         table = self.l4_obj.data[f"{chip.upper()}_{fiber.upper()}_RV"]
         return np.asarray(table["WEIGHT"], dtype=np.float64)
@@ -121,9 +119,8 @@ class RadialVelocity:
         """
         Native per-pixel velocity scale [km/s] of an order, from its wavelength
         endpoints and column count: c * (dispersion per pixel) / mean wavelength.
-
         The RVn WAVE_START/WAVE_END and detector ncol stand in for the full WAVE
-        array; this feeds the CCF-noise correlation length in _compute_rv_1d.
+        array; feeds the CCF-noise correlation length in _compute_rv_1d.
         """
         speed_of_light_kms = c.to("km/s").value
         return (
@@ -136,18 +133,12 @@ class RadialVelocity:
     @staticmethod
     def _ccf_noise_corr_length(vel_span_per_pixel, mask_width):
         """
-        Decorrelation length [km/s] of the CCF photon noise.
-
-        The Boisse (2010) N_scale factor divides the CCF velocity step by the
-        length over which CCF-noise bins are independent, correcting the
-        diagonal information sum for the fact that a finely-stepped CCF is
-        oversampled. That length is *not* the native pixel: the CCF is the
-        spectrum seen through a mask hole, so its noise kernel is the
-        cross-correlation of two top-hats -- the mask hole (full width
-        `mask_width`) and the native pixel (`vel_span_per_pixel`) -- i.e. a
-        trapezoid. The integral length of a trapezoid's autocorrelation,
-        (integral)^2 / integral-of-square, is `M**2 / (M - m/3)` with M, m the
-        larger/smaller of the two widths (reduces to 1.5*w for equal widths).
+        Decorrelation length [km/s] of the CCF photon noise, for the Boisse (2010)
+        N_scale oversampling correction. The CCF noise kernel is the cross-
+        correlation of two top-hats -- the mask hole (`mask_width`) and the native
+        pixel (`vel_span_per_pixel`), i.e. a trapezoid -- whose autocorrelation
+        integral length (integral^2 / integral-of-square) is `M**2 / (M - m/3)`
+        with M, m the larger/smaller width (reduces to 1.5*w for equal widths).
         """
         big, small = (
             max(vel_span_per_pixel, mask_width),
@@ -167,50 +158,14 @@ class RadialVelocity:
         min_npts=9,
     ):
         """
-        Two-pass Gaussian fit to a CCF dip, with a photon-limited error.
-
-        The first pass fits the `window` ([min, max] km/s) about the CCF
-        minimum, yielding a mean and sigma. The second pass refits a window of
-        +/-`fit_nsigma` sigma about that mean (symmetric about it); those points
-        also set the error estimate (Bouchy et al. 2001). Both windows use at
-        least min_npts grid points.
-
-        Parameters
-        ----------
-        vel : ndarray
-            CCF velocity steps [km/s].
-        ccf : ndarray
-            CCF value at each velocity step.
-        ccf_var : ndarray
-            Per-velocity-bin CCF variance sum(w**2 * var) aligned with `ccf`; sets
-            the photon noise in the error estimate (Bouchy 2001).
-        vel_span_per_pixel : float
-            Native per-pixel velocity scale [km/s] of the order (from
-            _pixel_velocity_scale); with `mask_width` it sets the CCF-noise
-            correlation length (see `_ccf_noise_corr_length`).
-        mask_width : float
-            CCF mask hole full width [km/s] used to build the CCF (each top-hat
-            hole is `mask_width` wide, centered on its line).
-        window : list of float
-            [min, max] km/s velocity window about the dip for the first pass.
-        fit_nsigma : float
-            Half-width of the second-pass fit window, in units of the
-            first-pass fitted sigma.
-        min_npts : int
-            Minimum number of grid points to use in each fit window.
-
-        Returns
-        -------
-        rv : float
-            Fitted radial velocity [km/s], or NaN if the fit fails.
-        rv_err : float
-            Photon-limited RV uncertainty [km/s], or NaN if unavailable.
-
-        Raises
-        ------
-        ValueError
-            If the CCF or its variance is non-physical (zero/negative flux
-            counts) across the fit window, so a photon error cannot be computed.
+        Two-pass Gaussian fit to a CCF dip, returning an RV [km/s] and a photon-
+        limited error. Pass 1 fits `window` about the CCF minimum; pass 2 refits
+        +/-`fit_nsigma` sigma about the pass-1 mean (symmetric), and those points
+        set the Bouchy (2001) photon error, scaled by the Boisse (2010) N_scale
+        oversampling factor (`vel_span_per_pixel`/`mask_width` via
+        _ccf_noise_corr_length). Both windows use at least `min_npts` points.
+        Returns (NaN, NaN) if the fit fails; raises ValueError on a non-physical
+        (zero/negative-count) CCF in the fit window, where no photon error exists.
         """
         # Fail loudly on non-finite CCF values rather than masking them out.
         if ccf.size < min_npts or not np.all(np.isfinite(ccf)) or np.ptp(ccf) == 0:
@@ -276,47 +231,14 @@ class RadialVelocity:
 
     def _combine_ccfs(self, chip, fibers):
         """
-        Combine the cached per-order CCFs of one chip into a weighted-average CCF
-        (for the RV value) and an unweighted-sum CCF (for the photon error).
-
-        Summing happens within a single chip: the cached order CCFs are summed
-        across `fibers`, then collapsed across orders two ways -- normalized to
-        unit sum and scaled by each order's CCF weight (the value CCF), and a raw
-        nansum (the count-scale error CCF). Cross-CCD combination is done at the
-        RV level by compute_weighted_rvs, not here.
-
-        Parameters
-        ----------
-        chip : str
-            Chip identifier, i.e. 'GREEN' or 'RED'.
-        fibers : str or list of str
-            A single fiber (e.g. 'SCI1') OR exactly the three science fibers
-            (SCI1, SCI2, SCI3), which are summed before collapsing. All summed
-            fibers share a mask, so the first is used for the grid, pixel scale,
-            and order weights.
-
-        Returns
-        -------
-        velocity_grid : ndarray
-            Shared CCF velocity grid [km/s].
-        weighted_ccf : ndarray
-            Order-weighted collapsed CCF (the RV value); identically zero if no
-            order carries weight.
-        summed_ccf : ndarray
-            Unweighted order-summed collapsed CCF (the photon-error signal).
-        summed_ccf_var : ndarray
-            Per-bin photon variance of summed_ccf.
-        rep_scale : float
-            Native per-pixel velocity scale of the strongest order (the
-            photon-error velocity scale).
-
-        Raises
-        ------
-        ValueError
-            If `fibers` is neither a single fiber nor exactly the three science
-            fibers.
-        RuntimeError
-            If the CCFs have not been loaded for any requested fiber.
+        Combine one chip's cached per-order CCFs into a weighted-average CCF (the
+        RV value) and an unweighted-sum CCF (the photon error). `fibers` is a
+        single fiber or exactly the three science fibers (summed before collapsing,
+        sharing a mask/grid so the first is representative). Returns
+        (velocity_grid, weighted_ccf, summed_ccf, summed_ccf_var, rep_scale), the
+        last being the strongest order's pixel scale. Cross-CCD combination happens
+        at the RV level in compute_weighted_rvs, not here. Raises ValueError on a
+        bad `fibers`, RuntimeError if the CCFs are unloaded.
         """
         chip = chip.upper()
         fibers = [fibers] if isinstance(fibers, str) else list(fibers)
@@ -635,16 +557,13 @@ class RadialVelocity:
 
     def _set_headers(self, l4_obj):
         """
-        Write all RV keywords, the single place this module writes headers, called
-        just before the receipt entry. Reads only the stashes filled by perform().
-
-        Per illuminated orderlet: the RVn RV-processing descriptors
-        (RVMETHOD/SKYRMVD/TELLRMVD) and the legacy per-fiber per-CCD RV
-        CCD{n}RV{sfx}/CCD{n}ERV{sfx} (routed to the RV# table). On PRIMARY:
-        RVMETHOD, and -- when a science combine ran -- the SCI-combined per-CCD
-        CCD{n}RV/CCD{n}ERV and the EPRV RV/RVERR/BERV/BJDTDB. A non-finite value is
-        written as None (a FITS UNDEFINED card). The RVn CTYPE cards belong to
-        CrossCorrelation and are not rewritten here.
+        Write all RV keywords -- the only place this module writes headers --
+        from the perform()-filled stashes, just before the receipt entry. Per
+        orderlet: RVn RVMETHOD/SKYRMVD/TELLRMVD and per-fiber per-CCD
+        CCD{n}RV{sfx}/CCD{n}ERV{sfx}. On PRIMARY: RVMETHOD, and (when a science
+        combine ran) the SCI-combined CCD{n}RV/CCD{n}ERV and EPRV
+        RV/RVERR/BERV/BJDTDB. Non-finite values are written as None (FITS
+        UNDEFINED). The RVn CTYPE cards belong to CrossCorrelation.
         """
         sfx = {"SCI1": "1", "SCI2": "2", "SCI3": "3", "CAL": "C", "SKY": "S"}
         for fiber in self._processed:

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -6,13 +6,6 @@ functions were already built by CrossCorrelation. For each illuminated orderlet
 it fits the per-order CCFs to radial velocities, collapses them into RVs per
 order, orderlet, and CCD (weighted where appropriate), and fills the results into
 the L4's per-order RV tables and headers plus the PRIMARY combined RV.
-
-Everything the fit needs is read from the L4: the CCF cubes (CCFn) and their
-per-bin variances (CCF_VARn); the velocity grid, reconstructed from each CCFn
-header (VELSTART/VELSTEP/VELNSTEP); the mask width (VELMASK); and the per-order
-WEIGHT / BERV / BJD_TDB / WAVE_START / WAVE_END columns of the RVn tables. The
-native per-pixel velocity scale for the photon error comes from the WAVE
-endpoints and the detector column count (detector.toml ncol).
 """
 
 import logging

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -135,9 +135,9 @@ class RadialVelocity:
         """
         Decorrelation length [km/s] of the CCF photon noise, for the Boisse (2010)
         N_scale oversampling correction. The CCF noise kernel is the cross-
-        correlation of two top-hats -- the mask hole (`mask_width`) and the native
-        pixel (`vel_span_per_pixel`), i.e. a trapezoid -- whose autocorrelation
-        integral length (integral^2 / integral-of-square) is `M**2 / (M - m/3)`
+        correlation of two top-hats -- the mask hole (``mask_width``) and the native
+        pixel (``vel_span_per_pixel``), i.e. a trapezoid -- whose autocorrelation
+        integral length (integral^2 / integral-of-square) is ``M**2 / (M - m/3)``
         with M, m the larger/smaller width (reduces to 1.5*w for equal widths).
         """
         big, small = (
@@ -159,11 +159,11 @@ class RadialVelocity:
     ):
         """
         Two-pass Gaussian fit to a CCF dip, returning an RV [km/s] and a photon-
-        limited error. Pass 1 fits `window` about the CCF minimum; pass 2 refits
-        +/-`fit_nsigma` sigma about the pass-1 mean (symmetric), and those points
+        limited error. Pass 1 fits ``window`` about the CCF minimum; pass 2 refits
+        +/-``fit_nsigma`` sigma about the pass-1 mean (symmetric), and those points
         set the Bouchy (2001) photon error, scaled by the Boisse (2010) N_scale
-        oversampling factor (`vel_span_per_pixel`/`mask_width` via
-        _ccf_noise_corr_length). Both windows use at least `min_npts` points.
+        oversampling factor (``vel_span_per_pixel``/``mask_width`` via
+        _ccf_noise_corr_length). Both windows use at least ``min_npts`` points.
         Returns (NaN, NaN) if the fit fails; raises ValueError on a non-physical
         (zero/negative-count) CCF in the fit window, where no photon error exists.
         """
@@ -232,13 +232,13 @@ class RadialVelocity:
     def _combine_ccfs(self, chip, fibers):
         """
         Combine one chip's cached per-order CCFs into a weighted-average CCF (the
-        RV value) and an unweighted-sum CCF (the photon error). `fibers` is a
+        RV value) and an unweighted-sum CCF (the photon error). ``fibers`` is a
         single fiber or exactly the three science fibers (summed before collapsing,
         sharing a mask/grid so the first is representative). Returns
         (velocity_grid, weighted_ccf, summed_ccf, summed_ccf_var, rep_scale), the
         last being the strongest order's pixel scale. Cross-CCD combination happens
         at the RV level in compute_weighted_rvs, not here. Raises ValueError on a
-        bad `fibers`, RuntimeError if the CCFs are unloaded.
+        bad ``fibers``, RuntimeError if the CCFs are unloaded.
         """
         chip = chip.upper()
         fibers = [fibers] if isinstance(fibers, str) else list(fibers)
@@ -387,7 +387,7 @@ class RadialVelocity:
         compute_order_by_order_rvs). Two flags control the rest:
 
           combine_fibers : sum the three science fibers' CCFs before collapsing.
-                           True requires `fibers` == the three SCI fibers; False
+                           True requires ``fibers`` == the three SCI fibers; False
                            requires a single fiber.
           combine_ccds   : combine the per-chip RVs across CCDs at the RV level --
                            value = order-weight-weighted mean of the per-chip RVs,
@@ -418,14 +418,14 @@ class RadialVelocity:
         Returns
         -------
         dict or tuple
-            combine_ccds=False -> dict {chip: (rv, rv_err)} over `chips`.
+            combine_ccds=False -> dict {chip: (rv, rv_err)} over ``chips``.
             combine_ccds=True  -> a single (rv, rv_err) tuple [km/s].
             A non-finite fit (no order carrying weight) yields (NaN, NaN).
 
         Raises
         ------
         ValueError
-            If the combine_fibers flag and `fibers` are inconsistent.
+            If the combine_fibers flag and ``fibers`` are inconsistent.
         RuntimeError
             If the CCFs have not been loaded for any requested chip/fiber.
         """
@@ -557,8 +557,7 @@ class RadialVelocity:
 
     def _set_headers(self, l4_obj):
         """
-        Write all RV keywords -- the only place this module writes headers --
-        from the perform()-filled stashes, just before the receipt entry. Per
+        Write all RV keywords from the perform()-filled stashes. Per
         orderlet: RVn RVMETHOD/SKYRMVD/TELLRMVD and per-fiber per-CCD
         CCD{n}RV{sfx}/CCD{n}ERV{sfx}. On PRIMARY: RVMETHOD, and (when a science
         combine ran) the SCI-combined CCD{n}RV/CCD{n}ERV and EPRV

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -49,19 +49,8 @@ class SpectralExtraction:
     # ------------------------------------------------------------------
 
     def _read_order_trace_reference(self, chip):
-        """
-        Load and cache the order trace reference table for a given chip.
-
-        Parameters
-        ----------
-        chip : str
-            Chip identifier (e.g., 'GREEN', 'RED').
-
-        Notes
-        -----
-        The trace reference file is read from the repository reference
-        directory and cached in `self.order_trace` to avoid repeated I/O.
-        """
+        """Load the ``chip`` order trace table, caching in ``self.order_trace``
+        to avoid repeated I/O."""
         if not hasattr(self, "order_trace"):
             self.order_trace = {}
         if not hasattr(self, "order_trace_path"):
@@ -76,43 +65,12 @@ class SpectralExtraction:
         self.order_trace_path[chip.upper()] = filepath
 
     def _get_orderlet_pixels(self, chip, fiber, order, return_coords=False):
-        """
-        Extract the 2D pixel region corresponding to a single orderlet.
+        """Slice the 2D bounding box (data ``D``, variance ``V``, weights ``W``)
+        for a single orderlet, optionally with its detector row bounds.
 
-        Parameters
-        ----------
-        chip : str
-            Chip identifier, i.e. 'GREEN' or 'RED'
-        fiber : str
-            Fiber identifier, e.g. 'SCI2'
-        order : int
-            Spectral order number.
-        return_coords : bool, optional
-            If True, also return the detector row bounds of the extracted box.
-
-        Returns
-        -------
-        D : ndarray
-            2D array of data values within the bounding box.
-        V : ndarray
-            2D array of variance values within the bounding box.
-        W : ndarray
-            2D weight array accounting for fractional pixel coverage at
-            order boundaries.
-        row_min : int, optional
-            Lower detector row index of the bounding box (if return_coords=True).
-        row_max : int, optional
-            Upper detector row index of the bounding box (if return_coords=True).
-
-        Notes
-        -----
-        The bounding region fully encloses the traced orderlet. Due to order
-        tilt and curvature, the box may include pixels from adjacent orders.
-        Weights are assigned as:
-        - 1 for fully enclosed pixels,
-        - 0 for pixels outside the orderlet,
-        - fractional values at the top and bottom trace edges.
-        """
+        The box encloses the traced orderlet; order tilt/curvature can pull in
+        adjacent-order pixels. ``W`` is 1 inside, 0 outside, and fractional at
+        the top/bottom trace edges."""
         chip = chip.upper()
         fiber = fiber.upper()
 
@@ -197,34 +155,10 @@ class SpectralExtraction:
 
     @staticmethod
     def _box_extraction(D, V, *, S=None, M=None, W=None):
-        """
-        Perform simple box (summation) extraction of a 2D spectral trace.
+        """Box (summation) extraction of a 2D trace, returning 1D flux/variance.
 
-        Parameters
-        ----------
-        D : ndarray
-            2D data array.
-        V : ndarray
-            2D variance array.
-        S : ndarray, optional
-            2D sky/scattered light model.
-        M : ndarray, optional
-            Binary bad-pixel mask (1 = good, 0 = bad).
-        W : ndarray, optional
-            Pixel weights accounting for trace geometry.
-
-        Returns
-        -------
-        flux_1d : ndarray
-            Extracted 1D flux spectrum.
-        var_1d : ndarray
-            Corresponding 1D variance spectrum.
-
-        Notes
-        -----
-        The single-letter array names (D, V, S, M, W) follow the Horne (1986)
-        optimal-extraction convention.
-        """
+        Single-letter array names (D, V, S, M, W) follow the Horne (1986)
+        optimal-extraction convention."""
         if S is None:
             S = np.zeros_like(D)
         if M is None:
@@ -244,69 +178,18 @@ class SpectralExtraction:
 
     @staticmethod
     def _optimal_extraction(D, V, *, S=None, M=None, W=None, P=None):
-        """
-        Perform optimal extraction of a 2D spectral trace.
+        """Optimal extraction of a 2D trace (not yet implemented).
 
-        Parameters
-        ----------
-        D : ndarray
-            2D data array.
-        V : ndarray
-            2D variance array.
-        S : ndarray, optional
-            2D sky/scattered light model.
-        M : ndarray, optional
-            Binary bad-pixel mask (1 = good, 0 = bad).
-        W : ndarray, optional
-            Pixel weights accounting for trace geometry.
-        P : ndarray, optional
-            Spatial profile model of the spectral trace.
-
-        Returns
-        -------
-        flux_1d : ndarray
-            Extracted 1D flux spectrum.
-        var_1d : ndarray
-            Corresponding 1D variance spectrum.
-
-        Notes
-        -----
-        Follows the Horne (1986) optimal extraction algorithm; the single-letter
-        array names (D, V, S, M, W, P) follow its convention.
-        """
+        Follows the Horne (1986) optimal-extraction algorithm; the single-letter
+        array names (D, V, S, M, W, P) follow its convention."""
         raise NotImplementedError("optimal extraction not yet implemented")
 
     @staticmethod
     def _flat_relative_extraction(D, V, *, S=None, M=None, W=None, F=None):
-        """
-        Perform flat-relative spectral extraction.
+        """Flat-relative extraction of a 2D trace (not yet implemented).
 
-        Parameters
-        ----------
-        D : ndarray
-            2D data array.
-        V : ndarray
-            2D variance array.
-        S : ndarray, optional
-            2D sky/scattered light model.
-        M : ndarray, optional
-            Binary bad-pixel mask (1 = good, 0 = bad).
-        W : ndarray, optional
-            Pixel weights accounting for trace geometry.
-        F : ndarray, optional
-            Flat-field reference image.
-
-        Returns
-        -------
-        flux_1d : ndarray
-            Extracted 1D flux spectrum.
-        var_1d : ndarray
-            Corresponding 1D variance spectrum.
-
-        Notes
-        -----
-        Follows Zechmeister et al. (2014) flat-relative extraction algorithm.
-        """
+        Follows the Zechmeister et al. (2014) flat-relative extraction
+        algorithm; single-letter array names follow the Horne (1986) convention."""
         raise NotImplementedError("flat relative extraction not yet implemented")
 
     # ------------------------------------------------------------------

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -23,6 +23,14 @@ _DEFAULTS = {**DEFAULTS, "extraction_method": "box"}
 class SpectralExtraction:
     """
     Extract per-order 1D spectra from a KPF1, producing a KPF2.
+
+    Parameters
+    ----------
+    l1_obj : KPF1
+        Assembled L1 frame carrying the per-chip ``{CHIP}_CCD`` / ``{CHIP}_VAR``
+        full-frame images to extract from.
+    config : None | dict | ConfigHandler
+        Module configuration. Recognized keys: extraction_method.
     """
 
     def __init__(self, l1_obj, config=None):
@@ -180,16 +188,18 @@ class SpectralExtraction:
     def _optimal_extraction(D, V, *, S=None, M=None, W=None, P=None):
         """Optimal extraction of a 2D trace (not yet implemented).
 
-        Follows the Horne (1986) optimal-extraction algorithm; the single-letter
-        array names (D, V, S, M, W, P) follow its convention."""
+        Follows the Horne (1986) optimal-extraction algorithm; single-letter array
+        names follow the ``_box_extraction`` convention (``P`` adds the spatial
+        profile)."""
         raise NotImplementedError("optimal extraction not yet implemented")
 
     @staticmethod
     def _flat_relative_extraction(D, V, *, S=None, M=None, W=None, F=None):
         """Flat-relative extraction of a 2D trace (not yet implemented).
 
-        Follows the Zechmeister et al. (2014) flat-relative extraction
-        algorithm; single-letter array names follow the Horne (1986) convention."""
+        Follows the Zechmeister et al. (2014) flat-relative extraction algorithm;
+        single-letter array names follow the ``_box_extraction`` convention
+        (``F`` adds the flat)."""
         raise NotImplementedError("flat relative extraction not yet implemented")
 
     # ------------------------------------------------------------------
@@ -347,12 +357,7 @@ class SpectralExtraction:
         self._info = "\n".join(lines)
 
     def _set_headers(self, l2_obj):
-        """Write all PRIMARY-header keywords for spectral extraction.
-
-        Reserved: this module writes no PRIMARY metadata yet. Present so every
-        module consolidates header writes in one place, called just before the
-        receipt entry.
-        """
+        """Reserved header-consolidation hook; writes no PRIMARY metadata yet."""
 
     # ------------------------------------------------------------------
     # Public entry point

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -1,5 +1,8 @@
 """
 KPF Spectral Extraction module.
+
+Extracts per-order 1D spectra from an assembled L1 frame into a KPF2 (L2),
+populating the per-fiber FLUX and VAR arrays.
 """
 
 import logging
@@ -19,20 +22,7 @@ _DEFAULTS = {**DEFAULTS, "extraction_method": "box"}
 
 class SpectralExtraction:
     """
-    This class performs spectral extraction of the 1D spectrum.
-    Processes data from KPF1 to KPF2.
-
-    Notes
-    -----
-    Single-letter variable names for 2D images in this class follow
-    Horne 1986 optimal extraction, with small modifcations:
-      - D = data
-      - V = variance
-      - S = sky / scattered light
-      - F = flat
-      - P = profile
-      - M = mask
-      - W = weight
+    Extract per-order 1D spectra from a KPF1, producing a KPF2.
     """
 
     def __init__(self, l1_obj, config=None):
@@ -229,6 +219,11 @@ class SpectralExtraction:
             Extracted 1D flux spectrum.
         var_1d : ndarray
             Corresponding 1D variance spectrum.
+
+        Notes
+        -----
+        The single-letter array names (D, V, S, M, W) follow the Horne (1986)
+        optimal-extraction convention.
         """
         if S is None:
             S = np.zeros_like(D)
@@ -276,7 +271,8 @@ class SpectralExtraction:
 
         Notes
         -----
-        Follows Horne (1986) optimal extraction algorithm.
+        Follows the Horne (1986) optimal extraction algorithm; the single-letter
+        array names (D, V, S, M, W, P) follow its convention.
         """
         raise NotImplementedError("optimal extraction not yet implemented")
 

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -123,11 +123,10 @@ class WavelengthCalibration:
         self._info = "\n".join(lines)
 
     def _set_headers(self, l2_obj):
-        """Write all PRIMARY-header keywords for wavelength calibration.
+        """Write PRIMARY-header keywords for wavelength calibration.
 
-        Reserved: this module writes no PRIMARY metadata yet. Present so every
-        module consolidates header writes in one place, called just before the
-        receipt entry.
+        Reserved: no PRIMARY metadata written yet. Present so every module
+        consolidates header writes in one place.
         """
 
     # ------------------------------------------------------------------

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -23,7 +23,7 @@ class WavelengthCalibration:
     """
     Apply a precomputed wavelength solution to an extracted KPF L2 frame.
 
-    Reads the master WLS path from the L2 RECEIPT header (`WLSFILE`, written
+    Reads the master WLS path from the L2 RECEIPT header (``WLSFILE``, written
     by CalibrationAssociation), loads the corresponding KPFMasterL2, and copies
     each per-fiber {CHIP}_{FIBER}_WAVE array onto the science L2.
 
@@ -63,8 +63,8 @@ class WavelengthCalibration:
         """
         Load the master wavelength solution from disk.
 
-        If `wls_path` is provided it is used directly, bypassing the header
-        lookup. Otherwise the path is read from `WLSFILE` in the L2 RECEIPT
+        If ``wls_path`` is provided it is used directly, bypassing the header
+        lookup. Otherwise the path is read from ``WLSFILE`` in the L2 RECEIPT
         header (where CalibrationAssociation wrote it as a full path per the
         legacy WLS convention).
 
@@ -81,7 +81,7 @@ class WavelengthCalibration:
         Raises
         ------
         KeyError
-            If neither `wls_path` is given nor WLSFILE is present in the L2
+            If neither ``wls_path`` is given nor WLSFILE is present in the L2
             RECEIPT header.
         FileNotFoundError
             If the resolved path does not exist.
@@ -123,11 +123,7 @@ class WavelengthCalibration:
         self._info = "\n".join(lines)
 
     def _set_headers(self, l2_obj):
-        """Write PRIMARY-header keywords for wavelength calibration.
-
-        Reserved: no PRIMARY metadata written yet. Present so every module
-        consolidates header writes in one place.
-        """
+        """Reserved header-consolidation hook; writes no PRIMARY metadata yet."""
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -138,7 +134,7 @@ class WavelengthCalibration:
         Copy the master wavelength solution onto the science L2.
 
         For every (chip, fiber) in the configured chips × fibers, copies
-        `{CHIP}_{FIBER}_WAVE` from the master L2 onto the science L2. The
+        ``{CHIP}_{FIBER}_WAVE`` from the master L2 onto the science L2. The
         chip-prefix keys resolve through the KPF2 alias system into slices
         of the underlying concatenated TRACE{n}_WAVE arrays.
 
@@ -159,6 +155,15 @@ class WavelengthCalibration:
             The input L2 with per-fiber _WAVE extensions populated and a
             'wavelength_calibration' receipt entry. WLSFILE on RECEIPT is
             left untouched.
+
+        Raises
+        ------
+        KeyError
+            If the master WLS has no data for a requested
+            ``{CHIP}_{FIBER}_WAVE``, or (via ``load_wls``) if WLSFILE is absent
+            from the L2 RECEIPT and no ``wls_path`` was given.
+        FileNotFoundError
+            Via ``load_wls``, if the resolved WLS path does not exist.
         """
         if chips is None:
             chips = self.chips

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -2,9 +2,7 @@
 KPF Wavelength Calibration module.
 
 Copies the per-fiber wavelength solution from a precomputed master WLS L2
-product onto a science L2. The master is located by CalibrationAssociation,
-which writes the full WLSFILE path to the RECEIPT header (its registry home);
-to_kpf2 forwards the L1 RECEIPT header to the L2, where this module reads it.
+product onto a science L2. The master is located by CalibrationAssociation.
 """
 
 import logging
@@ -25,10 +23,9 @@ class WavelengthCalibration:
     """
     Apply a precomputed wavelength solution to an extracted KPF L2 frame.
 
-    Reads `WLSFILE` (full path, legacy convention) from the L2 RECEIPT
-    header (written by CalibrationAssociation on the L1 RECEIPT and carried
-    through by to_kpf2), loads the corresponding KPFMasterL2, and copies each
-    per-fiber {CHIP}_{FIBER}_WAVE array onto the science L2.
+    Reads the master WLS path from the L2 RECEIPT header (`WLSFILE`, written
+    by CalibrationAssociation), loads the corresponding KPFMasterL2, and copies
+    each per-fiber {CHIP}_{FIBER}_WAVE array onto the science L2.
 
     Parameters
     ----------

--- a/kpfpipe/quality_control/__init__.py
+++ b/kpfpipe/quality_control/__init__.py
@@ -1,1 +1,1 @@
-"""Quality control: diagnostics, QC flags, and quicklook plots."""
+"""Quality control: diagnostics, QC flags, checkpoints, and quicklook plots."""

--- a/kpfpipe/quality_control/__init__.py
+++ b/kpfpipe/quality_control/__init__.py
@@ -1,1 +1,1 @@
-"""Read-only quality layers: diagnostics, QC booleans, and quicklook."""
+"""Quality control: diagnostics, QC flags, and quicklook plots."""

--- a/kpfpipe/quality_control/checkpoints/__init__.py
+++ b/kpfpipe/quality_control/checkpoints/__init__.py
@@ -1,3 +1,5 @@
+"""Checkpoints: per-level validation that warns or raises on QC results."""
+
 from kpfpipe.quality_control.checkpoints.base import Checkpoint
 from kpfpipe.quality_control.checkpoints.level0 import CheckpointL0
 from kpfpipe.quality_control.checkpoints.level1 import CheckpointL1

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -109,15 +109,9 @@ class Checkpoint:
     qc_flags._checkpoint_name = "qc_flags"
 
     def _iter_checkpoints(self):
-        """Yield each checkpoint method tagged with `_checkpoint_name`.
+        """Yield ``(name, bound_method)`` for each `_checkpoint_name`-tagged method.
 
-        Walks the MRO so subclass methods come before the base class and ordering
-        is stable across runs.
-
-        Yields
-        ------
-        tuple
-            ``(name, bound_method)`` for each tagged checkpoint method.
+        Walks the MRO so subclass methods precede the base and ordering is stable.
         """
         seen = set()
         for cls in type(self).__mro__:

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -1,25 +1,13 @@
 """Checkpoint framework base class.
 
-The third quality-control stage (after Diagnostics and QC). A Checkpoint's
-checkpoint methods READ the 0/1 QC flags written to QUALITY_CONTROL and the
-product headers, then emit warnings or raise errors -- they never write
-keywords. A method opts in by setting ``_checkpoint_name`` on the function
-object; ``run()`` walks all such methods (MRO order) and calls each.
-
-``run()`` also folds in the two upstream read-only stages: it first runs the
-subclass's paired Diagnostics and QC classes (``DIAGNOSTICS``/``QC``) -- which
-write the metrics and 0/1 flags -- then the checkpoint methods. So the recipe
-drives the whole pipeline order science modules -> Diagnostics -> QC ->
-Checkpoints through one ``CheckpointL{n}(obj).run()`` call.
-
-Two responsibilities, both inherited base checkpoints:
-  - ``unregistered_keywords`` -- structural header validation: any non-structural
-    card not registered for its extension raises ``ValueError`` (this logic used
-    to live in ``QC._validate_headers``).
-  - ``qc_flags`` -- read each 0/1 QC flag; a failed (0) flag named in the
-    subclass's ``RAISE_FLAGS`` raises, every other failed flag warns.
-
-Severity policy lives in the per-level subclasses (their ``RAISE_FLAGS``).
+The third and final read-only quality-control stage (after Diagnostics and QC).
+A Checkpoint reads the 0/1 QC flags and the product headers and emits warnings
+or raises errors — it never writes keywords. ``run()`` also folds in the paired
+Diagnostics and QC classes first, so the recipe drives the whole
+Diagnostics -> QC -> Checkpoints sequence through one ``CheckpointL{n}(obj).run()``
+call. Two base checkpoints are inherited by every level: ``unregistered_keywords``
+(structural header validation) and ``qc_flags`` (raise on a failed flag named in
+the subclass's ``RAISE_FLAGS``, warn on the rest).
 """
 
 import warnings

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -2,7 +2,7 @@
 
 The third and final read-only quality-control stage (after Diagnostics and QC).
 A Checkpoint reads the 0/1 QC flags and the product headers and emits warnings
-or raises errors — it never writes keywords. ``run()`` also folds in the paired
+or raises errors -- it never writes keywords. ``run()`` also folds in the paired
 Diagnostics and QC classes first, so the recipe drives the whole
 Diagnostics -> QC -> Checkpoints sequence through one ``CheckpointL{n}(obj).run()``
 call. Two base checkpoints are inherited by every level: ``unregistered_keywords``
@@ -22,7 +22,7 @@ class Checkpoint:
         Finished data product whose flags/headers are read (never written).
     """
 
-    LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2").
+    LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2", "L4").
     RAISE_FLAGS = ()  # QC keywords whose failure (0) raises; every other 0 warns.
     DIAGNOSTICS = None  # Paired Diagnostics class, run first by run() (None = skip).
     QC = None  # Paired QC class, run second; its results land in self.qc_results.
@@ -109,9 +109,9 @@ class Checkpoint:
     qc_flags._checkpoint_name = "qc_flags"
 
     def _iter_checkpoints(self):
-        """Yield ``(name, bound_method)`` for each `_checkpoint_name`-tagged method.
+        """Yield each ``(name, method)`` tagged ``_checkpoint_name``.
 
-        Walks the MRO so subclass methods precede the base and ordering is stable.
+        MRO-walk discovery; the mechanism is documented in style guide §9.
         """
         seen = set()
         for cls in type(self).__mro__:

--- a/kpfpipe/quality_control/checkpoints/level0.py
+++ b/kpfpipe/quality_control/checkpoints/level0.py
@@ -6,12 +6,7 @@ from kpfpipe.quality_control.qc_flags import QCL0
 
 
 class CheckpointL0(Checkpoint):
-    """Checkpoints for KPF Level 0 raw data products.
-
-    The raw WMKO L0 PRIMARY is not registry-governed, so ``unregistered_keywords``
-    skips it and validates only the KPF-custom extensions (QUALITY_CONTROL,
-    RECEIPT) present on the product.
-    """
+    """Checkpoints for KPF Level 0 raw data products."""
 
     LEVEL = "L0"
     RAISE_FLAGS = ("DATAPRL0",)  # missing raw data is fatal; other flags warn.

--- a/kpfpipe/quality_control/diagnostics/__init__.py
+++ b/kpfpipe/quality_control/diagnostics/__init__.py
@@ -1,3 +1,5 @@
+"""Diagnostics: per-level metric computation written to product headers."""
+
 from kpfpipe.quality_control.diagnostics.base import Diagnostics
 from kpfpipe.quality_control.diagnostics.level0 import DiagL0
 from kpfpipe.quality_control.diagnostics.level1 import DiagL1

--- a/kpfpipe/quality_control/diagnostics/base.py
+++ b/kpfpipe/quality_control/diagnostics/base.py
@@ -1,17 +1,9 @@
 """Diagnostics framework base class.
 
-Each Diagnostics subclass defines methods that compute metrics from a
-finished data product and return a dict of {keyword: (value, comment)}.
-The runner writes each via ``set_keyword`` (which routes the keyword to its
-registry-home extension — DiagL2 metrics land on QUALITY_CONTROL) and stores
-them on self.results.
-
-A method opts in by setting `_diag_name` on the function object.
-If a method raises, run() raises (loud failure, no silent suppression).
-
-Diagnostics is read-only with respect to the data extensions — it only
-adds header keywords via ``set_keyword``. Pair with QC, which reads the
-metrics Diagnostics writes and applies pass/fail thresholds.
+The first of the three quality-control stages (Diagnostics -> QC -> Checkpoints).
+Each Diagnostics subclass computes metrics from a finished data product and writes
+them to the product headers via ``set_keyword``; it never modifies the science
+extensions. QC then reads those metrics and applies pass/fail thresholds.
 """
 
 

--- a/kpfpipe/quality_control/diagnostics/base.py
+++ b/kpfpipe/quality_control/diagnostics/base.py
@@ -17,7 +17,7 @@ class Diagnostics:
         ``set_keyword``, routed to each keyword's registry-home extension).
     """
 
-    LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2").
+    LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2", "L4").
 
     def __init__(self, kpf_obj):
         self.kpf_obj = kpf_obj
@@ -67,10 +67,9 @@ class Diagnostics:
         return self.results
 
     def _iter_methods(self):
-        """Yield each ``(name, bound_method)`` tagged with `_diag_name`.
+        """Yield each ``(name, method)`` tagged ``_diag_name``.
 
-        Walks the MRO so subclass methods precede the base class and ordering
-        is stable across runs.
+        MRO-walk discovery; the mechanism is documented in style guide §9.
         """
         seen = set()
         for cls in type(self).__mro__:

--- a/kpfpipe/quality_control/diagnostics/base.py
+++ b/kpfpipe/quality_control/diagnostics/base.py
@@ -26,11 +26,8 @@ class Diagnostics:
     def _tag(self, **values):
         """Pair each ``keyword=value`` with its registry-sourced FITS comment.
 
-        Diagnostic methods build their result dict with this rather than
-        hardcoding comment strings, so the FITS comment has a single source of
-        truth (the keyword registry / ``config/L{n}-headers.csv`` Description)
-        and never drifts from it. ``set_keyword`` already uses the registry
-        Description for the header write; this keeps ``self.results`` in sync.
+        Sources the comment from the keyword registry (single source of truth)
+        so ``self.results`` stays in sync with the ``set_keyword`` header write.
         """
         routing = self.kpf_obj.keyword_registry.routing
         out = {}
@@ -70,15 +67,10 @@ class Diagnostics:
         return self.results
 
     def _iter_methods(self):
-        """Yield each method tagged with `_diag_name`.
+        """Yield each ``(name, bound_method)`` tagged with `_diag_name`.
 
-        Walks the MRO so subclasses' methods come before the base class
-        and ordering is stable across runs.
-
-        Yields
-        ------
-        tuple
-            ``(name, bound_method)`` for each tagged diagnostic method.
+        Walks the MRO so subclass methods precede the base class and ordering
+        is stable across runs.
         """
         seen = set()
         for cls in type(self).__mro__:

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -1,14 +1,4 @@
-"""Diagnostics for KPF Level 0 (raw CCD) data products.
-
-Pointing/identity checks that cross-match the telescope pointing (RA/DEC) against
-three reference positions: the loaded DCS target (TARGRA/DEC), the Gaia DR3
-catalog position of GAIAID, and the SIMBAD position of the OBJECT name. All three
-metrics are fail-soft: a frame with no pointing/target (e.g. a calibration frame)
-skips them, and a Gaia/SIMBAD lookup failure warns and skips rather than failing
-the L0 checkpoint. Diagnostics that read the overscan region (read noise,
-non-Gaussian RN) are owned by ImageAssembly because they need to run before gain
-conversion modifies the amp data.
-"""
+"""Diagnostics for KPF Level 0 (raw CCD) data products."""
 
 import re
 import warnings
@@ -24,6 +14,8 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 
 class DiagL0(Diagnostics):
+    """Diagnostics for KPF Level 0 raw data products."""
+
     LEVEL = "L0"
 
     # Keys each metric needs; absent -> metric is N/A for that frame (skip).

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -90,9 +90,8 @@ class DiagL0(Diagnostics):
     def _object_name(self):
         """SIMBAD-resolvable name from L0 PRIMARY OBJECT, or None if absent.
 
-        KPF OBJECT for standard stars is the bare HD number (e.g. '10700'),
-        which SIMBAD only resolves with an 'HD ' prefix; named targets pass
-        through unchanged.
+        KPF OBJECT for standard stars is a bare HD number (e.g. '10700') that
+        SIMBAD resolves only with an 'HD ' prefix; named targets pass through.
         """
         obj = self.kpf_obj.headers["PRIMARY"].get("OBJECT")
         if obj is None:

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -32,13 +32,12 @@ class DiagL0(Diagnostics):
 
     @staticmethod
     def _present(hdr, keys):
-        """True if every key in `keys` is present and non-None in `hdr`."""
+        """True if every key in ``keys`` is present and non-None in ``hdr``."""
         return all(hdr.get(k) is not None for k in keys)
 
     # Astrometry helpers reproduced from BarycentricCorrection._gaia_astrometry /
     # ._wmko_astrometry (there they read INSTRUMENT_HEADER; at L0 the natives are
-    # on PRIMARY). The shared copies move to utils/astro.py in a follow-up -- keep
-    # the two in sync until then.
+    # on PRIMARY). The two copies are kept in sync by hand.
 
     def _gaia_source_id(self):
         """Digit-only Gaia DR3 id from L0 GAIAID, or None if absent/malformed."""

--- a/kpfpipe/quality_control/diagnostics/level1.py
+++ b/kpfpipe/quality_control/diagnostics/level1.py
@@ -1,11 +1,8 @@
 """Diagnostics for KPF Level 1 (assembled FFI) data products.
 
-The L1 metrics consumed by QCL1 that depend on intermediate processing
-state (read noise from raw overscan, the BIASSUB flag) are still written by
-the modules that produce them — ImageAssembly, ImageProcessing. Metrics that
-can be recomputed from the finished L1 product alone live here: the master
-calibration ages, derived from the master paths CalibrationAssociation wrote
-to RECEIPT plus the observation timestamp (DATE-OBS) on PRIMARY.
+Metrics recomputable from the finished L1 product — chiefly the master
+calibration ages (bias/dark/flat/WLS), each the signed age of the associated
+master relative to the observation time.
 """
 
 from datetime import datetime
@@ -26,6 +23,8 @@ _CAL_AGE_KEYS = {
 
 
 class DiagL1(Diagnostics):
+    """Diagnostics for KPF Level 1 assembled FFI products."""
+
     LEVEL = "L1"
 
     def calibration_ages(self):

--- a/kpfpipe/quality_control/diagnostics/level1.py
+++ b/kpfpipe/quality_control/diagnostics/level1.py
@@ -1,6 +1,6 @@
 """Diagnostics for KPF Level 1 (assembled FFI) data products.
 
-Metrics recomputable from the finished L1 product — chiefly the master
+Metrics recomputable from the finished L1 product -- chiefly the master
 calibration ages (bias/dark/flat/WLS), each the signed age of the associated
 master relative to the observation time.
 """
@@ -12,8 +12,7 @@ from kpfpipe.utils.kpf_utils import get_timestamp, kpf_timestamp_to_datetime
 
 # Master-calibration age metrics: the RECEIPT path keyword (written by
 # CalibrationAssociation) -> the age keyword whose signed (master - obs) value
-# this diagnostic computes. The FITS comment comes from the registry (via the
-# _tag helper / set_keyword), so it is not duplicated here.
+# this diagnostic computes. (FITS comment from the registry -- see ``_tag``.)
 _CAL_AGE_KEYS = {
     "BIASFILE": "BIASAGE",
     "DARKFILE": "DARKAGE",

--- a/kpfpipe/quality_control/diagnostics/level2.py
+++ b/kpfpipe/quality_control/diagnostics/level2.py
@@ -10,8 +10,7 @@ _SCI_FIBERS = ("SCI1", "SCI2", "SCI3")
 _SNR_PERCENTILE = 95
 _CHIP_PREFIX = {"GREEN": "G", "RED": "R"}
 
-# Fiber -> NaN-count keyword. The FITS comment comes from the registry (via
-# the _tag helper / set_keyword), so it is not duplicated here.
+# Fiber -> NaN-count keyword. (FITS comment from the registry -- see ``_tag``.)
 _NAN_KEYS = {
     "SCI1": "NANSCI1",
     "SCI2": "NANSCI2",
@@ -27,7 +26,7 @@ class DiagL2(Diagnostics):
     LEVEL = "L2"
 
     def nan_counts(self):
-        """Count NaN pixels per fiber in `{CHIP}_{FIBER}_FLUX`, summed across chips.
+        """Count NaN pixels per fiber in ``{CHIP}_{FIBER}_FLUX``, summed across chips.
 
         Always emits all five keys; fibers with no extracted data report 0.
 
@@ -51,8 +50,8 @@ class DiagL2(Diagnostics):
     def zero_flux_fraction(self):
         """Compute the fraction of L2 flux pixels exactly equal to zero.
 
-        Counts across all `{CHIP}_{FIBER}_FLUX` extensions. Skipped (no key
-        written) when no L2 data is present — `QCL2.DATAPRL2` will have
+        Counts across all ``{CHIP}_{FIBER}_FLUX`` extensions. Skipped (no key
+        written) when no L2 data is present -- ``QCL2.DATAPRL2`` will have
         already failed in that case.
 
         Returns

--- a/kpfpipe/quality_control/diagnostics/level4.py
+++ b/kpfpipe/quality_control/diagnostics/level4.py
@@ -1,15 +1,10 @@
 """Diagnostics for KPF Level 4 (RVs and CCFs) data products.
 
-Ports the per-order BJD and barycentric-RV dispersion statistics from the
-v2.12 ``AnalyzeL2.compute_statistics``: photon-weighted means (``BJDMEAN`` /
-``BERVMEAN``) and the spread of the per-order values about them (``BJDSTD`` /
-``BJDRNG`` in seconds, ``BERVSTD`` / ``BERVRNG`` in m/s) plus the per-order BERV
-percent deviation (``BERVMAXP`` / ``BERVMINP``). They are weighted by the
-per-order CCF-combination ``WEIGHT`` column and computed on the primary science
-orderlet (SCI2), matching the old single-table behavior.
-
-The v2.12 ``AGES*``/``AGEU*`` wave-cal-age metrics needed the time-series
-database (calibration history) and are out of scope for the DB-free vNext L4.
+Per-order BJD and barycentric-RV dispersion statistics: photon-weighted means
+(``BJDMEAN``/``BERVMEAN``) and the spread of the per-order values about them
+(``BJDSTD``/``BJDRNG`` in seconds, ``BERVSTD``/``BERVRNG`` in m/s, and the BERV
+percent deviation ``BERVMAXP``/``BERVMINP``), weighted by the per-order
+CCF-combination ``WEIGHT`` and computed on the primary science orderlet (SCI2).
 """
 
 import numpy as np

--- a/kpfpipe/quality_control/qc_flags/__init__.py
+++ b/kpfpipe/quality_control/qc_flags/__init__.py
@@ -1,3 +1,5 @@
+"""QC flags: per-level pass/fail checks written to QUALITY_CONTROL."""
+
 from kpfpipe.quality_control.qc_flags.base import QC
 from kpfpipe.quality_control.qc_flags.level0 import QCL0
 from kpfpipe.quality_control.qc_flags.level1 import QCL1

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -61,19 +61,13 @@ class QC:
         return self.results
 
     def _required_primary_keywords(self):
-        """Keywords a level-N product must carry on PRIMARY (a presence set).
+        """Registry EPRV ``Required`` PRIMARY keywords at or below this level.
 
-        The registry's EPRV ``Required`` PRIMARY keywords at or below this
-        product's own level -- the EPRV L2 PRIMARY set is tagged Level 1 in the
-        registry (KPF holds the L1 PRIMARY to the EPRV L2 spec; see
-        ``keyword_registry._build_rows``), so the check needs no L1->L2 cap: the
-        level cap *is* the level. PRIMARY now holds EPRV-registered keywords only
-        (the DRP provenance cards moved to RECEIPT), so there is no
-        KPF-routed-PRIMARY set to union in. Read off the validated model's
-        registry singleton (``self.kpf_obj.keyword_registry``), so qc_flags
-        imports nothing from data_models. L0 -> Level 0 yields the empty set (no
-        PRIMARY keyword is Required there -- raw WMKO L0 PRIMARY is not
-        registry-governed); an untagged subclass (``LEVEL`` None) also gets it.
+        The level cap *is* the level (the EPRV L2 PRIMARY set is tagged Level 1),
+        so no L1->L2 adjustment is needed. Read off the model's registry singleton
+        so qc_flags imports nothing from data_models. L0 (and an untagged
+        ``LEVEL`` None) yields the empty set -- raw WMKO L0 PRIMARY is not
+        registry-governed.
         """
         level = str(self.LEVEL or "")
         if not (level[:1].upper() == "L" and level[1:].isdigit()):
@@ -83,15 +77,9 @@ class QC:
         return {k for k, lvl in reg.required.get("PRIMARY", {}).items() if lvl <= cap}
 
     def _iter_checks(self):
-        """Yield each check method tagged with `_qc_key`.
+        """Yield ``(name, bound_method)`` for each ``_qc_key``-tagged check.
 
-        Iterates in source order via ``__dict__`` plus an MRO walk so check
-        ordering is stable.
-
-        Yields
-        ------
-        tuple
-            ``(name, bound_method)`` for each tagged check method.
+        Walks ``__dict__`` across the MRO so check ordering is stable.
         """
         seen = set()
         for cls in type(self).__mro__:

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -1,17 +1,9 @@
 """QC framework base class.
 
-Each QC subclass defines check methods. A check is a method whose function
-object has a `_qc_key` (8-char FITS keyword) attribute. The runner walks all
-such methods, calls each one, writes a 0/1 result via ``set_keyword`` (which
-routes it to its registry home, QUALITY_CONTROL, with the registry ``Description``
-as the FITS comment), and aggregates ISGOOD = AND of all checks. The per-check
-comment lives once — in the registry ``Description`` — not on the method. If any
-check raises, run() raises (loud failure, no silent suppression).
-
-QC writes only 0/1 keywords. Header validation (unregistered cards, missing
-required keywords) is NOT done here -- it lives in the separate ``checkpoints``
-layer, which reads these flags plus the product headers and emits warnings or
-raises. The pipeline order is: science modules -> Diagnostics -> QC -> Checkpoints.
+The second of three quality-control stages (Diagnostics -> QC -> Checkpoints).
+Each QC subclass runs pass/fail check methods, writing a 0/1 flag per check to
+QUALITY_CONTROL via ``set_keyword`` and aggregating ISGOOD as the AND of all
+checks. Header validation and raising live in the separate Checkpoints layer.
 """
 
 

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -16,7 +16,7 @@ class QC:
         Finished data product whose QUALITY_CONTROL header receives the 0/1 flags.
     """
 
-    LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2").
+    LEVEL = None  # Subclasses set the level tag ("L0", "L1", "L2", "L4").
 
     def __init__(self, kpf_obj):
         self.kpf_obj = kpf_obj
@@ -43,14 +43,14 @@ class QC:
                 raise RuntimeError(f"QC check {name!r} raised: {e}") from e
 
             kw = fn._qc_key
-            # The comment is the registry Description (the single source) — the same
-            # string set_keyword writes as the FITS comment; mirror it into results.
+            # Mirror the registry Description into results (the FITS comment
+            # source; see ``_tag`` and style guide §9).
             comment = self.kpf_obj.keyword_registry.routing.get(kw, (None, ""))[1]
             self.results[kw] = (passed, comment)
             self.kpf_obj.set_keyword(kw, 1 if passed else 0)
 
         # ISGOOD is the running aggregate: AND over every QC flag now on
-        # QUALITY_CONTROL — the flags this level just wrote PLUS those propagated
+        # QUALITY_CONTROL -- the flags this level just wrote PLUS those propagated
         # from lower levels (QUALITY_CONTROL accumulates L0->L1->L2->L4). Reading
         # the accumulated header makes it level-agnostic; exclude ISGOOD itself.
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
@@ -63,11 +63,11 @@ class QC:
     def _required_primary_keywords(self):
         """Registry EPRV ``Required`` PRIMARY keywords at or below this level.
 
-        The level cap *is* the level (the EPRV L2 PRIMARY set is tagged Level 1),
-        so no L1->L2 adjustment is needed. Read off the model's registry singleton
-        so qc_flags imports nothing from data_models. L0 (and an untagged
-        ``LEVEL`` None) yields the empty set -- raw WMKO L0 PRIMARY is not
-        registry-governed.
+        The level cap is the level's own number, so this runs unchanged for L1,
+        L2, and L4 -- each returns the required PRIMARY keywords tagged at or
+        below its own level. Read off the model's registry singleton so qc_flags
+        imports nothing from data_models. L0 (and an untagged ``LEVEL`` None)
+        yields the empty set -- raw WMKO L0 PRIMARY is not registry-governed.
         """
         level = str(self.LEVEL or "")
         if not (level[:1].upper() == "L" and level[1:].isdigit()):
@@ -77,9 +77,9 @@ class QC:
         return {k for k, lvl in reg.required.get("PRIMARY", {}).items() if lvl <= cap}
 
     def _iter_checks(self):
-        """Yield ``(name, bound_method)`` for each ``_qc_key``-tagged check.
+        """Yield each ``(name, method)`` tagged ``_qc_key``.
 
-        Walks ``__dict__`` across the MRO so check ordering is stable.
+        MRO-walk discovery; the mechanism is documented in style guide §9.
         """
         seen = set()
         for cls in type(self).__mro__:

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -40,14 +40,11 @@ class QCL0(QC):
     def data_l0_red_green(self):
         """Raw CCD data present: each of GREEN/RED is a supported amp readout.
 
-        KPF reads out either 2 or 4 amplifiers per chip, so the expected amp
-        count is inferred from the data rather than fixed: a chip passes when the
-        number of present, non-empty amplifier extensions is a supported readout
-        mode (``_SUPPORTED_NAMP``), mirroring ``ImageAssembly.count_amplifiers``.
-        This accepts both 2-amp and 4-amp frames and rejects a chip with no data
-        or a partial/invalid amp set (1 or 3). Absent amps are stored as
-        ``array(None, dtype=object)`` and skipped -- the same present-amp scan
-        QCL1 uses for read noise.
+        KPF reads out either 2 or 4 amplifiers per chip, so the amp count is
+        inferred from the data: a chip passes when its number of present,
+        non-empty amplifier extensions is a supported readout mode
+        (``_SUPPORTED_NAMP``), mirroring ``ImageAssembly.count_amplifiers``. A
+        chip with no data or a partial/invalid amp set (1 or 3) fails.
         """
         for chip in _CHIPS:
             namp = 0

--- a/kpfpipe/quality_control/qc_flags/level1.py
+++ b/kpfpipe/quality_control/qc_flags/level1.py
@@ -47,27 +47,12 @@ class QCL1(QC):
     required_keywords_present._qc_key = "KWRDPRL1"
 
     def _present_rn_in_range(self, idx, lo, hi):
-        """Validate a read-noise keyword across every amplifier present.
+        """True iff every present amp's ``idx``-th RN keyword is in ``[lo, hi]``.
 
-        Checks the ``idx``-th RN keyword for every amplifier whose keyword is
-        present, so 2-amp and 4-amp readouts both pass. Absent amps are
-        skipped.
-
-        Parameters
-        ----------
-        idx : int
-            Index into each amp's RN keyword pair (0 = RN, 1 = non-Gaussian RN).
-        lo : float
-            Lower bound of the accepted range, inclusive.
-        hi : float
-            Upper bound of the accepted range, inclusive.
-
-        Returns
-        -------
-        bool
-            True if all present values fall in ``[lo, hi]``. False if any is
-            out of range, or if no RN keyword is present at all (read noise
-            should always be recorded).
+        ``idx`` selects the RN keyword pair (0 = RN, 1 = non-Gaussian RN); absent
+        amps are skipped so 2-amp and 4-amp readouts both pass. False if any is
+        out of range, or if no RN keyword is present at all (read noise should
+        always be recorded).
         """
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         found = False

--- a/kpfpipe/quality_control/qc_flags/level2.py
+++ b/kpfpipe/quality_control/qc_flags/level2.py
@@ -102,9 +102,9 @@ class QCL2(QC):
     def science_snr(self):
         """Science SNR is finite and above a minimum floor.
 
-        Reads the GSNRSCI/RSNRSCI metrics written by DiagL2.snr (run DiagL2
-        before QCL2, mirroring the flux_finite_fraction -> nan_counts
-        dependency). Guards against a silently failed extraction.
+        Reads the GSNRSCI/RSNRSCI metrics written by ``DiagL2.snr`` (run DiagL2
+        before QCL2, the same Diagnostics -> QC ordering every metric-backed
+        check relies on). Guards against a silently failed extraction.
         """
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         values = [_hdr_float(hdr, k) for k in ("GSNRSCI", "RSNRSCI")]

--- a/kpfpipe/quality_control/qc_flags/level4.py
+++ b/kpfpipe/quality_control/qc_flags/level4.py
@@ -1,11 +1,8 @@
 """QC checks for KPF Level 4 (RVs and CCFs) data products.
 
-Ports the v2.12 RV/CCF QC checks (``data_L2`` presence,
-``L2_barycentric_rv_percent_change``) to vNext L4, plus the framework
-required-PRIMARY-keyword presence check. Every result is a 0/1 flag written to
-QUALITY_CONTROL via ``set_keyword``. (The timing-consistency check ported from
-v2.12 ``L2_datetime`` now lives in QCL0 as ``DATTIMOK`` -- it is a raw-frame
-property and propagates downstream via the QUALITY_CONTROL history.)
+Checks the presence of the RV/CCF data and the per-order barycentric-RV percent
+change, plus the framework required-PRIMARY-keyword presence check. Each result
+is a 0/1 flag written to QUALITY_CONTROL.
 """
 
 import numpy as np

--- a/kpfpipe/quality_control/quicklook/__init__.py
+++ b/kpfpipe/quality_control/quicklook/__init__.py
@@ -1,3 +1,5 @@
+"""Quicklook: per-level PNG plots of data products."""
+
 from kpfpipe.quality_control.quicklook.level0 import PlotL0
 from kpfpipe.quality_control.quicklook.level1 import PlotL1
 from kpfpipe.quality_control.quicklook.level2 import PlotL2

--- a/kpfpipe/quality_control/quicklook/_save_png.py
+++ b/kpfpipe/quality_control/quicklook/_save_png.py
@@ -11,21 +11,21 @@ logger = logging.getLogger(__name__)
 
 
 def save_png(fig, path, dpi, compress_level):
-    """Save `fig` to `path` as an RGB PNG at `dpi`.
+    """Save ``fig`` to ``path`` as an RGB PNG at ``dpi``.
 
-    Renders the figure at `dpi`, then writes the Agg buffer's RGB channels
+    Renders the figure at ``dpi``, then writes the Agg buffer's RGB channels
     straight through Pillow, skipping the constant (opaque) alpha channel that
     ``Figure.savefig`` would encode. Pixel-identical to
     ``savefig(path, dpi=dpi, facecolor="w")`` at the same resolution, but ~30%
     faster to encode and a smaller file.
 
-    `compress_level` (0-9, the PNG zlib level) is caller-supplied because the
+    ``compress_level`` (0-9, the PNG zlib level) is caller-supplied because the
     speed/size trade-off depends on the content: dense detector images (L0/L1)
     favour a low level (~1) for a big encode win at negligible size cost, while
     highly compressible line plots (L2) favour the default (~6), where a low
     level barely saves time but inflates the file by ~55%.
 
-    `dpi` is applied here rather than at save time on purpose: the Agg buffer's
+    ``dpi`` is applied here rather than at save time on purpose: the Agg buffer's
     pixel dimensions are fixed by the figure dpi at ``draw`` time, so it must be
     set before the draw or the image silently renders at the default dpi.
     """
@@ -40,11 +40,11 @@ def save_png(fig, path, dpi, compress_level):
 
 
 def save_image_png(image, path, cmap, vmin, vmax, origin="lower", compress_level=1):
-    """Save `image` directly as a native-size RGB PNG.
+    """Save ``image`` directly as a native-size RGB PNG.
 
     This bypasses matplotlib's figure rasterization so the output dimensions are
-    exactly one PNG pixel per input array pixel. `origin="lower"` mirrors the
-    display orientation used by `imshow(..., origin="lower")`.
+    exactly one PNG pixel per input array pixel. ``origin="lower"`` mirrors the
+    display orientation used by ``imshow(..., origin="lower")``.
     """
     arr = np.asarray(image)
     if origin == "lower":

--- a/kpfpipe/quality_control/quicklook/level0.py
+++ b/kpfpipe/quality_control/quicklook/level0.py
@@ -54,11 +54,9 @@ class PlotL0:
     def _stitch(self, chip):
         """Concatenate raw amplifier arrays into a single display image.
 
-        Uses ImageAssembly to count amps and (for 4-amp mode) apply per-amp
-        orientation, then applies the same blue -> red FFI orientation as
-        ImageAssembly so the L0 display matches the assembled output. Per-amp
-        orientation is performed on a deepcopy of the L0 so the caller's object
-        is not mutated.
+        Delegates amp counting/orientation to ImageAssembly (on a deepcopy, since
+        orient_channels mutates l0.data), then applies the same blue -> red FFI
+        orientation so the L0 display matches the assembled output.
         """
         chip = chip.upper()
 
@@ -159,7 +157,6 @@ class PlotL0:
         cbar.ax.tick_params(labelsize=12)
         plt.grid(False)
 
-        # Timestamp annotation
         current_time = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
         timestamp_label = f"KPF QLP: {current_time} UT"
         plt.annotate(

--- a/kpfpipe/quality_control/quicklook/level0.py
+++ b/kpfpipe/quality_control/quicklook/level0.py
@@ -12,11 +12,10 @@ from kpfpipe.quality_control.quicklook._save_png import save_image_png, save_png
 
 
 class PlotL0:
-    """
-    Quicklook plots for KPF L0 (raw CCD) data.
+    """Quicklook plots for KPF L0 (raw CCD) data.
 
     Takes a KPF0 object and generates plots of the raw detector images.
-    Pure visualization — no science computation. Amplifier counting and
+    Pure visualization -- no science computation. Amplifier counting and
     orientation delegate to ImageAssembly so detector-geometry knowledge
     has a single home.
 
@@ -94,8 +93,7 @@ class PlotL0:
         return ImageAssembly.orient_ffi(image, chip)
 
     def stitched_image(self, chip, *, full_res=None):
-        """
-        Plot the stitched raw detector image for one CCD.
+        """Plot the stitched raw detector image for one CCD.
 
         Replicates v2.12 plot_L0_stitched_image.
 
@@ -105,7 +103,7 @@ class PlotL0:
             'green' or 'red'.
         full_res : bool or None
             Save a native-size, one-output-pixel-per-CCD-pixel PNG when true.
-            None uses the constructor's `full_res` setting.
+            None uses the constructor's ``full_res`` setting.
 
         Returns
         -------
@@ -120,7 +118,7 @@ class PlotL0:
         image = self._stitch(chip_upper)
         # Stats run on the unmasked pixels (mask -> NaN), mirroring the L1 path;
         # nan* over the masked array would otherwise ignore the mask and warn.
-        # imshow keeps the masked `image` so masked pixels still render as blank.
+        # imshow keeps the masked ``image`` so masked pixels still render as blank.
         finite = np.ma.filled(image, np.nan)
 
         # Legacy data format: values stored with extra 2^16 factor
@@ -196,33 +194,31 @@ class PlotL0:
         return fig
 
     def run(self, which, *, full_res=None):
-        """
-        Generate the requested plot(s) for every chip that has data.
+        """Generate the requested plot(s) for every chip that has data.
 
-        Saves each to `output_dir` and, in that save-to-disk mode, closes the
-        matplotlib figure so callers don't accumulate them. When `output_dir`
-        is None the figures are returned open, so they display when the caller
-        renders them (e.g. interactively in a notebook).
+        Follows the shared Quicklook ``run()`` contract (style guide §9):
+        saved-and-closed when ``output_dir`` is set, returned open when it
+        is ``None``.
 
         Parameters
         ----------
         which : str
             'all' to run every implemented plot, or the name of a single
-            plot method (one of `self._PLOT_METHODS`).
+            plot method (one of ``self._PLOT_METHODS``).
         full_res : bool or None
             Save native-size PNGs when true. None uses the constructor's
-            `full_res` setting.
+            ``full_res`` setting.
 
         Returns
         -------
         dict
-            Maps `{method_name}_{chip}` to its matplotlib.Figure (closed only
-            when saved to `output_dir`); useful for tests and introspection.
+            Maps ``{method_name}_{chip}`` to its matplotlib.Figure; useful
+            for tests and introspection.
 
         Raises
         ------
         ValueError
-            If `which` is neither 'all' nor a known plot method name.
+            If ``which`` is neither 'all' nor a known plot method name.
         """
         if which == "all":
             names = self._PLOT_METHODS

--- a/kpfpipe/quality_control/quicklook/level1.py
+++ b/kpfpipe/quality_control/quicklook/level1.py
@@ -11,11 +11,10 @@ from kpfpipe.quality_control.quicklook._save_png import save_image_png, save_png
 
 
 class PlotL1:
-    """
-    Quicklook plots for KPF L1 (assembled FFI) data.
+    """Quicklook plots for KPF L1 (assembled FFI) data.
 
     Takes a KPF1 object and generates plots of the assembled detector image.
-    Pure visualization — no science computation. Read-noise header mapping
+    Pure visualization -- no science computation. Read-noise header mapping
     is imported from ImageAssembly so there is one source of truth for which
     FITS keywords hold which amplifier's read noise.
 
@@ -59,8 +58,7 @@ class PlotL1:
         return rn_values, rnng_values
 
     def image(self, chip, *, full_res=None):
-        """
-        Plot the assembled FFI for one CCD.
+        """Plot the assembled FFI for one CCD.
 
         Replicates v2.12 plot_2D_image for the basic science-frame case.
 
@@ -70,7 +68,7 @@ class PlotL1:
             'green' or 'red'.
         full_res : bool or None
             Save a native-size, one-output-pixel-per-CCD-pixel PNG when true.
-            None uses the constructor's `full_res` setting.
+            None uses the constructor's ``full_res`` setting.
 
         Returns
         -------
@@ -209,33 +207,31 @@ class PlotL1:
         return np.size(self.l1_obj.data[ext]) > 0
 
     def run(self, which, *, full_res=None):
-        """
-        Generate the requested plot(s) for every chip that has data.
+        """Generate the requested plot(s) for every chip that has data.
 
-        Saves each to `output_dir` and, in that save-to-disk mode, closes the
-        matplotlib figure so callers don't accumulate them. When `output_dir`
-        is None the figures are returned open, so they display when the caller
-        renders them (e.g. interactively in a notebook).
+        Follows the shared Quicklook ``run()`` contract (style guide §9):
+        saved-and-closed when ``output_dir`` is set, returned open when it
+        is ``None``.
 
         Parameters
         ----------
         which : str
             'all' to run every implemented plot, or the name of a single
-            plot method (one of `self._PLOT_METHODS`).
+            plot method (one of ``self._PLOT_METHODS``).
         full_res : bool or None
             Save native-size PNGs when true. None uses the constructor's
-            `full_res` setting.
+            ``full_res`` setting.
 
         Returns
         -------
         dict
-            Maps `{method_name}_{chip}` to its matplotlib.Figure (closed only
-            when saved to `output_dir`); useful for tests and introspection.
+            Maps ``{method_name}_{chip}`` to its matplotlib.Figure; useful
+            for tests and introspection.
 
         Raises
         ------
         ValueError
-            If `which` is neither 'all' nor a known plot method name.
+            If ``which`` is neither 'all' nor a known plot method name.
         """
         if which == "all":
             names = self._PLOT_METHODS
@@ -258,8 +254,7 @@ class PlotL1:
             for name in names:
                 fig = getattr(self, name)(chip, full_res=full_res)
                 figures[f"{name}_{chip}"] = fig
-                # Closing frees memory in save-to-disk mode; when returning
-                # figures for interactive display, leave them open.
+                # Close only saved figures (Quicklook run() contract).
                 if self.output_dir is not None:
                     plt.close(fig)
         return figures

--- a/kpfpipe/quality_control/quicklook/level1.py
+++ b/kpfpipe/quality_control/quicklook/level1.py
@@ -135,7 +135,6 @@ class PlotL1:
                 textcoords="offset points",
             )
 
-        # Timestamp
         current_time = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
         plt.annotate(
             f"KPF QLP: {current_time} UT",

--- a/kpfpipe/quality_control/quicklook/level2.py
+++ b/kpfpipe/quality_control/quicklook/level2.py
@@ -81,11 +81,10 @@ class PlotL2:
         return self._flux(chip, "SCI2") is not None
 
     def _require_wave(self, chip, fiber="SCI2"):
-        """Return the (norder, ncol) wavelength array for a fiber, or raise.
+        """Return a fiber's (norder, ncol) wavelength array, or raise if absent.
 
-        PlotL2 requires an attached wavelength solution; failing loudly here
-        prevents a wavelength-less plot from being mistaken for a calibrated
-        one. Run WavelengthCalibration before PlotL2.
+        Fails loudly so a wavelength-less plot can't pass for a calibrated one;
+        run WavelengthCalibration before PlotL2.
         """
         wave = self._wave(chip, fiber)
         if wave is None:
@@ -151,7 +150,6 @@ class PlotL2:
             per_order = np.nanpercentile(snr, _SNR_PERCENTILE, axis=1)
             ax.plot(x, per_order, marker=".", linewidth=1, label=fiber, alpha=0.8)
 
-        # summed science orderlet
         sci_flux = [self._flux(chip, f) for f in _SCI_FIBERS]
         sci_var = [self._var(chip, f) for f in _SCI_FIBERS]
         if all(a is not None for a in sci_flux + sci_var):
@@ -234,7 +232,7 @@ class PlotL2:
             return None
         norder = self._flux(chip, "SCI2").shape[0]
         if order is None:
-            order = norder // 2  # representative middle order
+            order = norder // 2
         if not (1 <= order <= norder):
             raise ValueError(f"order {order} out of range 1..{norder} for {chip}")
         o = order - 1

--- a/kpfpipe/quality_control/quicklook/level2.py
+++ b/kpfpipe/quality_control/quicklook/level2.py
@@ -1,14 +1,4 @@
-"""L2 quicklook plots for extracted KPF 1D spectra.
-
-Ports the extracted-spectrum quicklook plots from the v2.12 ``AnalyzeL1``
-class (the old pipeline's "L1" level is vNext's L2). These plots REQUIRE an
-attached wavelength solution: the per-fiber ``{chip}_{fiber}_WAVE`` arrays
-must be populated (i.e. WavelengthCalibration has run). If they are not, the
-plot methods raise rather than silently producing a pixel-axis plot that
-could be mistaken for a wavelength-calibrated one (charter: fail loudly).
-
-Pure visualization — no science computation is written back to the product.
-"""
+"""L2 quicklook plots for extracted KPF 1D spectra."""
 
 import os
 from datetime import UTC, datetime
@@ -29,12 +19,16 @@ class PlotL2:
     """
     Quicklook plots for KPF L2 (extracted 1D spectra) data.
 
-    Args:
-        l2_obj: KPF2 data object (post-SpectralExtraction; requires
-            WavelengthCalibration to have populated the per-fiber WAVE arrays).
-        output_dir: directory to save PNG files. None = return Figure only.
-        obs_id: observation ID for titles/filenames. If None, falls back to
-            the l2_obj.obs_id attribute (populated on every construction path).
+    Parameters
+    ----------
+    l2_obj : KPF2
+        Extracted L2 frame (post-SpectralExtraction; requires
+        WavelengthCalibration to have populated the per-fiber WAVE arrays).
+    output_dir : str or None
+        Directory to save PNG files. None returns the Figure only.
+    obs_id : str or None
+        Observation ID for titles/filenames. If None, falls back to
+        ``l2_obj.obs_id`` (populated on every construction path).
     """
 
     _PLOT_METHODS = (

--- a/kpfpipe/quality_control/quicklook/level2.py
+++ b/kpfpipe/quality_control/quicklook/level2.py
@@ -16,8 +16,7 @@ _FLUX_PERCENTILE = 95
 
 
 class PlotL2:
-    """
-    Quicklook plots for KPF L2 (extracted 1D spectra) data.
+    """Quicklook plots for KPF L2 (extracted 1D spectra) data.
 
     Parameters
     ----------
@@ -222,10 +221,13 @@ class PlotL2:
         """Overplot the science orderlets (and SKY/CAL) for a single spectral
         order vs wavelength.
 
-        Args:
-            chip: 'GREEN' or 'RED'.
-            order: 1-indexed spectral order. Defaults to a representative
-                order near the middle of the chip.
+        Parameters
+        ----------
+        chip : str
+            'GREEN' or 'RED'.
+        order : int or None
+            1-indexed spectral order. Defaults to a representative order
+            near the middle of the chip.
         """
         chip = chip.upper()
         if not self._has_chip(chip):
@@ -369,19 +371,23 @@ class PlotL2:
     # ------------------------------------------------------------------
 
     def run(self, which):
-        """Generate the requested plot(s) for every chip that has data,
-        saving each to ``output_dir``. In that save-to-disk mode the figure is
-        closed so callers don't accumulate them; when ``output_dir`` is None the
-        figures are returned open, so they display when the caller renders them
-        (e.g. interactively in a notebook).
+        """Generate the requested plot(s) for every chip that has data.
 
-        Args:
-            which: 'all' to run every implemented plot, or the name of a
-                single plot method (one of ``self._PLOT_METHODS``).
+        Follows the shared Quicklook ``run()`` contract (style guide §9):
+        saved-and-closed when ``output_dir`` is set, returned open when it
+        is ``None``.
 
-        Returns:
-            dict mapping ``{method_name}_{chip}`` to matplotlib.Figure (closed
-            only when saved to ``output_dir``; useful for tests/introspection).
+        Parameters
+        ----------
+        which : str
+            'all' to run every implemented plot, or the name of a single
+            plot method (one of ``self._PLOT_METHODS``).
+
+        Returns
+        -------
+        dict
+            Maps ``{method_name}_{chip}`` to its matplotlib.Figure; useful
+            for tests and introspection.
         """
         if which == "all":
             names = self._PLOT_METHODS
@@ -404,8 +410,7 @@ class PlotL2:
                 if fig is None:
                     continue
                 figures[f"{name}_{chip}"] = fig
-                # Closing frees memory in save-to-disk mode; when returning
-                # figures for interactive display, leave them open.
+                # Close only saved figures (Quicklook run() contract).
                 if self.output_dir is not None:
                     plt.close(fig)
         return figures

--- a/kpfpipe/quality_control/quicklook/level4.py
+++ b/kpfpipe/quality_control/quicklook/level4.py
@@ -172,15 +172,11 @@ class PlotL4:
         return tab
 
     def _order_weights(self, rvtab):
-        """Per-order CCF-combination weights for the SCI annotations, read from
-        the RV table's WEIGHT column (written by CrossCorrelation).
-
-        These are the weights the pipeline actually uses to combine the per-order
-        CCFs (see RadialVelocity._combine_ccfs); orders with weight 0 are excluded
-        from the combined RV. Returns None when the fiber has no RV table, but
-        *raises* when a table is present yet lacks WEIGHT: there is no meaningful
-        substitute, and silently inventing one (e.g. from RV_ERR) would annotate
-        weights the pipeline never used and mask the missing column.
+        """Per-order CCF-combination weights (RV table WEIGHT column) for the SCI
+        annotations. Returns None if the fiber has no RV table, but *raises* if a
+        table is present yet lacks WEIGHT — the column the pipeline actually used
+        to combine CCFs (see RadialVelocity._combine_ccfs), with no meaningful
+        substitute.
         """
         if rvtab is None:
             return None
@@ -195,10 +191,9 @@ class PlotL4:
     def _draw_ccf_panel(self, ax, chip, fiber, norder, vref):
         """Draw one orderlet panel of stacked per-order CCFs (v2.12 layout).
 
-        Every panel shares the same `norder`-based y-range so the five orderlet
-        panels line up. An unilluminated orderlet (e.g. etalon/LFC CAL, no CCF)
-        gets a framed panel over the shared `vref` velocity range with a
-        'not illuminated' note instead of a blank default axis.
+        Panels share a `norder`-based y-range so the five line up; an
+        unilluminated orderlet (no CCF) gets a framed 'not illuminated' note
+        over the shared `vref` range instead of a blank default axis.
         """
         is_sci = fiber in _SCI_FIBERS
         top = norder * _ORDER_OFFSET

--- a/kpfpipe/quality_control/quicklook/level4.py
+++ b/kpfpipe/quality_control/quicklook/level4.py
@@ -24,8 +24,7 @@ _RV_SFX = {"SCI1": "1", "SCI2": "2", "SCI3": "3", "CAL": "C", "SKY": "S"}
 
 
 class PlotL4:
-    """
-    Quicklook plots for KPF L4 (RVs and CCFs) data.
+    """Quicklook plots for KPF L4 (RVs and CCFs) data.
 
     Parameters
     ----------
@@ -59,7 +58,7 @@ class PlotL4:
         """Return the (norder, nvel) CCF cube for one chip+fiber, or None.
 
         Returns None when the extension is absent/empty OR contains no real
-        signal (all zero/NaN) — e.g. the zero-filled half of the concatenated
+        signal (all zero/NaN) -- e.g. the zero-filled half of the concatenated
         cube when RVs were only computed for the other chip.
         """
         arr = self.l4_obj.data.get(f"{chip.upper()}_{fiber.upper()}_CCF")
@@ -174,7 +173,7 @@ class PlotL4:
     def _order_weights(self, rvtab):
         """Per-order CCF-combination weights (RV table WEIGHT column) for the SCI
         annotations. Returns None if the fiber has no RV table, but *raises* if a
-        table is present yet lacks WEIGHT — the column the pipeline actually used
+        table is present yet lacks WEIGHT -- the column the pipeline actually used
         to combine CCFs (see RadialVelocity._combine_ccfs), with no meaningful
         substitute.
         """
@@ -191,9 +190,9 @@ class PlotL4:
     def _draw_ccf_panel(self, ax, chip, fiber, norder, vref):
         """Draw one orderlet panel of stacked per-order CCFs (v2.12 layout).
 
-        Panels share a `norder`-based y-range so the five line up; an
+        Panels share a ``norder``-based y-range so the five line up; an
         unilluminated orderlet (no CCF) gets a framed 'not illuminated' note
-        over the shared `vref` range instead of a blank default axis.
+        over the shared ``vref`` range instead of a blank default axis.
         """
         is_sci = fiber in _SCI_FIBERS
         top = norder * _ORDER_OFFSET
@@ -339,19 +338,23 @@ class PlotL4:
     # ------------------------------------------------------------------
 
     def run(self, which):
-        """Generate the requested plot(s) for every chip that has CCF data,
-        saving each to ``output_dir``. In that save-to-disk mode the figure is
-        closed so callers don't accumulate them; when ``output_dir`` is None the
-        figures are returned open, so they display when the caller renders them
-        (e.g. interactively in a notebook).
+        """Generate the requested plot(s) for every chip that has CCF data.
 
-        Args:
-            which: 'all' to run every implemented plot, or the name of a
-                single plot method (one of ``self._PLOT_METHODS``).
+        Follows the shared Quicklook ``run()`` contract (style guide §9):
+        saved-and-closed when ``output_dir`` is set, returned open when it
+        is ``None``.
 
-        Returns:
-            dict mapping ``{method_name}_{chip}`` to matplotlib.Figure (closed
-            only when saved to ``output_dir``; useful for tests/introspection).
+        Parameters
+        ----------
+        which : str
+            'all' to run every implemented plot, or the name of a single
+            plot method (one of ``self._PLOT_METHODS``).
+
+        Returns
+        -------
+        dict
+            Maps ``{method_name}_{chip}`` to its matplotlib.Figure; useful
+            for tests and introspection.
         """
         if which == "all":
             names = self._PLOT_METHODS
@@ -374,8 +377,7 @@ class PlotL4:
                 if fig is None:
                     continue
                 figures[f"{name}_{chip}"] = fig
-                # Closing frees memory in save-to-disk mode; when returning
-                # figures for interactive display, leave them open.
+                # Close only saved figures (Quicklook run() contract).
                 if self.output_dir is not None:
                     plt.close(fig)
         return figures

--- a/kpfpipe/quality_control/quicklook/level4.py
+++ b/kpfpipe/quality_control/quicklook/level4.py
@@ -1,12 +1,4 @@
-"""L4 quicklook plots for KPF cross-correlation functions (CCFs) and RVs.
-
-Ports the per-order CCF grid from the v2.12 ``AnalyzeL2`` class (the old
-pipeline's "L2" level is vNext's L4: CCFs and RVs live in the L4 product).
-The CCF grid shows, for each illuminated orderlet, every order's CCF stacked
-vertically so the per-order consistency of the dip is visible at a glance.
-
-Pure visualization — no science computation is written back to the product.
-"""
+"""L4 quicklook plots for KPF cross-correlation functions (CCFs) and RVs."""
 
 import os
 from datetime import UTC, datetime
@@ -35,11 +27,15 @@ class PlotL4:
     """
     Quicklook plots for KPF L4 (RVs and CCFs) data.
 
-    Args:
-        l4_obj: KPF4 data object (post-CrossCorrelation + RadialVelocity).
-        output_dir: directory to save PNG files. None = return Figure only.
-        obs_id: observation ID for titles/filenames. If None, falls back to
-            the l4_obj.obs_id attribute (populated on every construction path).
+    Parameters
+    ----------
+    l4_obj : KPF4
+        L4 frame (post-CrossCorrelation + RadialVelocity).
+    output_dir : str or None
+        Directory to save PNG files. None returns the Figure only.
+    obs_id : str or None
+        Observation ID for titles/filenames. If None, falls back to
+        ``l4_obj.obs_id`` (populated on every construction path).
     """
 
     _PLOT_METHODS = ("ccf_grid",)

--- a/kpfpipe/utils/__init__.py
+++ b/kpfpipe/utils/__init__.py
@@ -1,1 +1,1 @@
-"""Shared utility helpers: config loading, path building, stats, and KPF conventions."""
+"""Shared utility helpers."""

--- a/kpfpipe/utils/astro.py
+++ b/kpfpipe/utils/astro.py
@@ -1,4 +1,4 @@
-"""Air/vacuum wavelength conversion and relativistic Doppler/redshift helpers."""
+"""Astronomy-related helper functions, in the style of ``astropy``."""
 
 import astropy.units as u
 import numpy as np

--- a/kpfpipe/utils/astro.py
+++ b/kpfpipe/utils/astro.py
@@ -6,9 +6,8 @@ from astropy.constants import c
 
 
 def compute_doppler_factor(v):
-    """
-    Relativistic Doppler factor ``f = lambda_obs / lambda_rest`` for a source
-    with radial velocity `v`.
+    """Relativistic Doppler factor ``f = lambda_obs / lambda_rest`` for a source
+    with radial velocity ``v``.
 
     Standard astronomical convention: a receding source (``v > 0``) is
     redshifted, so ``f > 1``. The factor relates to the redshift by
@@ -31,9 +30,8 @@ def compute_doppler_factor(v):
 
 
 def compute_redshift(v):
-    """
-    Relativistic redshift ``z = lambda_obs / lambda_rest - 1`` for a source
-    with radial velocity `v`. A receding source (``v > 0``) gives ``z > 0``;
+    """Relativistic redshift ``z = lambda_obs / lambda_rest - 1`` for a source
+    with radial velocity ``v``. A receding source (``v > 0``) gives ``z > 0``;
     computed as ``compute_doppler_factor(v) - 1``.
 
     Parameters
@@ -52,8 +50,7 @@ def compute_redshift(v):
 
 
 def air_to_vac(wave_air):
-    """
-    Convert air wavelengths to vacuum via the Edlén 1953 formula (two
+    """Convert air wavelengths to vacuum via the Edlén 1953 formula (two
     iterations; only wavelengths > 2000 Å are modified).
 
     Not yet wired into a pipeline module: retained for the forthcoming

--- a/kpfpipe/utils/config.py
+++ b/kpfpipe/utils/config.py
@@ -31,7 +31,15 @@ class ConfigHandler:
                     self.config[section] = values
 
     def load_config(self, path=None):
-        """Load/reload the TOML into `self.config` (optional `path` override)."""
+        """Load/reload the TOML into ``self.config`` (optional ``path`` override).
+
+        Raises
+        ------
+        FileNotFoundError
+            If the config path does not exist.
+        tomllib.TOMLDecodeError
+            If the file is not valid TOML.
+        """
         if path is not None:
             self.path = Path(path)
 
@@ -41,7 +49,7 @@ class ConfigHandler:
         return self.config
 
     def get_params(self, sections=None):
-        """Flatten `sections` into one dict; nested dicts join as `key_subkey`."""
+        """Flatten ``sections`` into one dict; nested dicts join as ``key_subkey``."""
         if not self.config:
             self.load_config()
 

--- a/kpfpipe/utils/config.py
+++ b/kpfpipe/utils/config.py
@@ -1,4 +1,4 @@
-"""ConfigHandler: load TOML config files with optional section overrides."""
+"""ConfigHandler: load TOML config files with optional overrides."""
 
 import tomllib
 from pathlib import Path

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -1,4 +1,4 @@
-"""KPF data-file discovery: the FileHandler class plus product-path builders."""
+"""KPF data-file discovery: FileHandler class plus path builders."""
 
 import glob
 import logging

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -135,28 +135,10 @@ class FileHandler:
         return os.path.join(self._data_input, "vNext", "mini_db", f"{datecode}_L0.csv")
 
     def _read_mini_db_cache(self, datecode):
-        """The cached mini database for `datecode` as a DataFrame if the on-disk
-        cache is trustworthy for the current L0 directory, else None (the caller
-        then rescans). Reads the cache CSV at most once: the loaded frame is both
-        validated and returned. The cache path, L0 directory, and its FITS file
-        list are all derived from `datecode` plus the instance's ``KPF_DATA_INPUT``
-        root.
-
-        Two guardrails protect against a stale cache:
-
-        * **Count** -- the cache's row count must equal the number of FITS files
-          on disk, so a frame added or removed since the cache was written
-          invalidates it. The cache records *every* file, including unreadable ones
-          (as header-null rows), so a persistently-corrupt frame no longer skews the
-          count and defeats the cache.
-        * **Freshness** -- the cache must be at least as new as every input's
-          timestamp: for each file the later of its modification time
-          (``st_mtime``, when its contents were written) and its change time
-          (``st_ctime``, when it was last moved/linked into the directory -- so a
-          frame copied in with an old mtime is still caught); plus the directory's
-          own ``st_mtime`` (its entry list changes when a file is added or
-          removed). A same-count swap thus still invalidates the cache.
-        """
+        """The cached mini database for ``datecode`` if trustworthy, else None
+        (caller rescans). Rejects a stale cache when the row count differs from the
+        FITS files on disk, or the cache is older than any input or the directory
+        (by ``st_mtime``/``st_ctime``, so a same-count swap is still caught)."""
         cache_path = self._mini_db_cache_path(datecode)
         data_dir = os.path.join(self._data_input, "L0", datecode)
         file_list = sorted(glob.glob(os.path.join(data_dir, "*.fits")))
@@ -190,19 +172,10 @@ class FileHandler:
         return cached
 
     def _write_mini_db_cache(self, datecode):
-        """Atomically write the full scan (``self._full_scan_mini_db`` -- one row
-        per file, including unreadable frames) to the on-disk cache CSV for
-        `datecode`, creating the cache directory as needed. Writing the full scan
-        (not the cleaned ``self._mini_db``) keeps the cache a faithful mirror of the
-        L0 directory, so the row-count guardrail in ``_read_mini_db_cache`` stays
-        honest.
-
-        pandas' ``to_csv`` truncates the target in place, so a concurrent reader
-        could observe an empty, partial, or half-written CSV. Fill a same-dir temp
-        file and ``os.replace`` it into position instead (atomic on POSIX), so
-        readers always see the old or new CSV whole; clean up the temp file if the
-        write fails.
-        """
+        """Atomically write the full scan (``self._full_scan_mini_db``, one row per
+        file) to ``datecode``'s cache CSV via a same-dir temp + ``os.replace``, so a
+        concurrent reader never sees a half-written file. Writes the full scan, not
+        the cleaned ``self._mini_db``, to keep the row-count guardrail honest."""
         cache_path = self._mini_db_cache_path(datecode)
         cache_dir = os.path.dirname(cache_path)
         os.makedirs(cache_dir, exist_ok=True)
@@ -219,17 +192,16 @@ class FileHandler:
 
     @staticmethod
     def _clean_mini_db(full_scan_mini_db):
-        """The readable-frame subset of a full scan: drop rows whose header could not
-        be read (every header column null). Such frames belong in the on-disk cache
-        -- which mirrors the L0 directory -- but are useless for stacking/discovery,
-        so the in-memory ``self._mini_db`` excludes them. Re-indexes the survivors."""
+        """The readable-frame subset of a full scan: drop rows whose header could
+        not be read (every header column null) and re-index. Such frames stay in
+        the on-disk cache (which mirrors the L0 directory) but are useless for
+        stacking/discovery, so the in-memory ``self._mini_db`` excludes them."""
         return full_scan_mini_db.dropna(
             subset=_MINI_DB_KEYS[1:], how="all"
         ).reset_index(drop=True)
 
     def build_mini_database(self, datecode, cache=False):
-        """
-        Scan the PRIMARY header of every L0 FITS file for one observing night,
+        """Scan the PRIMARY header of every L0 FITS file for one observing night,
         cache the resulting DataFrame on the instance, and return it.
 
         Reads ``{KPF_DATA_INPUT}/L0/{datecode}/*.fits`` and stores the result as
@@ -335,28 +307,18 @@ class FileHandler:
         return self._mini_db
 
     def _seconds_since_j2000(self, s):
-        """Seconds since J2000.0 (2000-01-01 12:00 UTC) for the KPF timestamp in
-        `s` (a timestamp, obs_id, filename, or path) -- the monotonic scalar this
-        handler sorts and gap-detects on when clustering frames; raises
-        ``ValueError`` if `s` holds no valid KPF timestamp.
-
-        Naive UTC arithmetic (leap seconds ignored): fine for frame ordering and
-        cluster-gap detection, not for astronomical (TT/TAI) timing.
-        """
+        """Seconds since J2000.0 for the KPF timestamp in ``s`` -- the monotonic
+        scalar this handler sorts and gap-detects on. Naive UTC (leap seconds
+        ignored): fine for ordering, not for astronomical timing. Raises
+        ``ValueError`` if ``s`` holds no valid KPF timestamp."""
         dt = kpf_timestamp_to_datetime(get_timestamp(s))
         return int((dt - _J2000_EPOCH).total_seconds())
 
     def _select_frames(self, cal_type, *, exclude_junk=True):
-        """
-        The junk-excluded, OBJECT-filtered frames of `cal_type` from the carried
-        mini database (``self._mini_db``).
-
-        The single frame-selection entry point the grouping paths share. Raises
-        ``ValueError`` if no mini database is loaded (call ``build_mini_database``
-        first) or if the type has no frames; a mini database lacking the ISJUNK
-        column raises ``KeyError`` under ``exclude_junk=True`` (a fail-loud guard
-        against a database built before junk tracking existed).
-        """
+        """The junk-excluded, OBJECT-filtered frames of ``cal_type`` from the
+        carried mini database -- the shared frame-selection entry point. Raises
+        ``ValueError`` if no database is loaded or the type has no frames;
+        ``exclude_junk`` on a pre-junk-tracking database raises ``KeyError``."""
         mini_db = self._mini_db
         if mini_db is None:
             raise ValueError(
@@ -370,32 +332,10 @@ class FileHandler:
         return cal_df
 
     def _identify_clusters(self, cal_type, *, cluster_gap_seconds, exclude_junk=True):
-        """
-        Group `cal_type` frames into observing-session clusters by time gaps.
-
-        Reads the carried mini database (``self._mini_db``) via `_select_frames`
-        and infers the morn/midday/eve/night/midnight sessions purely from the
-        frame timestamps: the OBJECT morn/eve/night suffix is only a label and
-        does not partition the result, so a mislabeled frame clusters with its
-        true session instead of splitting off. Consecutive time-sorted frames
-        start a new cluster wherever they are more than `cluster_gap_seconds`
-        apart; for the allowlisted cal types the morn and eve sessions sit hours
-        apart, so the gap alone separates them.
-
-        Parameters
-        ----------
-        cal_type : str
-            Calibration frame type (a key of `_OBJECT_MAP`).
-        cluster_gap_seconds : int
-            Gap [s] between consecutive frames that starts a new cluster.
-        exclude_junk : bool, default True
-            Drop observer-flagged junk frames before clustering.
-
-        Returns
-        -------
-        clusters : list of list of str
-            Chronologically-sorted filename lists, one per detected session.
-        """
+        """Group ``cal_type`` frames into observing-session clusters by time gaps:
+        a new cluster starts where consecutive time-sorted frames are more than
+        ``cluster_gap_seconds`` apart. The OBJECT suffix is only a label and does
+        not partition, so a mislabeled frame clusters with its true session."""
         cal_df = self._select_frames(cal_type, exclude_junk=exclude_junk)
         timed = sorted((self._seconds_since_j2000(fn), fn) for fn in cal_df["FILENAME"])
         clusters = []
@@ -421,8 +361,7 @@ class FileHandler:
         groupby="time_of_day",
         exclude_junk=True,
     ):
-        """
-        Return sorted file lists for all calibration stacks of the requested
+        """Return sorted file lists for all calibration stacks of the requested
         type, grouped from the mini database carried on the instance
         (``self._mini_db``, set by `build_mini_database`).
 
@@ -441,9 +380,7 @@ class FileHandler:
           routinely straddle HST midnight and belong in a single nightly stack.
 
         Every returned stack has at least `min_stack_size` files; undersized
-        stacks are dropped, and it raises when none meets the threshold. Reads the
-        mini database off the instance, so the recipe never handles the DataFrame
-        itself.
+        stacks are dropped, and it raises when none meets the threshold.
 
         Parameters
         ----------
@@ -520,8 +457,7 @@ class FileHandler:
         return clusters
 
     def find_masters(self, cal_type, level, datecode):
-        """
-        Sorted list of the master files matching ``cal_type``/``level`` written
+        """Sorted list of the master files matching ``cal_type``/``level`` written
         under ``KPF_MASTERS_OUTPUT`` for ``datecode`` -- everything matching
         ``{root}/masters/{datecode}/*_master_{cal_type}_{level}.fits`` (the KOAID
         prefix wildcarded).
@@ -545,8 +481,7 @@ class FileHandler:
 
 
 def kpf_filename(obs_id, level, *, master=None):
-    """
-    Base filename for a KPF data product (no directory). The single source of
+    """Base filename for a KPF data product (no directory). The single source of
     the naming rule; ``<model>.generate_standard_filename()`` and `kpf_filepath`
     both delegate here.
 
@@ -621,8 +556,7 @@ def masters_stack_subdir(masters, kind, level):
 
 
 def kpf_directory(kind, *, data_root, level=None, obs_id=None, datecode=None):
-    """
-    Output directory for a KPF product tree.
+    """Output directory for a KPF product tree.
 
     The single authority for the on-disk output layout; `kpf_filepath` and the
     recipes go through it rather than re-deriving ``os.path.join(data_root, ...)``
@@ -706,8 +640,7 @@ def kpf_directory(kind, *, data_root, level=None, obs_id=None, datecode=None):
 
 
 def kpf_filepath(obs_id, level, *, data_root=None, master=None):
-    """
-    Build a filepath for a KPF data product: the product's directory
+    """Build a filepath for a KPF data product: the product's directory
     (`kpf_directory`) joined with its basename (`kpf_filename`).
 
     The pipeline's authoritative path builder: constructs the output path from

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -71,7 +71,7 @@ def load_junk_obs_ids(data_input):
 
 
 def datecode_dirs_in_range(root, start, end):
-    """Sorted datecode subdirs of `root` within the inclusive [start, end] range.
+    """Sorted datecode subdirs of ``root`` within the inclusive [start, end] range.
 
     Used by the masters orchestrator to expand a ``--date_range`` against the L0
     tree. Non-datecode names and plain files are skipped; datecodes sort
@@ -209,7 +209,7 @@ class FileHandler:
         only the calibration type; callers rarely need the return value directly.
 
         The on-disk CSV cache lives at
-        ``{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv``. `cache` selects which
+        ``{KPF_DATA_INPUT}/vNext/mini_db/{datecode}_L0.csv``. ``cache`` selects which
         side of it to use, read and write being independent:
 
         * read (``"r"``) -- load a *current* cache instead of re-scanning the L0
@@ -245,7 +245,7 @@ class FileHandler:
         Raises
         ------
         ValueError
-            If `cache` is not one of the allowed modes, if KPF_DATA_INPUT is
+            If ``cache`` is not one of the allowed modes, if KPF_DATA_INPUT is
             unset, or if the L0 directory holds no FITS files.
         """
         if cache not in (False, "r", "w", "rw", "wr"):
@@ -363,14 +363,14 @@ class FileHandler:
     ):
         """Return sorted file lists for all calibration stacks of the requested
         type, grouped from the mini database carried on the instance
-        (``self._mini_db``, set by `build_mini_database`).
+        (``self._mini_db``, set by ``build_mini_database``).
 
-        Drops observer-flagged junk frames (unless `exclude_junk=False`), filters
+        Drops observer-flagged junk frames (unless ``exclude_junk=False``), filters
         by OBJECT, then groups the surviving frames into stacks according to
-        `groupby`:
+        ``groupby``:
 
         * ``'time_of_day'`` (default) -- one stack per observing session, split
-          wherever consecutive frames are more than `cluster_gap_seconds` apart
+          wherever consecutive frames are more than ``cluster_gap_seconds`` apart
           (the morn/eve/night sessions). The split is purely temporal, so the
           morn/eve/night OBJECT suffix does not partition it and a mislabeled
           frame stacks with its true session. Used for bias and thar.
@@ -379,7 +379,7 @@ class FileHandler:
           datecode), spanning HST midnight. Used for darks, whose sparse sequences
           routinely straddle HST midnight and belong in a single nightly stack.
 
-        Every returned stack has at least `min_stack_size` files; undersized
+        Every returned stack has at least ``min_stack_size`` files; undersized
         stacks are dropped, and it raises when none meets the threshold.
 
         Parameters
@@ -407,9 +407,9 @@ class FileHandler:
         Raises
         ------
         ValueError
-            If `groupby` or `cal_type` is not recognized, if no mini database is
+            If ``groupby`` or ``cal_type`` is not recognized, if no mini database is
             loaded on the instance, if no calibration frames of the requested type
-            are found, or if no stack meets `min_stack_size`.
+            are found, or if no stack meets ``min_stack_size``.
         """
         if groupby not in _GROUPBY_MODES:
             raise ValueError(
@@ -462,8 +462,8 @@ class FileHandler:
         ``{root}/masters/{datecode}/*_master_{cal_type}_{level}.fits`` (the KOAID
         prefix wildcarded).
 
-        The reader counterpart to a `kpf_filepath` master path;
-        `TestFindMasters.test_finds_kpf_filepath_output` guards that the two stay
+        The reader counterpart to a ``kpf_filepath`` master path;
+        ``TestFindMasters.test_finds_kpf_filepath_output`` guards that the two stay
         in step.
 
         Raises
@@ -482,7 +482,7 @@ class FileHandler:
 
 def kpf_filename(obs_id, level, *, master=None):
     """Base filename for a KPF data product (no directory). The single source of
-    the naming rule; ``<model>.generate_standard_filename()`` and `kpf_filepath`
+    the naming rule; ``<model>.generate_standard_filename()`` and ``kpf_filepath``
     both delegate here.
 
     Science basenames by level:
@@ -510,8 +510,8 @@ def kpf_filename(obs_id, level, *, master=None):
     Raises
     ------
     ValueError
-        If `obs_id` is not a valid observation ID, `level` is unrecognized, or
-        `master` is an unrecognized type or paired with an invalid level.
+        If ``obs_id`` is not a valid observation ID, ``level`` is unrecognized, or
+        ``master`` is an unrecognized type or paired with an invalid level.
     """
     if not is_obs_id(obs_id):
         raise ValueError(
@@ -558,7 +558,7 @@ def masters_stack_subdir(masters, kind, level):
 def kpf_directory(kind, *, data_root, level=None, obs_id=None, datecode=None):
     """Output directory for a KPF product tree.
 
-    The single authority for the on-disk output layout; `kpf_filepath` and the
+    The single authority for the on-disk output layout; ``kpf_filepath`` and the
     recipes go through it rather than re-deriving ``os.path.join(data_root, ...)``
     by hand. Pure path construction -- it does not touch the filesystem.
 
@@ -600,9 +600,9 @@ def kpf_directory(kind, *, data_root, level=None, obs_id=None, datecode=None):
     Raises
     ------
     ValueError
-        If `data_root` is not a non-empty string, `kind` is unrecognized, the
-        obs_id/datecode source is missing/ambiguous/invalid, `datecode` is given
-        for ``QLP``, or `level` is missing/invalid for a kind that needs it.
+        If ``data_root`` is not a non-empty string, ``kind`` is unrecognized, the
+        obs_id/datecode source is missing/ambiguous/invalid, ``datecode`` is given
+        for ``QLP``, or ``level`` is missing/invalid for a kind that needs it.
     """
     if not isinstance(data_root, str) or not data_root:
         raise ValueError(f"data_root must be a non-empty string; got {data_root!r}")
@@ -641,13 +641,13 @@ def kpf_directory(kind, *, data_root, level=None, obs_id=None, datecode=None):
 
 def kpf_filepath(obs_id, level, *, data_root=None, master=None):
     """Build a filepath for a KPF data product: the product's directory
-    (`kpf_directory`) joined with its basename (`kpf_filename`).
+    (``kpf_directory``) joined with its basename (``kpf_filename``).
 
     The pipeline's authoritative path builder: constructs the output path from
     an obs_id string (before/without a populated data object), as every recipe
     does when deciding where to write. Its basename twin,
     ``<model>.generate_standard_filename()``, builds the same name from a
-    populated object; `TestFilenameConsistency` enforces they agree per level.
+    populated object; ``TestFilenameConsistency`` enforces they agree per level.
 
     Parameters
     ----------
@@ -658,7 +658,7 @@ def kpf_filepath(obs_id, level, *, data_root=None, master=None):
         Data level string, one of 'L0', 'L1', 'L2', 'L4'.
     data_root : str or None, optional
         Root data directory (e.g. '/data/kpf/'). When None (the default),
-        returns the bare filename (`kpf_filename`). Otherwise must be a
+        returns the bare filename (``kpf_filename``). Otherwise must be a
         non-empty string and a full path is returned.
     master : str or None, optional
         Master calibration type, one of 'bias', 'dark', 'flat', 'thar'. If
@@ -668,14 +668,14 @@ def kpf_filepath(obs_id, level, *, data_root=None, master=None):
     Returns
     -------
     str
-        Filepath (full path if `data_root` is set, bare filename if
-        `data_root` is None).
+        Filepath (full path if ``data_root`` is set, bare filename if
+        ``data_root`` is None).
 
     Raises
     ------
     ValueError
-        If `level` is unrecognized, if `obs_id` is not a valid observation
-        ID, if `master` type is unrecognized, or if `data_root` is not None
+        If ``level`` is unrecognized, if ``obs_id`` is not a valid observation
+        ID, if ``master`` type is unrecognized, or if ``data_root`` is not None
         and not a non-empty string.
     """
     if data_root is not None and (not isinstance(data_root, str) or not data_root):

--- a/kpfpipe/utils/kpf_utils.py
+++ b/kpfpipe/utils/kpf_utils.py
@@ -1,4 +1,4 @@
-"""Obs-id, datecode, and timestamp parsing plus UTC/HST and EPRV conversions."""
+"""obs_id, datecode, and timestamp parsing, plus UTC/HST and KPF/EPRV conversions."""
 
 import os
 import re

--- a/kpfpipe/utils/kpf_utils.py
+++ b/kpfpipe/utils/kpf_utils.py
@@ -16,8 +16,7 @@ _HST_UTC_OFFSET_SECONDS = 36000
 
 
 def is_timestamp(s):
-    """
-    Return True if `s` is a valid KPF timestamp, e.g. '20240113.23249.10'.
+    """Return True if ``s`` is a valid KPF timestamp, e.g. '20240113.23249.10'.
 
     Checks all three: the 'YYYYMMDD.SSSSS.FF' format, that YYYYMMDD is a real
     calendar date, and that SSSSS (seconds past midnight) is in [0, 86399]; the
@@ -36,8 +35,7 @@ def is_timestamp(s):
 
 
 def is_obs_id(s):
-    """
-    Return True if `s` is a valid KPF observation ID, e.g.
+    """Return True if ``s`` is a valid KPF observation ID, e.g.
     'KP.20240113.23249.10'. Both the format and the embedded date/seconds
     are checked.
     """
@@ -47,8 +45,7 @@ def is_obs_id(s):
 
 
 def is_datecode(s):
-    """
-    Return True if `s` is a valid 8-digit datecode that parses as a real
+    """Return True if ``s`` is a valid 8-digit datecode that parses as a real
     calendar date, e.g. '20240405'.
     """
     if not isinstance(s, str) or not _DATECODE_PATTERN.fullmatch(s):

--- a/kpfpipe/utils/kpf_utils.py
+++ b/kpfpipe/utils/kpf_utils.py
@@ -115,8 +115,8 @@ def utc_to_hst(timestamp):
 
 def hst_to_utc(timestamp):
     """Convert a KPF HST timestamp ('YYYYMMDD.SSSSS.FF') to UTC, in the same KPF
-    format. The inverse of `utc_to_hst`, kept as its symmetric counterpart: the
-    pipeline only calls `utc_to_hst` (the data tree is UTC-keyed), so this backs
+    format. The inverse of ``utc_to_hst``, kept as its symmetric counterpart: the
+    pipeline only calls ``utc_to_hst`` (the data tree is UTC-keyed), so this backs
     round-trip tests and any future HST-keyed input."""
     if not is_timestamp(timestamp):
         raise ValueError(f"Invalid KPF timestamp: {timestamp!r}")
@@ -131,7 +131,7 @@ def hst_to_utc(timestamp):
 
 def kpf_timestamp_to_datetime(timestamp):
     """Parse a KPF UTC timestamp ('YYYYMMDD.SSSSS.FF', sub-second field ignored)
-    into a naive UTC `datetime`, e.g. '20240405.40113.57' ->
+    into a naive UTC ``datetime``, e.g. '20240405.40113.57' ->
     ``datetime(2024, 4, 5, 11, 8, 33)``."""
     if not is_timestamp(timestamp):
         raise ValueError(f"Invalid KPF timestamp: {timestamp!r}")

--- a/kpfpipe/utils/logger.py
+++ b/kpfpipe/utils/logger.py
@@ -107,6 +107,11 @@ def build_log_path(log_dir, recipe_name, target, start_time=None):
     -------
     str
         The absolute log-file path.
+
+    Raises
+    ------
+    ValueError
+        If ``log_dir`` is empty or not a string.
     """
     if not log_dir or not isinstance(log_dir, str):
         raise ValueError(f"log_dir must be a non-empty string; got {log_dir!r}")
@@ -168,6 +173,13 @@ def setup_logging(
     -------
     str
         The absolute path of the created log file.
+
+    Raises
+    ------
+    ValueError
+        If ``log_dir`` is empty/not a string, or ``level`` is an unknown level name.
+    FileExistsError
+        If a unique log file cannot be created after the collision retries.
     """
     global _prior_root_level
     teardown_logging()

--- a/kpfpipe/utils/logger.py
+++ b/kpfpipe/utils/logger.py
@@ -217,8 +217,8 @@ def setup_batch_logging(log_dir, label, level="INFO", console=True):
     own decision points -- units dispatched, canary result, per-unit ok/failed,
     and the failure sentinels -- alongside (not replacing) each unit's
     per-reduction log. The console echo is pinned to ``sys.stdout`` so an operator
-    can watch batch progress live (parity with the ``print()``s this replaces),
-    while each record is also persisted to the batch log file. The stdout echo is
+    can watch batch progress live, while each record is also persisted to the
+    batch log file. The stdout echo is
     filtered (``_BatchConsoleFilter``) so that below WARNING only the driver's own
     ``scripts.*``/``__main__`` narration reaches the terminal -- library INFO
     chatter is kept out of the live view but still written to the batch log file.

--- a/kpfpipe/utils/stats.py
+++ b/kpfpipe/utils/stats.py
@@ -1,4 +1,4 @@
-"""Statistical helpers: monotonicity, outliers, line fits, bad-pixel interpolation."""
+"""Statistical helpers, in the style of ``scipy`` & ``numpy``."""
 
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator

--- a/kpfpipe/utils/stats.py
+++ b/kpfpipe/utils/stats.py
@@ -18,13 +18,13 @@ def strictly_increasing(x):
 
 
 def _gaussian_dist(theta, x):
-    """Gaussian model at `x` for theta = [b, a, mu, sigma]."""
+    """Gaussian model at ``x`` for theta = [b, a, mu, sigma]."""
     b, a, mu, sigma = theta
     return b + a * np.exp(-((x - mu) ** 2) / (2 * sigma**2))
 
 
 def _gaussian_jac(theta, x):
-    """Analytic Jacobian of `_gaussian_dist` w.r.t. theta; shape (x.size, 4)."""
+    """Analytic Jacobian of ``_gaussian_dist`` w.r.t. theta; shape (x.size, 4)."""
     b, a, mu, sigma = theta
     dx = x - mu
     exp_term = np.exp(-(dx**2) / (2 * sigma**2))
@@ -80,8 +80,8 @@ def optimize_lsq(x, y, linemodel):
     """Fit a 1D line model to (x, y) by non-linear least squares.
 
     Looks up the model function, analytic Jacobian, and initial-guess
-    generator registered under `linemodel`, then fits via MINPACK's lmder
-    (`scipy.optimize.leastsq`, not `least_squares` -- see the implementation
+    generator registered under ``linemodel``, then fits via MINPACK's lmder
+    (``scipy.optimize.leastsq``, not ``least_squares`` -- see the implementation
     note below), and maps the solution back with the model's untransform.
 
     Parameters
@@ -89,7 +89,7 @@ def optimize_lsq(x, y, linemodel):
     x : ndarray
         1D independent variable (e.g. velocity or pixel grid).
     y : ndarray
-        1D dependent variable to fit, same shape as `x`.
+        1D dependent variable to fit, same shape as ``x``.
     linemodel : str
         Registered line-profile name. Currently only 'gaussian' is supported;
         an unknown name raises.
@@ -105,7 +105,7 @@ def optimize_lsq(x, y, linemodel):
     Raises
     ------
     ValueError
-        If `linemodel` is not a registered line-profile name.
+        If ``linemodel`` is not a registered line-profile name.
     """
     try:
         func, jac, theta0_generator, untransform = _FUNCTIONS[linemodel]
@@ -120,12 +120,12 @@ def optimize_lsq(x, y, linemodel):
 
     theta0 = theta0_generator(x, y)
 
-    # Call MINPACK's lmder directly via `leastsq` instead of `least_squares`.
-    # Both bottom out in the same Fortran routine, but for `method="lm"` with no
-    # bounds the `least_squares` wrapper adds per-call overhead (input checks, an
+    # Call MINPACK's lmder directly via ``leastsq`` instead of ``least_squares``.
+    # Both bottom out in the same Fortran routine, but for ``method="lm"`` with no
+    # bounds the ``least_squares`` wrapper adds per-call overhead (input checks, an
     # extra residual evaluation, building OptimizeResult) that dominates for the
-    # many tiny line fits here. The tolerances and `maxfev` below are exactly what
-    # `least_squares` forwards to lmder, so the fit is bit-for-bit identical.
+    # many tiny line fits here. The tolerances and ``maxfev`` below are exactly what
+    # ``least_squares`` forwards to lmder, so the fit is bit-for-bit identical.
     sol, _cov, info, _msg, _ier = leastsq(
         residual,
         theta0,
@@ -173,15 +173,15 @@ def _smooth_filter(x, size=None, *, axes=None):
 def flag_outliers(x, sigma, axis=None, kernel_size=None, method="median"):
     """Flag elements of ``x`` more than ``sigma`` robust deviations from their peers.
 
-    `axis` selects the axis along which each element is compared to its peers:
+    ``axis`` selects the axis along which each element is compared to its peers:
 
-    - ``method="median"`` computes the median and MAD *reducing over* `axis`,
+    - ``method="median"`` computes the median and MAD *reducing over* ``axis``,
       so each element is judged against the others sharing its remaining
       indices (e.g. ``axis=0`` on a (frame, row, col) cube flags, per pixel,
       the frames that deviate across the stack).
-    - ``method="trend"`` smooths `x` *along* `axis` (see `_smooth_filter`) and
+    - ``method="trend"`` smooths ``x`` *along* ``axis`` (see ``_smooth_filter``) and
       judges each element against that local trend, so it tolerates structure
-      that varies smoothly along `axis` (e.g. illumination along dispersion).
+      that varies smoothly along ``axis`` (e.g. illumination along dispersion).
 
     ``axis=None`` compares every element to a single global statistic.
     """
@@ -217,7 +217,7 @@ def interpolate_bad_pixels(data, mask, method="local", fill_outside=True):
         2D image; bad pixels are filled, good pixels pass through unchanged.
         Not modified in place (a copy is returned).
     mask : ndarray
-        Good-pixel mask broadcastable to `data`, truthy where a pixel is good.
+        Good-pixel mask broadcastable to ``data``, truthy where a pixel is good.
         Its logical complement marks the pixels to interpolate.
     method : {'local', 'global'}, default 'local'
         - ``'local'``: fill each bad pixel from a 3x3 weighted mean of its good
@@ -235,12 +235,12 @@ def interpolate_bad_pixels(data, mask, method="local", fill_outside=True):
     Returns
     -------
     ndarray
-        Copy of `data` with bad pixels interpolated.
+        Copy of ``data`` with bad pixels interpolated.
 
     Raises
     ------
     ValueError
-        If `method` is not 'local' or 'global'.
+        If ``method`` is not 'local' or 'global'.
     """
 
     good = mask.astype(bool)
@@ -249,7 +249,7 @@ def interpolate_bad_pixels(data, mask, method="local", fill_outside=True):
     data_interp = data.copy()
 
     # The local convolution-based method assumes isolated bad pixels. Cast the
-    # kernel and weight mask to the input dtype so `scipy.convolve` does not
+    # kernel and weight mask to the input dtype so ``scipy.convolve`` does not
     # promote float32 image data to float64 in its intermediates.
     if method == "local":
         kernel = np.array([[1, 2, 1], [2, 0, 2], [1, 2, 1]], dtype=data.dtype) / 12.0

--- a/kpfpipe/utils/stats.py
+++ b/kpfpipe/utils/stats.py
@@ -57,10 +57,8 @@ def _gaussian_theta0_generator(x, y):
 def _gaussian_untransform(theta):
     """Report fitted [b, a, mu, sigma], forcing sigma >= 0.
 
-    The model depends only on ``sigma**2``, so the fit may converge to a
-    negative sigma; ``abs`` picks the physical (positive) width. Fitting sigma
-    directly (rather than log-sigma) avoids the per-evaluation ``exp``/``log``
-    round-trip that constrained it positive.
+    The model depends only on ``sigma**2``, so the fit may converge to a negative
+    sigma; ``abs`` picks the physical (positive) width.
     """
     b, a, mu, sigma = theta
     return np.array([b, a, mu, np.abs(sigma)])
@@ -79,8 +77,7 @@ _FUNCTIONS = {
 
 
 def optimize_lsq(x, y, linemodel):
-    """
-    Fit a 1D line model to (x, y) by non-linear least squares.
+    """Fit a 1D line model to (x, y) by non-linear least squares.
 
     Looks up the model function, analytic Jacobian, and initial-guess
     generator registered under `linemodel`, then fits via MINPACK's lmder
@@ -146,15 +143,12 @@ def optimize_lsq(x, y, linemodel):
 
 
 def _mad_std(x, med=None, axis=None, keepdims=False):
-    """Lightweight NaN-aware drop-in for ``astropy.stats.mad_std``.
+    """NaN-aware drop-in for ``astropy.stats.mad_std``: MAD scaled to a Gaussian
+    sigma, ``1.482602218505602 * median(|x - median(x)|)``, reduced over ``axis``.
 
-    Returns the MAD scaled to a Gaussian sigma, ``MAD / norm.ppf(0.75)`` =
-    ``1.482602218505602 * median(|x - median(x)|)``, reduced over ``axis``
-    (ignoring NaNs). Adds two things astropy's ``mad_std`` lacks: a reusable
-    pre-computed median ``med`` (must be reduced over the same ``axis`` with
-    ``keepdims=True`` so it broadcasts against ``x``) to skip a redundant
-    median, and ``axis``/``keepdims`` control over the final MAD reduction
-    (matching ``np.median`` semantics).
+    Adds a reusable pre-computed median ``med`` (must be reduced over the same
+    ``axis`` with ``keepdims=True`` so it broadcasts against ``x``) plus
+    ``axis``/``keepdims`` control over the final MAD reduction.
     """
     if med is None:
         med = np.nanmedian(x, axis=axis, keepdims=True)
@@ -164,12 +158,12 @@ def _mad_std(x, med=None, axis=None, keepdims=False):
 
 
 def _smooth_filter(x, size=None, *, axes=None):
-    """Median- then Gaussian-smooth `x`; a drop-in for chaining scipy's
-    ``median_filter`` and ``gaussian_filter``.
+    """Median- then Gaussian-smooth ``x`` (chains scipy's ``median_filter`` and
+    ``gaussian_filter``).
 
-    `size` sets both the median window and the Gaussian sigma; `axes` restricts
-    the smoothing to those axes (all axes when None), so the trend follows
-    structure along them without blurring across the others.
+    ``size`` sets both the median window and the Gaussian sigma; ``axes`` restricts
+    smoothing to those axes (all when None), so the trend follows structure along
+    them without blurring across the others.
     """
     return gaussian_filter(
         median_filter(x, size=size, axes=axes), sigma=size, axes=axes
@@ -177,8 +171,7 @@ def _smooth_filter(x, size=None, *, axes=None):
 
 
 def flag_outliers(x, sigma, axis=None, kernel_size=None, method="median"):
-    """
-    Flag elements of `x` more than `sigma` robust deviations from their peers.
+    """Flag elements of ``x`` more than ``sigma`` robust deviations from their peers.
 
     `axis` selects the axis along which each element is compared to its peers:
 
@@ -215,8 +208,7 @@ def flag_outliers(x, sigma, axis=None, kernel_size=None, method="median"):
 
 
 def interpolate_bad_pixels(data, mask, method="local", fill_outside=True):
-    """
-    Interpolate over bad pixels of a 2D image, replacing each with a value
+    """Interpolate over bad pixels of a 2D image, replacing each with a value
     inferred from its good neighbors.
 
     Parameters

--- a/scripts/processing/masters.py
+++ b/scripts/processing/masters.py
@@ -17,9 +17,9 @@ within [START, END].
 Builds run in a bounded process pool. The L0 mini-database caches are warmed up
 front by a parallel per-datecode pre-scan (``--cache``, ``rw`` by default; ``r``
 skips the pre-scan and leaves each reduce to read-only); the first night then runs
-alone as a
-canary to warm the *other* shared caches (barycorrpy leap-seconds, astropy IERS,
-matplotlib fonts, bytecode) before the rest fan out. The run is fail-soft (a night
+alone as a canary to warm the *other* shared caches (barycorrpy leap-seconds,
+astropy IERS, matplotlib fonts, bytecode) before the rest fan out. The run is
+fail-soft (a night
 that fails to build is reported and the others continue) but exits nonzero if any
 night failed.
 """

--- a/scripts/processing/science.py
+++ b/scripts/processing/science.py
@@ -6,7 +6,7 @@ A lightweight, fail-loud orchestrator: it dispatches each frame as a separate
 ``kpfpipe run`` leaf), so every frame gets its own log file, clean process state,
 and independent exit code. It reimplements no pipeline logic; the caller supplies
 which frames to reduce (discovering a target's frames from the L0 tree lives in
-the orchestrator, not here), via the input form:
+the timeseries wrapper, not here), via the input form:
 
     kpfpipe science --obs_ids KP.20240405.40113.57 KP.20240405.40237.36
     kpfpipe science --obs_ids frames.txt        # a file of obs_ids
@@ -15,9 +15,9 @@ Reductions run in a bounded process pool. The L0 mini-database caches for the
 nights the frames span are warmed up front by a parallel per-datecode pre-scan
 (``--cache``, ``rw`` by default; ``r`` skips the pre-scan and leaves each reduce to
 read-only); the first frame then runs alone as a canary to warm the *other* shared
-caches,
-then the rest fan out (paced apart, since the per-frame L0 pointing QC queries
-SIMBAD/Gaia). The run is fail-soft (a frame that fails to reduce is reported and
+caches, then the rest fan out (paced apart, since the per-frame L0 pointing QC
+queries SIMBAD/Gaia). The run is fail-soft (a frame that fails to reduce is
+reported and
 the others continue) but exits nonzero if any frame failed.
 """
 

--- a/scripts/processing/timeseries.py
+++ b/scripts/processing/timeseries.py
@@ -279,8 +279,8 @@ def main(argv=None):
         if value:
             common_forward += [flag, value]
     common_forward += ["--job_timeout", str(args.job_timeout)]
-    # Discovery above is the sole mini-db writer; force both launched stages
-    # read-only so they don't redundantly re-warm the caches it just wrote.
+    # Discovery is the sole mini-db writer; force both launched stages read-only
+    # so they don't redundantly re-warm the caches it will have just written.
     common_forward += ["--cache", "r"]
 
     # --jobs sizes only the science fan-out: forwarding a large --jobs to masters

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""
-Standalone QC runner.
+"""Standalone QC runner.
 
 Usage:
     python scripts/quality_control/qc.py \
@@ -9,9 +8,9 @@ Usage:
         --obs_id <obs_id> --level L1 --config <toml> [--write]
 
 Exit codes:
-    0 — ISGOOD=1 (all checks passed)
-    1 — ISGOOD=0 (one or more checks failed)
-    2 — Input / IO error
+    0 -- ISGOOD=1 (all checks passed)
+    1 -- ISGOOD=0 (one or more checks failed)
+    2 -- Input / IO error
 """
 
 import argparse

--- a/scripts/quality_control/qlp.py
+++ b/scripts/quality_control/qlp.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-"""
-Standalone QLP (quicklook plot) generator.
+"""Standalone QLP (quicklook plot) generator.
 
 Usage:
     python scripts/quality_control/qlp.py \

--- a/tests/profiling/profile_radial_velocity.py
+++ b/tests/profiling/profile_radial_velocity.py
@@ -1,8 +1,8 @@
-"""Profile ``RadialVelocity.perform`` (CCF computation and RV fitting, L2 -> L4).
+"""Profile ``RadialVelocity.perform`` (fit the per-order CCFs to RVs).
 
-This is the expected tallest tentpole of the science pipeline (per-velocity,
-per-line inner loops in ``_compute_ccf_1d``), so the line-level drill-down pass
-is kept enabled and this harness is the slowest to run.
+The per-order CCFs are built upstream by ``CrossCorrelation``; this module only
+fits them, so its cost is the order-by-order two-pass Gaussian CCF-dip fits in
+``_compute_rv_1d``. The line-level drill-down pass is kept enabled.
 
 Run with ``make profile-radial_velocity`` or
 ``python tests/profiling/profile_radial_velocity.py``. Requires real frames in

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -1,5 +1,4 @@
-"""
-Tests for the BarycentricCorrection module (KPF2 → KPF2).
+"""Tests for the BarycentricCorrection module (KPF2 -> KPF2).
 
 Static-method unit tests require no fixtures. Integration tests use a
 synthetic KPF2 with a small EXPMETER_SCI table and populated SCI2_WAVE.
@@ -54,7 +53,7 @@ def _make_expmeter_table():
 def synthetic_kpf2():
     """KPF2 with synthetic EXPMETER_SCI and wavelength arrays.
 
-    SCI2_WAVE is filled with 5000.0 — order_center = 5000 for every order,
+    SCI2_WAVE is filled with 5000.0 -- order_center = 5000 for every order,
     so np.interp returns the per-channel value at 5000Å (i.e. the first
     PHOTON_JD) for every order. Tests that need per-order variation
     populate SCI2_WAVE themselves.
@@ -92,7 +91,7 @@ def _fake_skycoord():
 
 
 # ---------------------------------------------------------------------------
-# Static helpers — unchanged behavior across the split
+# Static helpers -- unchanged behavior across the split
 # ---------------------------------------------------------------------------
 
 
@@ -664,7 +663,7 @@ class TestQueryGaiaValidation:
 
 
 # ---------------------------------------------------------------------------
-# _get_skycoord — Gaia first, WMKO header fallback, else raise
+# _get_skycoord -- Gaia first, WMKO header fallback, else raise
 # ---------------------------------------------------------------------------
 
 
@@ -742,7 +741,7 @@ class TestAstrometryResolution:
 
 
 # ---------------------------------------------------------------------------
-# perform() — Gaia and barycorrpy stubbed
+# perform() -- Gaia and barycorrpy stubbed
 # ---------------------------------------------------------------------------
 
 
@@ -991,7 +990,7 @@ class TestPerform:
             BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
         )
 
-        # No monkeypatch on _fix_expmeter_outliers — real filter runs.
+        # No monkeypatch on _fix_expmeter_outliers -- real filter runs.
         kpf2 = BarycentricCorrection(synthetic_kpf2).perform(fix_expmeter_outliers=True)
         assert np.all(np.isfinite(np.asarray(kpf2.data["BJD_TDB"])))
 

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -1,6 +1,4 @@
-"""
-Unit tests for CalibrationAssociation.
-"""
+"""Unit tests for CalibrationAssociation."""
 
 import pytest
 from astropy.io import fits
@@ -178,8 +176,8 @@ class TestSelectNearest:
     def test_selects_nearest_of_two(self, tmp_path):
         mod = _make_module(tmp_path)
         # Science frame at 40113s (~11:08 UTC).
-        # Candidate A at 03637s (~01:00 UTC) — delta ~7.1 hours.
-        # Candidate B at 36000s (~10:00 UTC) — delta ~1.1 hours.
+        # Candidate A at 03637s (~01:00 UTC) -- delta ~7.1 hours.
+        # Candidate B at 36000s (~10:00 UTC) -- delta ~1.1 hours.
         result = mod._select_nearest(
             "2024-04-05T11:08:33",
             [

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -3,11 +3,11 @@
 Checkpoints are the third QC stage: they READ the 0/1 QC flags and the product
 headers, then warn or raise (never write). This pins:
 
-  - ``unregistered_keywords`` — raises on a card not registered for a governed
+  - ``unregistered_keywords`` -- raises on a card not registered for a governed
     extension (including a raw WMKO native leaked onto an EPRV PRIMARY); skips the
     raw WMKO L0 PRIMARY; passes a clean product. (Migrated from the old
     ``QC._validate_headers`` tests.)
-  - ``qc_flags`` — a failed (0) flag named in the level's ``RAISE_FLAGS`` raises;
+  - ``qc_flags`` -- a failed (0) flag named in the level's ``RAISE_FLAGS`` raises;
     any other failed flag warns; all-pass is silent.
 
 ``run()`` additionally folds in the paired Diagnostics + QC stages before the
@@ -187,7 +187,7 @@ class TestRunFoldsDiagnosticsAndQC:
 
 
 # ---------------------------------------------------------------------------
-# CheckpointL4 — folds DiagL4 + QCL4, then validates the RV/CCF product
+# CheckpointL4 -- folds DiagL4 + QCL4, then validates the RV/CCF product
 # ---------------------------------------------------------------------------
 
 

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -1,5 +1,4 @@
-"""
-Tests for the CrossCorrelation module (KPF2 -> KPF4: per-orderlet CCFs).
+"""Tests for the CrossCorrelation module (KPF2 -> KPF4: per-orderlet CCFs).
 
 Mirrors the CCF-side coverage of test_radial_velocity.py against the standalone
 CrossCorrelation module. Static-method unit tests (_compute_ccf_1d) build

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -154,7 +154,7 @@ class TestEmptyLevels:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 — pointing / identity offsets (GAIAOFF, TARGOFF)
+# DiagL0 -- pointing / identity offsets (GAIAOFF, TARGOFF)
 # ---------------------------------------------------------------------------
 
 _PT_RA, _PT_DEC = "01:44:01.30", "-15:55:54.0"
@@ -265,7 +265,7 @@ class TestDiagL0Pointing:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 — OBJECT-name offset via SIMBAD (OBJOFF)
+# DiagL0 -- OBJECT-name offset via SIMBAD (OBJOFF)
 # ---------------------------------------------------------------------------
 
 
@@ -330,7 +330,7 @@ class TestDiagL0Object:
 
 
 # ---------------------------------------------------------------------------
-# DiagL1 — master calibration ages
+# DiagL1 -- master calibration ages
 # ---------------------------------------------------------------------------
 
 
@@ -404,7 +404,7 @@ class TestDiagL1CalibrationAges:
 
 
 # ---------------------------------------------------------------------------
-# DiagL2 — NaN counts + zero-flux fraction
+# DiagL2 -- NaN counts + zero-flux fraction
 # ---------------------------------------------------------------------------
 
 
@@ -584,7 +584,7 @@ def _set_fiber_arrays(kpf2, suffix, value, chips=("GREEN", "RED"), fibers=_FIBER
 
 
 # ---------------------------------------------------------------------------
-# DiagL2 — per-fiber SNR
+# DiagL2 -- per-fiber SNR
 # ---------------------------------------------------------------------------
 
 
@@ -641,7 +641,7 @@ class TestDiagL2Snr:
 
 
 # ---------------------------------------------------------------------------
-# DiagL2 — orderlet flux ratios
+# DiagL2 -- orderlet flux ratios
 # ---------------------------------------------------------------------------
 
 
@@ -674,7 +674,7 @@ class TestDiagL2OrderletFluxRatios:
 
 
 # ---------------------------------------------------------------------------
-# DiagL4 — per-order BJD / barycentric-RV dispersion (ported from v2.12)
+# DiagL4 -- per-order BJD / barycentric-RV dispersion (ported from v2.12)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -1,9 +1,10 @@
 """
 Regression tests for image assembly (L0 → L1).
 
-Uses real L0 FITS files for regression tests (skipped if data unavailable).
-Set KPF_TESTDATA env var to your L0 data directory, or defaults to
-/data/kpf/L0 (Keck server) then ~/analysis/kpf/L0 (local).
+The 2-amp regression and round-trip tests are marked ``slow`` and read real L0
+FITS frames from the gitignored ``tests/testdata/L0/20240405`` tree (paths
+hard-coded below). The 4-amp, dtype-provenance, orientation, and expmeter tests
+run on synthetic data generated into ``tmp_path`` and need no external frames.
 """
 
 import os
@@ -258,7 +259,7 @@ class TestImageAssembly4Amp:
 
 
 # ---------------------------------------------------------------------------
-# orient_ffi: standard FFI orientation (load-bearing flux/wave co-orientation)
+# Dtype provenance (L1 CCD/VAR float32; L0 amps never upscale to float64)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/regression/test_image_processing.py
+++ b/tests/regression/test_image_processing.py
@@ -123,12 +123,12 @@ def _master_dark(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# TestInit
+# TestDtypeProvenance
 # ---------------------------------------------------------------------------
 
 
 class TestDtypeProvenance:
-    """L1 CCD/VAR must stay float32 through bias AND dark subtraction — the
+    """L1 CCD/VAR must stay float32 through bias AND dark subtraction -- the
     dark*exptime(float64) scaling is the prime upcast trap."""
 
     def _module_bias_dark(self, tmp_path):
@@ -146,6 +146,11 @@ class TestDtypeProvenance:
         mod.perform()
         for ext in ("GREEN_CCD", "RED_CCD", "GREEN_VAR", "RED_VAR"):
             assert_dtype(mod.l1_obj.data[ext], L1_IMAGE, f"{ext} after bias+dark")
+
+
+# ---------------------------------------------------------------------------
+# TestInit
+# ---------------------------------------------------------------------------
 
 
 class TestInit:
@@ -174,7 +179,7 @@ class TestInit:
 
 
 # ---------------------------------------------------------------------------
-# TestBiasResolution — perform() resolves the bias source (bool | str |
+# TestBiasResolution -- perform() resolves the bias source (bool | str |
 # KPFMasterL1) and records its path. Dark is disabled to isolate bias.
 # ---------------------------------------------------------------------------
 
@@ -203,7 +208,7 @@ class TestBiasResolution:
     def test_explicit_path_overrides_headers(self, tmp_path):
         bias_path = str(tmp_path / "master_bias.fits")
         _write_master_bias(bias_path)
-        # Headers point nowhere valid — explicit path should win.
+        # Headers point nowhere valid -- explicit path should win.
         mod = _make_module(bias_file="wrong.fits", bias_dir="/wrong/dir")
         mod.perform(bias=bias_path, dark=False)
         assert mod._bias_path == bias_path
@@ -220,7 +225,7 @@ class TestBiasResolution:
         bias_path = str(tmp_path / "master_bias.fits")
         _write_master_bias(bias_path)
         master = KPFMasterL1.from_fits(bias_path)
-        # No BIAS headers — the object is used directly, no disk lookup.
+        # No BIAS headers -- the object is used directly, no disk lookup.
         mod = _make_module()
         mod.perform(bias=master, dark=False)
         assert mod._bias_path is not None
@@ -298,7 +303,7 @@ class TestSubtractBias:
 
 
 # ---------------------------------------------------------------------------
-# TestDarkResolution — perform() resolves the dark source (bool | str |
+# TestDarkResolution -- perform() resolves the dark source (bool | str |
 # KPFMasterL1) and records its path. Bias is disabled to isolate dark.
 # ---------------------------------------------------------------------------
 
@@ -595,7 +600,7 @@ class TestPerformDark:
 
 
 # ---------------------------------------------------------------------------
-# TestVarianceBudget — bias/dark add only a small fraction to the error budget
+# TestVarianceBudget -- bias/dark add only a small fraction to the error budget
 # ---------------------------------------------------------------------------
 
 
@@ -701,7 +706,7 @@ class TestMasterCache:
         assert mod._bias_ml1 is first
 
     def test_separate_instances_do_not_share(self, tmp_path):
-        # The cache is per instance — there is no class-level sharing.
+        # The cache is per instance -- there is no class-level sharing.
         path = str(tmp_path / "master_bias.fits")
         _write_master_bias(path)
         a = _make_module()

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -430,7 +430,7 @@ class TestRateEstimator:
 class TestPerPixelRejection:
     """Counts and exposure time are summed over the SAME per-pixel survivor set,
     so a pixel with fewer good frames yields the same rate as a fully-sampled
-    pixel — only its SNR drops (photon statistics)."""
+    pixel -- only its SNR drops (photon statistics)."""
 
     def test_datacube_partial_rejection_preserves_rate(self, monkeypatch):
         # 5 identical frames (100 e- over 10 s -> 10 e-/sec). flag_outliers is
@@ -788,7 +788,7 @@ class TestDtypeProvenance:
 
 
 # ---------------------------------------------------------------------------
-# save_master / make_master_l1(master_path=...) — the shared write path
+# save_master / make_master_l1(master_path=...) -- the shared write path
 # ---------------------------------------------------------------------------
 
 

--- a/tests/regression/test_master_bias.py
+++ b/tests/regression/test_master_bias.py
@@ -31,7 +31,7 @@ TESTDATA_BIAS_FILES = sorted(
 
 CHIPS = ["GREEN", "RED"]
 NROW, NCOL = 10, 10  # small arrays for unit tests
-# make_l1_arrays() — shared synthetic stack_frames builder — lives in _masters.py
+# make_l1_arrays() -- shared synthetic stack_frames builder -- lives in _masters.py
 
 FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
@@ -42,7 +42,7 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 class TestMasterBiasUnit:
-    """Unit tests using a mocked stack_frames — no real data needed."""
+    """Unit tests using a mocked stack_frames -- no real data needed."""
 
     @pytest.fixture(scope="class")
     def master_bias(self):

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -2,9 +2,9 @@
 
 Unit tests mock stack_frames (no real data). TestMasterDarkRegression builds a
 real master dark from the bundled L0 darks: the five frames span two default-gap
-clusters and HST midnight, so it widens cluster_gap_seconds and lifts the
-midnight boundary to group them into one stack, bias-subtracting each frame. The
-shared stacking engine these exercise (`BaseMasterModule`) is unit-tested in
+clusters and HST midnight, so it groups them with groupby='obs_night' (the whole
+loaded night in one stack) before bias-subtracting each frame. The shared
+stacking engine these exercise (`BaseMasterModule`) is unit-tested in
 test_master_base.py.
 """
 
@@ -24,7 +24,7 @@ from ._masters import make_l1_arrays
 
 CHIPS = ["GREEN", "RED"]
 NROW, NCOL = 10, 10  # small arrays for unit tests
-# make_l1_arrays() — shared synthetic stack_frames builder — lives in _masters.py
+# make_l1_arrays() -- shared synthetic stack_frames builder -- lives in _masters.py
 
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 
@@ -37,7 +37,7 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 class TestMasterDarkUnit:
-    """Unit tests using a mocked stack_frames — no real data needed."""
+    """Unit tests using a mocked stack_frames -- no real data needed."""
 
     @pytest.fixture(scope="class")
     def master_dark(self):

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -1,5 +1,4 @@
-"""
-Unit tests for the WLS module.
+"""Unit tests for the WLS module.
 
 All sub-module I/O is mocked; no real data or FITS files are required.
 """
@@ -55,8 +54,7 @@ def _linelist_df(chip, norder, waves):
 
 @pytest.fixture
 def mock_pipeline(monkeypatch):
-    """
-    Patch CalibrationAssociation, ImageProcessing, and SpectralExtraction so
+    """Patch CalibrationAssociation, ImageProcessing, and SpectralExtraction so
     that _process_frame and _extract_frame run without touching disk or real
     data.
 
@@ -196,8 +194,7 @@ class TestProcessIndividualFrames:
 
 @pytest.fixture
 def mock_make_master_l2(monkeypatch):
-    """
-    Patch frame loading, _fit_and_qc_lines_stack, and _combine_coeffs_stack so
+    """Patch frame loading, _fit_and_qc_lines_stack, and _combine_coeffs_stack so
     make_master_l2 runs without touching disk or real spectra. The fitting
     stub reports one non-rejected frame per input (FILE_LIST has 8 frames, so
     the default min_stack_size=5 gate passes), and the combine stub returns
@@ -446,7 +443,7 @@ class TestMakeMasterL2:
 
     def test_save_diagnostics_with_empty_stash_raises(self, tmp_path):
         # make_master_l2 initialises _frame_diagnostics to {} before populating
-        # it. If the chip loop raises before any chip is added, it stays empty —
+        # it. If the chip loop raises before any chip is added, it stays empty --
         # save_diagnostics must refuse rather than write an empty HDF5.
         wls = WLS(FILE_LIST)
         wls._frame_diagnostics = {}

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -1,5 +1,4 @@
-"""
-Tests for the KPF QC framework (Tasks 2-7).
+"""Tests for the KPF QC framework (quality_control/qc_flags).
 
 Covers:
   - QC base class runner (TestQCBase)
@@ -7,9 +6,10 @@ Covers:
   - QCL1 checks (TestQCL1)
   - QCL1 full run on an all-good synthetic L1 (TestQCL1Run)
   - QCL2 checks (TestQCL2)
+  - QCL4 checks (TestQCL4)
   - CLI smoke tests (TestQCScript)
 
-All tests use synthetic in-memory data — no real KPF files required.
+All tests use synthetic in-memory data -- no real KPF files required.
 """
 
 import os
@@ -348,15 +348,15 @@ class TestQCL0:
         hdus = [primary]
         for chip in ["GREEN", "RED"]:
             for amp in range(1, 5):
-                # data=None → KPF0 stores array(None, dtype=object) — treated as absent.
+                # data=None: KPF0 stores array(None, dtype=object), treated as absent.
                 hdus.append(fits.ImageHDU(data=None, name=f"{chip}_AMP{amp}"))
         fits.HDUList(hdus).writeto(fn, overwrite=True)
         l0 = KPF0.from_fits(fn)
         assert QCL0(l0).data_l0_red_green() is False
 
     def test_data_l0_red_green_pass_two_amp(self, tmp_path):
-        """2-amp readout (only AMP1/AMP2 per chip; AMP3/4 absent) — the truth-frame
-        layout — has data present and must pass."""
+        """2-amp readout (only AMP1/AMP2 per chip; AMP3/4 absent) -- the truth-frame
+        layout -- has data present and must pass."""
         fn = str(tmp_path / "KP.20240405.00003.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
@@ -796,7 +796,7 @@ class TestQCL2:
 
     def test_required_keywords_present_pass(self):
         # Fresh KPF2 is rvdata-seeded with the EPRV-required PRIMARY keywords; seed
-        # the KPF provenance cards too so all 44 are present.
+        # the KPF provenance cards too so all required keywords are present.
         kpf2 = _make_kpf2_with_flux()
         _seed_required_primary(kpf2, QCL2)
         assert QCL2(kpf2).required_keywords_present() is True
@@ -1031,7 +1031,7 @@ class TestQCScript:
 
 
 # ---------------------------------------------------------------------------
-# QCL4 — CCF/RV presence and BERV percent-change (ported from v2.12)
+# QCL4 -- CCF/RV presence and BERV percent-change (ported from v2.12)
 # (timing consistency moved to QCL0 / DATTIMOK)
 # ---------------------------------------------------------------------------
 

--- a/tests/regression/test_quicklook_l1.py
+++ b/tests/regression/test_quicklook_l1.py
@@ -56,7 +56,7 @@ def _seed_read_noise(l1):
     """Seed RN*/RNNG* via set_keyword, exactly as ImageAssembly does.
 
     set_keyword routes these to QUALITY_CONTROL (their registry home), so this
-    exercises the real read path the quicklook annotation depends on — writing
+    exercises the real read path the quicklook annotation depends on -- writing
     them onto PRIMARY here would let the annotation test pass while production
     (which reads QUALITY_CONTROL) silently rendered nothing.
     """

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -1,5 +1,4 @@
-"""
-Tests for the RadialVelocity module (KPF4 -> KPF4: fit per-order CCFs to RVs).
+"""Tests for the RadialVelocity module (KPF4 -> KPF4: fit per-order CCFs to RVs).
 
 RadialVelocity consumes the CCF-bearing L4 that CrossCorrelation produces and
 fills the RV/RV_ERR columns and RV headers. Static-method unit tests
@@ -82,8 +81,7 @@ def _make_l4(
     bjd=0.0,
     perform_fibers=None,
 ):
-    """
-    Build a synthetic KPF2 (absorption injected at _MASK_CENTERS, shifted by
+    """Build a synthetic KPF2 (absorption injected at _MASK_CENTERS, shifted by
     _V_INJECT) and run CrossCorrelation (mask stubbed, narrow grid) to a KPF4.
     """
     kpf2 = KPF2()

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -1,7 +1,6 @@
-"""
-Tests for the kpf_drp_science recipe.
+"""Tests for the kpf_drp_science recipe.
 
-Integration tests run the full recipe (L0 → L1 → L2) against a real star
+Integration tests run the full recipe (L0 -> L1 -> L2) against a real star
 observation from tests/testdata/L0/20240405/.
 """
 

--- a/tests/regression/test_spectral_extraction.py
+++ b/tests/regression/test_spectral_extraction.py
@@ -54,7 +54,7 @@ def minimal_l1(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Box extraction (unit tests — no data or fixtures required)
+# Box extraction (unit tests -- no data or fixtures required)
 # ---------------------------------------------------------------------------
 
 
@@ -111,7 +111,7 @@ class TestBoxExtraction:
 
 
 # ---------------------------------------------------------------------------
-# Unimplemented extraction stubs
+# Dtype provenance
 # ---------------------------------------------------------------------------
 
 
@@ -145,6 +145,11 @@ class TestDtypeProvenance:
         assert_dtype(l2.data["SCI2_VAR"], FLUX, "L2 SCI2_VAR")
 
 
+# ---------------------------------------------------------------------------
+# Unimplemented extraction stubs
+# ---------------------------------------------------------------------------
+
+
 class TestUnimplementedExtraction:
     def test_optimal_raises(self):
         D = V = np.ones((5, 10))
@@ -158,7 +163,7 @@ class TestUnimplementedExtraction:
 
 
 # ---------------------------------------------------------------------------
-# perform() shape tests (monkeypatched — no real data or trace files needed)
+# perform() shape tests (monkeypatched -- no real data or trace files needed)
 # ---------------------------------------------------------------------------
 
 
@@ -357,7 +362,7 @@ class TestOrderTraceErrors:
             se.extract_orderlet("GREEN", "SCI1", 2)
 
     def test_duplicate_trace_raises_value_error(self):
-        # Two rows for the same (Fiber, Order) — a corrupt reference file.
+        # Two rows for the same (Fiber, Order) -- a corrupt reference file.
         rows = [
             {
                 "Fiber": "SCI1",

--- a/tests/regression/test_timeseries.py
+++ b/tests/regression/test_timeseries.py
@@ -2,11 +2,12 @@
 
 timeseries is a thin discovery + dispatch wrapper: it combs the L0 tree for a
 target's science frames over a datecode range (steps 1-2), then runs one masters
-and one science orchestrator subprocess (steps 3-4). The robust fan-out engine
-lives in _dispatch (tested in test_dispatch.py) and the orchestrators own their
-own arg parsing (test_masters_script.py / test_science_script.py). These cover
-only what timeseries owns: arg parsing, the threaded L0 discovery, the
-orchestrator argv it builds, and the main() dispatch order.
+orchestrator, one science orchestrator, and one plotter subprocess (steps 3-5).
+The robust fan-out engine lives in _dispatch (tested in test_dispatch.py) and the
+orchestrators own their own arg parsing (test_masters_script.py /
+test_science_script.py). These cover only what timeseries owns: arg parsing, the
+threaded L0 discovery, the orchestrator argv it builds, and the main() dispatch
+order.
 
 Unit tests use synthetic FITS frames in temp trees -- no real testdata needed.
 """

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -214,7 +214,7 @@ class TestPerform:
 
     def test_subset_chips_and_fibers(self, master_wls_path):
         # Only the requested (chip, fiber) blocks are copied; everything
-        # else stays zero — both un-requested fibers within the requested
+        # else stays zero -- both un-requested fibers within the requested
         # chip, and un-requested chips entirely.
         l2 = _make_science_l2(wls_path=master_wls_path)
         WavelengthCalibration(l2).perform(chips=["GREEN"], fibers=["SCI2"])
@@ -312,9 +312,8 @@ def _trough_depth(wave_order, flux_order, lambda_air, halfwin=3.0):
 @pytest.mark.slow
 @pytest.mark.requires_testdata
 class TestSpectrumOrientation:
-    """
-    Discriminator: the WLS-calibrated L2 must have its flux co-oriented with the
-    assigned wavelength axis.
+    """Discriminator: the WLS-calibrated L2 must have its flux co-oriented with
+    the assigned wavelength axis.
 
     For every in-coverage Fraunhofer anchor on every science fiber, the native
     ``(wave, flux)`` pairing must show a DEEPER absorption trough at the catalog

--- a/tools/fetch_l0.sh
+++ b/tools/fetch_l0.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# fetch_l0.sh — retrieve KPF L0 files for a list of obs_ids from a remote server.
+# fetch_l0.sh -- retrieve KPF L0 files for a list of obs_ids from a remote server.
 #
 # Reads a text file of obs_ids (one per line, optionally preceded by an index
 # column, e.g. "1<TAB>KP.20240727.56085.97") and rsyncs the matching L0 FITS
@@ -9,7 +9,7 @@
 # middle field of the obs_id (KP.<datecode>.<seconds>...).
 #
 # The remote and local L0 roots are supplied as arguments (or via the
-# KPF_REMOTE_L0 / KPF_LOCAL_L0 environment variables) — nothing is tied to a
+# KPF_REMOTE_L0 / KPF_LOCAL_L0 environment variables) -- nothing is tied to a
 # particular machine or account.
 #
 # Usage:

--- a/tools/select_master_cals.py
+++ b/tools/select_master_cals.py
@@ -10,14 +10,17 @@ The header scan and clustering are done by the pipeline's own
 ``kpfpipe.utils.io.FileHandler`` (``build_mini_database`` +
 ``build_calibration_stacks``), so this tool always matches the masters recipe
 exactly: same OBJECT typing, gap splitting, HST-midnight handling, observer-junk
-exclusion, and per-type thresholds. Of the eligible clusters for each type the
+exclusion, and per-type grouping. Of the eligible clusters for each type the
 largest (earliest on a tie) is chosen, and up to --count of its frames are
 emitted.
 
-Per-type settings match recipes/kpf_drp_masters.py (see _TYPE_KWARGS):
-bias/flat/thar require 5 frames; darks require 3, merge undersized clusters, and
-ignore the HST-midnight split (their sparse sequences legitimately span a
-night's HST midnight).
+Per-type grouping mirrors recipes/kpf_drp_masters.py (see _TYPE_KWARGS): darks
+set min_stack_size=3 and group the whole night into one stack
+(groupby='obs_night'), so their sparse sequences that straddle HST midnight stay
+together; bias/flat/thar keep the build_calibration_stacks defaults
+(min_stack_size=1, per-session time_of_day grouping). Selection is deliberately
+permissive here -- the tool only needs the largest cluster of each type, not the
+recipe's configured per-type minima.
 
 Output is an obs_id list in the exact format of the input (index<TAB>obs_id,
 one per line), ready to feed straight back into fetch_l0.sh. A human-readable
@@ -36,10 +39,11 @@ import sys
 from kpfpipe.utils.io import FileHandler
 from kpfpipe.utils.kpf_utils import get_datecode, get_obs_id, get_timestamp, is_obs_id
 
-# Per-type kwargs for build_calibration_stacks, matching recipes/kpf_drp_masters.py.
-# Darks are sparse long exposures whose sequences straddle HST midnight, so they
-# drop the threshold to 3 and group the whole night into one stack (obs_night);
-# bias/thar use the default time_of_day (one stack per morn/eve session).
+# Per-type kwargs for build_calibration_stacks; the grouping mirrors
+# recipes/kpf_drp_masters.py. Darks are sparse long exposures whose sequences
+# straddle HST midnight, so they set min_stack_size=3 and group the whole night
+# into one stack (groupby='obs_night'); bias/flat/thar keep the defaults
+# (min_stack_size=1, time_of_day -- one stack per morning/evening session).
 _TYPE_KWARGS = {
     "bias": {},
     "dark": {"min_stack_size": 3, "groupby": "obs_night"},


### PR DESCRIPTION
  ## Summary
  
  A repo-wide sweep of **docstrings and inline comments only** — no logic changes —
  so the auto-generated Sphinx/ReadTheDocs API reference renders cleanly and the
  in-code documentation matches the code. Covers `kpfpipe/` (all subpackages),
  `scripts/`, `tests/`, and `tools/`, plus the style guide and two small Sphinx-config
  tweaks.
  
  Net **−1100 lines**: trimmed verbosity and collapsed copy-pasted explanation while
  *adding* accuracy.
  
  ## What changed
  
  - **Fixed inaccuracies** where a docstring/comment contradicted the code — e.g.
    `DRPVERNO`'s home extension (RECEIPT, not PRIMARY), `to_kpf2`'s CA_HK pass-through,
    a `compute_ccfs` `Raises` block that listed an impossible exception and omitted the
    real one, `rn_nongauss = sqrt(2/pi)·std/mad`, the QC `LEVEL` L4 tags, and several
    stale references in test/tool docstrings (`select_master_cals` thresholds,
    `RadialVelocity` vs `CrossCorrelation` CCF ownership). Each verified against source.
  - **Normalized conventions**: same-line docstring opener, double-backtick identifiers
    (RST inline-code literals), ASCII `--` instead of em-dash, Google `Args:` → numpydoc,
    uniform `Raises`/`Returns` on public methods.
  - **Removed redundancy**: copy-pasted rationale collapsed to one canonical instance +
    pointers; comments that merely restated code dropped.
  - **Style guide** (`KPF_DRP_VNEXT_STYLE_GUIDE.md` §13/§1/§9): corrected the opener rule
    and its example, added the double-backtick / Raises-Returns / ASCII-dash rules, hoisted
    recurring conventions (chip/fiber glossary, memmap idiom, calibration-override forms,
    Quicklook `run()` contract). `CLAUDE.md` needs no change (holds no style rules).
  - **Sphinx config**: minor `conf.py`/`api/index.rst` trims.
  
  ## Scope

  `kpfpipe/` 58 · `tests/` 19 · `scripts/` 5 · `tools/` 2 · style guide 1 · `docs/` 2.

  ## Verification
  
  `ruff format --check` + `ruff check` clean; all files compile; structural diff-scan
  confirms no code lines removed and no function/class signatures changed. The test suite
  was **not** run — these are comment/docstring-only edits.