### PR TITLE
docs: fix docstring formatting in data_models/ and modules/

### DIFF
--- a/kpfpipe/data_models/__init__.py
+++ b/kpfpipe/data_models/__init__.py
@@ -1,10 +1,10 @@
 """
 KPF data models.
 
-KPF0 -- Raw CCD data (Level 0)
-KPF1 -- Assembled FFIs (Level 1)
-KPF2 -- Extracted spectra (Level 2, extends RV2 with KPF aliases)
-KPF4 -- RVs and CCFs (Level 4, extends RV4 with KPF aliases)
+* KPF0 -- Raw CCD data (Level 0)
+* KPF1 -- Assembled FFIs (Level 1)
+* KPF2 -- Extracted spectra (Level 2, extends RV2 with KPF aliases)
+* KPF4 -- RVs and CCFs (Level 4, extends RV4 with KPF aliases)
 """
 
 from kpfpipe.data_models.level0 import KPF0

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -1,9 +1,21 @@
 """
 KPF base data model.
 
-Shared base for every KPF data model (L0, L1, L2, L4). Extends the EPRV
-``RVDataModel`` with the behaviour common to all KPF products: FITS-header
+Shared base for every KPF data model (L0, L1, L2, L4). Extends the EPRV Data
+Standard ``RVDataModel`` with the behavior common to all KPF products: FITS-header
 storage, provenance receipts, and alias-aware data and header access.
+
+Bi-directional extension aliasing allows use of either EPRV Data Standard
+or KPF naming conventions for order traces:
+
+* TRACE1 = SKY
+* TRACE2 = SCI1
+* TRACE3 = SCI2
+* TRACE4 = SCI3
+* TRACE5 = CAL
+
+For example, "SCI2_FLUX" is registered as an alias for "TRACE3_FLUX", so reading
+``d["SCI2_FLUX"]`` returns the same object stored under "TRACE3_FLUX".
 """
 
 import logging

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -2,8 +2,7 @@
 KPF Level 0 (raw CCD) data model.
 
 Raw FITS readout from the KPF instrument: amplifier arrays plus exposure
-meter, guide camera, telemetry, and telescope metadata. The extensions
-present vary between observations.
+meter, guide camera, telemetry, and telescope metadata.
 """
 
 import importlib.resources

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -1,9 +1,9 @@
 """
 KPF Level 1 (assembled FFI) data model.
 
-Assembled CCD frames (GREEN and RED, with variance) built by combining the
-L0 amplifier readouts. Also used for 2D master calibrations (bias, dark,
-flat), which share the same structure.
+Assembled full frame images (FFIs) built by combining the L0 amplifier
+readouts. GREEN and RED CCDs are stored in separate extensions. Also
+used for FFI masters calibrations (bias, dark, flat).
 """
 
 import importlib.resources

--- a/kpfpipe/data_models/masters/__init__.py
+++ b/kpfpipe/data_models/masters/__init__.py
@@ -1,9 +1,9 @@
 """
 KPF masters data models.
 
-KPFMasterL1 -- FFI calibrations (bias, dark, flat)
-KPFMasterL2 -- Extracted spectra (stub)
-KPFMasterL4 -- RV/CCF products (stub)
+* KPFMasterL1 -- FFI calibrations (bias, dark, flat)
+* KPFMasterL2 -- Extracted spectra (wls, flat)
+* KPFMasterL4 -- RV/CCF products (stub; NotYetImplemented)
 """
 
 from kpfpipe.data_models.masters.level1 import KPFMasterL1

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -2,7 +2,7 @@
 KPF Calibration Association module.
 
 Given a KPF observation frame, finds the most appropriate master calibration
-file for each calibration type (bias, dark, flat, thar) by searching
+file for each calibration type (bias, dark, flat, wls) by searching
 the masters directory and selecting the nearest-in-time match.
 """
 

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -10,13 +10,21 @@ radial-velocity step later fills with fitted RVs.
 Each fiber's mask, barycentric handling, and CCF grid center are dispatched from
 its illumination source (SCI-OBJ/SKY-OBJ/CAL-OBJ in INSTRUMENT_HEADER):
 
-  source   mask                 barycorr  grid center
-  target   TARGTEFF-lookup      yes       TARGRADV (systemic)
-  sky      G2_espresso (solar)  yes       0
-  thar     ThAr list (unit wt)  no        0
-  etalon   [NOT IMPLEMENTED]
-  lfc      [NOT IMPLEMENTED]
-  none     not illuminated -> skipped (no CCF)
+  +--------+-------------------------------------+----------+---------------------+
+  | source | mask                                | barycorr | grid center         |
+  +========+=====================================+==========+=====================+
+  | target | TARGTEFF-lookup                     | yes      | TARGRADV (systemic) |
+  +--------+-------------------------------------+----------+---------------------+
+  | sky    | G2_espresso (solar)                 | yes      | 0                   |
+  +--------+-------------------------------------+----------+---------------------+
+  | thar   | ThAr list (unit wt)                 | no       | 0                   |
+  +--------+-------------------------------------+----------+---------------------+
+  | etalon | [NOT IMPLEMENTED]                   |          |                     |
+  +--------+-------------------------------------+----------+---------------------+
+  | lfc    | [NOT IMPLEMENTED]                   |          |                     |
+  +--------+-------------------------------------+----------+---------------------+
+  | none   | not illuminated -> skipped (no CCF) |          |                     |
+  +--------+-------------------------------------+----------+---------------------+
 
 All reference wavelengths (stellar line masks, ThAr line list) are in vacuum;
 no air/vacuum conversion is performed.

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -1,11 +1,15 @@
 """
 KPF Image Assembly module.
 
-Assembles a raw L0 readout into a single L1 full-frame image (overscan
-correction, amplifier stitching). It applies no calibrations:
-bias/dark/flat are handled downstream by ImageProcessing following the
-standard CCD reduction sequence (bias subtraction, then exposure-scaled dark
-subtraction, then flat division), gated per file type by the masters modules.
+Assembles a raw L0 readout into a single L1 full-frame image (FFI). Automatically
+detects whether observations were obtained in 2- or 4-amplifier mode, subtracts
+per-amplifier overscan bias, measures read noise, and stitches together the FFI
+(4080 x 4080 arrays) for both GREEN and RED CCDs.
+
+ImageAssembly applies no external calibrations: bias/dark/flat are handled
+downstream by ImageProcessing following the standard CCD reduction sequence
+(bias subtraction, then exposure-scaled dark subtraction, then flat division),
+gated per file type by the masters modules.
 """
 
 import logging

--- a/kpfpipe/modules/masters/__init__.py
+++ b/kpfpipe/modules/masters/__init__.py
@@ -1,4 +1,4 @@
-"""Masters modules: stack L0 frames into bias, dark, flat, and WLS products."""
+"""Masters modules: bias, dark, flat, and wls."""
 
 from kpfpipe.modules.masters.base import BaseMasterModule
 from kpfpipe.modules.masters.bias import Bias


### PR DESCRIPTION
Render the cross_correlation illumination-dispatch block as an RST grid table (readable in source, renders on RTD). Fix RST bullet markers in base.py (# -> *), strip trailing whitespace flagged by ruff in level1.py and image_assembly.py, and correct minor typos (arays -> arrays, ccds -> CCDs, add missing "or").