### PR TITLE
Optimize CLAUDE.md and governing docs for AI/LLM development

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ KPF-DRP vNext: a cleanroom rebuild of the Keck Planet Finder (KPF) data reductio
 pipeline for the Keck Observatory. The scientific priority is intermediate and
 long-term radial velocity (RV) stability.
 
-## Governing documents (precedence order)
+## Governing Documents (precedence order)
 
 Five references govern this project. **When they conflict, the higher one wins.**
 Each is the source of truth for its domain — consult before making related
@@ -113,7 +113,7 @@ the governing docs must never cite CLAUDE.md.** Operational/policy material belo
   (a tagged PyPI release, not a moving branch). Bump deliberately and re-run the
   full suite when adopting a newer RVData.
 
-## Git workflow
+## Git Workflow
 
 v3 work branches from and PRs into **`kpf-next`** (the v3 develop branch). Never
 target `master` (production/stable) or `develop` (frozen at v2.12, legacy).
@@ -155,7 +155,7 @@ constants, anything integration tests exercise; or a cross-cutting refactor). `t
 the `slow` integration tests (real-frame assembly/overscan, master stacking, full L0→L2, WLS
 orientation). Layout: architecture *Tests → Regression*; conventions: style guide §C.8.
 
-## Design decisions
+## Design Decisions
 
 Before a non-trivial design or structural change, verify against the governing docs
 (precedence table above) — consult, don't guess:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,9 +131,8 @@ make test-fast   # fast pre-commit subset: everything except @pytest.mark.slow (
 make test        # full suite, parallel
 make test-serial # serial fallback for debugging parallel/receipt issues
 
-# Single test class or test (while iterating on one area)
+# Single test/class — append ::Class or ::Class::test_name to the file path
 conda run -n kpfpipe python -m pytest tests/regression/test_data_models_l2.py::TestKPF2Aliases -v
-conda run -n kpfpipe python -m pytest tests/regression/test_data_models_l2.py::TestKPF2Aliases::test_chip_prefix_access -v
 
 # Formatting and linting (Ruff; config in pyproject.toml [tool.ruff])
 ruff format kpfpipe/ tests/ recipes/      # format (black-compatible)
@@ -147,31 +146,31 @@ pre-commit run --all-files  # run all hooks across the repo
 make profile   # all; also profile-science / profile-masters / profile-<module>
 ```
 
-## Running tests — which tier
+## Testing
 
-No git hook runs tests (`pre-commit` is ruff-only), so match scope to the change:
+No git hook runs tests (`pre-commit` is ruff-only), so match scope to the change: touched
+file(s) while iterating; `make test-fast` before committing; `make test` (full) only for wide
+blast radius (a PR; a core/shared-module change — data models, base classes, `kpfpipe/__init__.py`
+constants, anything integration tests exercise; or a cross-cutting refactor). `test-fast` skips
+the `slow` integration tests (real-frame assembly/overscan, master stacking, full L0→L2, WLS
+orientation). Layout: architecture *Tests → Regression*; conventions: style guide §C.8.
 
-| Scope | When |
-|-------|------|
-| The file(s) you touched | While iterating (most runs) |
-| `make test-fast` | Before wrapping up / committing |
-| `make test` (full) | Wide blast radius: opening/updating a PR; a change to a core/shared module (data models, `kpfpipe/__init__.py` constants, base classes, anything integration tests exercise); a cross-cutting refactor. |
+## Design decisions
 
-The fast subset skips `slow` integration tests (real-frame assembly/overscan,
-master stacking, full L0→L2, WLS orientation) — the triggers above are what catch
-those. Suite layout is in the architecture guide (*Tests → Regression*);
-test-writing conventions are in the style guide §C.8.
+Before a non-trivial design or structural change, verify against the governing docs
+(precedence table above) — consult, don't guess:
 
-## Architecture, principles, and success criteria
+1. **Requirements / data format** — does it touch a WMKO requirement or the L2/L4 data
+   products? Check `WMKO_REQUIREMENTS.md` / `EPRV_DATA_STANDARD.md` first.
+2. **Principles** — determinism, no hidden state, fail-loud, explicit calibration,
+   simplicity (charter §9 Guardrails, §10 Core Design Principles; calibration §5).
+3. **Structure** — matches the data-model / alias / layering / QC contracts
+   (architecture reference).
+4. **Change gate** — preserves deterministic behavior, runs on the truth dataset, and
+   documents RV-metric impact (charter §6); measure against §3 Definition of Success.
 
-Do not restate these here (past copies drifted — keep one source):
+The governing docs are the single source of truth — read them, don't restate them here
+(past inline copies drifted). Intent & principles: [`KPF_VNEXT_CHARTER.md`](docs/dev/KPF_VNEXT_CHARTER.md). Structure (data model, aliases, layering, masters,
+QC/checkpoint/quicklook, tests): [`KPF_VNEXT_ARCHITECTURE.md`](docs/dev/KPF_VNEXT_ARCHITECTURE.md). Code style: [`KPF_VNEXT_STYLE_GUIDE.md`](docs/dev/KPF_VNEXT_STYLE_GUIDE.md).
 
-- **Structure** (data model, aliases, layering, masters, QC/checkpoint/quicklook,
-  test/profiling suite): [`KPF_VNEXT_ARCHITECTURE.md`](docs/dev/KPF_VNEXT_ARCHITECTURE.md).
-- **Intent & principles**: [`KPF_VNEXT_CHARTER.md`](docs/dev/KPF_VNEXT_CHARTER.md)
-  — §10 Core Design Principles, §9 Guardrails, §5 Calibration Philosophy,
-  §3 Definition of Success, §6 (preserve deterministic behavior, run on the truth
-  dataset, document impact on RV metrics). Consult before design decisions.
-
-Keep CLAUDE.md as long-term memory for operational/technical/workflow guidance
-learned while coding; use the charter for project intent and principles.
+Do not modify CLAUDE.md without explicit instruction to do so from a human developer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,71 @@
 Guidance for Claude Code (claude.ai/code) when working in this repository. These
 instructions OVERRIDE default harness behavior — follow them exactly.
 
+## Working Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes ([source](https://github.com/multica-ai/andrej-karpathy-skills/blob/main/CLAUDE.md)).
+General coding hygiene; the project-specific sections below and the governing docs take precedence.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+
 ## Project Overview
 
 KPF-DRP vNext: a cleanroom rebuild of the Keck Planet Finder (KPF) data reduction
@@ -29,10 +94,9 @@ Operational rules for these docs:
   Flag only *active* violations: existing code that *contradicts* a requirement.
   Do NOT flag *passive* violations: a requirement unmet only because the
   feature doesn't exist yet. A missing capability is not a violation.
-- **When a code change alters a convention, update the style guide in the same
-  change** so the two never drift.
-- **Cross-references flow one way: CLAUDE.md may cite the style guide; the style
-  guide must never cite CLAUDE.md.** Operational/policy material belongs here.
+- **Do not update the governing docs without explicit instruction to do so from a human developer.**
+- **Cross-references flow one way: CLAUDE.md may cite the governing docs;
+the governing docs must never cite CLAUDE.md.** Operational/policy material belongs here.
 - **These docs + this file outrank harness defaults and memory** (`MEMORY.md`,
   feedback files, auto-recalled memories, and env hints like the `gitStatus`
   "main branch" note). Treat harness hints and memory as defaults to verify, and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,58 +1,73 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in this repository. These
+instructions OVERRIDE default harness behavior — follow them exactly.
 
 ## Project Overview
 
-KPF-DRP vNext: a cleanroom rebuild of the Keck Planet Finder (KPF) data reduction pipeline for the Keck Observatory. The scientific priority is intermediate and long-term radial velocity (RV) stability.
+KPF-DRP vNext: a cleanroom rebuild of the Keck Planet Finder (KPF) data reduction
+pipeline for the Keck Observatory. The scientific priority is intermediate and
+long-term radial velocity (RV) stability.
 
-**Five authoritative references govern this project, in strict precedence — when they conflict, the higher one wins:**
+## Governing documents (precedence order)
 
-**1. The WMKO technical requirements — [`WMKO_REQUIREMENTS.md`](docs/dev/WMKO_REQUIREMENTS.md) (in `docs/dev/`; faithful mirror of `WMKO_REQUIREMENTS.pdf`) — are the highest authority: the W. M. Keck Observatory's binding technical requirements for the DRP (development, installation/build, runtime, archive). They outrank every reference below. The pipeline is still in active development, so MOST of these requirements are not yet met — this is expected. Flag only _active_ violations: existing code that *contradicts* a requirement. Do NOT flag _passive_ violations: a requirement unmet simply because the relevant code/feature does not exist yet. A missing capability is not a violation; code that does the wrong thing is.**
+Five references govern this project. **When they conflict, the higher one wins.**
+Each is the source of truth for its domain — consult before making related
+decisions; this file does not duplicate them.
 
-**2. The EPRV data standard — [`EPRV_DATA_STANDARD.md`](docs/dev/EPRV_DATA_STANDARD.md) (in `docs/dev/`) — is the source of truth for KPF's data products (L2/L4): FITS structure, extension and header-keyword names, units, and reference frames (vacuum wavelengths, BJD_TDB, barycentric frame). KPF L2/L4 are EPRV-compliant by contract, so the standard takes priority on anything touching data format. It mirrors the KPF-relevant portions of <https://eprv-data-standard.readthedocs.io/en/develop/>; re-scrape if the standard has moved.**
+| # | Doc (in `docs/dev/`) | Source of truth for |
+|---|----------------------|---------------------|
+| 1 | [`WMKO_REQUIREMENTS.md`](docs/dev/WMKO_REQUIREMENTS.md) | Binding WMKO technical requirements (dev, build, runtime, archive). Highest authority; mirrors `WMKO_REQUIREMENTS.pdf`. |
+| 2 | [`EPRV_DATA_STANDARD.md`](docs/dev/EPRV_DATA_STANDARD.md) | KPF L2/L4 data products: FITS structure, extension/keyword names, units, reference frames (vacuum wavelengths, BJD_TDB, barycentric). Wins on anything touching data format. |
+| 3 | [`KPF_VNEXT_CHARTER.md`](docs/dev/KPF_VNEXT_CHARTER.md) | Project *why*: intent, scope, scientific focus, Path-3 approach, calibration philosophy, guardrails, design principles, success criteria. |
+| 4 | [`KPF_VNEXT_ARCHITECTURE.md`](docs/dev/KPF_VNEXT_ARCHITECTURE.md) | Pipeline *how it's built*: data-model hierarchy, extension aliases, header standardization, CLI/module layering, filename conventions, masters pipeline, diagnostics/QC/checkpoint/quicklook layers. |
+| 5 | [`KPF_VNEXT_STYLE_GUIDE.md`](docs/dev/KPF_VNEXT_STYLE_GUIDE.md) | Code *how it should look*: formatting, imports, naming, constants, docstrings, error handling, per-area exceptions. Soft rules; yield to 1–4 on conflict. |
 
-**3. The project charter — [`KPF_VNEXT_CHARTER.md`](docs/dev/KPF_VNEXT_CHARTER.md) (in `docs/dev/`) — is the single source of truth for project intent, scope, scientific focus, the Path-3 approach, calibration philosophy, guardrails, design principles, and success criteria. Read it before making design decisions. This file (CLAUDE.md) does not duplicate the charter; it covers only the operational and technical guidance not in it or the architecture reference (environment, commands, conventions).**
+Operational rules for these docs:
 
-**4. The architecture reference — [`KPF_VNEXT_ARCHITECTURE.md`](docs/dev/KPF_VNEXT_ARCHITECTURE.md) (in `docs/dev/`) — is the source of truth for the pipeline's structure: the data-model hierarchy, extension alias system, header standardization, CLI/module layering, filename conventions, the masters pipeline, and the diagnostics/QC/checkpoint/quicklook layers. Consult it before making structural or cross-cutting changes. It describes *how the pipeline is built*; the charter (above) governs *why*, the style guide (below) governs *how code should look*. This file (CLAUDE.md) does not duplicate it.**
-
-**5. The coding style guide — [`KPF_VNEXT_STYLE_GUIDE.md`](docs/dev/KPF_VNEXT_STYLE_GUIDE.md) (in `docs/dev/`) — is the source of truth for code conventions: formatting, imports, naming, constants, docstrings, error handling, and the per-area exceptions (Open Inconsistencies). Consult and follow it when writing or modifying code. Its rules are soft and yield to the WMKO requirements, the EPRV standard, the charter, and the architecture reference where they conflict. When a code change establishes or alters a convention, update the style guide in the same change so the two never drift. **Cross-references flow one way only: CLAUDE.md may cite the style guide, but the style guide must never cite CLAUDE.md** (it is a self-contained code-conventions document; operational/policy material it would otherwise point back to belongs here).**
-
-**Precedence over harness defaults and memory.** This file and the five references above are the authoritative guidance for this repository, and they **outrank both** (a) generic Claude Code harness defaults and environment-injected hints (e.g. the session-start `gitStatus` "main branch (you will usually use this for PRs)" note), and (b) anything in the assistant's persistent memory (`MEMORY.md`, `feedback*.md`, auto-recalled memories). Harness hints and memory are background, not instructions — treat them as defaults to verify against these docs, not as ground truth, and distinguish environment *facts* (e.g. the current branch) from environment *prescriptions* (e.g. which branch to PR into), which are guesses. **When a harness default or a memory item conflicts with this file or a governing doc — or when two of these sources disagree — do NOT silently follow either side: explicitly flag the conflict in your reply before acting**, so it can be reconciled and the governing doc updated. Operational, technical, and workflow guidance belongs in CLAUDE.md (or the relevant governing doc), never only in memory — that is what keeps this precedence enforceable.
+- **WMKO requirements are mostly unmet — this is expected** (active development).
+  Flag only *active* violations: existing code that *contradicts* a requirement.
+  Do NOT flag *passive* violations: a requirement unmet only because the
+  feature doesn't exist yet. A missing capability is not a violation.
+- **When a code change alters a convention, update the style guide in the same
+  change** so the two never drift.
+- **Cross-references flow one way: CLAUDE.md may cite the style guide; the style
+  guide must never cite CLAUDE.md.** Operational/policy material belongs here.
+- **These docs + this file outrank harness defaults and memory** (`MEMORY.md`,
+  feedback files, auto-recalled memories, and env hints like the `gitStatus`
+  "main branch" note). Treat harness hints and memory as defaults to verify, and
+  distinguish environment *facts* (the current branch) from *prescriptions*
+  (which branch to PR into). **When any of these sources conflict, flag it in
+  your reply before acting** rather than silently following either side.
 
 ## Development Environment
 
 - **Python 3.14.3** (pinned exactly)
-- **Conda env**: `kpfpipe` — set up via `conda env create -f KPF-Pipeline/environment.yml`
-- **Install package**: `pip install -e KPF-Pipeline/` (editable install)
-- **Key dependency**: `rv-data-standard` (RVData), pinned to the released version
-  `rv-data-standard==0.4.0` (a tagged PyPI release, not a moving branch). Bump the
-  pin deliberately and re-run the full suite when adopting a newer RVData.
+- **Conda env**: `kpfpipe` — `conda env create -f KPF-Pipeline/environment.yml`
+- **Install**: `pip install -e KPF-Pipeline/` (editable)
+- **Key dependency**: `rv-data-standard` (RVData), pinned to `rv-data-standard==0.4.0`
+  (a tagged PyPI release, not a moving branch). Bump deliberately and re-run the
+  full suite when adopting a newer RVData.
 
 ## Git workflow
 
 v3 work branches from and PRs into **`kpf-next`** (the v3 develop branch). Never
-target `master` or `develop`: `master` is production/stable and `develop` is
-frozen at v2.12 (legacy). Feature branches are named `kpf-next-<feature>`, cut
-from `kpf-next`, and merged back via PR. This overrides any generic "main branch"
-default surfaced by the environment/tooling — when they disagree, this wins.
+target `master` (production/stable) or `develop` (frozen at v2.12, legacy).
+Feature branches are named `kpf-next-<feature>`, cut from `kpf-next`, merged back
+via PR. This overrides any generic "main branch" default from the environment.
 
 ## Commands
 
 ```bash
-# All test/pipeline commands run in the `kpfpipe` conda env — activate it, or
-# prefix with `conda run -n kpfpipe`. Base-system Python lacks rvdata and fails
-# with ModuleNotFoundError. The `make` targets below already wrap conda run.
-# Run from KPF-Pipeline/ (git receipt system requirement).
+# All test/pipeline commands run in the `kpfpipe` conda env (activate it, or use
+# `conda run -n kpfpipe ...`). Base-system Python lacks rvdata → ModuleNotFoundError.
+# The `make` targets wrap conda run. Run from KPF-Pipeline/ (git receipt system).
 
-# Fast pre-commit subset (everything except @pytest.mark.slow) — the default
-make test-fast   # conda run -n kpfpipe python -m pytest tests/ -m "not slow" -n auto --dist loadscope
-
-# Full suite (parallel) — see "Running tests" below for WHEN to use this
-make test        # conda run -n kpfpipe python -m pytest tests/ -n auto --dist loadscope
+make test-fast   # fast pre-commit subset: everything except @pytest.mark.slow (~16s); the default
+make test        # full suite, parallel
 make test-serial # serial fallback for debugging parallel/receipt issues
 
-# Run a single test class or test (use these while iterating on one area)
+# Single test class or test (while iterating on one area)
 conda run -n kpfpipe python -m pytest tests/regression/test_data_models_l2.py::TestKPF2Aliases -v
 conda run -n kpfpipe python -m pytest tests/regression/test_data_models_l2.py::TestKPF2Aliases::test_chip_prefix_access -v
 
@@ -60,45 +75,39 @@ conda run -n kpfpipe python -m pytest tests/regression/test_data_models_l2.py::T
 ruff format kpfpipe/ tests/ recipes/      # format (black-compatible)
 ruff check --fix kpfpipe/ tests/ recipes/ # lint + auto-fix
 
-# Pre-commit hook (enforces ruff format + lint on commit)
+# Pre-commit hook (ruff format + lint on commit; NO tests)
 pre-commit install          # one-time, after creating the env
 pre-commit run --all-files  # run all hooks across the repo
 
 # Profiling harnesses (design: architecture guide → Tests → Profiling)
-make profile   # all harnesses; also profile-science / profile-masters / profile-<module>
+make profile   # all; also profile-science / profile-masters / profile-<module>
 ```
 
-## Running tests — subset vs full
+## Running tests — which tier
 
-Which *tier* to run, not how often: testing is a judgment call made continuously
-while working, not deferred to commit/PR time (no git hook runs tests — `pre-commit`
-is ruff-only). Match the scope to the change instead of defaulting to the full suite:
+No git hook runs tests (`pre-commit` is ruff-only), so match scope to the change:
 
-- **While iterating (most runs):** only the file(s) for the code you touched
-  (`python -m pytest tests/regression/test_<area>.py`).
-- **Before wrapping up / committing:** `make test-fast` (the `-m "not slow"` subset, ~16s).
-- **The full suite (`make test`)** — when the blast radius is wide: opening/updating a
-  PR; a change to a **core/shared** module other tests depend on (the data models,
-  `kpfpipe/__init__.py` constants, base classes, anything the integration tests exercise);
-  or a cross-cutting refactor.
+| Scope | When |
+|-------|------|
+| The file(s) you touched | While iterating (most runs) |
+| `make test-fast` | Before wrapping up / committing |
+| `make test` (full) | Wide blast radius: opening/updating a PR; a change to a core/shared module (data models, `kpfpipe/__init__.py` constants, base classes, anything integration tests exercise); a cross-cutting refactor. |
 
-The fast subset skips the `slow` integration tests (real-frame assembly/overscan, master
-stacking, full L0→L2, WLS orientation), which is why the full-suite triggers above are what
-catch those. How the suite is laid out and split — and the masters test layout — is in the
-architecture guide (*Tests → Regression*); test-writing conventions are in the style guide §C.8.
+The fast subset skips `slow` integration tests (real-frame assembly/overscan,
+master stacking, full L0→L2, WLS orientation) — the triggers above are what catch
+those. Suite layout is in the architecture guide (*Tests → Regression*);
+test-writing conventions are in the style guide §C.8.
 
-## Architecture
+## Architecture, principles, and success criteria
 
-The pipeline architecture — the data-model hierarchy, extension alias system, data flow,
-header standardization, configuration, the CLI/module layering, logging, filename
-conventions, the masters pipeline, the diagnostics/QC/checkpoint/quicklook layers, and the
-test/profiling suite structure — lives in
-[`KPF_VNEXT_ARCHITECTURE.md`](docs/dev/KPF_VNEXT_ARCHITECTURE.md) (governing doc #4).
-It is not duplicated here; consult it before making structural or cross-cutting changes.
+Do not restate these here (past copies drifted — keep one source):
 
-## Design Principles & Success Criteria
+- **Structure** (data model, aliases, layering, masters, QC/checkpoint/quicklook,
+  test/profiling suite): [`KPF_VNEXT_ARCHITECTURE.md`](docs/dev/KPF_VNEXT_ARCHITECTURE.md).
+- **Intent & principles**: [`KPF_VNEXT_CHARTER.md`](docs/dev/KPF_VNEXT_CHARTER.md)
+  — §10 Core Design Principles, §9 Guardrails, §5 Calibration Philosophy,
+  §3 Definition of Success, §6 (preserve deterministic behavior, run on the truth
+  dataset, document impact on RV metrics). Consult before design decisions.
 
-These live in the charter and are NOT restated here (the two copies drifted in the past — keep one source). See [`KPF_VNEXT_CHARTER.md`](docs/dev/KPF_VNEXT_CHARTER.md): §10 Core Design Principles, §9 Guardrails, §5 Calibration Philosophy, §3 Definition of Success, §6 (every major change must preserve deterministic behavior, run on the truth dataset, and document impact on RV metrics). Consult the charter before design decisions.
-
-- Keep this file (CLAUDE.md) updated with operational lessons, conventions, and more efficient workflows learned while coding.
-- Use CLAUDE.md as long-term memory for technical/operational guidance; use the charter for project intent and principles.
+Keep CLAUDE.md as long-term memory for operational/technical/workflow guidance
+learned while coding; use the charter for project intent and principles.

--- a/docs/dev/EPRV_DATA_STANDARD.md
+++ b/docs/dev/EPRV_DATA_STANDARD.md
@@ -14,7 +14,7 @@ When requirements or design principles conflict, the order of governing document
 2. EPRV data standard ([`EPRV_DATA_STANDARD.md`](EPRV_DATA_STANDARD.md))
 3. KPF vNext project charter ([`KPF_VNEXT_CHARTER.md`](KPF_VNEXT_CHARTER.md))
 4. KPF vNext architecture reference ([`KPF_VNEXT_ARCHITECTURE.md`](KPF_VNEXT_ARCHITECTURE.md))
-5. KPF vNext the style guide. ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
+5. KPF vNext style guide ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
 
 When any two conflict, the higher one wins.
 
@@ -189,7 +189,7 @@ L2/L4 products and the barycentric/RV path depend on:
 | `EXSNR#`,`EXSNRW#` | Extracted SNR + its wavelength | SNR/pix, Å | No |
 | `DRPTAG`,`EPRVTAG`,`VOCLASS` | DRP / EPRV-standard versions | | Yes |
 | `DRPHASH` | Git commit hash | | No |
-| `INSTERA` | Instrument-era tag (see §9) | | Yes |
+| `INSTERA` | Instrument-era tag (see §8) | | Yes |
 | `FULLCOMP` | EPRV-standard compliance (`Yes`/`No`) | | Yes |
 | `SUMMFLAG`,`TELFLAG`,`INSTFLAG`,`DRPFLAG` | Quality flags (`Pass`/`Fail`/`Warn`) | | Yes/No |
 | `DQLVL0/1/2` | Per-level quality-check bitfields | | Yes |

--- a/docs/dev/EPRV_DATA_STANDARD.md
+++ b/docs/dev/EPRV_DATA_STANDARD.md
@@ -237,7 +237,7 @@ numbering; that was stale and does not bind vNext.)
 | 6 | SCI | **Virtual fiber** (EPRV translator only, not produced by vNext) — `SCI1/2/3` resampled onto SCI2's grid, outlier-rejected and weighted |
 
 **Known deviations from the EPRV KPF translator doc** (the doc describes the official
-translator; vNext may differ by design per the charter — confirm each is intended):
+translator; vNext may differ by design — confirm each is intended):
 
 1. **No Trace 6 (virtual combined science fiber).** Our `trace-map.csv` and `fibers`
    (`SKY,SCI1,SCI2,SCI3,CAL`) stop at trace 5; the standard defines a 6th combined-science

--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -44,7 +44,7 @@ When requirements or design principles conflict, the order of governing document
 2. EPRV data standard ([`EPRV_DATA_STANDARD.md`](EPRV_DATA_STANDARD.md))
 3. KPF vNext project charter ([`KPF_VNEXT_CHARTER.md`](KPF_VNEXT_CHARTER.md))
 4. KPF vNext architecture reference ([`KPF_VNEXT_ARCHITECTURE.md`](KPF_VNEXT_ARCHITECTURE.md))
-5. KPF vNext the style guide. ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
+5. KPF vNext style guide ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
 
 When any two conflict, the higher one wins.
 
@@ -138,7 +138,7 @@ alongside rvdata's `RV2`/`RV4` — `KPFDataModel` is listed **first** so its ove
   so it wins).
 - **L2/L4 add KPF-friendly extension aliases** via `AliasedOrderedDict`.
 
-The rvdata `RVDataModel` base provides the `extensions`/`headers`/`data` OrderedDicts plus `create_extension()`, `set_data()`, `set_header()`, `from_fits()`, `to_fits()`, and a receipt system. `KPFDataModel` overrides `set_data`/`set_header` (in `base.py`, not the level classes) with a `hasattr` guard, so alias resolution runs during init — the base's `.keys()` checks would otherwise bypass the `__contains__` overrides — yet stays inert for non-aliased L0/L1. It likewise overrides `create_extension` so every extension header is a `fits.Header` rather than an `OrderedDict` (see *Header standardization*).
+`KPFDataModel` overrides `set_data`/`set_header` in `base.py` (not the level classes) with a `hasattr` guard so alias resolution runs during init — the rvdata base's `.keys()` checks would otherwise bypass the `__contains__` overrides — yet stays inert for non-aliased L0/L1. Its `create_extension` override makes every extension header a `fits.Header` rather than an `OrderedDict` (see *Header standardization*).
 
 ### Extension alias system
 
@@ -175,7 +175,7 @@ The architecture invariants:
   advanced per module. `ORIGID` (the original L0 obs_id) is also how L1/L2/L4 recover `self.obs_id` on
   read, so every model carries `obs_id` on every construction path.
 - **`QUALITY_CONTROL` + `RECEIPT` propagate L0→L1→L2→L4** card-by-card (`KPFDataModel._forward_headers`)
-  as an **append-only history**; only `ISGOOD` — the running AND over every accumulated QC flag —
+  as an **append-only history**; only `ISGOOD` (the running QC aggregate — see *QC flags*)
   changes per level.
 - **Structural header validation lives in the checkpoints layer** (`Checkpoint.unregistered_keywords`),
   not in QC or `to_kpfN`: every card on a registry-governed extension must be a registered keyword or a
@@ -454,8 +454,9 @@ master stacking, WLS orientation) off from the fast `-m "not slow"` subset.
 
 The masters tests mirror the masters subpackage by *responsibility*: `test_master_base.py` covers
 the shared stacking engine (`BaseMasterModule`), `test_master_bias.py`/`test_master_dark.py` the
-concrete bias/dark modules, `test_master_wls.py` the WLS path (a separate ML2), and
-`test_masters_recipe.py` the `kpf_drp_masters` recipe; `flat` has no test file while stubbed.
+concrete bias/dark modules, `test_master_wls.py` the WLS path (a separate ML2),
+`test_masters_recipe.py` the `kpf_drp_masters` recipe, and `test_masters_script.py` the masters
+CLI script; `flat` has no test file while stubbed.
 (Which file a new masters test belongs in is a style-guide §C.8 rule.)
 
 ### Profiling

--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -190,8 +190,7 @@ The keyword registry (`kpfpipe/data_models/keyword_registry.py`) is a single `Ke
 with one module singleton `keyword_registry`, imported **only** by `data_models/base.py` and surfaced as
 the `KPFDataModel.keyword_registry` class attribute. It derives its mapping/validation/routing lookups
 from a **single source-of-truth table** unioning the `L{0,1,2,4}-headers.csv` registries with the EPRV
-keyword defs. *(Coding rules — reading/writing headers, `set_keyword`, registering keywords — are in the
-style guide §B.4.)*
+keyword defs.
 
 **Each registered keyword has one home extension** (the registry `Extension` column) that `set_keyword`
 routes to: **PRIMARY** (EPRV keywords), **QUALITY_CONTROL** (QC flags + `ISGOOD`, read-noise,
@@ -380,8 +379,7 @@ fatal (DRP-RUN-07). Library code only declares `logger = logging.getLogger(__nam
 with no handlers installed — tests call `recipe.main(config, args)` directly with none configured, so
 setup must never move into recipes. `warnings.warn` stays the recoverable-condition API, bridged in
 via `logging.captureWarnings`; tests that configure logging must tear down with `teardown_logging`
-(see the autouse fixture in `tests/regression/test_logger.py`). *(Coding rules — levels, lazy
-`%`-formatting, named loggers, the `print()`/`info()` carve-out — live in the style guide §B.6.)*
+(see the autouse fixture in `tests/regression/test_logger.py`).
 
 
 ## File handling
@@ -441,8 +439,7 @@ for L2/L4.
 `tests/` splits into `regression/` (the pytest suite) and `profiling/` (performance harnesses),
 with `tests/conftest.py` at the root serving both (its fixtures and the `requires_testdata`
 marker) and the real frames under the gitignored `tests/testdata/`. This section covers how the
-suites are **laid out**; how to *write* a regression test or profiling harness is in the style
-guide §C.8 (same two subsections), and *when* to run which tier is in CLAUDE.md.
+suites are **laid out**.
 
 ### Regression
 
@@ -457,7 +454,6 @@ the shared stacking engine (`BaseMasterModule`), `test_master_bias.py`/`test_mas
 concrete bias/dark modules, `test_master_wls.py` the WLS path (a separate ML2),
 `test_masters_recipe.py` the `kpf_drp_masters` recipe, and `test_masters_script.py` the masters
 CLI script; `flat` has no test file while stubbed.
-(Which file a new masters test belongs in is a style-guide §C.8 rule.)
 
 ### Profiling
 
@@ -468,5 +464,4 @@ Two recipe harnesses (`profile_science_recipe.py`, `profile_masters_recipe.py`) 
 one module. `flat` is skipped while stubbed, and the shared stacking engine (`masters/base.py`)
 has no dedicated harness — its work is attributed to `base.py` methods inside the bias/dark
 harnesses (whereas the *test* suite isolates the engine in `test_master_base.py`, because
-profiling partitions by wall-clock and tests by responsibility). How a harness attributes time
-and flags hotspots is specified in the style guide §C.8.
+profiling partitions by wall-clock and tests by responsibility).

--- a/docs/dev/KPF_VNEXT_CHARTER.md
+++ b/docs/dev/KPF_VNEXT_CHARTER.md
@@ -1,7 +1,5 @@
 # KPF-DRP vNext: Project Context and Intent
 
-This charter describes the project intent and design.
-
 **Authority precedence.**
 When requirements or design principles conflict, the order of governing document precedence is:
 
@@ -9,7 +7,7 @@ When requirements or design principles conflict, the order of governing document
 2. EPRV data standard ([`EPRV_DATA_STANDARD.md`](EPRV_DATA_STANDARD.md))
 3. KPF vNext project charter ([`KPF_VNEXT_CHARTER.md`](KPF_VNEXT_CHARTER.md))
 4. KPF vNext architecture reference ([`KPF_VNEXT_ARCHITECTURE.md`](KPF_VNEXT_ARCHITECTURE.md))
-5. KPF vNext the style guide. ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
+5. KPF vNext style guide ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
 
 When any two conflict, the higher one wins.
 
@@ -25,10 +23,10 @@ The legacy v2.12 DRP has reached a point where:
 -   Silent failures and nondeterministic behavior undermine confidence.
 -   Long-term RV stability remains the dominant scientific challenge.
 
-This effort is not a cosmetic refactor.
+This is not a cosmetic refactor.
 
-It is a controlled reset aimed at restoring scientific confidence,
-deterministic behavior, and development agility.
+It is a controlled reset aimed at restoring scientific
+confidence, deterministic behavior, and development agility.
 
 ------------------------------------------------------------------------
 

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -12,22 +12,19 @@ When requirements or design principles conflict, the order of governing document
 2. EPRV data standard ([`EPRV_DATA_STANDARD.md`](EPRV_DATA_STANDARD.md))
 3. KPF vNext project charter ([`KPF_VNEXT_CHARTER.md`](KPF_VNEXT_CHARTER.md))
 4. KPF vNext architecture reference ([`KPF_VNEXT_ARCHITECTURE.md`](KPF_VNEXT_ARCHITECTURE.md))
-5. KPF vNext the style guide. ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
+5. KPF vNext style guide ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
 
 When any two conflict, the higher one wins.
 
 
-**Status of these rules.** These are *soft* requirements, and this guide sits at the **bottom**
-of the project's authority hierarchy:
+**Status of these rules.** These are *soft* requirements — this guide sits at the **bottom** of
+the authority hierarchy above, so where a rule here conflicts with any of those four documents,
+**the higher one wins** (style yields to science). It describes the dominant, prevailing pattern;
+where the codebase contradicts itself, the recommended variant is called out explicitly.
 
-This style guide describes the dominant, prevailing pattern; where the codebase
-contradicts itself, the recommended variant is called out explicitly. When a rule here
-conflicts with any of those four documents, **the higher one wins** — style yields to science.
-
-This file covers *how code should look and be organized* — not operational or technical
-guidance (environment, commands) or the pipeline's structure (the architecture reference),
-which are documented separately. It does not restate what the architecture guide already
-covers; where a rule needs that context, it points there rather than duplicating it.
+This file covers *how code should look and be organized* — not operational/technical guidance
+(environment, commands) or the pipeline's structure (the architecture reference). Where a rule
+needs that context, it points there rather than restating it.
 
 Contents:
 

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -23,8 +23,7 @@ the authority hierarchy above, so where a rule here conflicts with any of those 
 where the codebase contradicts itself, the recommended variant is called out explicitly.
 
 This file covers *how code should look and be organized* — not operational/technical guidance
-(environment, commands) or the pipeline's structure (the architecture reference). Where a rule
-needs that context, it points there rather than restating it.
+(environment, commands) or the pipeline's structure (the architecture reference).
 
 Contents:
 
@@ -54,34 +53,31 @@ Contents:
 
 ## A. Core Design Principles
 
-These are the values the rest of this guide operationalizes. They deliberately mirror the
-charter (§9 Guardrails, §10 Core Design Principles) — where this section and the charter ever
-diverge, the charter wins. Each principle names where it is enforced concretely.
+These are the values the rest of this guide operationalizes. Each principle names where it is
+enforced concretely.
 
 - **Code is self-documenting.** Names carry intent, so a reader rarely needs a comment to learn
   *what* a line does; comments are reserved for *why*. This is the lever behind the naming rules
   (§C.1) and the comment discipline (§D.2).
 - **Prefer clarity over cleverness.** Write the obvious version. A longer, plainly-readable
   implementation beats a terse or clever one that a future reader — human or AI assistant — has
-  to decode (charter §10.7).
+  to decode.
 - **Do not over-engineer.** Implement the simplest thing that meets the requirement; don't build
-  for hypothetical futures (YAGNI). A new utility earns its place with a real caller (§C.5)
-  (charter §10.8).
+  for hypothetical futures (YAGNI). A new utility earns its place with a real caller (§C.5).
 - **Avoid excessive abstraction.** Keep layers minimal. Transform modules are plain standalone
   classes — no base classes, mixins, ABCs, or `dataclasses` unless a concrete, shared need
-  already exists (§C.2) (charter §9).
+  already exists (§C.2).
 - **No hidden state.** No implicit global state, no database coupling in science code, no
   calibration hierarchy resolved behind the caller's back. Every lazily-filled attribute is
   declared up front in `__init__`, and configuration flows through one explicit three-tier
-  override chain (§C.2) (charter §10.1).
+  override chain (§C.2).
 - **Fail loudly.** Validate early and raise a specific, typed exception that shows the offending
   value; never swallow an error or press on with degraded data. Raise rather than catch-and-log
-  (§B.6) (charter §10.4).
+  (§B.6).
 - **Do not introduce quiet fallbacks.** No silent retries, no "default on missing key" that masks
-  a real problem — a missing keyword or master should raise, not be papered over (§B.6)
-  (charter §9).
+  a real problem — a missing keyword or master should raise, not be papered over (§B.6).
 - **Be explicit.** Explicit calibration paths, explicit units and reference frames, explicit
-  arguments. Every step should be readable and debuggable in isolation (charter §9).
+  arguments. Every step should be readable and debuggable in isolation.
 
 ---
 
@@ -92,9 +88,8 @@ Conventions organized by pipeline subsystem. Where a subsystem has distinct **sc
 
 ### B.1 KPF data models
 
-The models (`data_models/`) are what modules operate *on*; their hierarchy, shared
-`KPFDataModel` behavior, and I/O overrides are described in the architecture guide. Conventions
-specific to writing model code:
+The models (`data_models/`) are what modules operate *on*. Conventions specific to writing model
+code:
 
 #### Science
 
@@ -272,9 +267,7 @@ but its values are EPRV targets.)*
 
 #### Headers
 
-Every extension header is an `astropy.io.fits.Header` (the WMKO→EPRV conversion and the
-`INSTRUMENT_HEADER` snapshot are described in the architecture guide's *Header standardization*).
-When writing code:
+Every extension header is an `astropy.io.fits.Header`. When writing code:
 
 - **Read a value** with `header.get(key)`/`header[key]` on the keyword's home extension (per the
   registry `Extension` column); the comment is in `header.comments[key]`. Never hand-roll
@@ -307,8 +300,7 @@ When writing code:
 
 ### B.5 Quality control (Diagnostics / QC / Checkpoints / Quicklook)
 
-The four read-only layers (`kpfpipe/quality_control/`) and their strict run order are described in
-the architecture guide. Conventions for writing QC code:
+The four read-only layers live in `kpfpipe/quality_control/`. Conventions for writing QC code:
 
 - **Read-only.** Diagnostics/QC write header keywords **only via `set_keyword`** (→
   QUALITY_CONTROL), never `data`; Quicklook writes only PNGs. To mutate `l0.data` in a helper, work
@@ -333,8 +325,7 @@ the architecture guide. Conventions for writing QC code:
 
 ### B.6 Error handling, validation & logging
 
-Logging follows WMKO DRP-RUN-07/08/09; the `setup_logging`/`setup_batch_logging` entry points are
-described in the architecture guide. The coding rules:
+Logging follows WMKO DRP-RUN-07/08/09. The coding rules:
 
 - **Named loggers only**: `logger = logging.getLogger(__name__)` at module top; recipes (exec'd, so
   `__name__ == "recipe"`) name theirs explicitly (`"kpfpipe.recipe.science"`). Never the root-logger
@@ -525,8 +516,7 @@ Cross-cutting conventions that apply regardless of subsystem.
   `test_<behavior>`, error paths suffixed `_raises`. Files `test_<module>.py` mirror the source,
   sectioned with the same 66-dash banners and opened with a scope-stating module docstring.
 - **Masters test placement**: a test belongs in `test_master_base.py` iff it exercises a `base.py`
-  method vehicle-incidentally; module-specific behavior stays in `test_master_<type>.py` (the file
-  layout is in the architecture guide).
+  method vehicle-incidentally; module-specific behavior stays in `test_master_<type>.py`.
 - **Fixtures** are named for what they produce; multi-file fixtures live in `tests/conftest.py` and
   multi-file plain helpers in a non-collected `_underscore.py` module — don't duplicate builders. Use
   `scope="class"` + `tmp_path_factory` for expensive real-data pipelines.

--- a/docs/dev/WMKO_REQUIREMENTS.md
+++ b/docs/dev/WMKO_REQUIREMENTS.md
@@ -5,15 +5,17 @@
 > This Markdown mirror exists so the requirements are greppable and linkable alongside the
 > code. Re-transcribe if the requirements are revised.
 
+> **The two blocks below (Authority precedence, Active vs. passive compliance) are repo-added
+> governance for the vNext project — they are not part of the transcribed WMKO PDF.**
+
 **Authority precedence.**
-The WMKO technical requirements are the **top** of the project's reference hierarchy —
-they outrank every other governing document:
+When requirements or design principles conflict, the order of governing document precedence is:
 
 1. WMKO technical requirements ([`WMKO_REQUIREMENTS.md`](WMKO_REQUIREMENTS.md))
 2. EPRV data standard ([`EPRV_DATA_STANDARD.md`](EPRV_DATA_STANDARD.md))
 3. KPF vNext project charter ([`KPF_VNEXT_CHARTER.md`](KPF_VNEXT_CHARTER.md))
 4. KPF vNext architecture reference ([`KPF_VNEXT_ARCHITECTURE.md`](KPF_VNEXT_ARCHITECTURE.md))
-5. KPF vNext the style guide. ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
+5. KPF vNext style guide ([`KPF_VNEXT_STYLE_GUIDE.md`](KPF_VNEXT_STYLE_GUIDE.md))
 
 When any two conflict, the higher one wins.
 


### PR DESCRIPTION
  ## Optimize CLAUDE.md and governing docs for AI/LLM development

  Restructures the project's guidance docs so they support AI-assisted development
  more effectively while staying easy to maintain. Docs-only — no code or behavior
  changes.

  ### CLAUDE.md
  - Streamlined governance prose into scannable tables/pointers (~33% smaller).
  - Added general coding-hygiene **Working Guidelines** ([Karpathy's skills](https://github.com/multica-ai/andrej-karpathy-skills/blob/main/CLAUDE.md)) and
    tightened the operational rules.
  - Compacted the test policy and foregrounded design guidance as an actionable
    **Design decisions** checklist — so salience tracks importance rather than text volume.

  ### Governing docs
  - Fixed a broken cross-reference and a stale test-listing; synced the precedence
    preamble wording across all five docs.
  - Removed inter-document cross-references from body text so each doc is a
    self-contained authority in its domain — docs now reference one another only in
    the precedence preamble. Improves maintainability (less coupling/drift) and
    makes each section independently readable.

  ### Scope
  `CLAUDE.md` + the five governing docs under `docs/dev/`. No source, tests, or
  pipeline behavior touched.
