### PR TITLE
Kpf next cleanup 20260716

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ test-serial:
 # Per-module: `make profile-radial_velocity`, `make profile-master_wls`, etc.
 # These names mirror the test files 1-to-1 (test_<x>.py <-> profile_<x>.py).
 PROFILE_MODULES = image_assembly image_processing spectral_extraction \
-	wavelength_calibration barycentric_correction radial_velocity \
-	calibration_association master_bias master_dark master_wls
+	wavelength_calibration barycentric_correction cross_correlation \
+	radial_velocity calibration_association master_bias master_dark master_wls
 
 # Run every harness (both recipes + all per-module files) and regenerate reports.
 profile: profile-masters profile-science $(addprefix profile-,$(PROFILE_MODULES))

--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -310,7 +310,7 @@ the remaining argv verbatim (each subcommand owns its own argparse). Full flag u
 
 ## Quality control
 
-Four read-only layers, consolidated under `kpfpipe/quality_control/`, consume data products. None of
+Four layers, consolidated under `kpfpipe/quality_control/`, consume data products. None of
 them mutate the scientific arrays — they only read data and write header keywords via `set_keyword`
 (routed to QUALITY_CONTROL — see *Keyword registry*) (and, in Quicklook's case, to PNG files).
 Per-level files follow the `levelN.py` naming used by `data_models/`.

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -300,9 +300,9 @@ Every extension header is an `astropy.io.fits.Header`. When writing code:
 
 ### B.5 Quality control (Diagnostics / QC / Checkpoints / Quicklook)
 
-The four read-only layers live in `kpfpipe/quality_control/`. Conventions for writing QC code:
+The four layers live in `kpfpipe/quality_control/`. Conventions for writing QC code:
 
-- **Read-only.** Diagnostics/QC write header keywords **only via `set_keyword`** (→
+- **Never mutate `data`.** Diagnostics/QC write header keywords **only via `set_keyword`** (→
   QUALITY_CONTROL), never `data`; Quicklook writes only PNGs. To mutate `l0.data` in a helper, work
   on a `deepcopy`.
 - **Register methods by attribute, no decorators** — assign the tag right after the `def`; the base

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -247,7 +247,7 @@ class BarycentricCorrection:
         f_ext = rate * dt_gap
         return t_ext, f_ext
 
-    def _compute_per_chanel_flux_weighted_midpoint_time(
+    def _compute_per_channel_flux_weighted_midpoint_time(
         self, interpolate=True, extrapolate=True, fix_expmeter_outliers=True
     ):
         """
@@ -522,7 +522,7 @@ class BarycentricCorrection:
         # for 'orders' then 'ccds').
         key = (interpolate, extrapolate, fix_expmeter_outliers)
         if self._exposure_meter is None or self._exposure_meter[0] != key:
-            w_em, t_em = self._compute_per_chanel_flux_weighted_midpoint_time(
+            w_em, t_em = self._compute_per_channel_flux_weighted_midpoint_time(
                 interpolate=interpolate,
                 extrapolate=extrapolate,
                 fix_expmeter_outliers=fix_expmeter_outliers,

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -34,7 +34,7 @@ class Checkpoint:
     def run(self):
         """Run the paired Diagnostics and QC, then every checkpoint method.
 
-        Folds in the two upstream read-only stages: Diagnostics writes its
+        Folds in the two upstream stages: Diagnostics writes its
         metrics, QC writes the 0/1 flags + ISGOOD (captured in ``self.qc_results``
         for callers that report them), then each checkpoint method warns or
         raises. A level with no paired ``DIAGNOSTICS``/``QC`` skips that stage.

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -22,6 +22,17 @@ class QC:
         self.kpf_obj = kpf_obj
         self.results = {}  # Populated by run(): maps keyword to (passed, comment).
 
+    @staticmethod
+    def _hdr_float(hdr, key):
+        """Return float value for a header key, or None if absent."""
+        val = hdr.get(key)
+        return None if val is None else float(val)
+
+    @staticmethod
+    def _hdr_bool(hdr, key):
+        """Return bool value for a header key, or False if absent."""
+        return bool(hdr.get(key, False))
+
     def run(self):
         """Run all checks, write each 0/1 result, and aggregate ISGOOD.
 

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -16,12 +16,6 @@ _SUPPORTED_NAMP = (2, 4)  # valid KPF readout modes (see ImageAssembly.count_amp
 _TIME_TOL_S = 0.1  # DATE-END - DATE-BEG vs ELAPSED tolerance (v2.12 quality_control.py)
 
 
-def _hdr_float(hdr, key):
-    """Return float value for a header key, or None if absent."""
-    val = hdr.get(key)
-    return None if val is None else float(val)
-
-
 def _parse_iso(value):
     """Parse an ISO-8601 datetime string, or None if missing/unparseable."""
     if value is None:
@@ -88,7 +82,7 @@ class QCL0(QC):
             return False
         if not (beg <= mid <= end):
             return False
-        elapsed = _hdr_float(hdr, "ELAPSED")
+        elapsed = self._hdr_float(hdr, "ELAPSED")
         if (
             elapsed is not None
             and abs((end - beg).total_seconds() - elapsed) > _TIME_TOL_S
@@ -117,7 +111,7 @@ class QCL0(QC):
         if not (np.isfinite(exptime) and exptime >= 0):
             return False
 
-        elapsed = _hdr_float(hdr, "ELAPSED")
+        elapsed = self._hdr_float(hdr, "ELAPSED")
         if elapsed is not None and not (0 <= elapsed - exptime <= _TIME_TOL_S):
             return False
         return True
@@ -155,7 +149,7 @@ class QCL0(QC):
         """
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         for key, limit in (("TARGOFF", 1.0), ("OBJOFF", 5.0), ("GAIAOFF", 5.0)):
-            val = _hdr_float(hdr, key)
+            val = self._hdr_float(hdr, key)
             if val is not None and val >= limit:
                 return False
         return True

--- a/kpfpipe/quality_control/qc_flags/level1.py
+++ b/kpfpipe/quality_control/qc_flags/level1.py
@@ -9,17 +9,6 @@ _RN_LO, _RN_HI = 2.0, 6.0
 _RNNG_LO, _RNNG_HI = 0.8, 1.5
 
 
-def _hdr_float(hdr, key):
-    """Return float value for a header key, or None if absent."""
-    val = hdr.get(key)
-    return None if val is None else float(val)
-
-
-def _hdr_flag(hdr, key):
-    """Return bool value for a header key, or False if absent."""
-    return bool(hdr.get(key, False))
-
-
 class QCL1(QC):
     """QC checks for KPF Level 1 assembled FFI products."""
 
@@ -57,7 +46,7 @@ class QCL1(QC):
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         found = False
         for keys in RN_KEYS.values():
-            v = _hdr_float(hdr, keys[idx])
+            v = self._hdr_float(hdr, keys[idx])
             if v is None:
                 continue
             found = True
@@ -79,27 +68,27 @@ class QCL1(QC):
 
     def bias_ok(self):
         """Bias subtracted (RECEIPT BIASSUB) and master bias age <= 7 days."""
-        if not _hdr_flag(self.kpf_obj.headers["RECEIPT"], "BIASSUB"):
+        if not self._hdr_bool(self.kpf_obj.headers["RECEIPT"], "BIASSUB"):
             return False
-        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "BIASAGE")
+        v = self._hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "BIASAGE")
         return v is not None and abs(v) <= 7
 
     bias_ok._qc_key = "BIASOK"
 
     def dark_ok(self):
         """Dark subtracted (RECEIPT DARKSUB) and master dark age <= 14 days."""
-        if not _hdr_flag(self.kpf_obj.headers["RECEIPT"], "DARKSUB"):
+        if not self._hdr_bool(self.kpf_obj.headers["RECEIPT"], "DARKSUB"):
             return False
-        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "DARKAGE")
+        v = self._hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "DARKAGE")
         return v is not None and abs(v) <= 14
 
     dark_ok._qc_key = "DARKOK"
 
     def flat_ok(self):
         """Flat divided (RECEIPT FLATDIV) and master flat age <= 30 days."""
-        if not _hdr_flag(self.kpf_obj.headers["RECEIPT"], "FLATDIV"):
+        if not self._hdr_bool(self.kpf_obj.headers["RECEIPT"], "FLATDIV"):
             return False
-        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "FLATAGE")
+        v = self._hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "FLATAGE")
         return v is not None and abs(v) <= 30
 
     flat_ok._qc_key = "FLATOK"

--- a/kpfpipe/quality_control/qc_flags/level2.py
+++ b/kpfpipe/quality_control/qc_flags/level2.py
@@ -13,12 +13,6 @@ _NAN_KEYS = ["NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL"]
 _MIN_SCI_SNR = 1.0
 
 
-def _hdr_float(hdr, key):
-    """Return float value for a header key, or None if absent."""
-    val = hdr.get(key)
-    return None if val is None else float(val)
-
-
 class QCL2(QC):
     """QC checks for KPF Level 2 extracted spectra products."""
 
@@ -58,7 +52,7 @@ class QCL2(QC):
 
         nan_total = 0
         for k in _NAN_KEYS:
-            v = _hdr_float(hdr, k)
+            v = self._hdr_float(hdr, k)
             if v is None:
                 return False
             nan_total += v
@@ -69,7 +63,7 @@ class QCL2(QC):
 
     def nonzero_flux(self):
         """ZEROFRAC < 0.5."""
-        v = _hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "ZEROFRAC")
+        v = self._hdr_float(self.kpf_obj.headers["QUALITY_CONTROL"], "ZEROFRAC")
         return v is not None and v < 0.5
 
     nonzero_flux._qc_key = "L2FLXOK"
@@ -107,7 +101,7 @@ class QCL2(QC):
         check relies on). Guards against a silently failed extraction.
         """
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
-        values = [_hdr_float(hdr, k) for k in ("GSNRSCI", "RSNRSCI")]
+        values = [self._hdr_float(hdr, k) for k in ("GSNRSCI", "RSNRSCI")]
         values = [v for v in values if v is not None]
         if not values:
             return False

--- a/kpfpipe/quality_control/qc_flags/level4.py
+++ b/kpfpipe/quality_control/qc_flags/level4.py
@@ -14,12 +14,6 @@ _SCI_FIBERS = ("SCI1", "SCI2", "SCI3")
 _BERV_PCT_TOL = 1.0
 
 
-def _hdr_float(hdr, key):
-    """Return float value for a header key, or None if absent."""
-    val = hdr.get(key)
-    return None if val is None else float(val)
-
-
 class QCL4(QC):
     """QC checks for KPF Level 4 RV/CCF products."""
 
@@ -63,8 +57,8 @@ class QCL4(QC):
         is nothing to flag.
         """
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
-        mx = _hdr_float(hdr, "BERVMAXP")
-        mn = _hdr_float(hdr, "BERVMINP")
+        mx = self._hdr_float(hdr, "BERVMAXP")
+        mn = self._hdr_float(hdr, "BERVMINP")
         if mx is None or mn is None:
             return True
         return mx <= _BERV_PCT_TOL and mn >= -_BERV_PCT_TOL

--- a/tests/profiling/_profiling.py
+++ b/tests/profiling/_profiling.py
@@ -75,6 +75,13 @@ NETWORK_MARKERS = (
     "certifi",
 )
 
+# DiagL0 resolves each frame's pointing against Gaia DR3 and SIMBAD (astroquery)
+# -- network catalog round-trips as nondeterministic as the barycentric IERS
+# fetch, so they are likewise quarantined from the QC slice of the recipe summary
+# (reported separately, never in the denominator). Matched on the astroquery
+# package path; see _astrometry_cumtime.
+ASTROQUERY_MARKER = "/astroquery/"
+
 # The masters I/O-vs-compute split measures disk I/O at the data-model
 # serialization boundary rather than by low-level primitives: every read is a
 # `from_fits` call (in base._load_frame and base._load_calibration) and every
@@ -393,14 +400,40 @@ def _flags(rows):
 def _network_own(rows):
     """Total own time of network calls (SSL/socket), for the separate report line.
 
-    Network is a nondeterministic IERS download during barycentric correction, so
-    it is quarantined from the recipe's High-level summary.
+    Network is a nondeterministic IERS download during barycentric correction plus
+    the DiagL0 Gaia/SIMBAD pointing lookups, so it is quarantined from the recipe's
+    High-level summary.
     """
     return sum(
         r["tottime"]
         for r in rows
         if any(m in f"{r['file']} {r['name']}" for m in NETWORK_MARKERS)
     )
+
+
+def _astrometry_cumtime(stats):
+    """Cumulative time of DiagL0's nondeterministic astrometry catalog queries.
+
+    DiagL0 resolves each frame's pointing against Gaia DR3 and SIMBAD (astroquery)
+    -- network round-trips as nondeterministic as the barycentric IERS fetch. Sum
+    the *outermost* astroquery frames (caller not itself astroquery) whose caller
+    is a ``diagnostics/`` method, so the full per-query time is counted once and
+    the identical Gaia query inside BarycentricCorrection -- already excluded with
+    that whole quarantined stage -- is not double-counted here.
+    """
+    total = 0.0
+    for func, (_cc, _nc, _tt, _ct, callers) in stats.stats.items():
+        if ASTROQUERY_MARKER not in func[0]:
+            continue
+        for caller, cvals in callers.items():
+            cfn = caller[0]
+            if ASTROQUERY_MARKER in cfn:
+                continue  # nested astroquery frame; its time is in the outer one
+            if _is_kpf_module(cfn) and _module_label(cfn).startswith(
+                "quality_control/diagnostics/"
+            ):
+                total += cvals[3]  # per-caller cumtime; outermost DiagL0 query only
+    return total
 
 
 def _io_compute_split(stats):
@@ -481,6 +514,97 @@ def _quicklook_breakdown(stats):
     return {"rows": rows, "total": total}
 
 
+def _qc_sublayer_run_key(stats, subdir):
+    """The ``(file, line, 'run')`` key of the single base ``run`` in a QC sublayer.
+
+    Each of diagnostics / qc_flags / checkpoints defines ``run`` exactly once (on
+    its base class, no subclass overrides), so the first name-``run`` key whose
+    module sits under ``subdir`` uniquely identifies that sublayer's entry point.
+    Returns None when the sublayer never ran.
+    """
+    for k in stats.stats:
+        fn, _ln, name = k
+        if name != "run" or not _is_kpf_module(fn):
+            continue
+        if _module_label(fn).startswith(subdir):
+            return k
+    return None
+
+
+def _qc_level_label(filename):
+    """``diagnostics/level2.py`` -> ``DiagL2``; ``qc_flags/level1.py`` -> ``QCL1``."""
+    label = _module_label(filename)
+    n = label.rsplit("/", 1)[-1].removesuffix(".py").removeprefix("level")  # "2"
+    prefix = "Diag" if label.startswith("quality_control/diagnostics/") else "QC"
+    return f"{prefix}L{n}"
+
+
+def _quality_control_breakdown(stats):
+    """Per-level wall-clock within the quality-control stage (science recipe).
+
+    The recipe runs all QC through ``CheckpointL{n}.run()``, which folds in
+    ``DiagL{n}.run()`` then ``QCL{n}.run()`` before its own header/flag validation.
+    Diagnostics and QC each dispatch their tagged, level-specific check methods
+    (in ``diagnostics/level{n}.py`` / ``qc_flags/level{n}.py``) as direct children
+    of a single shared base ``run`` -- so each level's cost is the cumtime its
+    check methods contribute there, keyed ``DiagL{n}`` / ``QCL{n}``. ``checkpoints``
+    is the remainder (the thin base-``run`` dispatch/keyword-routing plus the
+    checkpoint validation methods). DiagL0's nondeterministic Gaia/SIMBAD pointing
+    lookups are carved out of its row (and the total), matching the recipe
+    summary, which reports them as a separate quarantined slice. Returns ``rows``
+    (``(label, seconds, fraction)``) and the QC ``total``; empty when no
+    checkpoints ran (masters).
+    """
+    ck_key = _qc_sublayer_run_key(stats, "quality_control/checkpoints/")
+    if ck_key is None:
+        return {"rows": [], "total": 0.0}
+    total = stats.stats[ck_key][3]  # cumtime of Checkpoint.run across all levels
+
+    # The base run of each folded-in sublayer; its level check methods are its
+    # direct children (charged via their per-caller cumtime, like _quicklook).
+    run_keys = {}
+    for subdir in ("quality_control/diagnostics/", "quality_control/qc_flags/"):
+        key = _qc_sublayer_run_key(stats, subdir)
+        if key is not None:
+            run_keys[key] = subdir
+
+    agg = {}
+    for func, (_cc, _nc, _tt, _ct, callers) in stats.stats.items():
+        filename = func[0]
+        if not _is_kpf_module(filename):
+            continue
+        label = _module_label(filename)
+        # Only the level-specific check-method files (level{n}.py) get a level
+        # row; the shared base-run dispatch helpers fold into the checkpoints
+        # remainder below.
+        stem = label.rsplit("/", 1)[-1].removesuffix(".py")
+        if not (stem.startswith("level") and stem.removeprefix("level").isdigit()):
+            continue
+        for run_key, subdir in run_keys.items():
+            if label.startswith(subdir) and run_key in callers:
+                lvl = _qc_level_label(filename)
+                agg[lvl] = agg.get(lvl, 0.0) + callers[run_key][3]
+
+    # Quarantine DiagL0's Gaia/SIMBAD lookups from its row and the total, matching
+    # the recipe summary (which reports them separately as a nondeterministic slice).
+    astrometry = _astrometry_cumtime(stats)
+    if "DiagL0" in agg:
+        agg["DiagL0"] = max(agg["DiagL0"] - astrometry, 0.0)
+    total = max(total - astrometry, 0.0)
+
+    # Everything not charged to a level's checks is the checkpoint wrapper (the
+    # base-run dispatch + keyword routing + validation); max() guards float noise.
+    agg["checkpoints"] = max(total - sum(agg.values()), 0.0)
+
+    base = total or 1e-12
+    rows = sorted(
+        ((lbl, s, s / base) for lbl, s in agg.items()),
+        key=lambda e: e[1],
+        reverse=True,
+    )
+    return {"rows": rows, "total": total}
+
+
 def _stage_name(module_label):
     """``modules/radial_velocity.py`` -> ``radial_velocity``; ``modules/masters/
     bias.py`` -> ``bias`` (the product, per the masters "by product" rule)."""
@@ -491,10 +615,17 @@ def _summary_bucket(filename, name):
     """Map a recipe-``main`` direct child to a (label, kind) High-level bucket.
 
     ``from_fits``/``to_fits`` are the data-product reads/writes (I/O); the KPF
-    pipeline stages, quicklook, and QC/diagnostics map to their respective rows;
-    barycentric correction is quarantined; everything else (path helpers, config,
-    glue) is orchestration overhead. ``utils``/``data_models`` are deliberately
-    *not* their own rows — their time is absorbed into the calling stage.
+    pipeline stages, quicklook, and QC map to their respective rows; barycentric
+    correction is quarantined; everything else (path helpers, config, glue) is
+    orchestration overhead. ``utils``/``data_models`` are deliberately *not* their
+    own rows — their time is absorbed into the calling stage.
+
+    The recipe drives all quality control through ``CheckpointL{n}.run()`` (which
+    folds in the paired Diagnostics and QC before its own validation), so the QC
+    row is keyed on ``checkpoints/``; the ``qc_flags/`` / ``diagnostics/`` prefixes
+    are matched too for robustness, though in the recipe they are never a direct
+    child of ``main`` (their time nests inside the checkpoint subtree). Without the
+    ``checkpoints/`` match the whole QC subtree falls through to overhead.
     """
     if name in ("from_fits", "to_fits"):
         return IO_SUMMARY_LABEL, "io"
@@ -505,7 +636,11 @@ def _summary_bucket(filename, name):
         if label.startswith("quality_control/quicklook/"):
             return QUICKLOOK_LABEL, "quicklook"
         if label.startswith(
-            ("quality_control/qc_flags/", "quality_control/diagnostics/")
+            (
+                "quality_control/checkpoints/",
+                "quality_control/qc_flags/",
+                "quality_control/diagnostics/",
+            )
         ):
             return QC_LABEL, "qc"
         if label.startswith("modules/"):
@@ -535,9 +670,12 @@ def _recipe_summary(stats, call, network_own):
     ``calibration_association`` (it lands in that stage, never double-counted).
 
     Barycentric correction is quarantined (nondeterministic IERS fetch): its
-    slice is reported separately and excluded from the denominator. Returns the
-    sorted ``rows`` (``(label, seconds, fraction, kind)``), the ``denominator``
-    (wall-clock minus barycentric), ``bary_seconds``, and ``network_seconds``.
+    slice is reported separately and excluded from the denominator. The DiagL0
+    Gaia/SIMBAD pointing lookups are quarantined the same way -- carved out of the
+    QC slice, since they nest inside it rather than being a top-level stage.
+    Returns the sorted ``rows`` (``(label, seconds, fraction, kind)``), the
+    ``denominator`` (wall-clock minus those quarantined slices), ``bary_seconds``,
+    ``astrometry_seconds``, and ``network_seconds``.
     """
     main_key = _find_main_key(stats, call)
     buckets = {}
@@ -559,6 +697,15 @@ def _recipe_summary(stats, call, network_own):
         buckets[OVERHEAD_LABEL] = buckets.get(OVERHEAD_LABEL, 0.0) + main_own
         kinds[OVERHEAD_LABEL] = "overhead"
 
+    # Carve DiagL0's nondeterministic astrometry lookups out of the QC slice, the
+    # same quarantine the barycentric stage gets (reported separately below).
+    astrometry_seconds = _astrometry_cumtime(stats)
+    if astrometry_seconds and QC_LABEL in buckets:
+        astrometry_seconds = min(astrometry_seconds, buckets[QC_LABEL])
+        buckets[QC_LABEL] -= astrometry_seconds
+    else:
+        astrometry_seconds = 0.0
+
     denominator = sum(buckets.values()) or 1e-12
     rows = sorted(
         ((lbl, s, s / denominator, kinds[lbl]) for lbl, s in buckets.items()),
@@ -569,6 +716,7 @@ def _recipe_summary(stats, call, network_own):
         "rows": rows,
         "denominator": denominator,
         "bary_seconds": bary_seconds,
+        "astrometry_seconds": astrometry_seconds,
         "network_seconds": network_own,
     }
 
@@ -765,7 +913,7 @@ def _render(title, total, rows, flags, line_text):
     return "\n".join(out)
 
 
-def _render_recipe(title, summary, split=None, quicklook=None):
+def _render_recipe(title, summary, split=None, quicklook=None, quality=None):
     """Render an end-to-end recipe report.
 
     Just the cumulative **High-level summary** (wall-clock per pipeline stage, a
@@ -780,10 +928,14 @@ def _render_recipe(title, summary, split=None, quicklook=None):
     modules and so is not otherwise visible in the per-stage summary.
     ``quicklook`` (optional, from :func:`_quicklook_breakdown`) adds a per-plot
     breakdown of the quicklook stage; rendered only when non-empty (science).
+    ``quality`` (optional, from :func:`_quality_control_breakdown`) adds a per-
+    sublayer breakdown of the quality-control stage (checkpoints / diagnostics /
+    qc_flags); rendered only when non-empty (science).
     """
     ts = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
     denom = summary["denominator"]
     has_bary = summary["bary_seconds"] > 0
+    has_astro = summary.get("astrometry_seconds", 0) > 0
     out = []
     w = out.append
 
@@ -792,12 +944,22 @@ def _render_recipe(title, summary, split=None, quicklook=None):
     excl = " (excl. barycentric)" if has_bary else ""
     w(f"_Generated {ts} • recipe wall-clock{excl}: {denom:.3f} s._")
     w("")
-    quarantined = (
-        "The barycentric-correction stage and network time are reported "
-        "separately (excluded from the rows) because they are nondeterministic. "
-        if has_bary
-        else "Network time is reported separately because it is nondeterministic. "
-    )
+    items = []
+    if has_bary:
+        items.append("the barycentric-correction stage")
+    if has_astro:
+        items.append("the DiagL0 astrometry lookups")
+    items.append("network time")
+    if len(items) > 1:
+        joined = ", ".join(items[:-1]) + ", and " + items[-1]
+        quarantined = (
+            f"{joined[0].upper()}{joined[1:]} are reported separately (excluded "
+            "from the rows) because they are nondeterministic. "
+        )
+    else:
+        quarantined = (
+            "Network time is reported separately because it is nondeterministic. "
+        )
     w(
         "> Auto-generated by `tests/profiling/_profiling.py`. The High-level "
         "summary is cumulative wall-clock per pipeline stage (each stage includes "
@@ -822,8 +984,19 @@ def _render_recipe(title, summary, split=None, quicklook=None):
             f"- **Barycentric correction stage** — {summary['bary_seconds']:.3f} s "
             "wall-clock (excluded; triggers a nondeterministic IERS network fetch)."
         )
+    if has_astro:
+        excluded.append(
+            f"- **Astrometry lookups** (Gaia DR3 + SIMBAD, in DiagL0) — "
+            f"{summary['astrometry_seconds']:.3f} s cumulative (excluded; "
+            "nondeterministic catalog network queries)."
+        )
     if summary["network_seconds"] > 0:
-        whence = "mostly inside barycentric" if has_bary else "not disk I/O"
+        if not has_bary:
+            whence = "not disk I/O"
+        elif has_astro:
+            whence = "inside barycentric + the DiagL0 lookups"
+        else:
+            whence = "mostly inside barycentric"
         excluded.append(
             f"- **Network** (SSL/socket) — {summary['network_seconds']:.3f} s own "
             f"time (excluded; nondeterministic, {whence})."
@@ -871,6 +1044,26 @@ def _render_recipe(title, summary, split=None, quicklook=None):
         w("| plot | % | s |")
         w("|---|---:|---:|")
         for lbl, secs, frac in quicklook["rows"]:
+            w(f"| `{lbl}` | {frac:.1%} | {secs:.3f} |")
+        w("")
+
+    # Quality-control per-level breakdown (science recipe) ----------------
+    if quality and quality["rows"]:
+        w("## Quality control breakdown")
+        w("")
+        w(
+            f"Wall-clock per level within the quality-control stage "
+            f"({quality['total']:.3f} s total; % of that). The recipe runs all QC "
+            "through `CheckpointL{n}.run()`, which folds in each level's "
+            "diagnostics (`DiagL{n}`) then QC flags (`QCL{n}`); `checkpoints` is "
+            "the thin dispatch/keyword-routing plus header/flag validation. "
+            "DiagL0's nondeterministic Gaia/SIMBAD pointing lookups are excluded "
+            "here (reported with the quarantined slices above)."
+        )
+        w("")
+        w("| level | % | s |")
+        w("|---|---:|---:|")
+        for lbl, secs, frac in quality["rows"]:
             w(f"| `{lbl}` | {frac:.1%} | {secs:.3f} |")
         w("")
 
@@ -948,7 +1141,8 @@ def run_profile(
         summary = _recipe_summary(stats, call, _network_own(rows))
         split = _io_compute_split(stats) if io_compute else None
         quicklook = _quicklook_breakdown(stats)
-        report = _render_recipe(title, summary, split, quicklook)
+        quality = _quality_control_breakdown(stats)
+        report = _render_recipe(title, summary, split, quicklook, quality)
         print(report)
         return _write_report(report, report_name)
 

--- a/tests/profiling/_profiling.py
+++ b/tests/profiling/_profiling.py
@@ -152,7 +152,7 @@ def masters_config(output_dir=None):
 
 
 # ---------------------------------------------------------------------------
-# Intermediate-product builders (the science L0 -> L2 chain)
+# Intermediate-product builders (the science L0 -> L4 chain)
 #
 # Each rebuilds from scratch so a harness can call it twice (the cProfile pass
 # and the line_profiler pass each get a fresh, unmutated input). Construction is
@@ -200,6 +200,12 @@ def bary_l2(config):
     from kpfpipe.modules.barycentric_correction import BarycentricCorrection
 
     return BarycentricCorrection(wls_l2(config), config).perform()
+
+
+def ccf_l4(config):
+    from kpfpipe.modules.cross_correlation import CrossCorrelation
+
+    return CrossCorrelation(bary_l2(config), config).perform()
 
 
 # --- masters inputs --------------------------------------------------------

--- a/tests/profiling/profile_cross_correlation.py
+++ b/tests/profiling/profile_cross_correlation.py
@@ -1,0 +1,35 @@
+"""Profile ``CrossCorrelation.perform`` (build the per-order CCFs, L2 -> L4).
+
+Cross-correlates each illuminated orderlet against its mask to build the per-
+order CCF cubes and seed the RV table; the fits themselves are done downstream by
+``RadialVelocity``. The line-level drill-down pass is kept enabled.
+
+Run with ``make profile-cross_correlation`` or
+``python tests/profiling/profile_cross_correlation.py``. Requires real frames in
+``tests/testdata`` (skips cleanly otherwise).
+"""
+
+try:  # importable via `-m tests.profiling.profile_*` or runnable as a script
+    from tests.profiling import _profiling as P
+except ModuleNotFoundError:
+    import _profiling as P
+
+import kpfpipe.modules.cross_correlation as m_ccf
+
+
+def run():
+    def setup():
+        config = P.science_config()
+        return m_ccf.CrossCorrelation(P.bary_l2(config), config)
+
+    P.run_profile(
+        title="CrossCorrelation.perform (L2 -> L4)",
+        report_name="cross_correlation",
+        setup=setup,
+        call=lambda mod: mod.perform(),
+        candidate_modules=[m_ccf],
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/profiling/profile_radial_velocity.py
+++ b/tests/profiling/profile_radial_velocity.py
@@ -20,7 +20,7 @@ import kpfpipe.modules.radial_velocity as m_rv
 def run():
     def setup():
         config = P.science_config()
-        return m_rv.RadialVelocity(P.bary_l2(config), config)
+        return m_rv.RadialVelocity(P.ccf_l4(config), config)
 
     P.run_profile(
         title="RadialVelocity.perform (L2 -> L4)",

--- a/tests/profiling/profile_science_recipe.py
+++ b/tests/profiling/profile_science_recipe.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:
 # Pipeline modules eligible for the (here disabled) line-level drill-down.
 import kpfpipe.modules.barycentric_correction as m_bary
 import kpfpipe.modules.calibration_association as m_calib
+import kpfpipe.modules.cross_correlation as m_ccf
 import kpfpipe.modules.image_assembly as m_assembly
 import kpfpipe.modules.image_processing as m_proc
 import kpfpipe.modules.radial_velocity as m_rv
@@ -36,6 +37,7 @@ PIPELINE_MODULES = [
     m_extract,
     m_wls,
     m_bary,
+    m_ccf,
     m_rv,
 ]
 

--- a/tests/regression/test_cli.py
+++ b/tests/regression/test_cli.py
@@ -14,9 +14,7 @@ from tools import cli
 
 
 class TestDispatch:
-    @pytest.mark.parametrize(
-        "command", ["run", "masters", "science", "timeseries", "plot-timeseries"]
-    )
+    @pytest.mark.parametrize("command", ["run", "masters", "science", "timeseries"])
     def test_routes_to_command_with_forwarded_argv(self, command, monkeypatch):
         seen = []
         monkeypatch.setitem(cli._COMMANDS, command, lambda rest: seen.append(rest))
@@ -35,7 +33,7 @@ class TestUsage:
         out = capsys.readouterr().out
         assert "usage: kpfpipe <command>" in out
         assert "run" in out and "masters" in out and "science" in out
-        assert "timeseries" in out and "plot-timeseries" in out
+        assert "timeseries" in out
 
     @pytest.mark.parametrize("flag", ["-h", "--help"])
     def test_help_flag_prints_usage(self, flag, capsys):
@@ -50,3 +48,11 @@ class TestUnknownCommand:
         assert exc.value.code == 2
         err = capsys.readouterr().err
         assert "unknown command" in err and "frobnicate" in err
+
+    def test_plot_timeseries_is_not_a_command(self, capsys):
+        # The plotter is invoked only via `scripts.plots.plot_timeseries` (as a
+        # script and from the timeseries stage); it is deliberately not a CLI command.
+        assert "plot-timeseries" not in cli._COMMANDS
+        with pytest.raises(SystemExit) as exc:
+            cli.main(["plot-timeseries", "--target", "10700"])
+        assert exc.value.code == 2

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -1,15 +1,14 @@
 """KPF Pipeline CLI entry point: the ``kpfpipe`` command dispatcher.
 
 ``kpfpipe`` is the single front door to the pipeline. It is a thin, git-style
-dispatcher that routes a subcommand to its implementation under ``scripts/`` (the
-``processing/`` orchestrators and the ``plots/`` plotter) and forwards the
-remaining arguments verbatim -- the subcommand owns its own argument parsing:
+dispatcher that routes a subcommand to its ``processing/`` orchestrator under
+``scripts/`` and forwards the remaining arguments verbatim -- the subcommand owns
+its own argument parsing:
 
-    kpfpipe run             -- reduce one recipe on one unit, in-process (the leaf)
-    kpfpipe masters         -- build nightly master calibrations for a set of datecodes
-    kpfpipe science         -- reduce a set of science frames end-to-end (L0 -> L4)
-    kpfpipe timeseries      -- reduce a star's RV timeseries over a datecode range
-    kpfpipe plot-timeseries -- plot a star's RV timeseries from its L4 products
+    kpfpipe run         -- reduce one recipe on one unit, in-process (the leaf)
+    kpfpipe masters     -- build nightly master calibrations for a set of datecodes
+    kpfpipe science     -- reduce a set of science frames end-to-end (L0 -> L4)
+    kpfpipe timeseries  -- reduce a star's RV timeseries over a datecode range
 
 Examples:
 
@@ -17,8 +16,6 @@ Examples:
     kpfpipe masters --dates 20240405 20240712         # batch (fans out `run`)
     kpfpipe science --obs_ids KP.20240405.40113.57
     kpfpipe timeseries --target 10700 --date_range 20240101 20240131
-    kpfpipe plot-timeseries --target 10700 --obs_ids KP.20240101.03600.00 \\
-        --data_dir /data/kpf/science --plot_dir ./plots
 
 Run ``kpfpipe <command> -h`` for a command's own options.
 
@@ -28,7 +25,6 @@ layer; the scripts never import ``tools`` (see CLAUDE.md, "CLI architecture").
 
 import sys
 
-from scripts.plots import plot_timeseries
 from scripts.processing import masters, reduce, science, timeseries
 
 _COMMANDS = {
@@ -36,7 +32,6 @@ _COMMANDS = {
     "masters": masters.main,
     "science": science.main,
     "timeseries": timeseries.main,
-    "plot-timeseries": plot_timeseries.main,
 }
 
 
@@ -45,11 +40,10 @@ def _usage():
     return (
         "usage: kpfpipe <command> [options]\n\n"
         "commands:\n"
-        "  run              reduce one recipe on one unit, in-process (the leaf)\n"
-        "  masters          build nightly master calibrations for a set of datecodes\n"
-        "  science          reduce a set of science frames end-to-end (L0 -> L4)\n"
-        "  timeseries       reduce a star's RV timeseries over a datecode range\n"
-        "  plot-timeseries  plot a star's RV timeseries from its L4 products\n\n"
+        "  run         reduce one recipe on one unit, in-process (the leaf)\n"
+        "  masters     build nightly master calibrations for a set of datecodes\n"
+        "  science     reduce a set of science frames end-to-end (L0 -> L4)\n"
+        "  timeseries  reduce a star's RV timeseries over a datecode range\n\n"
         "Run `kpfpipe <command> -h` for a command's own options."
     )
 


### PR DESCRIPTION
  ## Summary

  A batch of small, mostly-independent cleanup tasks on the KPF-DRP vNext pipeline —
  a typo fix, a QC helper consolidation, profiling-harness coverage/accuracy, a CLI
  trim, and a docs wording fix. No behavior change to the science path.

  ## Changes

  - **fix:** correct the `_compute_per_chanel_...` →
  `_compute_per_channel_flux_weighted_midpoint_time`
    typo in `barycentric_correction.py` and its call site.
  - **refactor:** consolidate the 4×-duplicated `_hdr_float` and the `_hdr_flag` helper
    into `QC._hdr_float` / `QC._hdr_bool` static methods on the qc_flags base; drop the
    redundant inline ops across `quality_control/qc_flags/`.
  - **refactor:** drop `plot-timeseries` from the `kpfpipe` CLI (now `run` / `masters` /
    `science` / `timeseries` only). The plotter still runs as a script and is still
    auto-invoked by the `timeseries` stage.
  - **test:** add a `cross_correlation` profiling harness and wire it into the science
    profiling chain (`profile_science_recipe.py` / `_profiling.py` / Makefile); fix the
    RV harness to build an L4 with CCFs.
  - **test:** break out quality control as its own profiling stage — the checkpoint-driven
    QC subtree was being misattributed to "orchestration / overhead" (~13.6 s). Adds a
    per-level `DiagL{n}`/`QCL{n}` breakdown, and quarantines DiagL0's nondeterministic
    Gaia/SIMBAD lookups from the denominator (as the barycentric IERS fetch already is).
  - **docs:** stop calling the Diagnostics/QC layers "read-only" — they write header
    keywords via `set_keyword`; the real invariant is that they never mutate the science
    arrays.

  ## Testing

  - `make test-fast` passes; `test_cli.py` updated for the CLI trim.
  - Profiling harnesses regenerate their reports (pre-existing `master_wls` /
    `masters_recipe` failure is unrelated — bundled testdata has 4 ThAr frames vs.
    `min_stack_size=5`).