### PR TITLE
Logging overhaul: unified levels, structured QC/diagnostics output, end-of-run summaries

### DIFF
--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -231,7 +231,10 @@ The master filename (`{KOAID}_master_{type}_L{N}.fits`, WMKO DRP-RUN-05) is set 
 The pipeline is built in strictly one-directional layers — each layer may import *down* but
 never up: `kpfpipe/` (scientist-facing building blocks) ← `recipes/` (compose modules) ←
 `scripts/` (run a recipe many times) ← `tools/` (the CLI interface). So `tools/cli.py`
-imports `scripts.processing.*`, but **the scripts must never import `tools`**.
+imports `scripts.processing.*`, but **the scripts must never import `tools`**. All four are
+installed, importable packages; code shared across a layer's siblings goes **down** into
+`kpfpipe/`, or — when it is layer-specific — lives beside them as a `_`-prefixed private helper
+(e.g. `scripts/processing/_argparse.py`, `recipes/_logging.py`) that only its own layer imports.
 
 ### Modules
 

--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -377,8 +377,9 @@ Both siblings write one UT-timestamped file per invocation under the `[LOGGER] l
 (`log_level`/`console` also honored; CLI `--log_dir`/`--log_level` override); a missing `log_dir` is
 fatal (DRP-RUN-07). Library code only declares `logger = logging.getLogger(__name__)` and must work
 with no handlers installed — tests call `recipe.main(config, args)` directly with none configured, so
-setup must never move into recipes. `warnings.warn` stays the recoverable-condition API, bridged in
-via `logging.captureWarnings`; tests that configure logging must tear down with `teardown_logging`
+setup must never move into recipes. Recoverable/degraded conditions use `logger.warning` (not
+`warnings.warn`); `logging.captureWarnings` still funnels any third-party/stdlib `warnings.warn` into
+the log at `WARNING`. Tests that configure logging must tear down with `teardown_logging`
 (see the autouse fixture in `tests/regression/test_logger.py`).
 
 

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -333,9 +333,9 @@ Logging follows WMKO DRP-RUN-07/08/09. The coding rules:
 - **Handler/level configuration lives only in `kpfpipe.utils.logger`**, never at import time or in
   recipes/modules/tests; library code must work with no handlers installed.
 - **Level policy**: `INFO` = production (steps, decisions, I/O, end-of-`perform()` summaries),
-  `DEBUG` = inner-loop detail, `WARNING` via the warnings bridge. Never gate log calls behind
-  `verbose` — the level is the gate. Use lazy `%`-formatting (`logger.info("wrote %s", fn)`, Ruff
-  `G`), not f-strings.
+  `DEBUG` = inner-loop detail, `WARNING` = recoverable/degraded runtime conditions. Never gate log
+  calls behind `verbose` — the level is the gate. Use lazy `%`-formatting (`logger.info("wrote %s",
+  fn)`, Ruff `G`), not f-strings.
 - **No `print()` in pipeline code.** Anything that runs as part of a reduction — `perform()` and its
   helpers, recipes, the CLI, utils, data-model read/write paths — logs, never prints. The **only**
   sanctioned `print()` is the interactive `info()` reporter (data models and modules), which exists
@@ -353,8 +353,13 @@ Logging follows WMKO DRP-RUN-07/08/09. The coding rules:
 - **Predicate/extractor split**: `is_*` predicates validate inline and return `bool` (never raise);
   the matching raising extractor/converter (`get_*`, `utc_to_hst`, …) validates through the predicate
   and raises `ValueError` at its own boundary.
-- **Recoverable/degraded conditions** → `if verbose: warnings.warn(..., stacklevel=2)` (the explicit
-  `stacklevel` is required, Ruff `B028`); `setup_logging` bridges these to `WARNING`.
+- **Recoverable/degraded conditions** → `logger.warning(...)`, not `warnings.warn`. A degraded
+  runtime condition (missing header, dropped frame, failed lookup) is an operational event the log
+  must record (DRP-RUN-08), and `logger.warning` — unlike `warnings.warn` — does not dedup per
+  call-site, so a per-frame condition is logged every time. Reserve `warnings.warn` for
+  developer-facing deprecations / API misuse. `setup_logging` still calls
+  `logging.captureWarnings(True)`, so any third-party/stdlib `warnings.warn` is funneled into the log
+  at `WARNING`.
 
 ---
 

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -336,8 +336,10 @@ Logging follows WMKO DRP-RUN-07/08/09. The coding rules:
   `DEBUG` = inner-loop detail, `WARNING` via the warnings bridge. Never gate log calls behind
   `verbose` — the level is the gate. Use lazy `%`-formatting (`logger.info("wrote %s", fn)`, Ruff
   `G`), not f-strings.
-- **`print()` only in interactive `info()` reporters**, never in `perform()`/pipeline paths (the
-  `_info` rendering is in §B.2).
+- **No `print()` in pipeline code.** Anything that runs as part of a reduction — `perform()` and its
+  helpers, recipes, the CLI, utils, data-model read/write paths — logs, never prints. The **only**
+  sanctioned `print()` is the interactive `info()` reporter (data models and modules), which exists
+  for notebook/REPL use and is never called from pipeline paths (the `_info` rendering is in §B.2).
 - **Raise; don't catch-and-log.** The sole sanctioned catch-log-reraise point is the leaf runner
   (`reduce.py`: `logger.critical(..., exc_info=True); raise`). Elsewhere pick the semantic type:
   `TypeError` (wrong `config` type), `ValueError` (bad domain value — the workhorse),

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -333,9 +333,10 @@ Logging follows WMKO DRP-RUN-07/08/09. The coding rules:
 - **Handler/level configuration lives only in `kpfpipe.utils.logger`**, never at import time or in
   recipes/modules/tests; library code must work with no handlers installed.
 - **Level policy**: `INFO` = production (steps, decisions, I/O, end-of-`perform()` summaries),
-  `DEBUG` = inner-loop detail, `WARNING` = recoverable/degraded runtime conditions. Never gate log
-  calls behind `verbose` — the level is the gate. Use lazy `%`-formatting (`logger.info("wrote %s",
-  fn)`, Ruff `G`), not f-strings.
+  `DEBUG` = inner-loop (per-order/-chip/-frame) detail, `WARNING` = recoverable/degraded runtime
+  conditions. Per-item logging inside a loop stays `DEBUG` (or aggregate to one line) so it never
+  floods `INFO`/`WARNING`. Never gate log calls behind `verbose` — the level is the gate. Use lazy
+  `%`-formatting (`logger.info("wrote %s", fn)`, Ruff `G`), not f-strings.
 - **No `print()` in pipeline code.** Anything that runs as part of a reduction — `perform()` and its
   helpers, recipes, the CLI, utils, data-model read/write paths — logs, never prints. The **only**
   sanctioned `print()` is the interactive `info()` reporter (data models and modules), which exists

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -163,7 +163,7 @@ class StageName:
     # ------------------------------------------------------------------
     def _track_info(self, chips=None, fibers=None):
         """Build & cache the info() summary text (takes only chips/fibers)."""
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"   # blank-line padding lives here
 
     def _set_headers(self, l2_obj):
         """Sole place this module writes headers; reads instance attributes."""
@@ -177,7 +177,7 @@ class StageName:
         self._set_headers(self.l2_obj)         # consolidates ALL header writes
         self._track_info(chips)                # caches _info text, before the receipt
         self.l2_obj.receipt_add_entry("stage_name", "", "PASS")
-        logger.info("summary:\n%s", self._info)
+        logger.info("%s", self._info)         # padding is baked into _info; keep this clean
         return self.l2_obj
 
     def info(self):       # prints self._info (the cached text), always last

--- a/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
+++ b/docs/dev/KPF_VNEXT_STYLE_GUIDE.md
@@ -335,7 +335,10 @@ Logging follows WMKO DRP-RUN-07/08/09. The coding rules:
 - **Level policy**: `INFO` = production (steps, decisions, I/O, end-of-`perform()` summaries),
   `DEBUG` = inner-loop (per-order/-chip/-frame) detail, `WARNING` = recoverable/degraded runtime
   conditions. Per-item logging inside a loop stays `DEBUG` (or aggregate to one line) so it never
-  floods `INFO`/`WARNING`. Never gate log calls behind `verbose` — the level is the gate. Use lazy
+  floods `INFO`/`WARNING`. Emit QC/diagnostics keyword logs one keyword per line as
+  `keyword = value — comment` (the FITS comment, read off the header) — verbosely at `DEBUG`, but
+  only for failing/fatal flags at the rare `WARNING`/`ERROR` levels. Never gate log calls behind
+  `verbose` — the level is the gate. Use lazy
   `%`-formatting (`logger.info("wrote %s", fn)`, Ruff `G`), not f-strings.
 - **No `print()` in pipeline code.** Anything that runs as part of a reduction — `perform()` and its
   helpers, recipes, the CLI, utils, data-model read/write paths — logs, never prints. The **only**

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -19,7 +19,6 @@ For example, "SCI2_FLUX" is registered as an alias for "TRACE3_FLUX", so reading
 """
 
 import logging
-import warnings
 
 import numpy as np
 from astropy.io import fits
@@ -228,12 +227,13 @@ class KPFDataModel(RVDataModel):
             target = np.dtype(f"uint{min_depth}")
         else:
             target = np.dtype(f"int{min_depth}")
-        warnings.warn(
-            f"Extension '{label}' has dtype {data.dtype} "
-            f"({data.dtype.itemsize * 8}-bit) but MinBitDepth={min_depth}. "
-            f"Upcasting to {target.name}.",
-            UserWarning,
-            stacklevel=2,
+        logger.warning(
+            "Extension '%s' has dtype %s (%d-bit) but MinBitDepth=%d. Upcasting to %s.",
+            label,
+            data.dtype,
+            data.dtype.itemsize * 8,
+            min_depth,
+            target.name,
         )
         return data.astype(target)
 

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -44,7 +44,7 @@ per-frame value, not a static default).
 
 import importlib.metadata
 import importlib.resources
-import warnings
+import logging
 from types import MappingProxyType
 
 import pandas as pd
@@ -55,6 +55,8 @@ from rvdata.core.models.definitions import (
 from rvdata.core.tools.headers import parse_value_to_datatype
 
 from kpfpipe import DETECTOR, __version__
+
+logger = logging.getLogger(__name__)
 
 _rvdata_inst_cfg = importlib.resources.files("rvdata.instruments.kpf.config")
 _rvdata_core_cfg = importlib.resources.files("rvdata.core.models.config")
@@ -274,11 +276,10 @@ class KeywordRegistry:
             set(eprv_keys[raw["STANDARD"].notna()]) - self.registered - {""}
         )
         if unregistered:
-            warnings.warn(
+            logger.warning(
                 "header_map.csv maps to STANDARD keys absent from the keyword "
-                f"registry; they are dropped (not emitted): {unregistered}",
-                UserWarning,
-                stacklevel=2,
+                "registry; they are dropped (not emitted): %s",
+                unregistered,
             )
         keep = eprv_keys.isin(self.registered) & ~eprv_keys.isin(
             self._DEFAULT_OVERRIDES.keys()

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -9,7 +9,6 @@ import importlib.resources
 import logging
 import os
 import re
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -92,10 +91,8 @@ class KPF0(KPFDataModel):
         for key in ("PROGID", "KOAID"):
             value = primary.get(key)
             if not value:
-                warnings.warn(
-                    f"{key} absent from L0 PRIMARY; defaulting to 'UNKNOWN'",
-                    UserWarning,
-                    stacklevel=2,
+                logger.warning(
+                    "%s absent from L0 PRIMARY; defaulting to 'UNKNOWN'", key
                 )
                 value = "UNKNOWN"
             self.set_keyword(key, value)
@@ -122,10 +119,8 @@ class KPF0(KPFDataModel):
             if ext_name not in self.extensions:
                 if ext_name != "PRIMARY":
                     if ext_name not in _KNOWN_L0_EXTENSIONS:
-                        warnings.warn(
-                            f"Non-standard extension '{ext_name}' found in L0 file.",
-                            UserWarning,
-                            stacklevel=2,
+                        logger.warning(
+                            "Non-standard extension '%s' found in L0 file.", ext_name
                         )
                     self.create_extension(ext_name, fits_type)
 
@@ -154,10 +149,10 @@ class KPF0(KPFDataModel):
         """KPF L0 uses the WMKO-native KP.YYYYMMDD.NNNNN.NN.fits name."""
         basename = os.path.basename(filename)
         if not _L0_FILENAME_PATTERN.fullmatch(basename):
-            warnings.warn(
-                f"Filename '{basename}' does not follow the KPF L0 naming "
+            logger.warning(
+                "Filename '%s' does not follow the KPF L0 naming "
                 "convention (KP.YYYYMMDD.NNNNN.NN.fits)",
-                stacklevel=2,
+                basename,
             )
             return False
         return True

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -10,7 +10,6 @@ import importlib.resources
 import logging
 import os
 import re
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -95,10 +94,8 @@ class KPF1(KPFDataModel):
             if ext_name not in self.extensions:
                 if ext_name != "PRIMARY":
                     if ext_name not in self._known_extensions:
-                        warnings.warn(
-                            f"Non-standard extension '{ext_name}' found in L1 file.",
-                            UserWarning,
-                            stacklevel=2,
+                        logger.warning(
+                            "Non-standard extension '%s' found in L1 file.", ext_name
                         )
                     self.create_extension(ext_name, fits_type)
 
@@ -130,10 +127,10 @@ class KPF1(KPFDataModel):
         """
         basename = os.path.basename(filename)
         if not _L1_FILENAME_PATTERN.fullmatch(basename):
-            warnings.warn(
-                f"Filename '{basename}' does not follow the KPF L1 naming "
+            logger.warning(
+                "Filename '%s' does not follow the KPF L1 naming "
                 "convention (kpf_L1_YYYYMMDDThhmmss.fits)",
-                stacklevel=2,
+                basename,
             )
             return False
         return True

--- a/kpfpipe/data_models/masters/base.py
+++ b/kpfpipe/data_models/masters/base.py
@@ -9,15 +9,17 @@ Masters products differ from science products in extension naming to
 avoid confusion (see KPFMasterL1/L2/L4)
 """
 
+import logging
 import os
 import re
-import warnings
 
 import pandas as pd
 
 from kpfpipe.data_models.base import KPFDataModel
 from kpfpipe.utils.io import kpf_filename
 from kpfpipe.utils.kpf_utils import get_obs_id
+
+logger = logging.getLogger(__name__)
 
 # WMKO DRP-RUN-05 master name: {KOAID}_master_{type}_L{N}.fits, where KOAID is a
 # KP.YYYYMMDD.NNNNN.NN obs_id, type is bias/dark/flat/thar, and N is 1/2/4.
@@ -46,10 +48,10 @@ class KPFMasterModel(KPFDataModel):
         """
         basename = os.path.basename(filename)
         if not _MASTER_FILENAME_PATTERN.fullmatch(basename):
-            warnings.warn(
-                f"Filename '{basename}' does not follow the KPF masters naming "
+            logger.warning(
+                "Filename '%s' does not follow the KPF masters naming "
                 "convention ({KOAID}_master_{bias,dark,flat,thar}_L{1,2,4}.fits)",
-                stacklevel=2,
+                basename,
             )
             return False
         return True

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -9,7 +9,6 @@ solutions, while a flat master (kind="flat") holds extracted spectra.
 import importlib.resources
 import logging
 import os
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -157,10 +156,8 @@ class KPFMasterL2(KPFMasterModel, KPF2):
             if ext_name not in self.extensions:
                 if ext_name != "PRIMARY":
                     if ext_name not in self._known_extensions:
-                        warnings.warn(
-                            f"Non-standard extension '{ext_name}' found in L2 file.",
-                            UserWarning,
-                            stacklevel=2,
+                        logger.warning(
+                            "Non-standard extension '%s' found in L2 file.", ext_name
                         )
                     self.create_extension(ext_name, fits_type)
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -675,7 +675,7 @@ class BarycentricCorrection:
             f"\n  per-order spread:   BJD {np.ptp(bjd) * 86400:.3f} sec,"
             f" BARY {np.ptp(kms) * 1000:.3f} m/s"
         )
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l2_obj):
         """Write the per-CCD summary keywords.
@@ -757,7 +757,7 @@ class BarycentricCorrection:
         self._track_info()
         self.l2_obj.receipt_add_entry("barycentric_correction", "", "PASS")
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return self.l2_obj
 
     def info(self):

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -328,6 +328,7 @@ class BarycentricCorrection:
             FROM gaiadr3.gaia_source
             WHERE source_id = {gaia_id}
             """
+            logger.info("querying Gaia DR3 for source_id %s", gaia_id)
             job = Gaia.launch_job(query)
             result = job.get_results()[0]
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -12,7 +12,6 @@ barycorrpy) with the flux-weighted midpoint time of Butler et al. (1996).
 
 import logging
 import re
-import warnings
 
 import astropy.units as u
 import numpy as np
@@ -381,10 +380,11 @@ class BarycentricCorrection:
                 gaia_error = e
         if self.use_wmko_fallback:
             if gaia_error is not None:
-                warnings.warn(
-                    f"Gaia astrometry unavailable ({type(gaia_error).__name__}: "
-                    f"{gaia_error}); using WMKO header astrometry",
-                    stacklevel=2,
+                logger.warning(
+                    "Gaia astrometry unavailable (%s: %s); "
+                    "using WMKO header astrometry",
+                    type(gaia_error).__name__,
+                    gaia_error,
                 )
             self._astrometry_source = "WMKO header"
             return self._wmko_astrometry()

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -757,7 +757,7 @@ class BarycentricCorrection:
         self._track_info()
         self.l2_obj.receipt_add_entry("barycentric_correction", "", "PASS")
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return self.l2_obj
 
     def info(self):

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -155,7 +155,7 @@ class CalibrationAssociation:
         for cal_type, cal in self._calibrations.items():
             lines.append(f"  {cal_type:<12s} {cal['filepath']}")
             lines.append("")
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l1_obj):
         """Write the master-path keyword for each associated calibration.
@@ -234,7 +234,7 @@ class CalibrationAssociation:
         self._track_info()
         self.l1_obj.receipt_add_entry("calibration_association", "", "PASS")
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return self.l1_obj
 
     def info(self):

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -223,6 +223,12 @@ class CalibrationAssociation:
                 )
 
             self._calibrations[cal_type] = {"filepath": filepath}
+            logger.debug(
+                "%s: selected %s from %d candidate(s)",
+                cal_type,
+                filepath,
+                len(master_files),
+            )
 
         self._set_headers(self.l1_obj)
         self._track_info()

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -234,7 +234,7 @@ class CalibrationAssociation:
         self._track_info()
         self.l1_obj.receipt_add_entry("calibration_association", "", "PASS")
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return self.l1_obj
 
     def info(self):

--- a/kpfpipe/modules/calibration_association.py
+++ b/kpfpipe/modules/calibration_association.py
@@ -7,7 +7,6 @@ the masters directory and selecting the nearest-in-time match.
 """
 
 import logging
-import warnings
 from datetime import datetime, timedelta
 
 from kpfpipe import DEFAULTS
@@ -113,10 +112,10 @@ class CalibrationAssociation:
                 try:
                     ts = get_timestamp(filepath)
                 except ValueError as e:
-                    warnings.warn(
-                        f"dropping master with unparseable timestamp: "
-                        f"{filepath!r} ({e})",
-                        stacklevel=2,
+                    logger.warning(
+                        "dropping master with unparseable timestamp: %r (%s)",
+                        filepath,
+                        e,
                     )
                     continue
                 master_files.append((filepath, ts))

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -594,7 +594,7 @@ class CrossCorrelation:
                 lines.append(
                     f"  {chip:<8s}{fiber:<8s}{res.get('source', ''):<10s}{nccf:>8d}"
                 )
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l4_obj):
         """
@@ -782,7 +782,7 @@ class CrossCorrelation:
         self._set_headers(l4_obj)
         self._track_info(chips, fibers)
         l4_obj.receipt_add_entry("cross_correlation", "", "PASS")
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return l4_obj
 
     def info(self):

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -31,7 +31,6 @@ no air/vacuum conversion is performed.
 """
 
 import logging
-import warnings
 
 import astropy.units as u
 import numpy as np
@@ -172,11 +171,9 @@ class CrossCorrelation:
                 "apply_barycorr": None,
                 "vel_grid_center": None,
             }
-            warnings.warn(
-                f"{fiber.upper()} is lfc-illuminated; CCF is not implemented. "
-                "Skipping this fiber.",
-                UserWarning,
-                stacklevel=2,
+            logger.warning(
+                "%s is lfc-illuminated; CCF is not implemented. Skipping this fiber.",
+                fiber.upper(),
             )
         elif "etalon" in v:
             source = {
@@ -185,11 +182,10 @@ class CrossCorrelation:
                 "apply_barycorr": None,
                 "vel_grid_center": None,
             }
-            warnings.warn(
-                f"{fiber.upper()} is etalon-illuminated; CCF is not implemented. "
+            logger.warning(
+                "%s is etalon-illuminated; CCF is not implemented. "
                 "Skipping this fiber.",
-                UserWarning,
-                stacklevel=2,
+                fiber.upper(),
             )
         else:
             raise ValueError(f"unrecognized illumination source {raw!r}")

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -782,7 +782,7 @@ class CrossCorrelation:
         self._set_headers(l4_obj)
         self._track_info(chips, fibers)
         l4_obj.receipt_add_entry("cross_correlation", "", "PASS")
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return l4_obj
 
     def info(self):

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -580,7 +580,7 @@ class ImageAssembly:
         self._track_info(chips)
         l1_obj.receipt_add_entry("image_assembly", "", "PASS")
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return l1_obj
 
     def info(self):

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -499,7 +499,7 @@ class ImageAssembly:
                 rnng = round(float(self.rn_nongauss[ch]), 4)
                 lines.append(f"  {ch:<14s} {rn:<18} {rnng}")
             lines.append("")
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l1_obj):
         """
@@ -580,7 +580,7 @@ class ImageAssembly:
         self._track_info(chips)
         l1_obj.receipt_add_entry("image_assembly", "", "PASS")
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return l1_obj
 
     def info(self):

--- a/kpfpipe/modules/image_assembly.py
+++ b/kpfpipe/modules/image_assembly.py
@@ -241,6 +241,8 @@ class ImageAssembly:
                 f"detected {self.namp[chip]} on {chip} CCD"
             )
 
+        logger.debug("%s CCD: %d-amplifier mode", chip, self.namp[chip])
+
     def orient_channels(self, chip):
         """
         Reorient amplifier channels to a standard orientation in-place.

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -366,7 +366,7 @@ class ImageProcessing:
         self._track_info()
         self.l1_obj.receipt_add_entry("image_processing", "", "PASS")
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return self.l1_obj
 
     def info(self):

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -349,10 +349,12 @@ class ImageProcessing:
 
         if self.bias:
             for chip in self.chips:
+                logger.debug("subtracting bias from %s CCD", chip)
                 self.subtract_bias(chip)
 
         if self.dark:
             for chip in self.chips:
+                logger.debug("subtracting dark from %s CCD", chip)
                 self.subtract_dark(chip)
 
         # OR with the prior flag so applying one calibration never clears

--- a/kpfpipe/modules/image_processing.py
+++ b/kpfpipe/modules/image_processing.py
@@ -245,7 +245,7 @@ class ImageProcessing:
             lines.append(f"  {'bias':<10s} {self._bias_path}")
         if self.dark:
             lines.append(f"  {'dark':<10s} {self._dark_path}")
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l1_obj):
         """Write the applied-flag keywords (BIASSUB/DARKSUB) for image processing.
@@ -366,7 +366,7 @@ class ImageProcessing:
         self._track_info()
         self.l1_obj.receipt_add_entry("image_processing", "", "PASS")
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return self.l1_obj
 
     def info(self):

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -2,8 +2,8 @@
 Base class for KPF Masters modules.
 """
 
+import logging
 import os
-import warnings
 
 import numpy as np
 
@@ -17,6 +17,8 @@ from kpfpipe.modules.spectral_extraction import SpectralExtraction
 from kpfpipe.quality_control.qc_flags.level0 import QCL0
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.stats import flag_outliers, interpolate_bad_pixels
+
+logger = logging.getLogger(__name__)
 
 
 class BaseMasterModule:
@@ -201,7 +203,7 @@ class BaseMasterModule:
             qc = QCL0(l0_obj).run()
             failed = [kw for kw in self._REQUIRED_L0_QC_FLAGS if not qc[kw][0]]
             if failed:
-                warnings.warn(f"QC failed for {fn}: {', '.join(failed)}", stacklevel=2)
+                logger.warning("QC failed for %s: %s", fn, ", ".join(failed))
                 return None
 
             l1_obj = ImageAssembly(l0_obj).perform()
@@ -210,7 +212,7 @@ class BaseMasterModule:
                 self._l1_obj_cache[fn] = l1_obj
 
         except (FileNotFoundError, OSError) as e:
-            warnings.warn(f"Failed to load {fn}: {e}", stacklevel=2)
+            logger.warning("Failed to load %s: %s", fn, e)
             return None
 
         return l1_obj

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -700,6 +700,12 @@ class BaseMasterModule:
         if nframe < 2:
             raise ValueError(f"Stacking requires at least two frames, got {nframe}")
 
+        logger.debug(
+            "stacking %d frames via %s method",
+            nframe,
+            "datacube" if nframe < nstream else "streaming",
+        )
+
         if nframe < nstream:
             stats, _ = self._compute_stats_from_datacube(
                 l0_file_list,

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -98,7 +98,7 @@ class Bias(BaseMasterModule):
         if master_path is not None:
             self.save_master("L1", master_path, overwrite=True)
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
 
         return self.ml1_obj
 

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -98,7 +98,7 @@ class Bias(BaseMasterModule):
         if master_path is not None:
             self.save_master("L1", master_path, overwrite=True)
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
 
         return self.ml1_obj
 
@@ -117,7 +117,7 @@ class Bias(BaseMasterModule):
                 f"  {chip:<8s} {stats['median']:<15.4f} {stats['rms']:<10.4f} "
                 f"{stats['num_bad']} ({stats['pct_bad']:.3f}%)"
             )
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def info(self):
         """Print a summary of the module configuration and stacking results."""

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -114,7 +114,7 @@ class Dark(BaseMasterModule):
         if master_path is not None:
             self.save_master("L1", master_path, overwrite=True)
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
 
         return self.ml1_obj
 
@@ -134,7 +134,7 @@ class Dark(BaseMasterModule):
                 f"  {chip:<8s} {stats['median']:<15.4f} {stats['rms']:<10.4f} "
                 f"{stats['num_bad']} ({stats['pct_bad']:.3f}%)"
             )
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def info(self):
         """Print a summary of the module configuration and stacking results."""

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -114,7 +114,7 @@ class Dark(BaseMasterModule):
         if master_path is not None:
             self.save_master("L1", master_path, overwrite=True)
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
 
         return self.ml1_obj
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -793,7 +793,7 @@ class WLS(BaseMasterModule):
             self.save_diagnostics(master_path, overwrite=True)
 
         self._track_info()
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
 
         for chip in self.chips:
             n_survivors = self._stack_info[chip]["n_survivors"]
@@ -978,7 +978,7 @@ class WLS(BaseMasterModule):
             lines.append(
                 f"  {chip:<8s} {survived:<18s} {n_fit} / {n_total} ({pct:.1f}%)"
             )
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def info(self):
         """Print a summary of the module configuration and WLS results."""

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -4,7 +4,6 @@ KPF Master Wavelength Solution construction module.
 
 import logging
 import os
-import warnings
 
 import h5py
 import numpy as np
@@ -365,10 +364,12 @@ class WLS(BaseMasterModule):
 
                 nlines = len(line_dict["wav"])
                 if nlines == 0:
-                    warnings.warn(
-                        f"{chip} {fiber} order {o}: orderlet skipped "
-                        f"(no fittable lines; flux likely NaN-filled)",
-                        stacklevel=2,
+                    logger.warning(
+                        "%s %s order %s: orderlet skipped "
+                        "(no fittable lines; flux likely NaN-filled)",
+                        chip,
+                        fiber,
+                        o,
                     )
                 line_dict["chip"] = np.full(nlines, chip)
                 line_dict["fiber"] = np.full(nlines, fiber)
@@ -385,10 +386,12 @@ class WLS(BaseMasterModule):
             n_good = int(np.sum(lines["isgood"][i]))
             logger.info("%s %s: %d/%d good lines", chip, fiber, n_good, n_total)
             if n_good == 0:
-                warnings.warn(
-                    f"{chip} {fiber}: no good lines retained "
-                    f"({n_total} attempted; all rejected or NaN-filled)",
-                    stacklevel=2,
+                logger.warning(
+                    "%s %s: no good lines retained "
+                    "(%d attempted; all rejected or NaN-filled)",
+                    chip,
+                    fiber,
+                    n_total,
                 )
 
         for k in lines:
@@ -590,10 +593,13 @@ class WLS(BaseMasterModule):
 
             if bad_frac > max_bad_frac:
                 frame["rejected"] = True
-                warnings.warn(
-                    f"{chip} frame {l2_obj.obs_id}: {bad_frac:.1%} of line fits "
-                    f"failed QC (> {max_bad_frac:.0%}); frame rejected from stack",
-                    stacklevel=2,
+                logger.warning(
+                    "%s frame %s: %.1f%% of line fits failed QC (> %.0f%%); "
+                    "frame rejected from stack",
+                    chip,
+                    l2_obj.obs_id,
+                    bad_frac * 100,
+                    max_bad_frac * 100,
                 )
                 continue
 
@@ -609,19 +615,21 @@ class WLS(BaseMasterModule):
                 )
             except ValueError as exc:
                 frame["rejected"] = True
-                warnings.warn(
-                    f"{chip} frame {l2_obj.obs_id}: WLS fit failed ({exc}); "
-                    f"frame rejected from stack",
-                    stacklevel=2,
+                logger.warning(
+                    "%s frame %s: WLS fit failed (%s); frame rejected from stack",
+                    chip,
+                    l2_obj.obs_id,
+                    exc,
                 )
                 continue
 
             if not np.isfinite(coeffs).all():
                 frame["rejected"] = True
-                warnings.warn(
-                    f"{chip} frame {l2_obj.obs_id}: non-finite Legendre "
-                    f"coefficients; frame rejected from stack",
-                    stacklevel=2,
+                logger.warning(
+                    "%s frame %s: non-finite Legendre coefficients; "
+                    "frame rejected from stack",
+                    chip,
+                    l2_obj.obs_id,
                 )
                 continue
 
@@ -930,17 +938,15 @@ class WLS(BaseMasterModule):
 
         directory = masters_stack_subdir(os.path.dirname(master_path), "thar", "L2")
         os.makedirs(directory, exist_ok=True)
-        # These are deliberately non-EPRV diagnostic products; suppress KPF2.to_fits'
-        # EPRV filename-convention warning for the {obs_id}_thar_L2 name.
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=".*EPRV naming convention.*")
-            for l2_obj in self._l2_obj_cache:
-                path = os.path.join(directory, f"{l2_obj.obs_id}_thar_L2.fits")
-                if not overwrite and os.path.exists(path):
-                    raise FileExistsError(
-                        f"{path} already exists; pass overwrite=True to replace it"
-                    )
-                l2_obj.to_fits(path)
+        # These are deliberately non-EPRV diagnostic products; KPF2.to_fits' EPRV
+        # filename-convention warning for the {obs_id}_thar_L2 name is expected.
+        for l2_obj in self._l2_obj_cache:
+            path = os.path.join(directory, f"{l2_obj.obs_id}_thar_L2.fits")
+            if not overwrite and os.path.exists(path):
+                raise FileExistsError(
+                    f"{path} already exists; pass overwrite=True to replace it"
+                )
+            l2_obj.to_fits(path)
         logger.info(
             "wrote %d individual ThAr L2 frames to %s",
             len(self._l2_obj_cache),

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -364,7 +364,7 @@ class WLS(BaseMasterModule):
 
                 nlines = len(line_dict["wav"])
                 if nlines == 0:
-                    logger.warning(
+                    logger.debug(
                         "%s %s order %s: orderlet skipped "
                         "(no fittable lines; flux likely NaN-filled)",
                         chip,

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -793,7 +793,7 @@ class WLS(BaseMasterModule):
             self.save_diagnostics(master_path, overwrite=True)
 
         self._track_info()
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
 
         for chip in self.chips:
             n_survivors = self._stack_info[chip]["n_survivors"]

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -562,7 +562,7 @@ class RadialVelocity:
                 f"   err {self._combined_rverr * 1e3:.3f} m/s"
                 f"   @ BJD_TDB {self._primary_bjdtdb:.6f}"
             )
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l4_obj):
         """
@@ -815,7 +815,7 @@ class RadialVelocity:
         self._set_headers(l4_obj)
         self._track_info(fibers)
         l4_obj.receipt_add_entry("radial_velocity", "", "PASS")
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return l4_obj
 
     def info(self):

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -815,7 +815,7 @@ class RadialVelocity:
         self._set_headers(l4_obj)
         self._track_info(fibers)
         l4_obj.receipt_add_entry("radial_velocity", "", "PASS")
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return l4_obj
 
     def info(self):

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -553,6 +553,15 @@ class RadialVelocity:
                     f"{nvalid:>8d}{ccd_rv:>+16.5f}{ccd_erv * 1e3:>16.3f}"
                     f"{rv_rms:>16.3f}"
                 )
+
+        # Headline science product: the cross-CCD/-fiber combined RV written to
+        # PRIMARY (RV/RVERR/BJDTDB), formed only when a science combine ran.
+        if self._sci_combined_ran and np.isfinite(self._combined_rv):
+            lines.append(
+                f"\n  combined science RV: {self._combined_rv:+.5f} km/s"
+                f"   err {self._combined_rverr * 1e3:.3f} m/s"
+                f"   @ BJD_TDB {self._primary_bjdtdb:.6f}"
+            )
         self._info = "\n".join(lines)
 
     def _set_headers(self, l4_obj):

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -360,7 +360,7 @@ class RadialVelocity:
                     min_npts,
                 )
             except ValueError as e:
-                logger.warning(
+                logger.debug(
                     "%s order %d: non-physical CCF window (%s); RV/RV_ERR set NaN",
                     ext,
                     o,

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -409,7 +409,7 @@ class SpectralExtraction:
         self._track_info(chips, fibers)
         l2_obj.receipt_add_entry("spectral_extraction", "", "PASS")
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return l2_obj
 
     def info(self):

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -252,7 +252,7 @@ class SpectralExtraction:
             n_bad = int(np.sum(~np.isfinite(arr)))
             n_neg = int(np.sum(arr < 0))
             if n_bad or n_neg:
-                logger.warning(
+                logger.debug(
                     "%s array: %s %s %s has %d non-finite, %d negative values",
                     name,
                     chip,

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -355,7 +355,7 @@ class SpectralExtraction:
         fibers_str = " ".join(fibers)
         for chip in chips:
             lines.append(f"  {chip:<8s} {fibers_str:<30s} {self.norder[chip.upper()]}")
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l2_obj):
         """Reserved header-consolidation hook; writes no PRIMARY metadata yet."""
@@ -409,7 +409,7 @@ class SpectralExtraction:
         self._track_info(chips, fibers)
         l2_obj.receipt_add_entry("spectral_extraction", "", "PASS")
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return l2_obj
 
     def info(self):

--- a/kpfpipe/modules/spectral_extraction.py
+++ b/kpfpipe/modules/spectral_extraction.py
@@ -6,7 +6,6 @@ populating the per-fiber FLUX and VAR arrays.
 """
 
 import logging
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -253,10 +252,14 @@ class SpectralExtraction:
             n_bad = int(np.sum(~np.isfinite(arr)))
             n_neg = int(np.sum(arr < 0))
             if n_bad or n_neg:
-                warnings.warn(
-                    f"{name} array: {chip} {fiber} {order} has "
-                    f"{n_bad} non-finite, {n_neg} negative values",
-                    stacklevel=2,
+                logger.warning(
+                    "%s array: %s %s %s has %d non-finite, %d negative values",
+                    name,
+                    chip,
+                    fiber,
+                    order,
+                    n_bad,
+                    n_neg,
                 )
 
         return flux_1d, var_1d
@@ -326,10 +329,8 @@ class SpectralExtraction:
         # the loop to continue through all orders provides useful diagnostic
         # information for cases where the algorithm truly fails.
         if failure == 1:
-            warnings.warn(
-                f"1 orderlet failed to extract from the {chip} CCD; filled with NaN.",
-                UserWarning,
-                stacklevel=2,
+            logger.warning(
+                "1 orderlet failed to extract from the %s CCD; filled with NaN.", chip
             )
         elif failure > 1:
             raise LookupError(

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -187,7 +187,7 @@ class WavelengthCalibration:
         self._track_info()
         self.l2_obj.receipt_add_entry("wavelength_calibration", "", "PASS")
 
-        logger.info("summary:\n%s", self._info)
+        logger.info("\n\nsummary:\n%s\n\n", self._info)
         return self.l2_obj
 
     def info(self):

--- a/kpfpipe/modules/wavelength_calibration.py
+++ b/kpfpipe/modules/wavelength_calibration.py
@@ -120,7 +120,7 @@ class WavelengthCalibration:
         lines.append(f"  wls_path: {self._wls_path}")
         if agewls is not None:
             lines.append(f"  WLSAGE:   {agewls:+.4f} d  (master - obs)")
-        self._info = "\n".join(lines)
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _set_headers(self, l2_obj):
         """Reserved header-consolidation hook; writes no PRIMARY metadata yet."""
@@ -187,7 +187,7 @@ class WavelengthCalibration:
         self._track_info()
         self.l2_obj.receipt_add_entry("wavelength_calibration", "", "PASS")
 
-        logger.info("\n\nsummary:\n%s\n\n", self._info)
+        logger.info("%s", self._info)
         return self.l2_obj
 
     def info(self):

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -10,7 +10,9 @@ call. Two base checkpoints are inherited by every level: ``unregistered_keywords
 the subclass's ``RAISE_FLAGS``, warn on the rest).
 """
 
-import warnings
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Checkpoint:
@@ -100,11 +102,7 @@ class Checkpoint:
                 continue
             if key in self.RAISE_FLAGS:
                 raise ValueError(f"QC checkpoint failed: {key} = 0 ({self.LEVEL})")
-            warnings.warn(
-                f"QC checkpoint flagged: {key} = 0 ({self.LEVEL})",
-                UserWarning,
-                stacklevel=2,
-            )
+            logger.warning("QC checkpoint flagged: %s = 0 (%s)", key, self.LEVEL)
 
     qc_flags._checkpoint_name = "qc_flags"
 

--- a/kpfpipe/quality_control/checkpoints/base.py
+++ b/kpfpipe/quality_control/checkpoints/base.py
@@ -7,7 +7,7 @@ Diagnostics and QC classes first, so the recipe drives the whole
 Diagnostics -> QC -> Checkpoints sequence through one ``CheckpointL{n}(obj).run()``
 call. Two base checkpoints are inherited by every level: ``unregistered_keywords``
 (structural header validation) and ``qc_flags`` (raise on a failed flag named in
-the subclass's ``RAISE_FLAGS``, warn on the rest).
+the subclass's ``RAISE_FLAGS``, else summarize the flags behind an ISGOOD=0).
 """
 
 import logging
@@ -46,8 +46,20 @@ class Checkpoint:
             self.DIAGNOSTICS(self.kpf_obj).run()
         if self.QC is not None:
             self.qc_results = self.QC(self.kpf_obj).run()
-        for _name, fn in self._iter_checkpoints():
-            fn()
+        for name, fn in self._iter_checkpoints():
+            try:
+                fn()
+            except Exception as e:
+                logger.error("%s checkpoint %r raised: %s", self.LEVEL, name, e)
+                raise
+        qc_hdr = self.kpf_obj.headers.get("QUALITY_CONTROL")
+        isgood = qc_hdr.get("ISGOOD") if qc_hdr is not None else None
+        logger.info(
+            "%s checkpoints passed (%d QC flag(s), ISGOOD=%s)",
+            self.LEVEL,
+            len(self.qc_results),
+            isgood,
+        )
 
     def unregistered_keywords(self):
         """Raise on any non-structural card not registered for its extension.
@@ -81,28 +93,29 @@ class Checkpoint:
     unregistered_keywords._checkpoint_name = "unregistered_keywords"
 
     def qc_flags(self):
-        """Read this level's 0/1 QC flags; raise a RAISE_FLAGS failure, warn the rest.
+        """Raise on a fatal flag failure; summarize the flags behind an ISGOOD=0.
 
-        Scoped to **this level's own** checks (the registry's
-        ``qc_flag_keywords_by_level[LEVEL]`` -- the ``QCL{n}`` flags), NOT the
-        flags propagated from lower levels: QUALITY_CONTROL accumulates the whole
-        L0->L1->L2->L4 history, but a lower-level flag was already surfaced at its
-        own level's checkpoint, so re-warning it here would just be noise. A flag
-        absent from the header is skipped (the check did not run); a flag equal to
-        0 raises if it is in ``RAISE_FLAGS``, else warns.
+        The fatal check is scoped to **this level's own** ``RAISE_FLAGS``: a 0
+        there raises. The summary then names every failing QC flag on
+        QUALITY_CONTROL (the cross-level L0->L4 accumulation, ISGOOD excluded) by
+        bare keyword -- each was already logged with its comment by the QC stage
+        as the flag was written, so the names alone suffice here. A flag absent
+        from the header is skipped (its check did not run).
         """
         header = self.kpf_obj.headers.get("QUALITY_CONTROL")
         if header is None:
             return
         reg = self.kpf_obj.keyword_registry
-        flag_keys = reg.qc_flag_keywords_by_level.get(self.LEVEL, frozenset())
-        for key in sorted(flag_keys):
-            value = header.get(key)
-            if value is None or value != 0:
-                continue
-            if key in self.RAISE_FLAGS:
+        for key in sorted(reg.qc_flag_keywords_by_level.get(self.LEVEL, frozenset())):
+            if key in self.RAISE_FLAGS and header.get(key) == 0:
                 raise ValueError(f"QC checkpoint failed: {key} = 0 ({self.LEVEL})")
-            logger.warning("QC checkpoint flagged: %s = 0 (%s)", key, self.LEVEL)
+        failing = sorted(
+            key for key in reg.qc_flag_keywords - {"ISGOOD"} if header.get(key) == 0
+        )
+        if failing:
+            logger.warning(
+                "%s ISGOOD=0; failing QC flags: %s", self.LEVEL, ", ".join(failing)
+            )
 
     qc_flags._checkpoint_name = "qc_flags"
 

--- a/kpfpipe/quality_control/diagnostics/base.py
+++ b/kpfpipe/quality_control/diagnostics/base.py
@@ -6,6 +6,10 @@ them to the product headers via ``set_keyword``; it never modifies the science
 extensions. QC then reads those metrics and applies pass/fail thresholds.
 """
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class Diagnostics:
     """Base runner for per-level diagnostic metric methods.
@@ -64,6 +68,8 @@ class Diagnostics:
                 # retained in self.results only).
                 self.kpf_obj.set_keyword(kw, value)
 
+        for kw, (value, comment) in self.results.items():
+            logger.debug("%s %s = %s — %s", self.LEVEL, kw, value, comment)
         return self.results
 
     def _iter_methods(self):

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -1,7 +1,7 @@
 """Diagnostics for KPF Level 0 (raw CCD) data products."""
 
+import logging
 import re
-import warnings
 
 import numpy as np
 from astropy import units as u
@@ -11,6 +11,8 @@ from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
 from kpfpipe.quality_control.diagnostics.base import Diagnostics
+
+logger = logging.getLogger(__name__)
 
 
 class DiagL0(Diagnostics):
@@ -151,9 +153,8 @@ class DiagL0(Diagnostics):
                 new_obstime=self._obs_time()
             )
         except Exception as e:
-            warnings.warn(
-                f"GAIAOFF skipped: Gaia lookup failed ({type(e).__name__}: {e})",
-                stacklevel=2,
+            logger.warning(
+                "GAIAOFF skipped: Gaia lookup failed (%s: %s)", type(e).__name__, e
             )
             return {}
         sep = float(self._pointing().separation(gaia).arcsec)
@@ -192,9 +193,8 @@ class DiagL0(Diagnostics):
                 new_obstime=self._obs_time()
             )
         except Exception as e:
-            warnings.warn(
-                f"OBJOFF skipped: SIMBAD lookup failed ({type(e).__name__}: {e})",
-                stacklevel=2,
+            logger.warning(
+                "OBJOFF skipped: SIMBAD lookup failed (%s: %s)", type(e).__name__, e
             )
             return {}
         sep = float(self._pointing().separation(obj).arcsec)

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -6,6 +6,10 @@ QUALITY_CONTROL via ``set_keyword`` and aggregating ISGOOD as the AND of all
 checks. Header validation and raising live in the separate Checkpoints layer.
 """
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 class QC:
     """Base runner for per-level pass/fail QC check methods.
@@ -36,8 +40,10 @@ class QC:
     def run(self):
         """Run all checks, write each 0/1 result, and aggregate ISGOOD.
 
-        Resets ``self.results`` at the start so calling ``run()`` repeatedly
-        on the same instance is deterministic.
+        Each result is logged as it is written -- ``DEBUG`` on a pass, ``WARNING``
+        on a fail -- both carrying the keyword's comment so the 8-char keyword
+        reads clearly. Resets ``self.results`` at the start so calling ``run()``
+        repeatedly on the same instance is deterministic.
 
         Returns
         -------
@@ -59,6 +65,14 @@ class QC:
             comment = self.kpf_obj.keyword_registry.routing.get(kw, (None, ""))[1]
             self.results[kw] = (passed, comment)
             self.kpf_obj.set_keyword(kw, 1 if passed else 0)
+            logger.log(
+                logging.DEBUG if passed else logging.WARNING,
+                "%s %s = %s — %s",
+                self.LEVEL,
+                kw,
+                1 if passed else 0,
+                comment,
+            )
 
         # ISGOOD is the running aggregate: AND over every QC flag now on
         # QUALITY_CONTROL -- the flags this level just wrote PLUS those propagated

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -4,7 +4,6 @@ import glob
 import logging
 import os
 import tempfile
-import warnings
 from datetime import datetime
 
 import pandas as pd
@@ -284,7 +283,7 @@ class FileHandler:
             try:
                 header = fits.getheader(fn, ext=0)
             except Exception as e:
-                warnings.warn(f"Could not read header from {fn}: {e}", stacklevel=2)
+                logger.warning("Could not read header from %s: %s", fn, e)
                 header = None
 
             mini_db["FILENAME"].append(fn)

--- a/kpfpipe/utils/logger.py
+++ b/kpfpipe/utils/logger.py
@@ -143,9 +143,10 @@ def setup_logging(
       (DRP-RUN-12).
     - Formats records with UT timestamps (``time.gmtime``).
     - Sets the root logger level, pins chatty third-party loggers to
-      WARNING, and calls ``logging.captureWarnings(True)`` so every
-      ``warnings.warn`` lands in the log at WARNING with its ``file:lineno``
-      source identification (DRP-RUN-08).
+      WARNING, and calls ``logging.captureWarnings(True)`` so any
+      third-party/stdlib ``warnings.warn`` still lands in the log at WARNING
+      (pipeline code logs recoverable conditions via ``logger.warning``
+      directly; DRP-RUN-08).
 
     Parameters
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,14 +62,6 @@ filterwarnings = [
     # naming rules themselves are enforced by check_filename_convention and
     # TestFilenameConsistency, so this is test-only noise (scoped to the suite).
     "ignore:Filename .* does not follow the EPRV naming convention:UserWarning",
-    "ignore:Filename .* does not follow the KPF masters naming convention:UserWarning",
-    # Synthetic test L0 frames often omit the WMKO-native PROGID/KOAID PRIMARY
-    # cards, so KPF0.from_fits defaults them to UNKNOWN and warns. Real frames
-    # always carry them; the default-and-warn path itself stays covered by a
-    # dedicated pytest.warns test (test_data_models_l0), which overrides this
-    # ignore. Test-only noise across the many synthetic-L0 builders.
-    "ignore:PROGID absent from L0 PRIMARY:UserWarning",
-    "ignore:KOAID absent from L0 PRIMARY:UserWarning",
 ]
 # The `requires_testdata` marker is registered in tests/conftest.py
 # (pytest_configure), which also skips those tests when tests/testdata is absent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ build-backend = "setuptools.build_meta"
 "kpfpipe.data_models.config" = ["*.csv"]
 
 [tool.setuptools.packages.find]
-include = ["kpfpipe*", "tools*", "scripts*"]
+include = ["kpfpipe*", "tools*", "scripts*", "recipes*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/recipes/_logging.py
+++ b/recipes/_logging.py
@@ -1,0 +1,96 @@
+"""End-of-run summary formatters shared by the KPF recipes.
+
+Pure string builders for the compact run-verdict block each recipe logs at
+completion. They live here (not in ``kpfpipe/utils/logger.py``, which is
+logging-setup infrastructure) so both recipes share one rendering while the
+setup module stays free of domain content. The recipes call these and pass the
+result to ``logger.info`` -- these functions never touch the logging system.
+"""
+
+import os
+
+
+def science_run_summary(l4, elapsed_s):
+    """Format the science recipe's end-of-run verdict from the finished L4.
+
+    A compact, greppable roll-up read off the L4 the recipe just built: obs_id
+    and the master-file cards from RECEIPT, the input/product paths from the
+    RECEIPT provenance table, ISGOOD from QUALITY_CONTROL, and the combined RV
+    from PRIMARY, plus the wall-clock elapsed. ``RV``/``RVERR``/``BJDTDB`` that
+    are not real numbers (absent or FITS UNDEFINED, e.g. no science combine ran)
+    render as ``n/a``; ``RV`` is km/s (error in m/s), ``BJDTDB`` is BJD_TDB. The
+    surrounding blank lines make the block stand out by eye in the log.
+    """
+    receipt = l4.headers.get("RECEIPT", {})
+    primary = l4.headers.get("PRIMARY", {})
+    qc = l4.headers.get("QUALITY_CONTROL", {})
+
+    def base(path):
+        return os.path.basename(path) if path else "n/a"
+
+    def receipt_paths(function, arg_key):
+        # The input/product paths are not first-class keywords (unlike the master
+        # cards); they survive only as key=value fragments in the RECEIPT ARGS.
+        table = getattr(l4, "receipt", None)
+        if table is None or getattr(table, "empty", True):
+            return []
+        out = []
+        for _, row in table.iterrows():
+            if row.get("FUNCTION") != function:
+                continue
+            for token in str(row.get("ARGS", "")).split(", "):
+                key, _, value = token.partition("=")
+                if key.strip() == arg_key and value.strip():
+                    out.append(value.strip())
+        return out
+
+    obs_id = getattr(l4, "obs_id", None) or receipt.get("ORIGID") or "unknown"
+    masters = {
+        "bias": receipt.get("BIASFILE"),
+        "dark": receipt.get("DARKFILE"),
+        "thar": receipt.get("WLSFILE"),
+    }
+    masters_str = "  ".join(f"{k}={base(v)}" for k, v in masters.items())
+    # First from_fits is the original L0 read; a reload would append its own.
+    inputs = receipt_paths("from_fits", "fn")[:1]
+    outputs = receipt_paths("to_fits", "out_filepath")
+    inputs_str = "  ".join(base(p) for p in inputs) or "n/a"
+    outputs_str = "  ".join(base(p) for p in outputs) or "n/a"
+
+    rv, rverr, bjd = primary.get("RV"), primary.get("RVERR"), primary.get("BJDTDB")
+    if isinstance(rv, (int, float)):
+        err = f"{rverr * 1e3:.3f}" if isinstance(rverr, (int, float)) else "n/a"
+        bjd_str = f"{bjd:.6f}" if isinstance(bjd, (int, float)) else "n/a"
+        rv_line = f"{rv:+.5f} km/s  err {err} m/s  @ BJD_TDB {bjd_str}"
+    else:
+        rv_line = "n/a (no science combine)"
+
+    lines = [
+        f"===== run summary: {obs_id} =====",
+        f"  inputs:   {inputs_str}",
+        f"  masters:  {masters_str}",
+        f"  outputs:  {outputs_str}",
+        f"  ISGOOD:   {qc.get('ISGOOD')}",
+        f"  RV:       {rv_line}",
+        f"  elapsed:  {elapsed_s:.1f} s",
+    ]
+    return "\n\n" + "\n".join(lines) + "\n\n"
+
+
+def masters_run_summary(datecode, built, elapsed_s):
+    """Format the masters recipe's end-of-run verdict.
+
+    ``built`` is the list of ``(cal_type, path, n_frames)`` stacked this run
+    (empty if none) -- masters have no single product to read back, so the
+    recipe passes what it stacked. The surrounding blank lines make the block
+    stand out by eye in the log.
+    """
+    lines = [f"===== masters run summary: {datecode} ====="]
+    if built:
+        for cal_type, path, n_frames in built:
+            name = os.path.basename(path) if path else "n/a"
+            lines.append(f"  {cal_type:<6s} {name}  ({n_frames} frames)")
+    else:
+        lines.append("  (no masters built)")
+    lines.append(f"  elapsed:  {elapsed_s:.1f} s")
+    return "\n\n" + "\n".join(lines) + "\n\n"

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -10,6 +10,7 @@ and written to the output data root via the pipeline path helpers.
 
 import logging
 import os
+import time
 
 from kpfpipe.modules.masters import WLS, Bias, Dark
 from kpfpipe.utils.io import FileHandler, kpf_filepath
@@ -21,6 +22,7 @@ logger = logging.getLogger("kpfpipe.recipe.masters")
 
 
 def main(config, args):
+    t0 = time.monotonic()
     logger.info("entering kpf_drp_masters pipeline")
 
     if not args.datecode:
@@ -45,6 +47,8 @@ def main(config, args):
     file_handler = FileHandler(data_dirs)
     file_handler.build_mini_database(datecode, cache="r")
 
+    built = []  # (cal_type, path, n_frames) per master stacked, for the run summary
+
     # Stack the bias frames into a master bias used to remove the detector
     # offset from every science and calibration frame.
     for files in file_handler.build_calibration_stacks(
@@ -58,6 +62,7 @@ def main(config, args):
         logger.info("stacking %d bias frames -> %s", len(files), bias_path)
         bias = Bias(files, config)
         bias.make_master_l1(master_path=bias_path)
+        built.append(("bias", bias_path, len(files)))
 
     # Stack the dark frames into a master dark used to remove dark current.
     # Runs after the master bias so CalibrationAssociation can subtract that
@@ -73,6 +78,7 @@ def main(config, args):
         logger.info("stacking %d dark frames -> %s", len(files), dark_path)
         dark = Dark(files, config)
         dark.make_master_l1(master_path=dark_path)
+        built.append(("dark", dark_path, len(files)))
 
     # master flat (not yet implemented)
     # for files in file_handler.build_calibration_stacks('flat'):
@@ -95,8 +101,29 @@ def main(config, args):
         logger.info("building WLS from %d ThAr frames -> %s", len(files), wls_path)
         wls = WLS(files, config)
         wls.make_master_l2(master_path=wls_path)
+        built.append(("thar", wls_path, len(files)))
 
+    logger.info(_summary(datecode, built, time.monotonic() - t0))
     logger.info("exiting kpf_drp_masters pipeline")
+
+
+def _summary(datecode, built, elapsed_s):
+    """Format this run's masters end-of-run verdict.
+
+    ``built`` is the list of ``(cal_type, path, n_frames)`` stacked this run
+    (empty if none) -- masters have no single product to read back, so main()
+    passes what it stacked. The surrounding blank lines make the block stand out
+    by eye in the log.
+    """
+    lines = [f"===== masters run summary: {datecode} ====="]
+    if built:
+        for cal_type, path, n_frames in built:
+            name = os.path.basename(path) if path else "n/a"
+            lines.append(f"  {cal_type:<6s} {name}  ({n_frames} frames)")
+    else:
+        lines.append("  (no masters built)")
+    lines.append(f"  elapsed:  {elapsed_s:.1f} s")
+    return "\n\n" + "\n".join(lines) + "\n\n"
 
 
 if __name__ == "__main__":

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -15,6 +15,7 @@ import time
 from kpfpipe.modules.masters import WLS, Bias, Dark
 from kpfpipe.utils.io import FileHandler, kpf_filepath
 from kpfpipe.utils.kpf_utils import get_obs_id
+from recipes._logging import masters_run_summary
 
 # Explicit name: the CLI execs recipes with __name__ == "recipe", so __name__
 # would not identify this module in the log.
@@ -103,27 +104,8 @@ def main(config, args):
         wls.make_master_l2(master_path=wls_path)
         built.append(("thar", wls_path, len(files)))
 
-    logger.info(_summary(datecode, built, time.monotonic() - t0))
+    logger.info(masters_run_summary(datecode, built, time.monotonic() - t0))
     logger.info("exiting kpf_drp_masters pipeline")
-
-
-def _summary(datecode, built, elapsed_s):
-    """Format this run's masters end-of-run verdict.
-
-    ``built`` is the list of ``(cal_type, path, n_frames)`` stacked this run
-    (empty if none) -- masters have no single product to read back, so main()
-    passes what it stacked. The surrounding blank lines make the block stand out
-    by eye in the log.
-    """
-    lines = [f"===== masters run summary: {datecode} ====="]
-    if built:
-        for cal_type, path, n_frames in built:
-            name = os.path.basename(path) if path else "n/a"
-            lines.append(f"  {cal_type:<6s} {name}  ({n_frames} frames)")
-    else:
-        lines.append("  (no masters built)")
-    lines.append(f"  elapsed:  {elapsed_s:.1f} s")
-    return "\n\n" + "\n".join(lines) + "\n\n"
 
 
 if __name__ == "__main__":

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -11,7 +11,6 @@ data products are written to the output data root.
 """
 
 import logging
-import os
 import time
 
 from kpfpipe.data_models import KPF0
@@ -31,6 +30,7 @@ from kpfpipe.quality_control.checkpoints import (
 )
 from kpfpipe.quality_control.quicklook import PlotL0, PlotL1, PlotL2, PlotL4
 from kpfpipe.utils.io import kpf_directory, kpf_filepath
+from recipes._logging import science_run_summary
 
 # Explicit name: the CLI execs recipes with __name__ == "recipe", so __name__
 # would not identify this module in the log.
@@ -164,76 +164,9 @@ def main(config, args):
 
     # End-of-run verdict: a compact roll-up read straight off the finished L4
     # product (masters, inputs/outputs, ISGOOD, combined RV), plus the elapsed.
-    logger.info(_summary(l4, time.monotonic() - t0))
+    logger.info(science_run_summary(l4, time.monotonic() - t0))
 
     logger.info("exiting kpf_drp_science pipeline")
-
-
-def _summary(l4, elapsed_s):
-    """Format this run's end-of-run verdict from the finished L4 product.
-
-    A compact, greppable roll-up read off the L4 the recipe just built: obs_id
-    and the master-file cards from RECEIPT, the input/product paths from the
-    RECEIPT provenance table, ISGOOD from QUALITY_CONTROL, and the combined RV
-    from PRIMARY, plus the wall-clock elapsed. ``RV``/``RVERR``/``BJDTDB`` that
-    are not real numbers (absent or FITS UNDEFINED, e.g. no science combine ran)
-    render as ``n/a``; ``RV`` is km/s (error in m/s), ``BJDTDB`` is BJD_TDB. The
-    surrounding blank lines make the block stand out by eye in the log.
-    """
-    receipt = l4.headers.get("RECEIPT", {})
-    primary = l4.headers.get("PRIMARY", {})
-    qc = l4.headers.get("QUALITY_CONTROL", {})
-
-    def base(path):
-        return os.path.basename(path) if path else "n/a"
-
-    def receipt_paths(function, arg_key):
-        # The input/product paths are not first-class keywords (unlike the master
-        # cards); they survive only as key=value fragments in the RECEIPT ARGS.
-        table = getattr(l4, "receipt", None)
-        if table is None or getattr(table, "empty", True):
-            return []
-        out = []
-        for _, row in table.iterrows():
-            if row.get("FUNCTION") != function:
-                continue
-            for token in str(row.get("ARGS", "")).split(", "):
-                key, _, value = token.partition("=")
-                if key.strip() == arg_key and value.strip():
-                    out.append(value.strip())
-        return out
-
-    obs_id = getattr(l4, "obs_id", None) or receipt.get("ORIGID") or "unknown"
-    masters = {
-        "bias": receipt.get("BIASFILE"),
-        "dark": receipt.get("DARKFILE"),
-        "thar": receipt.get("WLSFILE"),
-    }
-    masters_str = "  ".join(f"{k}={base(v)}" for k, v in masters.items())
-    # First from_fits is the original L0 read; a reload would append its own.
-    inputs = receipt_paths("from_fits", "fn")[:1]
-    outputs = receipt_paths("to_fits", "out_filepath")
-    inputs_str = "  ".join(base(p) for p in inputs) or "n/a"
-    outputs_str = "  ".join(base(p) for p in outputs) or "n/a"
-
-    rv, rverr, bjd = primary.get("RV"), primary.get("RVERR"), primary.get("BJDTDB")
-    if isinstance(rv, (int, float)):
-        err = f"{rverr * 1e3:.3f}" if isinstance(rverr, (int, float)) else "n/a"
-        bjd_str = f"{bjd:.6f}" if isinstance(bjd, (int, float)) else "n/a"
-        rv_line = f"{rv:+.5f} km/s  err {err} m/s  @ BJD_TDB {bjd_str}"
-    else:
-        rv_line = "n/a (no science combine)"
-
-    lines = [
-        f"===== run summary: {obs_id} =====",
-        f"  inputs:   {inputs_str}",
-        f"  masters:  {masters_str}",
-        f"  outputs:  {outputs_str}",
-        f"  ISGOOD:   {qc.get('ISGOOD')}",
-        f"  RV:       {rv_line}",
-        f"  elapsed:  {elapsed_s:.1f} s",
-    ]
-    return "\n\n" + "\n".join(lines) + "\n\n"
 
 
 if __name__ == "__main__":

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -11,6 +11,8 @@ data products are written to the output data root.
 """
 
 import logging
+import os
+import time
 
 from kpfpipe.data_models import KPF0
 from kpfpipe.modules.barycentric_correction import BarycentricCorrection
@@ -36,6 +38,7 @@ logger = logging.getLogger("kpfpipe.recipe.science")
 
 
 def main(config, args):
+    t0 = time.monotonic()
     logger.info("entering kpf_drp_science pipeline")
 
     if not args.obs_id:
@@ -159,7 +162,78 @@ def main(config, args):
     l4_out_path = kpf_filepath(obs_id, "L4", data_root=data_root_science)
     l4.to_fits(l4_out_path)
 
+    # End-of-run verdict: a compact roll-up read straight off the finished L4
+    # product (masters, inputs/outputs, ISGOOD, combined RV), plus the elapsed.
+    logger.info(_summary(l4, time.monotonic() - t0))
+
     logger.info("exiting kpf_drp_science pipeline")
+
+
+def _summary(l4, elapsed_s):
+    """Format this run's end-of-run verdict from the finished L4 product.
+
+    A compact, greppable roll-up read off the L4 the recipe just built: obs_id
+    and the master-file cards from RECEIPT, the input/product paths from the
+    RECEIPT provenance table, ISGOOD from QUALITY_CONTROL, and the combined RV
+    from PRIMARY, plus the wall-clock elapsed. ``RV``/``RVERR``/``BJDTDB`` that
+    are not real numbers (absent or FITS UNDEFINED, e.g. no science combine ran)
+    render as ``n/a``; ``RV`` is km/s (error in m/s), ``BJDTDB`` is BJD_TDB. The
+    surrounding blank lines make the block stand out by eye in the log.
+    """
+    receipt = l4.headers.get("RECEIPT", {})
+    primary = l4.headers.get("PRIMARY", {})
+    qc = l4.headers.get("QUALITY_CONTROL", {})
+
+    def base(path):
+        return os.path.basename(path) if path else "n/a"
+
+    def receipt_paths(function, arg_key):
+        # The input/product paths are not first-class keywords (unlike the master
+        # cards); they survive only as key=value fragments in the RECEIPT ARGS.
+        table = getattr(l4, "receipt", None)
+        if table is None or getattr(table, "empty", True):
+            return []
+        out = []
+        for _, row in table.iterrows():
+            if row.get("FUNCTION") != function:
+                continue
+            for token in str(row.get("ARGS", "")).split(", "):
+                key, _, value = token.partition("=")
+                if key.strip() == arg_key and value.strip():
+                    out.append(value.strip())
+        return out
+
+    obs_id = getattr(l4, "obs_id", None) or receipt.get("ORIGID") or "unknown"
+    masters = {
+        "bias": receipt.get("BIASFILE"),
+        "dark": receipt.get("DARKFILE"),
+        "thar": receipt.get("WLSFILE"),
+    }
+    masters_str = "  ".join(f"{k}={base(v)}" for k, v in masters.items())
+    # First from_fits is the original L0 read; a reload would append its own.
+    inputs = receipt_paths("from_fits", "fn")[:1]
+    outputs = receipt_paths("to_fits", "out_filepath")
+    inputs_str = "  ".join(base(p) for p in inputs) or "n/a"
+    outputs_str = "  ".join(base(p) for p in outputs) or "n/a"
+
+    rv, rverr, bjd = primary.get("RV"), primary.get("RVERR"), primary.get("BJDTDB")
+    if isinstance(rv, (int, float)):
+        err = f"{rverr * 1e3:.3f}" if isinstance(rverr, (int, float)) else "n/a"
+        bjd_str = f"{bjd:.6f}" if isinstance(bjd, (int, float)) else "n/a"
+        rv_line = f"{rv:+.5f} km/s  err {err} m/s  @ BJD_TDB {bjd_str}"
+    else:
+        rv_line = "n/a (no science combine)"
+
+    lines = [
+        f"===== run summary: {obs_id} =====",
+        f"  inputs:   {inputs_str}",
+        f"  masters:  {masters_str}",
+        f"  outputs:  {outputs_str}",
+        f"  ISGOOD:   {qc.get('ISGOOD')}",
+        f"  RV:       {rv_line}",
+        f"  elapsed:  {elapsed_s:.1f} s",
+    ]
+    return "\n\n" + "\n".join(lines) + "\n\n"
 
 
 if __name__ == "__main__":

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -5,6 +5,8 @@ synthetic KPF2 with a small EXPMETER_SCI table and populated SCI2_WAVE.
 Gaia and barycorrpy calls are stubbed via monkeypatching.
 """
 
+import logging
+
 import astropy.units as u
 import numpy as np
 import pytest
@@ -687,7 +689,9 @@ class TestAstrometryResolution:
         # defaults: use_gaia_astrometry=True, use_wmko_fallback=False
         assert BarycentricCorrection(synthetic_kpf2)._get_skycoord() is sentinel
 
-    def test_falls_back_to_wmko_on_gaia_error(self, synthetic_kpf2, monkeypatch):
+    def test_falls_back_to_wmko_on_gaia_error(
+        self, caplog, synthetic_kpf2, monkeypatch
+    ):
         self._add_wmko_keys(synthetic_kpf2)
 
         def boom(self):
@@ -696,8 +700,9 @@ class TestAstrometryResolution:
         monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", boom)
 
         bc = BarycentricCorrection(synthetic_kpf2, config={"use_wmko_fallback": True})
-        with pytest.warns(UserWarning, match="ConnectionError"):
+        with caplog.at_level(logging.WARNING):
             sc = bc._get_skycoord()
+        assert "ConnectionError" in caplog.text
         assert sc.icrs.distance.to(u.pc).value == pytest.approx(1e3 / 72.0)
 
     def test_wmko_only_when_gaia_disabled(self, synthetic_kpf2, monkeypatch):
@@ -928,7 +933,7 @@ class TestPerform:
         assert astrsrc == "Gaia DR3"
 
     def test_perform_falls_back_and_records_wmko_provenance(
-        self, synthetic_kpf2, monkeypatch
+        self, caplog, synthetic_kpf2, monkeypatch
     ):
         TestAstrometryResolution._add_wmko_keys(synthetic_kpf2)
 
@@ -950,10 +955,11 @@ class TestPerform:
         )
 
         bc = BarycentricCorrection(synthetic_kpf2)  # defaults: gaia on, wmko off
-        with pytest.warns(UserWarning, match="ConnectionError"):
+        with caplog.at_level(logging.WARNING):
             kpf2 = bc.perform(
                 use_wmko_fallback=True
             )  # override the toggle for this call
+        assert "ConnectionError" in caplog.text
 
         astrsrc = kpf2.headers["RECEIPT"].get("ASTRSRC")
         assert astrsrc == "WMKO header"

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -1,5 +1,7 @@
 """Unit tests for CalibrationAssociation."""
 
+import logging
+
 import pytest
 from astropy.io import fits
 
@@ -127,7 +129,7 @@ class TestFindMasterFiles:
 
         assert result[0][1] < result[1][1]
 
-    def test_warns_and_drops_master_with_unparseable_timestamp(self, tmp_path):
+    def test_warns_and_drops_master_with_unparseable_timestamp(self, caplog, tmp_path):
         d = tmp_path / "masters" / "20240405"
         d.mkdir(parents=True)
         _stub_master(d, "KP.20240405.03637.74", "bias")
@@ -135,8 +137,9 @@ class TestFindMasterFiles:
         (d / "nostamp_master_bias_L1.fits").touch()
 
         mod = _make_module(tmp_path)
-        with pytest.warns(UserWarning, match="unparseable timestamp"):
+        with caplog.at_level(logging.WARNING):
             result = mod._find_master_files("bias", "2024-04-05T11:08:33")
+        assert "unparseable timestamp" in caplog.text
 
         assert len(result) == 1
         assert result[0][0].endswith("KP.20240405.03637.74_master_bias_L1.fits")

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -14,7 +14,7 @@ headers, then warn or raise (never write). This pins:
 checkpoint methods; that orchestration is pinned in ``TestRunFoldsDiagnosticsAndQC``.
 """
 
-import warnings
+import logging
 
 import numpy as np
 import pytest
@@ -35,18 +35,18 @@ _NORDER_TOTAL = DETECTOR["norder"]["GREEN"] + DETECTOR["norder"]["RED"]
 
 
 class TestUnregisteredKeywords:
-    def test_clean_product_passes(self):
+    def test_clean_product_passes(self, caplog):
         # Fresh KPF2: EPRV-seeded PRIMARY (all registered) + empty governed
         # extensions -> no unregistered card, and no QC flags present -> qc_flags
         # is a no-op, so the checkpoint methods are silent. (run() is not used
         # here: it folds in QC, which a bare product can't satisfy -- the fold is
         # covered by TestRunFoldsDiagnosticsAndQC.)
         l2 = KPF2()
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")  # any warning would fail this
+        with caplog.at_level(logging.WARNING):
             chk = CheckpointL2(l2)
             chk.unregistered_keywords()
             chk.qc_flags()
+        assert not caplog.records
 
     def test_unexpected_keyword_on_governed_extension_raises(self):
         l2 = KPF2()
@@ -84,30 +84,31 @@ class TestQCFlags:
         with pytest.raises(ValueError, match="DATAPRL2 = 0"):
             CheckpointL2(l2).qc_flags()
 
-    def test_nonraise_flag_zero_warns(self):
+    def test_nonraise_flag_zero_warns(self, caplog):
         # KWRDPRL2 is not a RAISE_FLAG, so a 0 warns (data present so DATAPRL2 ok).
         l2 = KPF2()
         l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")
         l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (0, "required present")
-        with pytest.warns(UserWarning, match="KWRDPRL2 = 0"):
+        with caplog.at_level(logging.WARNING):
             CheckpointL2(l2).qc_flags()
+        assert "KWRDPRL2 = 0" in caplog.text
 
-    def test_all_pass_silent(self):
+    def test_all_pass_silent(self, caplog):
         l2 = KPF2()
         l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")
         l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (1, "required present")
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
+        with caplog.at_level(logging.WARNING):
             CheckpointL2(l2).qc_flags()
+        assert not caplog.records
 
-    def test_absent_flag_is_ignored(self):
+    def test_absent_flag_is_ignored(self, caplog):
         # A flag the QC stage never wrote is absent -> neither warns nor raises.
         l2 = KPF2()
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
+        with caplog.at_level(logging.WARNING):
             CheckpointL2(l2).qc_flags()
+        assert not caplog.records
 
-    def test_only_current_level_flags_are_checked(self):
+    def test_only_current_level_flags_are_checked(self, caplog):
         # QUALITY_CONTROL accumulates the L0->L1->L2 history, but qc_flags warns
         # only on THIS level's own checks. A failed L1 flag (RNOK) propagated onto
         # an L2 product must NOT re-warn at the L2 checkpoint; the L2 flag does.
@@ -115,12 +116,10 @@ class TestQCFlags:
         l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")  # avoid raise
         l2.headers["QUALITY_CONTROL"]["RNOK"] = (0, "L1 read noise (propagated)")
         l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (0, "L2 required present")
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with caplog.at_level(logging.WARNING):
             CheckpointL2(l2).qc_flags()
-        msgs = [str(w.message) for w in caught]
-        assert any("KWRDPRL2 = 0" in m for m in msgs)  # current-level flag warns
-        assert not any("RNOK" in m for m in msgs)  # propagated L1 flag ignored
+        assert "KWRDPRL2 = 0" in caplog.text  # current-level flag warns
+        assert "RNOK" not in caplog.text  # propagated L1 flag ignored
 
     def test_registry_qc_flag_sets_scoping(self):
         from kpfpipe.data_models.keyword_registry import keyword_registry as reg
@@ -176,14 +175,14 @@ class TestRunFoldsDiagnosticsAndQC:
         # QC's result dict is captured for callers (e.g. scripts/quality_control/qc.py).
         assert chk.qc_results == {"ISGOOD": (True, "")}
 
-    def test_missing_paired_classes_skip_those_stages(self):
+    def test_missing_paired_classes_skip_those_stages(self, caplog):
         # Base Checkpoint has DIAGNOSTICS = QC = None (LEVEL None skips PRIMARY):
         # run() does the checkpoint methods only and leaves qc_results empty.
         chk = Checkpoint(KPF2())  # clean, empty -> checkpoint methods are silent
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
+        with caplog.at_level(logging.WARNING):
             chk.run()
         assert chk.qc_results == {}
+        assert not caplog.records
 
 
 # ---------------------------------------------------------------------------
@@ -218,11 +217,11 @@ def _make_l4(*, sci=True):
 
 
 class TestCheckpointL4:
-    def test_run_good_product_passes_and_writes_flags(self):
+    def test_run_good_product_passes_and_writes_flags(self, caplog):
         l4 = _make_l4()
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")  # a good product must not warn
+        with caplog.at_level(logging.WARNING):
             CheckpointL4(l4).run()
+        assert not caplog.records
         qc = l4.headers["QUALITY_CONTROL"]
         # Folded DiagL4 metrics + QCL4 flags both landed on QUALITY_CONTROL.
         assert qc["BERVMEAN"] is not None and qc["BJDMEAN"] is not None
@@ -235,11 +234,12 @@ class TestCheckpointL4:
         with pytest.raises(ValueError, match="DATAPRL4 = 0"):
             CheckpointL4(l4).run()
 
-    def test_nonraise_flag_warns(self):
+    def test_nonraise_flag_warns(self, caplog):
         # KWRDPRL4 = 0 (a required PRIMARY keyword missing); not a RAISE_FLAG, so
         # it warns rather than raises.
         l4 = _make_l4()
         req = sorted(CheckpointL4.QC(l4)._required_primary_keywords())
         del l4.headers["PRIMARY"][req[0]]
-        with pytest.warns(UserWarning, match="KWRDPRL4 = 0"):
+        with caplog.at_level(logging.WARNING):
             CheckpointL4(l4).run()
+        assert "KWRDPRL4 = 0" in caplog.text

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -85,13 +85,15 @@ class TestQCFlags:
             CheckpointL2(l2).qc_flags()
 
     def test_nonraise_flag_zero_warns(self, caplog):
-        # KWRDPRL2 is not a RAISE_FLAG, so a 0 warns (data present so DATAPRL2 ok).
+        # KWRDPRL2 is not a RAISE_FLAG, so a 0 lands in the ISGOOD summary rather
+        # than raising (DATAPRL2 = 1, so no fatal flag).
         l2 = KPF2()
         l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")
         l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (0, "required present")
         with caplog.at_level(logging.WARNING):
             CheckpointL2(l2).qc_flags()
-        assert "KWRDPRL2 = 0" in caplog.text
+        assert "ISGOOD=0" in caplog.text
+        assert "KWRDPRL2" in caplog.text
 
     def test_all_pass_silent(self, caplog):
         l2 = KPF2()
@@ -108,18 +110,19 @@ class TestQCFlags:
             CheckpointL2(l2).qc_flags()
         assert not caplog.records
 
-    def test_only_current_level_flags_are_checked(self, caplog):
-        # QUALITY_CONTROL accumulates the L0->L1->L2 history, but qc_flags warns
-        # only on THIS level's own checks. A failed L1 flag (RNOK) propagated onto
-        # an L2 product must NOT re-warn at the L2 checkpoint; the L2 flag does.
+    def test_summary_lists_all_failing_flags_cross_level(self, caplog):
+        # The ISGOOD summary is the cross-level roll-up: it names every failing
+        # flag on QUALITY_CONTROL by bare keyword, including one propagated from a
+        # lower level (RNOK from L1). Per-flag detail with comments is the QC
+        # stage's job (see test_qc_flags), so the checkpoint need not repeat it.
         l2 = KPF2()
         l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")  # avoid raise
         l2.headers["QUALITY_CONTROL"]["RNOK"] = (0, "L1 read noise (propagated)")
         l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (0, "L2 required present")
         with caplog.at_level(logging.WARNING):
             CheckpointL2(l2).qc_flags()
-        assert "KWRDPRL2 = 0" in caplog.text  # current-level flag warns
-        assert "RNOK" not in caplog.text  # propagated L1 flag ignored
+        assert "KWRDPRL2" in caplog.text
+        assert "RNOK" in caplog.text
 
     def test_registry_qc_flag_sets_scoping(self):
         from kpfpipe.data_models.keyword_registry import keyword_registry as reg

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -10,6 +10,9 @@ CCF variance cubes, and the metadata-seeded RV tables (RV/RV_ERR left NaN for
 RadialVelocity); it does not fit RVs or write any PRIMARY/combined-RV keywords.
 """
 
+import logging
+import re
+
 import numpy as np
 import pytest
 from astropy.constants import c
@@ -257,12 +260,13 @@ class TestDispatch:
     @pytest.mark.parametrize(
         "raw, obj", [("EtalonFiber", "etalon"), ("LFCFiber", "lfc")]
     )
-    def test_unimplemented_source_warns_and_skips(self, header_kpf2, raw, obj):
+    def test_unimplemented_source_warns_and_skips(self, caplog, header_kpf2, raw, obj):
         header_kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = raw
-        with pytest.warns(UserWarning, match=f"{obj}.*not implemented"):
+        with caplog.at_level(logging.WARNING):
             source = CrossCorrelation(header_kpf2)._resolve_illumination_source(
                 "GREEN", "CAL"
             )
+        assert re.search(rf"{obj}.*not implemented", caplog.text)
         assert source == {
             "object": obj,
             "mask_name": None,
@@ -591,11 +595,12 @@ class TestPerform:
         l4 = cc_module.perform(fibers=["CAL"])
         assert l4.headers["CAL_CCF"]["CCFMASK"] == "thar"
 
-    def test_unimplemented_fiber_skipped(self, cc_module):
+    def test_unimplemented_fiber_skipped(self, caplog, cc_module):
         # An etalon/lfc fiber has no CCF path yet -> skipped, empty extensions.
         cc_module.l2_obj.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = "EtalonFiber"
-        with pytest.warns(UserWarning, match="etalon.*not implemented"):
+        with caplog.at_level(logging.WARNING):
             l4 = cc_module.perform(fibers=["CAL"])
+        assert re.search(r"etalon.*not implemented", caplog.text)
         assert l4.data["CAL_CCF"].size == 0
         assert len(l4.data["CAL_RV"]) == 0
 

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -5,6 +5,7 @@ Uses synthetic FITS fixtures — no real KPF data needed.
 """
 
 import importlib.metadata
+import logging
 import os
 
 import numpy as np
@@ -106,11 +107,12 @@ class TestKPF0ErrorPaths:
         hdul.close()
         return fn
 
-    def test_warns_on_unknown_extension(self, tmp_path):
+    def test_warns_on_unknown_extension(self, caplog, tmp_path):
         weird = fits.ImageHDU(data=np.zeros((4, 4), dtype=np.float32), name="MYSTERY")
         fn = self._minimal_l0(tmp_path, extra_hdus=[weird])
-        with pytest.warns(UserWarning, match="Non-standard extension"):
+        with caplog.at_level(logging.WARNING):
             KPF0.from_fits(fn)
+        assert "Non-standard extension" in caplog.text
 
     def test_parses_receipt_with_entries(self, tmp_path):
         receipt = Table({"FUNCTION": ["init"], "STATUS": ["PASS"]})
@@ -172,11 +174,12 @@ class TestKPF0Provenance:
         assert "ORIGID" not in l0.headers["PRIMARY"]
 
     def test_from_fits_defaults_program_ids_to_unknown_and_warns(
-        self, synthetic_l0_minimal
+        self, caplog, synthetic_l0_minimal
     ):
         """A file lacking PROGID/KOAID defaults both to UNKNOWN and warns."""
-        with pytest.warns(UserWarning, match="PROGID absent"):
+        with caplog.at_level(logging.WARNING):
             l0 = KPF0.from_fits(synthetic_l0_minimal)
+        assert "PROGID absent" in caplog.text
         receipt = l0.headers["RECEIPT"]
         assert receipt.get("PROGID") == "UNKNOWN"
         assert receipt.get("KOAID") == "UNKNOWN"

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -6,6 +6,7 @@ Uses synthetic FITS fixtures — no real KPF data needed.
 """
 
 import importlib.metadata
+import logging
 import re
 
 import numpy as np
@@ -125,7 +126,7 @@ class TestKPF1:
         with fits.open(out_fn) as hdul:
             assert hdul["PRIMARY"].header["DATALVL"] == "L1"
 
-    def test_warns_on_unknown_extension(self, tmp_path):
+    def test_warns_on_unknown_extension(self, caplog, tmp_path):
         fn = str(tmp_path / "unknown_ext.fits")
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-01-13T00:00:00"
@@ -135,8 +136,9 @@ class TestKPF1:
         hdul.writeto(fn, overwrite=True)
         hdul.close()
 
-        with pytest.warns(UserWarning, match="Non-standard extension"):
+        with caplog.at_level(logging.WARNING):
             KPF1.from_fits(fn)
+        assert "Non-standard extension" in caplog.text
 
 
 class TestL1PrimarySeed:
@@ -293,16 +295,12 @@ class TestToKpf1:
         """_map_header emits only registered keywords; header_map's non-standard
         STANDARD keys (e.g. PARANG <- PARANTEL) are dropped, not leaked onto the
         EPRV PRIMARY. The raw value survives verbatim in INSTRUMENT_HEADER."""
-        import warnings
-
         fn = str(tmp_path / "KP.20240113.00009.00.fits")
         p = fits.PrimaryHDU()
         p.header["INSTRUME"] = "KPF"
         p.header["PARANTEL"] = 108.03  # header_map maps PARANTEL -> non-standard PARANG
         fits.HDUList([p]).writeto(fn)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")  # PROGID/KOAID absent -> UNKNOWN
-            l1 = KPF0.from_fits(fn).to_kpf1()
+        l1 = KPF0.from_fits(fn).to_kpf1()
         assert "PARANG" not in l1.headers["PRIMARY"]
         assert l1.headers["INSTRUMENT_HEADER"]["PARANTEL"] == 108.03
 
@@ -485,12 +483,10 @@ class TestKPFMasterL1:
         with pytest.raises(ValueError):
             KPFMasterL1().generate_standard_filename()
 
-    def test_no_warning_on_known_extensions(self, synthetic_masters_l1_file):
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
+    def test_no_warning_on_known_extensions(self, caplog, synthetic_masters_l1_file):
+        with caplog.at_level(logging.WARNING):
             KPFMasterL1.from_fits(synthetic_masters_l1_file)
+        assert "Non-standard extension" not in caplog.text
 
     def test_set_input_files(self):
         m = KPFMasterL1()

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -6,6 +6,7 @@ calibration product.
 Uses synthetic FITS fixtures — no real KPF data needed.
 """
 
+import logging
 import warnings
 from collections import OrderedDict
 
@@ -404,27 +405,28 @@ class TestDtypeProvenance:
         assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_FLUX", FLUX, tmp_path)
         assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_WAVE", WAVE, tmp_path)
 
-    def test_chip_prefix_wave_write_enforces_min_bit_depth(self):
+    def test_chip_prefix_wave_write_enforces_min_bit_depth(self, caplog):
         """A float32 WAVE written via a chip-prefix key (which bypasses rvdata's
         base set_data) is still upcast to float64 with the MinBitDepth warning —
         the chip-split path enforces the born-64 WAVE policy like the canonical
         path does."""
         kpf2 = KPF2()
-        with pytest.warns(UserWarning, match="MinBitDepth=64"):
+        with caplog.at_level(logging.WARNING):
             kpf2.set_data(
                 "GREEN_SCI2_WAVE", np.ones((NORDER_GREEN, 8), dtype=np.float32)
             )
+        assert "MinBitDepth=64" in caplog.text
         assert_dtype(kpf2.data["TRACE3_WAVE"], WAVE, "underlying TRACE3_WAVE")
 
-    def test_chip_prefix_flux_write_keeps_float32(self):
+    def test_chip_prefix_flux_write_keeps_float32(self, caplog):
         """FLUX has no MinBitDepth requirement, so a float32 chip-prefix write is
         kept as-is (no upcast, no warning) — the enforcement is WAVE/QUALITY-only."""
         kpf2 = KPF2()
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
+        with caplog.at_level(logging.WARNING):
             kpf2.set_data(
                 "GREEN_SCI2_FLUX", np.ones((NORDER_GREEN, 8), dtype=np.float32)
             )
+        assert "MinBitDepth" not in caplog.text
         assert_dtype(kpf2.data["TRACE3_FLUX"], FLUX, "underlying TRACE3_FLUX")
 
 
@@ -516,10 +518,10 @@ class TestKPFMasterL2:
         with fits.open(out_fn) as hdul:
             assert hdul["PRIMARY"].header["DATALVL"] == "ML2"
 
-    def test_no_warning_on_known_extensions(self, synthetic_masters_l2_file):
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", UserWarning)
+    def test_no_warning_on_known_extensions(self, caplog, synthetic_masters_l2_file):
+        with caplog.at_level(logging.WARNING):
             KPFMasterL2.from_fits(synthetic_masters_l2_file)
+        assert "Non-standard extension" not in caplog.text
 
     def test_set_input_files(self):
         m = KPFMasterL2(kind="wls")
@@ -541,7 +543,7 @@ class TestKPFMasterL2:
         assert "INPUT_FILES" in m2.extensions
         assert m2.data["INPUT_FILES"]["FILENAME"].tolist() == files
 
-    def test_warns_on_unknown_extension(self, tmp_path):
+    def test_warns_on_unknown_extension(self, caplog, tmp_path):
         fn = str(tmp_path / "unknown_ext_ml2.fits")
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-01-13T00:00:00"
@@ -552,8 +554,9 @@ class TestKPFMasterL2:
         hdul.writeto(fn, overwrite=True)
         hdul.close()
 
-        with pytest.warns(UserWarning, match="Non-standard extension"):
+        with caplog.at_level(logging.WARNING):
             KPFMasterL2.from_fits(fn)
+        assert "Non-standard extension" in caplog.text
 
 
 class TestKPF2HeaderStorage:

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -1,6 +1,6 @@
 """Tests for the Diagnostics framework and per-level subclasses."""
 
-import warnings
+import logging
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -238,17 +238,16 @@ class TestDiagL0Pointing:
         assert "GAIAOFF" not in results
         assert "TARGOFF" not in results
 
-    def test_skip_gaiaoff_when_no_gaiaid(self):
+    def test_skip_gaiaoff_when_no_gaiaid(self, caplog):
         # Pointing + target present, GAIAID absent -> TARGOFF only, no warning.
         l0 = _make_l0_pointing(GAIAID=None)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with caplog.at_level(logging.WARNING):
             results = DiagL0(l0).run()
         assert "GAIAOFF" not in results
         assert "TARGOFF" in results
-        assert not any("GAIAOFF skipped" in str(c.message) for c in caught)
+        assert "GAIAOFF skipped" not in caplog.text
 
-    def test_gaia_failure_warns_and_skips(self):
+    def test_gaia_failure_warns_and_skips(self, caplog):
         # Gaia unreachable -> GAIAOFF warns and skips; the network-free TARGOFF
         # still computes (fail-soft, so the L0 checkpoint does not fail).
         l0 = _make_l0_pointing()
@@ -257,9 +256,10 @@ class TestDiagL0Pointing:
                 "kpfpipe.quality_control.diagnostics.level0.Gaia.launch_job",
                 side_effect=ConnectionError("gaia down"),
             ),
-            pytest.warns(UserWarning, match="GAIAOFF skipped"),
+            caplog.at_level(logging.WARNING),
         ):
             results = DiagL0(l0).run()
+        assert "GAIAOFF skipped" in caplog.text
         assert "GAIAOFF" not in results
         assert "TARGOFF" in results
 
@@ -316,7 +316,7 @@ class TestDiagL0Object:
         l0 = _make_l0_pointing()  # helper sets no OBJECT
         assert DiagL0(l0).object_ra_dec_offset() == {}
 
-    def test_simbad_no_match_warns_and_skips(self):
+    def test_simbad_no_match_warns_and_skips(self, caplog):
         l0 = _make_l0_pointing()
         l0.headers["PRIMARY"]["OBJECT"] = "NotARealStar"
         with (
@@ -324,9 +324,10 @@ class TestDiagL0Object:
                 "kpfpipe.quality_control.diagnostics.level0.Simbad",
                 return_value=_fake_simbad(no_match=True),
             ),
-            pytest.warns(UserWarning, match="OBJOFF skipped"),
+            caplog.at_level(logging.WARNING),
         ):
             assert DiagL0(l0).object_ra_dec_offset() == {}
+        assert "OBJOFF skipped" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -6,6 +6,7 @@ Unit tests use synthetic DataFrames and temp directories — no real data needed
 Integration tests (slow) use real L0 data from tests/testdata/L0/20240405/.
 """
 
+import logging
 import os
 from pathlib import Path
 
@@ -747,7 +748,7 @@ class TestMiniDatabaseCache:
         assert len(cached) == len(db)
         assert cached["FILENAME"].tolist() == db["FILENAME"].tolist()
 
-    def test_unreadable_frame_recorded_in_cache_not_in_memory(self, tmp_path):
+    def test_unreadable_frame_recorded_in_cache_not_in_memory(self, caplog, tmp_path):
         # An unreadable frame is omitted from the in-memory db (useless for
         # stacking) but still recorded in the on-disk cache, so the cache mirrors
         # the directory and its row-count guardrail treats it as current, not stale.
@@ -756,8 +757,9 @@ class TestMiniDatabaseCache:
         corrupt = tmp_path / "L0" / "20240405" / "KP.20240405.03000.00.fits"
         corrupt.write_bytes(b"not a valid FITS file")
 
-        with pytest.warns(UserWarning, match="Could not read header"):
+        with caplog.at_level(logging.WARNING):
             db = fh.build_mini_database("20240405", cache="rw")
+        assert "Could not read header" in caplog.text
 
         assert len(db) == 2  # in-memory: only the two readable frames
         cache = tmp_path / "vNext" / "mini_db" / "20240405_L0.csv"

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -9,7 +9,9 @@ orchestration path. Behavior specific to a concrete module lives in
 test_master_<type>.py.
 """
 
+import logging
 import os
+import re
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -50,15 +52,16 @@ class TestMasterBaseErrors:
         ):
             Dark(FILE_LIST, config="not-a-config")
 
-    def test_load_frame_missing_file_warns_and_skips(self):
+    def test_load_frame_missing_file_warns_and_skips(self, caplog):
         # A missing/unreadable L0 frame warns and returns None, not a crash.
         fn = "/nonexistent/KP.20240101.00001.00.fits"
         m = Dark([fn])
-        with pytest.warns(UserWarning, match="Failed to load"):
+        with caplog.at_level(logging.WARNING):
             l1_obj = m._load_frame(fn, cache=False)
+        assert "Failed to load" in caplog.text
         assert l1_obj is None
 
-    def test_load_frame_qc_failure_warns_and_skips(self, monkeypatch):
+    def test_load_frame_qc_failure_warns_and_skips(self, caplog, monkeypatch):
         # A frame failing a required QCL0 flag (here the EXPTIME/ELAPSED
         # consistency flag EXPTIMOK) is warned and dropped before assembly.
         m = Dark(FILE_LIST)
@@ -71,8 +74,9 @@ class TestMasterBaseErrors:
             "kpfpipe.modules.masters.base.QCL0",
             lambda l0: MagicMock(run=lambda: qc_result),
         )
-        with pytest.warns(UserWarning, match="QC failed.*EXPTIMOK"):
+        with caplog.at_level(logging.WARNING):
             l1_obj = m._load_frame(fn, cache=False)
+        assert re.search(r"QC failed.*EXPTIMOK", caplog.text)
         assert l1_obj is None
 
     def test_load_frame_qc_pass_returns_assembled(self, monkeypatch):

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -3,7 +3,7 @@
 All sub-module I/O is mocked; no real data or FITS files are required.
 """
 
-import warnings
+import logging
 from unittest.mock import MagicMock
 
 import h5py
@@ -532,25 +532,6 @@ class TestMakeMasterL2:
         with pytest.raises(FileExistsError, match="overwrite=True"):
             wls.save_reduced_frames(master_path)
 
-    def test_save_reduced_frames_suppresses_eprv_filename_warning(
-        self, mock_make_master_l2, tmp_path
-    ):
-        # These are deliberately non-EPRV products; KPF2.to_fits warns on the
-        # {obs_id}_thar_L2 name, which save_reduced_frames must silence.
-        class WarningL2:
-            obs_id = "KP.20240101.00000.00"
-
-            def to_fits(self, path):
-                warnings.warn(
-                    "Filename does not follow the EPRV naming convention.", stacklevel=2
-                )
-
-        wls = WLS(FILE_LIST)
-        wls._l2_obj_cache = [WarningL2()]
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")  # any leaked warning fails the test
-            wls.save_reduced_frames(str(tmp_path / "master.fits"), overwrite=True)
-
     def test_save_master_refuses_overwrite_by_default(
         self, mock_make_master_l2, tmp_path
     ):
@@ -668,7 +649,7 @@ class TestMakeMasterL2:
             assert "coeffs" not in rej
             assert "lines" in rej  # rejected frame's line diagnostics still written
 
-    def test_nan_orderlet_emits_warning_and_does_not_crash(self):
+    def test_nan_orderlet_emits_warning_and_does_not_crash(self, caplog):
         """
         A NaN-filled orderlet (extraction failure) should be skipped with a
         warning rather than crashing scipy's least_squares.
@@ -688,12 +669,13 @@ class TestMakeMasterL2:
         )
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
 
-        with pytest.warns(UserWarning, match=r"RED SCI1 order 102: orderlet skipped"):
+        with caplog.at_level(logging.WARNING):
             result = wls._fit_line_positions_ffi(
                 StubL2(),
                 "RED",
                 ["SCI1"],
             )
+        assert "RED SCI1 order 102: orderlet skipped" in caplog.text
 
         # The NaN order (bluest RED, echelle 102) contributed no lines; rest did.
         assert 102 not in result["echelle"]
@@ -881,22 +863,24 @@ class TestFitAndQcStack:
         assert [fr["rejected"] for fr in frames] == [False] * 5
         assert all(fr["coeffs"] is not None for fr in frames)
 
-    def test_single_bad_frame_dropped(self, monkeypatch):
+    def test_single_bad_frame_dropped(self, caplog, monkeypatch):
         wls = self._setup(monkeypatch, [0.01, 0.22, 0.0, 0.03, 0.01])
-        with pytest.warns(UserWarning, match=r"line fits failed QC"):
+        with caplog.at_level(logging.WARNING):
             frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
+        assert "line fits failed QC" in caplog.text
         # the 22%-bad frame (index 1) is flagged rejected with no coeffs, but
         # still reported alongside the four kept frames
         assert len(frames) == 5
         assert [fr["rejected"] for fr in frames] == [False, True, False, False, False]
         assert frames[1]["coeffs"] is None
 
-    def test_many_bad_frames_all_dropped_no_raise(self, monkeypatch):
+    def test_many_bad_frames_all_dropped_no_raise(self, caplog, monkeypatch):
         # more than one over-threshold frame no longer aborts: each is warned
         # and rejected, and every frame is still reported
         wls = self._setup(monkeypatch, [0.22, 0.01, 0.34, 0.01, 0.01])
-        with pytest.warns(UserWarning, match=r"line fits failed QC"):
+        with caplog.at_level(logging.WARNING):
             frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
+        assert "line fits failed QC" in caplog.text
         assert [fr["rejected"] for fr in frames] == [True, False, True, False, False]
         assert sum(not fr["rejected"] for fr in frames) == 3
 
@@ -906,7 +890,7 @@ class TestFitAndQcStack:
         frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
         assert [fr["rejected"] for fr in frames] == [False, False]
 
-    def test_nonfinite_coeffs_frame_rejected_not_raised(self, monkeypatch):
+    def test_nonfinite_coeffs_frame_rejected_not_raised(self, caplog, monkeypatch):
         # a per-frame fit yielding a NaN coefficient rejects (warns) that frame
         # rather than aborting the whole build
         wls = WLS(FILE_LIST)
@@ -919,12 +903,13 @@ class TestFitAndQcStack:
         monkeypatch.setattr(
             WLS, "_calculate_wls_coeffs", lambda self, *a, **k: next(coeffs)
         )
-        with pytest.warns(UserWarning, match=r"non-finite Legendre"):
+        with caplog.at_level(logging.WARNING):
             frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
+        assert "non-finite Legendre" in caplog.text
         assert [fr["rejected"] for fr in frames] == [False, True, False]
         assert frames[1]["coeffs"] is None
 
-    def test_underconstrained_frame_rejected_not_raised(self, monkeypatch):
+    def test_underconstrained_frame_rejected_not_raised(self, caplog, monkeypatch):
         # a per-frame fit that raises (e.g. underconstrained) rejects (warns)
         # that frame instead of aborting
         wls = WLS(FILE_LIST)
@@ -940,8 +925,9 @@ class TestFitAndQcStack:
 
         monkeypatch.setattr(WLS, "_fit_line_positions_ffi", lambda self, *a, **k: lines)
         monkeypatch.setattr(WLS, "_calculate_wls_coeffs", calc)
-        with pytest.warns(UserWarning, match=r"WLS fit failed"):
+        with caplog.at_level(logging.WARNING):
             frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
+        assert "WLS fit failed" in caplog.text
         assert [fr["rejected"] for fr in frames] == [False, True, False]
         assert frames[1]["coeffs"] is None
 
@@ -1132,7 +1118,7 @@ class TestFitLinePositions:
         for key in ["wav", "pix", "std", "amp"]:
             assert result[key].dtype == np.float64
 
-    def test_all_nan_fiber_emits_fiber_level_warning(self):
+    def test_all_nan_fiber_emits_fiber_level_warning(self, caplog):
         """A fiber whose every order is NaN should emit a fiber-level warning."""
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
@@ -1151,16 +1137,16 @@ class TestFitLinePositions:
         # The fabricated all-NaN fiber makes the code warn once per synthetic order
         # plus once at the fiber level; capture them all so the per-order ones don't
         # leak to the run summary, and assert the fiber-level one.
-        with pytest.warns(UserWarning) as record:
+        with caplog.at_level(logging.WARNING):
             result = wls._fit_line_positions_ffi(
                 StubL2(),
                 "RED",
                 ["SCI1"],
             )
-        assert any("RED SCI1: no good lines retained" in str(w.message) for w in record)
+        assert "RED SCI1: no good lines retained" in caplog.text
         assert len(result["wav"]) == 0
 
-    def test_nan_orderlet_emits_skip_warning(self):
+    def test_nan_orderlet_emits_skip_warning(self, caplog):
         """A single NaN-filled orderlet emits the per-orderlet skip warning."""
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
@@ -1177,10 +1163,10 @@ class TestFitLinePositions:
         )
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
 
-        with pytest.warns(UserWarning) as record:
+        with caplog.at_level(logging.WARNING):
             wls._fit_line_positions_ffi(StubL2(), "RED", ["SCI1"])
 
-        assert any("orderlet skipped" in str(w.message) for w in record)
+        assert "orderlet skipped" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -651,8 +651,8 @@ class TestMakeMasterL2:
 
     def test_nan_orderlet_emits_warning_and_does_not_crash(self, caplog):
         """
-        A NaN-filled orderlet (extraction failure) should be skipped with a
-        warning rather than crashing scipy's least_squares.
+        A NaN-filled orderlet (extraction failure) should be skipped (logged at
+        DEBUG) rather than crashing scipy's least_squares.
         """
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
@@ -669,7 +669,7 @@ class TestMakeMasterL2:
         )
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             result = wls._fit_line_positions_ffi(
                 StubL2(),
                 "RED",
@@ -1134,9 +1134,8 @@ class TestFitLinePositions:
         )
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0])
 
-        # The fabricated all-NaN fiber makes the code warn once per synthetic order
-        # plus once at the fiber level; capture them all so the per-order ones don't
-        # leak to the run summary, and assert the fiber-level one.
+        # The all-NaN fiber logs a per-order skip at DEBUG plus a fiber-level
+        # WARNING; capture at WARNING and assert the fiber-level one.
         with caplog.at_level(logging.WARNING):
             result = wls._fit_line_positions_ffi(
                 StubL2(),
@@ -1147,7 +1146,7 @@ class TestFitLinePositions:
         assert len(result["wav"]) == 0
 
     def test_nan_orderlet_emits_skip_warning(self, caplog):
-        """A single NaN-filled orderlet emits the per-orderlet skip warning."""
+        """A single NaN-filled orderlet logs the per-orderlet skip at DEBUG."""
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
         norder = wls.norder["RED"]
@@ -1163,7 +1162,7 @@ class TestFitLinePositions:
         )
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             wls._fit_line_positions_ffi(StubL2(), "RED", ["SCI1"])
 
         assert "orderlet skipped" in caplog.text

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -132,3 +132,26 @@ class TestMastersRecipeErrors:
         recipe = _load_masters_recipe()
         with pytest.raises(SystemExit, match="--datecode is required"):
             recipe.main(config, args)
+
+
+class TestMastersSummary:
+    """Unit tests for the recipe's private _summary() run-verdict formatter."""
+
+    def test_built_masters_listed(self):
+        text = _load_masters_recipe()._summary(
+            "20240405",
+            [
+                ("bias", "/m/kpf_20240405_bias_L1.fits", 32),
+                ("thar", "/m/kpf_20240405_thar_L2.fits", 12),
+            ],
+            240.5,
+        )
+        assert "masters run summary: 20240405" in text
+        assert "bias   kpf_20240405_bias_L1.fits  (32 frames)" in text
+        assert "thar   kpf_20240405_thar_L2.fits  (12 frames)" in text
+        assert "elapsed:  240.5 s" in text
+        assert text.startswith("\n\n") and text.endswith("\n\n")
+
+    def test_no_masters_built(self):
+        text = _load_masters_recipe()._summary("20240405", [], 1.0)
+        assert "(no masters built)" in text

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -14,6 +14,7 @@ import pytest
 from kpfpipe.data_models.masters.level1 import KPFMasterL1
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import FileHandler, kpf_filepath
+from recipes._logging import masters_run_summary
 
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 MASTERS_CONFIG_PATH = (
@@ -135,10 +136,10 @@ class TestMastersRecipeErrors:
 
 
 class TestMastersSummary:
-    """Unit tests for the recipe's private _summary() run-verdict formatter."""
+    """Unit tests for the masters_run_summary() run-verdict formatter."""
 
     def test_built_masters_listed(self):
-        text = _load_masters_recipe()._summary(
+        text = masters_run_summary(
             "20240405",
             [
                 ("bias", "/m/kpf_20240405_bias_L1.fits", 32),
@@ -153,5 +154,5 @@ class TestMastersSummary:
         assert text.startswith("\n\n") and text.endswith("\n\n")
 
     def test_no_masters_built(self):
-        text = _load_masters_recipe()._summary("20240405", [], 1.0)
+        text = masters_run_summary("20240405", [], 1.0)
         assert "(no masters built)" in text

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -12,6 +12,7 @@ Covers:
 All tests use synthetic in-memory data -- no real KPF files required.
 """
 
+import logging
 import os
 import subprocess
 import sys
@@ -324,6 +325,32 @@ class TestQCBase:
         assert obj.headers["QUALITY_CONTROL"]["ISGOOD"] == 1
         assert list(qc.results) == ["FLAG"]
         assert qc.results["FLAG"][0] is True
+
+    def test_run_logs_pass_debug_fail_warning(self, caplog):
+        """Each flag is logged as written: a pass at DEBUG, a failure at WARNING."""
+        obj = self._make_obj()
+
+        class MyQC(QC):
+            LEVEL = "L2"
+
+            def check_ok(self):
+                return True
+
+            check_ok._qc_key = "CHKOK"
+
+            def check_fail(self):
+                return False
+
+            check_fail._qc_key = "CHKFAIL"
+
+        with caplog.at_level(logging.DEBUG):
+            MyQC(obj).run()
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        debugs = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("CHKFAIL = 0" in r.getMessage() for r in warnings)
+        assert any("CHKOK = 1" in r.getMessage() for r in debugs)
+        # A passing flag never warns.
+        assert not any("CHKOK" in r.getMessage() for r in warnings)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -18,6 +18,7 @@ from kpfpipe import DETECTOR
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import kpf_filepath
+from recipes._logging import science_run_summary
 
 # ---------------------------------------------------------------------------
 # Test data paths and constants
@@ -272,7 +273,7 @@ class _FakeL4:
 
 
 class TestScienceSummary:
-    """Unit tests for the recipe's private _summary() run-verdict formatter."""
+    """Unit tests for the science_run_summary() run-verdict formatter."""
 
     def _l4(self):
         headers = {
@@ -302,7 +303,7 @@ class TestScienceSummary:
         return _FakeL4("KP.20240405.40113.57", headers, receipt)
 
     def test_all_fields_from_l4(self):
-        text = _load_recipe()._summary(self._l4(), 92.4)
+        text = science_run_summary(self._l4(), 92.4)
         assert "run summary: KP.20240405.40113.57" in text
         # Input/output paths come from the RECEIPT table, shown as basenames.
         assert "inputs:   KP.20240405.40113.57.fits" in text
@@ -328,7 +329,7 @@ class TestScienceSummary:
             {"RECEIPT": {}, "PRIMARY": {"RV": None}, "QUALITY_CONTROL": {}},
             None,
         )
-        text = _load_recipe()._summary(l4, 1.0)
+        text = science_run_summary(l4, 1.0)
         assert "RV:       n/a (no science combine)" in text
         assert "inputs:   n/a" in text
         assert "outputs:  n/a" in text

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from kpfpipe import DETECTOR
@@ -259,3 +260,76 @@ class TestScienceRecipeErrors:
         recipe = _load_recipe()
         with pytest.raises(SystemExit, match="--obs_id is required"):
             recipe.main(config, args)
+
+
+class _FakeL4:
+    """Minimal stand-in for a finished KPF4: the attributes _summary reads."""
+
+    def __init__(self, obs_id, headers, receipt):
+        self.obs_id = obs_id
+        self.headers = headers
+        self.receipt = receipt
+
+
+class TestScienceSummary:
+    """Unit tests for the recipe's private _summary() run-verdict formatter."""
+
+    def _l4(self):
+        headers = {
+            "RECEIPT": {
+                "ORIGID": "KP.20240405.40113.57",
+                "BIASFILE": "/m/20240405/KP.20240405.03637.74_master_bias_L1.fits",
+                "DARKFILE": "/m/20240405/KP.20240405.03637.74_master_dark_L1.fits",
+                "WLSFILE": "/m/20240405/KP.20240405.63499.95_master_thar_L2.fits",
+            },
+            "PRIMARY": {"RV": 11.290158, "RVERR": 0.000156, "BJDTDB": 2460405.968919},
+            "QUALITY_CONTROL": {"ISGOOD": 0},
+        }
+        receipt = pd.DataFrame(
+            [
+                ("from_fits", "fn=/in/L0/20240405/KP.20240405.40113.57.fits, foo=None"),
+                (
+                    "to_fits",
+                    "out_filepath=/out/L2/20240405/kpf_SL2_20240405T110833.fits",
+                ),
+                (
+                    "to_fits",
+                    "out_filepath=/out/L4/20240405/kpf_SL4_20240405T110833.fits",
+                ),
+            ],
+            columns=["FUNCTION", "ARGS"],
+        )
+        return _FakeL4("KP.20240405.40113.57", headers, receipt)
+
+    def test_all_fields_from_l4(self):
+        text = _load_recipe()._summary(self._l4(), 92.4)
+        assert "run summary: KP.20240405.40113.57" in text
+        # Input/output paths come from the RECEIPT table, shown as basenames.
+        assert "inputs:   KP.20240405.40113.57.fits" in text
+        assert "/in/" not in text
+        assert (
+            "outputs:  kpf_SL2_20240405T110833.fits  kpf_SL4_20240405T110833.fits"
+            in text
+        )
+        # Masters from the RECEIPT header cards.
+        assert "bias=KP.20240405.03637.74_master_bias_L1.fits" in text
+        assert "thar=KP.20240405.63499.95_master_thar_L2.fits" in text
+        assert "ISGOOD:   0" in text
+        # RV km/s, error m/s (0.000156 km/s -> 0.156 m/s).
+        assert "+11.29016 km/s  err 0.156 m/s  @ BJD_TDB 2460405.968919" in text
+        assert "elapsed:  92.4 s" in text
+        # Internal blank-line padding so the block stands out in the log.
+        assert text.startswith("\n\n") and text.endswith("\n\n")
+
+    def test_no_science_combine_and_no_receipt(self):
+        # RV absent (or FITS UNDEFINED) -> n/a; no receipt table -> paths n/a.
+        l4 = _FakeL4(
+            "obs",
+            {"RECEIPT": {}, "PRIMARY": {"RV": None}, "QUALITY_CONTROL": {}},
+            None,
+        )
+        text = _load_recipe()._summary(l4, 1.0)
+        assert "RV:       n/a (no science combine)" in text
+        assert "inputs:   n/a" in text
+        assert "outputs:  n/a" in text
+        assert "bias=n/a" in text


### PR DESCRIPTION
  ## Logging overhaul: unified levels, structured QC/diagnostics output, end-of-run summaries

  Brings the pipeline's logging up to a consistent, operator-readable standard end
  to end — from per-module stage summaries through QC/diagnostics keyword output to
  a compact per-run verdict — and codifies the conventions in the governing docs.

  ### What changed

  **Level discipline & recoverable conditions**
  - Recoverable/degraded runtime conditions now emit `logger.warning(...)` instead
    of `warnings.warn` — unlike `warnings.warn`, `logger.warning` doesn't dedup per
    call-site, so a per-frame condition is recorded every time (DRP-RUN-08).
    `warnings.warn` is reserved for developer-facing deprecations/API misuse, and
    `setup_logging` still funnels any third-party/stdlib warning into the log via
    `logging.captureWarnings(True)`.
  - De-flooded the level pipeline: inner-loop (per-order/-chip/-frame) detail moved
    to `DEBUG`, so `INFO`/`WARNING` stay scannable.
  - Test warning assertions migrated from `pytest.warns` to `caplog`, and the
    now-obsolete `filterwarnings` ignores (PROGID/KOAID/masters-naming) dropped.

  **Quality-control suite logging**
  - Diagnostics → DEBUG per metric; QC → one line per flag as
    `keyword = value — comment` (FITS comment read off the header), DEBUG on pass /
    WARNING on fail; checkpoints → INFO roll-up, a cross-level `ISGOOD=0` WARNING
    listing the failing flags, and ERROR on a hard-checkpoint raise.

  **Per-module & per-run summaries**
  - Each module's end-of-`perform()` summary gains blank-line padding (baked into
    `_info`, so the `logger.info` call stays clean) and drops the redundant
    `summary:` prefix, making stage boundaries easy to spot by eye.
  - RadialVelocity surfaces the combined science RV (RV/RVERR/BJD_TDB) in its
    summary headline.
  - New end-of-run verdict block at each recipe's completion — inputs, masters,
    outputs, ISGOOD, combined RV, elapsed — read straight off the finished L4
    (science) or what was stacked (masters). Formatters live in `recipes/_logging.py`
    (`science_run_summary` / `masters_run_summary`), keeping `kpfpipe/utils/logger.py`
    pure logging-setup infrastructure.

  **Packaging**
  - `recipes*` added to `[tool.setuptools.packages.find]`, mirroring `scripts*`, so
    `from recipes._logging import …` resolves from any working directory. Recipes
    and scripts now run from outside the repo root; the recipe entry files remain
    path-selected/exec-loaded (nothing imports them as `recipes.kpf_drp_*`).

  ### Governing-doc updates (please review)
  - **Style guide (§B.2, §6):** documents the level discipline, the no-`print()`
    rule (interactive `info()` excepted), the `logger.warning` vs `warnings.warn`
    split, the QC/diagnostics keyword-log format, and the updated `_info`/summary
    idiom.
  - **Architecture:** recoverable conditions use `logger.warning`; `captureWarnings`
    role clarified.

  ### Testing
  - Full fast suite green (1334 passed); recipe integration suites (33) pass;
    `recipes._logging` import + recipe exec-load verified from a non-repo-root CWD;
    ruff clean.