### PR TITLE
Implement master flat module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 ### 5. Communicate Clearly
 
-**Be extremely concise when reporting. Sacrifice grammar for brevity.**
+- Be extremely concise. Sacrifice grammar for conciseness.
+- Do not over-explain. Do not get lost in irrelevant details.
+- Choose your words carefully. A single clear explanation is better than several overlapping verbose explanations.
 
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
@@ -173,7 +175,7 @@ blast radius:
 
 Layout: architecture *Tests → Regression*; conventions: style guide §C.8.
 
-Revise tests as needed when production code changes. Code design should drive test design, not the 
+Revise tests as needed when production code changes. Code design should drive test design, not the
 other way around. Do not contort production code to match pre-existing tests.
 
 ## Reading Files

--- a/configs/kpf_drp_masters.toml
+++ b/configs/kpf_drp_masters.toml
@@ -29,7 +29,7 @@ stack_sigma = 5.0
 
 [WLS]
 min_stack_size = 5   # min frames passing line-fit QC per chip, else the master is withheld
-max_stack_size = 20  # reserved; not yet consumed
+max_stack_size = 20
 lineprofile = "gaussian"
 polyorder_x = 6
 polyorder_m = 6

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -63,12 +63,12 @@ class BaseMasterModule:
 
     # Physical pixel units (BUNIT) by master type, written to the IMG
     # extensions in ``_build_ml1_obj``. A bias master is a stacked count image
-    # (electrons); a dark is normalized to a rate (electrons/sec); a flat is a
-    # unitless relative throughput (no BUNIT). Unknown types get no BUNIT.
+    # (electrons); a dark is normalized to a rate (electrons/sec); a flat is the
+    # total electrons summed over the stack (electrons). Unknown types get no BUNIT.
     _BUNIT_BY_TYPE = {
         "bias": "electrons",
         "dark": "electrons/sec",
-        "flat": None,
+        "flat": "electrons",
     }
 
     # QCL0 flags a frame must pass to enter a stack: data present, required
@@ -742,12 +742,13 @@ class BaseMasterModule:
 
             good &= exptime_sum > 0
 
-            # Exposure-weighted rate estimate: total counts over total exposure
-            # time across the surviving frames (the ML rate under Poisson
-            # statistics, correct for mixed exposures). For a bias stack
-            # exptime_sum is the survivor count, so this is the mean in electrons.
             img = np.zeros_like(counts)
-            img[good] = counts[good] / exptime_sum[good]
+            if cal_type == "flat":
+                # Master flat: total electrons summed over the stack.
+                img[good] = counts[good]
+            else:
+                # Exposure-weighted rate: counts / total exposure (bias: /count).
+                img[good] = counts[good] / exptime_sum[good]
 
             # SNR of the rate is invariant to the exposure normalization: the
             # total exposure cancels in |sum(counts)| / sqrt(sum(var)).

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -15,7 +15,7 @@ class Flat(BaseMasterModule):
     Stacks frames using sigma-clipped statistics, interpolates bad pixels,
     and performs a final outlier pass on the combined image. Outputs a
     KPFMasterL1 containing per-chip IMG, SNR, and MASK extensions; the IMG is
-    a unitless relative throughput (no BUNIT).
+    the total electrons summed over the stack (BUNIT 'electrons').
 
     Standard reduction: a flat is bias- and dark-subtracted before stacking.
 

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -1,15 +1,23 @@
 """KPF Master Flat construction module."""
 
+import logging
+
 from kpfpipe.modules.masters.base import BaseMasterModule
 from kpfpipe.utils.config import ConfigHandler
+
+logger = logging.getLogger(__name__)
 
 
 class Flat(BaseMasterModule):
     """
     Construct a master flat frame from a stack of L0 flat exposures.
 
-    Standard reduction: a flat is bias- and dark-subtracted. Not yet
-    implemented.
+    Standard reduction: a flat is bias- and dark-subtracted. The associated
+    master bias and master dark are subtracted from each frame before stacking
+    with sigma-clipped statistics, interpolating bad pixels, and performing a
+    final trend-aware outlier pass. Outputs a KPFMasterL1 containing per-chip
+    IMG, SNR, and MASK extensions; the IMG is a unitless relative throughput
+    (no BUNIT).
 
     Parameters
     ----------
@@ -43,9 +51,92 @@ class Flat(BaseMasterModule):
             raise TypeError("config must be None, dict, or ConfigHandler")
         super().__init__(l0_file_list, params)
 
+        self._info = None
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def make_master_l1(
+        self,
+        l0_file_list=None,
+        *,
+        nstream=6,
+        sigma=None,
+        bias=None,
+        dark=None,
+        master_path=None,
+    ):
+        """
+        Build master flat from stack.
+
+        The constructed KPFMasterL1 is returned and cached on
+        ``self.ml1_obj``; pass ``master_path`` to also persist it to disk
+        via ``save_master('L1', ...)``.
+
+        Parameters
+        ----------
+        l0_file_list : list of str, optional
+            L0 files to stack. Defaults to self.l0_file_list.
+        nstream : int, optional
+            Stream threshold passed to stack_frames.
+        sigma : float, optional
+            Outlier rejection threshold passed to stack_frames.
+        bias : bool | str | KPFMasterL1, optional
+            Per-call master-bias override (same forms as ImageProcessing.perform:
+            bool, a master filepath, or a KPFMasterL1 object). ``bias=False``
+            skips bias subtraction and ``bias="/path/master_bias.fits"`` uses a
+            specific master.
+        dark : bool | str | KPFMasterL1, optional
+            Per-call master-dark override (same forms as ``bias``). A flat's
+            standard is bias- and dark-subtraction; flat division is never
+            applied when building a master flat, so no flat override is accepted.
+        master_path : str, optional
+            If provided, persist the master L1 to a FITS file at this path.
+        """
+        if l0_file_list is None:
+            l0_file_list = self.l0_file_list
+        if sigma is None:
+            sigma = self.stack_sigma
+
+        self._active_calibrations = self._resolve_calibrations(bias=bias, dark=dark)
+
+        l1_arrays = self.stack_frames(
+            l0_file_list=l0_file_list,
+            nstream=nstream,
+            sigma=sigma,
+            cal_type="flat",
+        )
+
+        self.ml1_obj = self._build_ml1_obj(l1_arrays, l0_file_list, master_type="flat")
+        self._populate_stack_info(l1_arrays)
+        self._track_info()
+
+        if master_path is not None:
+            self.save_master("L1", master_path, overwrite=True)
+
+        logger.info("%s", self._info)
+
+        return self.ml1_obj
+
+    def _track_info(self):
+        """Build and cache the info() summary text from _stack_info."""
+        lines = ["Flat", "  l0_file_list:"]
+        for fn in self.l0_file_list:
+            lines.append(f"    {fn}")
+        lines.append(f"  chips:  {self.chips}")
+        lines.append(f"\n  {'chip':<8s} {'median':<15s} {'rms':<10s} {'bad pixels'}")
+        lines.append("  " + "-" * 56)
+        for chip, stats in self._stack_info.items():
+            lines.append(
+                f"  {chip:<8s} {stats['median']:<15.4f} {stats['rms']:<10.4f} "
+                f"{stats['num_bad']} ({stats['pct_bad']:.3f}%)"
+            )
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
+
     def info(self):
-        """Print a summary of the module configuration (not yet implemented)."""
-        # Flat has no make_master_l1() yet, so nothing is tracked onto _info; the
-        # reporter is a terse not-implemented notice (mirrors the other masters'
-        # not-run state). When stacking lands, add _track_info()/_stack_info here.
-        print(f"{type(self).__name__}: make_master_l1() is not yet implemented")
+        """Print a summary of the module configuration and stacking results."""
+        if self._info is None:
+            print(f"{type(self).__name__}: make_master_l1() has not been called")
+        else:
+            print(self._info)

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -12,12 +12,12 @@ class Flat(BaseMasterModule):
     """
     Construct a master flat frame from a stack of L0 flat exposures.
 
-    Standard reduction: a flat is bias- and dark-subtracted. The associated
-    master bias and master dark are subtracted from each frame before stacking
-    with sigma-clipped statistics, interpolating bad pixels, and performing a
-    final trend-aware outlier pass. Outputs a KPFMasterL1 containing per-chip
-    IMG, SNR, and MASK extensions; the IMG is a unitless relative throughput
-    (no BUNIT).
+    Stacks frames using sigma-clipped statistics, interpolates bad pixels,
+    and performs a final outlier pass on the combined image. Outputs a
+    KPFMasterL1 containing per-chip IMG, SNR, and MASK extensions; the IMG is
+    a unitless relative throughput (no BUNIT).
+
+    Standard reduction: a flat is bias- and dark-subtracted before stacking.
 
     Parameters
     ----------

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -371,6 +371,7 @@ class FileHandler:
         cal_type,
         *,
         min_stack_size=1,
+        max_stack_size=None,
         cluster_gap_seconds=7200,
         groupby="time_of_day",
         exclude_junk=True,
@@ -394,7 +395,9 @@ class FileHandler:
           routinely straddle HST midnight and belong in a single nightly stack.
 
         Every returned stack has at least ``min_stack_size`` files; undersized
-        stacks are dropped, and it raises when none meets the threshold.
+        stacks are dropped, and it raises when none meets the threshold. A stack
+        with more than ``max_stack_size`` files is truncated to its first
+        ``max_stack_size`` (earliest by time), with a warning.
 
         Parameters
         ----------
@@ -404,6 +407,11 @@ class FileHandler:
             Minimum number of files required per stack; undersized stacks are
             dropped. The default of 1 keeps every cluster (a no-op filter); the
             masters recipe passes the configured per-cal-type value.
+        max_stack_size : int or None, default None
+            Maximum number of files used per stack; oversized stacks are
+            truncated to their earliest ``max_stack_size`` frames. The default of
+            None imposes no ceiling; the masters recipe passes the configured
+            per-cal-type value.
         cluster_gap_seconds : int, default 7200
             Gap [s] between consecutive frames that splits one session from the
             next. The 2-hour default separates KPF morning vs. evening sessions.
@@ -461,6 +469,23 @@ class FileHandler:
                 f"'{cal_type}' groupby={groupby} produced no cluster with at least "
                 f"min_stack_size={min_stack_size} files"
             )
+
+        if max_stack_size is not None:
+            capped = []
+            for c in clusters:
+                if len(c) > max_stack_size:
+                    logger.warning(
+                        "%d %s L0 frames detected...using only %d frames to "
+                        "construct master. Increase max_stack_size if higher S/N "
+                        "is desired",
+                        len(c),
+                        cal_type,
+                        max_stack_size,
+                    )
+                    c = c[:max_stack_size]
+                capped.append(c)
+            clusters = capped
+
         # Which frames feed each master is a decision point (DRP-RUN-08).
         logger.info(
             "'%s' frames form %d cluster(s); sizes: %s",

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -230,8 +230,9 @@ class FileHandler:
 
         Parameters
         ----------
-        datecode : str
-            Observing-night datecode 'YYYYMMDD'.
+        datecode : str or int
+            Observing-night datecode 'YYYYMMDD'; an int (e.g. 20240405) is
+            coerced to its string form.
         cache : {False, "r", "w", "rw", "wr"}, default False
             Which side(s) of the on-disk cache to use. ``False`` (default) always
             scans fresh and never touches the cache. ``"r"`` reads a current cache
@@ -260,6 +261,7 @@ class FileHandler:
             raise ValueError(
                 f"cache must be False or one of 'r'/'w'/'rw'/'wr', got {cache!r}"
             )
+        datecode = str(datecode)
         read_cache = cache and "r" in cache
         write_cache = cache and "w" in cache
 
@@ -481,6 +483,7 @@ class FileHandler:
         """
         if self._masters_output is None:
             raise ValueError("FileHandler has no KPF_MASTERS_OUTPUT configured")
+        datecode = str(datecode)
         night_dir = kpf_directory(
             kind="masters", data_root=self._masters_output, datecode=datecode
         )

--- a/kpfpipe/utils/io.py
+++ b/kpfpipe/utils/io.py
@@ -124,8 +124,12 @@ class FileHandler:
     """
 
     def __init__(self, data_dirs):
-        self._data_input = data_dirs.get("KPF_DATA_INPUT")
-        self._masters_output = data_dirs.get("KPF_MASTERS_OUTPUT")
+        data_input = data_dirs.get("KPF_DATA_INPUT")
+        masters_output = data_dirs.get("KPF_MASTERS_OUTPUT")
+        self._data_input = os.path.abspath(data_input) if data_input else None
+        self._masters_output = (
+            os.path.abspath(masters_output) if masters_output else None
+        )
         self._mini_db = None  # loaded night's readable frames (build_mini_database)
         self._full_scan_mini_db = None  # full scan of every file, written to the cache
 

--- a/kpfpipe/utils/stats.py
+++ b/kpfpipe/utils/stats.py
@@ -142,21 +142,6 @@ def optimize_lsq(x, y, linemodel):
     return theta, rms
 
 
-def _mad_std(x, med=None, axis=None, keepdims=False):
-    """NaN-aware drop-in for ``astropy.stats.mad_std``: MAD scaled to a Gaussian
-    sigma, ``1.482602218505602 * median(|x - median(x)|)``, reduced over ``axis``.
-
-    Adds a reusable pre-computed median ``med`` (must be reduced over the same
-    ``axis`` with ``keepdims=True`` so it broadcasts against ``x``) plus
-    ``axis``/``keepdims`` control over the final MAD reduction.
-    """
-    if med is None:
-        med = np.nanmedian(x, axis=axis, keepdims=True)
-    return 1.482602218505602 * np.nanmedian(
-        np.abs(x - med), axis=axis, keepdims=keepdims
-    )
-
-
 def _smooth_filter(x, size=None, *, axes=None):
     """Median- then Gaussian-smooth ``x`` (chains scipy's ``median_filter`` and
     ``gaussian_filter``).
@@ -181,7 +166,9 @@ def flag_outliers(x, sigma, axis=None, kernel_size=None, method="median"):
       the frames that deviate across the stack).
     - ``method="trend"`` smooths ``x`` *along* ``axis`` (see ``_smooth_filter``) and
       judges each element against that local trend, so it tolerates structure
-      that varies smoothly along ``axis`` (e.g. illumination along dispersion).
+      that varies smoothly along ``axis`` (e.g. illumination along dispersion). The
+      deviation is scaled by a local (rolling) MAD rather than one global MAD, so
+      it tolerates heteroscedasticity (scatter that grows with the local level).
 
     ``axis=None`` compares every element to a single global statistic.
     """
@@ -189,17 +176,19 @@ def flag_outliers(x, sigma, axis=None, kernel_size=None, method="median"):
 
     if method == "median":
         med = np.nanmedian(x, axis=axis, keepdims=True)
-        # Reuse one abs-dev buffer (MAD, then normalize in place) to avoid extra
-        # full-size temporaries on the datacube.
         dev = np.abs(x - med)
         mad = 1.482602218505602 * np.nanmedian(dev, axis=axis, keepdims=True)
+        # Reuse one abs-dev compute to avoid extra temporary arrays.
         dev /= mad + eps
         out = dev > sigma
 
     elif method == "trend":
         trend = _smooth_filter(x, size=kernel_size, axes=axis)
-        mad = _mad_std(x - trend)
-        out = np.abs(x - trend) / (mad + eps) > sigma
+        dev = np.abs(x - trend)
+        mad = 1.482602218505602 * _smooth_filter(dev, size=kernel_size, axes=axis)
+        # Reuse one abs-dev compute to avoid extra temporary arrays.
+        dev /= mad + eps
+        out = dev > sigma
 
     else:
         raise ValueError(f"method must be 'median' or 'trend'; {method} not supported")

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -55,6 +55,7 @@ def main(config, args):
     for files in file_handler.build_calibration_stacks(
         "bias",
         min_stack_size=config.get_params(["BIAS"])["min_stack_size"],
+        max_stack_size=config.get_params(["BIAS"])["max_stack_size"],
         groupby="time_of_day",
     ):
         bias_path = kpf_filepath(
@@ -71,6 +72,7 @@ def main(config, args):
     for files in file_handler.build_calibration_stacks(
         "dark",
         min_stack_size=config.get_params(["DARK"])["min_stack_size"],
+        max_stack_size=config.get_params(["DARK"])["max_stack_size"],
         groupby="obs_night",
     ):
         dark_path = kpf_filepath(
@@ -87,6 +89,7 @@ def main(config, args):
     for files in file_handler.build_calibration_stacks(
         "flat",
         min_stack_size=config.get_params(["FLAT"])["min_stack_size"],
+        max_stack_size=config.get_params(["FLAT"])["max_stack_size"],
         groupby="time_of_day",
     ):
         flat_path = kpf_filepath(
@@ -102,6 +105,7 @@ def main(config, args):
     for files in file_handler.build_calibration_stacks(
         "thar",
         min_stack_size=config.get_params(["WLS"])["min_stack_size"],
+        max_stack_size=config.get_params(["WLS"])["max_stack_size"],
         groupby="time_of_day",
     ):
         obs_id = get_obs_id(files[0])

--- a/recipes/kpf_drp_masters.py
+++ b/recipes/kpf_drp_masters.py
@@ -2,17 +2,17 @@
 KPF masters construction recipe.
 
 Builds the nightly calibration master products for a single datecode from its
-raw L0 frames: master bias and master dark (L1), and master wavelength solution
-(L2) from ThAr exposures. Flat masters are scaffolded but not yet implemented.
-Each master is stacked by the corresponding module under `kpfpipe.modules.masters`
-and written to the output data root via the pipeline path helpers.
+raw L0 frames: master bias, master dark, and master flat (L1), and master
+wavelength solution (L2) from ThAr exposures. Each master is stacked by the
+corresponding module under `kpfpipe.modules.masters` and written to the output
+data root via the pipeline path helpers.
 """
 
 import logging
 import os
 import time
 
-from kpfpipe.modules.masters import WLS, Bias, Dark
+from kpfpipe.modules.masters import WLS, Bias, Dark, Flat
 from kpfpipe.utils.io import FileHandler, kpf_filepath
 from kpfpipe.utils.kpf import get_obs_id
 from recipes._logging import masters_run_summary
@@ -81,12 +81,21 @@ def main(config, args):
         dark.make_master_l1(master_path=dark_path)
         built.append(("dark", dark_path, len(files)))
 
-    # master flat (not yet implemented)
-    # for files in file_handler.build_calibration_stacks('flat'):
-    #    flat_path = kpf_filepath(get_obs_id(files[0]), 'L1',
-    #                               data_root=data_root_masters, master='flat')
-    #    flat = Flat(files, config)
-    #    flat.make_master_l1(master_path=flat_path)
+    # Stack the flat frames into a master flat. Runs after the master bias and
+    # dark so CalibrationAssociation can subtract both from each flat frame (via
+    # _process_frame) before stacking.
+    for files in file_handler.build_calibration_stacks(
+        "flat",
+        min_stack_size=config.get_params(["FLAT"])["min_stack_size"],
+        groupby="time_of_day",
+    ):
+        flat_path = kpf_filepath(
+            get_obs_id(files[0]), "L1", data_root=data_root_masters, master="flat"
+        )
+        logger.info("stacking %d flat frames -> %s", len(files), flat_path)
+        flat = Flat(files, config)
+        flat.make_master_l1(master_path=flat_path)
+        built.append(("flat", flat_path, len(files)))
 
     # Stack the ThAr exposures into a master wavelength solution, since the
     # emission-line spectrum anchors the per-order wavelength calibration.

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -323,6 +323,20 @@ class TestBuildCalibrationStacksRealData:
         assert lists[0] == sorted(lists[0])
 
 
+@pytest.mark.slow
+class TestBuildMiniDatabaseDatecodeType:
+    """build_mini_database accepts an int datecode as well as a 'YYYYMMDD' string."""
+
+    def test_int_datecode_matches_string(self):
+        from_int = FileHandler(
+            {"KPF_DATA_INPUT": str(TESTDATA_DIR)}
+        ).build_mini_database(20240405)
+        from_str = FileHandler(
+            {"KPF_DATA_INPUT": str(TESTDATA_DIR)}
+        ).build_mini_database("20240405")
+        pd.testing.assert_frame_equal(from_int, from_str)
+
+
 # ---------------------------------------------------------------------------
 # datecode_dirs_in_range
 # ---------------------------------------------------------------------------
@@ -522,6 +536,10 @@ class TestFindMasters:
     def test_raises_without_masters_output(self):
         with pytest.raises(ValueError, match="KPF_MASTERS_OUTPUT"):
             FileHandler({}).find_masters("bias", "L1", "20240405")
+
+    def test_accepts_int_datecode(self, tmp_path):
+        fh = FileHandler({"KPF_MASTERS_OUTPUT": str(tmp_path)})
+        assert fh.find_masters("bias", "L1", 20240405) == []
 
     @pytest.mark.parametrize(
         "cal_type,level",

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -261,6 +261,24 @@ class TestBuildCalibrationStacks:
         assert len(lists) == 1
         assert lists[0] == sorted(before + after)
 
+    def test_max_stack_size_truncates_to_earliest(self):
+        # Each bias cluster holds 5 files; max_stack_size=3 keeps the earliest 3.
+        lists = _cluster("bias", _make_mini_db(), max_stack_size=3)
+        assert lists[0] == sorted(_BIAS_A)[:3]
+        assert lists[1] == sorted(_BIAS_B)[:3]
+
+    def test_max_stack_size_noop_when_within_limit(self):
+        # A ceiling at or above the cluster size leaves every stack intact.
+        lists = _cluster("bias", _make_mini_db(), max_stack_size=5)
+        assert lists[0] == sorted(_BIAS_A)
+        assert lists[1] == sorted(_BIAS_B)
+
+    def test_max_stack_size_warns_when_truncating(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            _cluster("bias", _make_mini_db(), max_stack_size=3)
+        assert "5 bias L0 frames detected" in caplog.text
+        assert "using only 3 frames" in caplog.text
+
     def test_invalid_imtype_raises(self):
         with pytest.raises(ValueError, match="cal_type must be one of"):
             _cluster("bogus", _make_mini_db())

--- a/tests/regression/test_master_flat.py
+++ b/tests/regression/test_master_flat.py
@@ -46,10 +46,10 @@ class TestMasterFlatUnit:
     def test_receipt_entry(self, master_flat):
         assert "master_flat" in master_flat.receipt["FUNCTION"].values
 
-    def test_bunit_is_unset(self, master_flat):
-        # A flat is a unitless relative throughput, so it carries no BUNIT.
+    def test_bunit_is_electrons(self, master_flat):
+        # A flat IMG is the total electrons summed over the stack.
         for chip in CHIPS:
-            assert master_flat.headers[f"{chip}_IMG"].get("BUNIT") is None
+            assert master_flat.headers[f"{chip}_IMG"].get("BUNIT") == "electrons"
 
 
 # ---------------------------------------------------------------------------
@@ -108,9 +108,9 @@ class TestMasterFlatRegression:
             median = np.nanmedian(master_flat.data[f"{chip}_IMG"])
             assert median > 0
 
-    def test_bunit_is_unset(self, master_flat):
+    def test_bunit_is_electrons(self, master_flat):
         for chip in CHIPS:
-            assert master_flat.headers[f"{chip}_IMG"].get("BUNIT") is None
+            assert master_flat.headers[f"{chip}_IMG"].get("BUNIT") == "electrons"
 
     def test_snr_never_negative(self, master_flat):
         for chip in CHIPS:

--- a/tests/regression/test_master_flat.py
+++ b/tests/regression/test_master_flat.py
@@ -1,0 +1,131 @@
+"""Unit and regression tests for the master flat module (`Flat`).
+
+Unit tests mock stack_frames (no real data). TestMasterFlatRegression builds a
+real master flat from the bundled L0 flats: the five frames fall within one
+time-of-day cluster, so it groups them with groupby='time_of_day' (as the masters
+recipe does for flats) before bias- and dark-subtracting each frame. The shared
+stacking engine these exercise (`BaseMasterModule`) is unit-tested in
+test_master_base.py.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from kpfpipe.data_models.masters import KPFMasterL1
+from kpfpipe.modules.masters.flat import Flat
+from kpfpipe.utils.io import FileHandler
+
+from ._masters import make_l1_arrays
+
+CHIPS = ["GREEN", "RED"]
+# make_l1_arrays() -- shared synthetic stack_frames builder -- lives in _masters.py
+
+TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
+
+FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
+
+
+# ---------------------------------------------------------------------------
+# Unit tests (mocked stack_frames)
+# ---------------------------------------------------------------------------
+
+
+class TestMasterFlatUnit:
+    """Unit tests using a mocked stack_frames -- no real data needed."""
+
+    @pytest.fixture(scope="class")
+    def master_flat(self):
+        synthetic = make_l1_arrays()
+        flat = Flat(FILE_LIST)
+        with patch.object(flat, "stack_frames", return_value=synthetic):
+            return flat.make_master_l1()
+
+    def test_receipt_entry(self, master_flat):
+        assert "master_flat" in master_flat.receipt["FUNCTION"].values
+
+    def test_bunit_is_unset(self, master_flat):
+        # A flat is a unitless relative throughput, so it carries no BUNIT
+        # (contrast the bias "electrons" / dark "electrons/sec").
+        for chip in CHIPS:
+            assert master_flat.headers[f"{chip}_IMG"].get("BUNIT") is None
+
+
+# ---------------------------------------------------------------------------
+# Signature: a flat is bias- and dark-subtracted, so make_master_l1 takes bias
+# and dark but not flat.
+# ---------------------------------------------------------------------------
+
+
+class TestMasterFlatSignature:
+    def test_flat_kwarg_rejected(self):
+        with pytest.raises(TypeError):
+            Flat(FILE_LIST).make_master_l1(flat=True)
+
+    @pytest.mark.parametrize("kwarg", ["bias", "dark"])
+    def test_bias_dark_kwargs_accepted(self, kwarg):
+        synthetic = make_l1_arrays()
+        flat = Flat(FILE_LIST)
+        with patch.object(flat, "stack_frames", return_value=synthetic):
+            ml1 = flat.make_master_l1(**{kwarg: False})
+        assert isinstance(ml1, KPFMasterL1)
+
+
+# ---------------------------------------------------------------------------
+# Regression: a real master flat from the bundled L0 flats (bias- and dark-
+# subtracted, real flag_outliers rejection, real bad-pixel cleaning)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+class TestMasterFlatRegression:
+    """End-to-end master flat from real L0 frames. The five bundled flats fall
+    within a single time-of-day cluster, so they are grouped with
+    groupby='time_of_day' (as the masters recipe does for flats); each frame is
+    bias- and dark-subtracted against the bundled master bias and dark."""
+
+    @pytest.fixture(scope="class")
+    def master_flat(self):
+        file_handler = FileHandler({"KPF_DATA_INPUT": str(TESTDATA_DIR)})
+        file_handler.build_mini_database("20240405")
+        files = file_handler.build_calibration_stacks(
+            "flat",
+            min_stack_size=5,
+            groupby="time_of_day",
+        )
+        assert len(files) == 1 and len(files[0]) == 5
+        config = {"KPF_MASTERS_OUTPUT": str(TESTDATA_DIR)}
+        return Flat(files[0], config=config).make_master_l1()
+
+    def test_returns_kpf_master_l1(self, master_flat):
+        assert isinstance(master_flat, KPFMasterL1)
+
+    def test_flat_is_illuminated(self, master_flat):
+        # A flat is an illuminated exposure, so the stacked image has real
+        # positive signal (unlike a near-zero bias or tiny dark-current rate).
+        for chip in CHIPS:
+            median = np.nanmedian(master_flat.data[f"{chip}_IMG"])
+            assert median > 0
+
+    def test_bunit_is_unset(self, master_flat):
+        for chip in CHIPS:
+            assert master_flat.headers[f"{chip}_IMG"].get("BUNIT") is None
+
+    def test_snr_never_negative(self, master_flat):
+        for chip in CHIPS:
+            assert np.all(master_flat.data[f"{chip}_SNR"] >= 0)
+
+    def test_mask_mostly_good(self, master_flat):
+        # A clean detector stack keeps the large majority of pixels. The final
+        # trend outlier pass scales its threshold by a local (not global) noise
+        # scale, so the flat's bright orders are not over-flagged against the
+        # dark inter-order floor.
+        for chip in CHIPS:
+            mask = master_flat.data[f"{chip}_MASK"]
+            assert mask.dtype == bool
+            assert np.mean(mask) > 0.9
+
+    def test_calibrated_via_receipt(self, master_flat):
+        assert "master_flat" in master_flat.receipt["FUNCTION"].values

--- a/tests/regression/test_master_flat.py
+++ b/tests/regression/test_master_flat.py
@@ -47,8 +47,7 @@ class TestMasterFlatUnit:
         assert "master_flat" in master_flat.receipt["FUNCTION"].values
 
     def test_bunit_is_unset(self, master_flat):
-        # A flat is a unitless relative throughput, so it carries no BUNIT
-        # (contrast the bias "electrons" / dark "electrons/sec").
+        # A flat is a unitless relative throughput, so it carries no BUNIT.
         for chip in CHIPS:
             assert master_flat.headers[f"{chip}_IMG"].get("BUNIT") is None
 
@@ -104,7 +103,7 @@ class TestMasterFlatRegression:
 
     def test_flat_is_illuminated(self, master_flat):
         # A flat is an illuminated exposure, so the stacked image has real
-        # positive signal (unlike a near-zero bias or tiny dark-current rate).
+        # positive signal.
         for chip in CHIPS:
             median = np.nanmedian(master_flat.data[f"{chip}_IMG"])
             assert median > 0


### PR DESCRIPTION
  ## Summary

  Implements master **flat** construction and adds a `max_stack_size` cap to
  calibration stacking, plus two small `FileHandler` input-coercion fixes and a
  trend-outlier improvement.

  - **Master flat**: `Flat.make_master_l1` bias- and dark-subtracts each frame,
    stacks with sigma-clipped statistics, interpolates bad pixels, and runs a
    trend-aware outlier pass. Produces a `KPFMasterL1` with per-chip IMG/SNR/MASK;
    the flat IMG is a total electron counts included in the stack. Wired into the
    masters recipe after bias/dark so both can be subtracted first.
  - **`max_stack_size`**: `build_calibration_stacks` truncates oversized stacks to
    their earliest N frames (deterministic; time-sorted) with a WARNING. Consumed
    by all cal types via config (`BIAS`/`DARK`/`FLAT`/`WLS`).
  - **FileHandler**: resolve data roots to absolute paths; accept an int datecode
    (coerced to str).
  - **`flag_outliers` trend method**: scale deviations by a local (rolling) MAD
    instead of one global MAD, tolerating heteroscedastic scatter.
  
  ## Testing
  
  `test_master_flat.py`, `test_io.py`, `test_stats.py` — 135 passed. Ruff clean.