### PR TITLE
Consolidate external-catalog lookups into AstroQuery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,6 @@ For multi-step tasks, state a brief plan:
 
 Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
 
-### 5. Communicate Clearly
-
-**Be extremely concise when reporting. Sacrifice grammar for brevity.**
-
 **These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
 ## Project Overview
@@ -173,24 +169,8 @@ blast radius:
 
 Layout: architecture *Tests → Regression*; conventions: style guide §C.8.
 
-Revise tests as needed when production code changes. Code design should drive test design, not the 
+Revise tests as needed when production code changes. Code design should drive test design, not the
 other way around. Do not contort production code to match pre-existing tests.
-
-## Reading Files
-
-Reading a file loads its full text into context, so locate before you load — the target
-span, not the whole file:
-
-- **Repo code** — Grep for the symbol/definition, then Read a bounded window
-  (`offset`/`limit`) around the hit. Read a file whole only when it's short or you're about
-  to edit much of it. For "where is X?" across many files, hand the search to an Explore
-  subagent — it reads the dumps, you keep the conclusion.
-- **Governing docs** (262–622 lines each) — grep the doc's headers
-  (`grep -nE '^#+ ' docs/dev/<doc>.md`) or the keyword, then Read only that section. Read one
-  end-to-end only for a comprehensive review, not a spot-check.
-- **Large command output** (full logs, `--durations`, wide greps) — redirect to the
-  scratchpad and inspect with `grep`/`head`/`wc` rather than letting it flood context:
-  `cmd > $SCRATCH/out.txt 2>&1; grep … $SCRATCH/out.txt`.
 
 ## Design Decisions
 
@@ -205,6 +185,8 @@ Before a non-trivial design or structural change, verify against the governing d
    (architecture reference).
 4. **Change gate** — preserves deterministic behavior, runs on the truth dataset, and
    documents RV-metric impact (charter §6); measure against §3 Definition of Success.
+
+**Reading the docs** (262–622 lines each) — grep the doc's headers (`grep -nE '^#+ ' docs/dev/<doc>.md`) or the keyword, then Read only that section. Read one end-to-end only for a comprehensive review, not a spot-check.
 
 The governing docs are the single source of truth — read them, don't restate them here
 (past inline copies drifted). Intent & principles: [`KPF_VNEXT_CHARTER.md`](docs/dev/KPF_VNEXT_CHARTER.md). Structure (data model, aliases, layering, masters,

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -15,7 +15,7 @@ fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 [MODULE_ASTRO_QUERY]
 do_gaia_query = true
 do_simbad_query = true
-use_wmko_tcs = true
+astrometry_priority = ["gaia", "simbad"]  # can include gaia/simbad/wmko
 
 [MODULE_IMAGE_ASSEMBLY]
 overscan_method = "rowmedian"

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -12,6 +12,10 @@ console = true                          # mirror records to stderr
 chips = ["GREEN", "RED"]
 fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 
+[MODULE_ASTRO_QUERY]
+use_gaia = true
+use_simbad = true
+
 [MODULE_IMAGE_ASSEMBLY]
 overscan_method = "rowmedian"
 readnoise_sigma = 10.0

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -15,6 +15,7 @@ fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 [MODULE_ASTRO_QUERY]
 use_gaia = true
 use_simbad = true
+use_wmko = true
 
 [MODULE_IMAGE_ASSEMBLY]
 overscan_method = "rowmedian"

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -35,8 +35,6 @@ extraction_method = "box"
 [MODULE_WAVELENGTH_CALIBRATION]
 
 [MODULE_BARYCENTRIC_CORRECTION]
-use_gaia_astrometry = true
-use_wmko_fallback = false
 
 [MODULE_CROSS_CORRELATION]
 ccf_mask_width = 1.0

--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -13,9 +13,9 @@ chips = ["GREEN", "RED"]
 fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 
 [MODULE_ASTRO_QUERY]
-use_gaia = true
-use_simbad = true
-use_wmko = true
+do_gaia_query = true
+do_simbad_query = true
+use_wmko_tcs = true
 
 [MODULE_IMAGE_ASSEMBLY]
 overscan_method = "rowmedian"

--- a/docs/dev/EPRV_DATA_STANDARD.md
+++ b/docs/dev/EPRV_DATA_STANDARD.md
@@ -183,7 +183,8 @@ L2/L4 products and the barycentric/RV path depend on:
 | `CZ#` | Catalog redshift z (derived from `CRV#`) | | No |
 | `CPLX#` | Catalog parallax | mas | No |
 | `CPMR#`,`CPMD#` | Catalog proper motion RA / Dec | arcsec/yr | No |
-| `CCLR#`,`CCLRN#` | Catalog color (color 1 − color 2) + its name (e.g. `Gaia BP-RP`) | mag | No |
+| `CCLR#` | Catalog color (color 1 − color 2) | mag | No |
+| `CCLRN#` | Catalog color name (e.g. `Gaia BP-RP`) | | No |
 | `OBSERVAT`,`TELESCOP` | Observatory / telescope | | Yes |
 | `OBSLON/LAT/ALT` | Observatory location | deg/deg/m | Yes |
 | `OBSGEO-X/Y/Z` | Cartesian site coordinates | m | No |

--- a/docs/dev/EPRV_DATA_STANDARD.md
+++ b/docs/dev/EPRV_DATA_STANDARD.md
@@ -53,7 +53,7 @@ while `KPF2`/`KPF4` subclass the EPRV `RV2`/`RV4` and must satisfy everything be
 | SNR | per pixel | wavelength via `EXSNRW*` keyword |
 | Coordinates (RA/Dec) | Sexagesimal | |
 | Epoch | Native survey epoch | e.g. 2015.5 for Gaia DR2 |
-| Proper motion | mas/yr | |
+| Proper motion | arcsec/yr | `CPMR#`/`CPMD#` (§6); RA term includes cos Dec |
 | Color index | Gaia Bp − Rp | default unless specified |
 | Systemic velocity / CCF velocity / RV | km/s | |
 

--- a/docs/dev/EPRV_DATA_STANDARD.md
+++ b/docs/dev/EPRV_DATA_STANDARD.md
@@ -180,8 +180,10 @@ L2/L4 products and the barycentric/RV path depend on:
 | `CRA#`,`CDEC#` | Catalog RA / Dec | sexagesimal | Yes |
 | `CEQNX#`,`CEPCH#` | Catalog equinox / epoch | yr | Yes |
 | `CRV#` | Catalog systemic RV | km/s | Yes |
+| `CZ#` | Catalog redshift z (derived from `CRV#`) | | No |
 | `CPLX#` | Catalog parallax | mas | No |
 | `CPMR#`,`CPMD#` | Catalog proper motion RA / Dec | arcsec/yr | No |
+| `CCLR#`,`CCLRN#` | Catalog color (color 1 − color 2) + its name (e.g. `Gaia BP-RP`) | mag | No |
 | `OBSERVAT`,`TELESCOP` | Observatory / telescope | | Yes |
 | `OBSLON/LAT/ALT` | Observatory location | deg/deg/m | Yes |
 | `OBSGEO-X/Y/Z` | Cartesian site coordinates | m | No |

--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -83,7 +83,7 @@ master calibrations that the science flow consumes.
 ### Science Pipeline
 
 ```
-L0 (raw CCD) → ImageAssembly → L1 → ImageProcessing
+L0 (raw CCD) → AstroQuery → ImageAssembly → L1 → ImageProcessing
 L1 (assembled FFI) → SpectralExtraction → L2 → WavelengthCalibration → BarycentricCorrection
 L2 (extracted spectra) → CrossCorrelation → L4 → RadialVelocity
 L4 (CCFs/RVs)
@@ -242,7 +242,8 @@ installed, importable packages; code shared across a layer's siblings goes **dow
 
 `kpfpipe/modules/` holds the scientist-facing processing primitives — each an importable
 building block a recipe composes, with no orchestration or logging setup of its own. The
-science modules run the *Science Pipeline* flow: `image_assembly` (L0 → assembled FFI),
+science modules run the *Science Pipeline* flow: `astro_query` (external-catalog
+astrometry onto L0), `image_assembly` (L0 → assembled FFI),
 `image_processing`, `spectral_extraction`, `wavelength_calibration`, `barycentric_correction`,
 and the radial-velocity pair `radial_velocity`/`cross_correlation`; `calibration_association`
 resolves which master calibrations a frame uses. The `masters/` submodule
@@ -331,7 +332,7 @@ prior wrote, driven by the recipe through a **single `CheckpointL{n}(obj).run()`
 
 The recipe runs `CheckpointL0(l0).run()` **before assembly**, on purpose: QCL0 writes the L0 QC flags
 + `ISGOOD` onto L0's QUALITY_CONTROL, which `to_kpf1` then propagates downstream so the L1/L2/L4
-products carry the full append-only QC history (e.g. `DATTIMOK`, the raw DATE-BEG/MID/END/ELAPSED
+products carry the full append-only QC history (e.g. `DATTIMOK`, the raw DATE-BEG/MID/END
 timing-consistency flag, is an L0 check whose result rides forward this way).
 
 This is unlike v2.12, which had one big `DiagnosticsFramework` primitive with a conditional dispatch tree over many functions and shared backend state with `AnalyzeL0/2D/L1/L2` classes. v3 uses per-level classes with method-attribute registration (`_diag_name` / `_qc_key` / `_checkpoint_name`) and no shared state.

--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -168,8 +168,9 @@ The architecture invariants:
 - **Read from PRIMARY, fall back to `INSTRUMENT_HEADER`.** `_map_header` carries only some natives to
   PRIMARY, mostly under renamed EPRV keys — so read a native from PRIMARY when it survives there under
   its own name (e.g. `DATE-OBS`, `OBJECT`), and from `INSTRUMENT_HEADER` when it never reaches PRIMARY or
-  when a coherent block of related natives (e.g. the WMKO astrometry/catalog block used in
-  `barycentric_correction`) reads more clearly together.
+  when a coherent block of related natives reads more clearly together (e.g. the raw `DATE-BEG`/`DATE-END`
+  pair `barycentric_correction` extrapolates the exposure meter against; its *target astrometry*, by
+  contrast, comes off the PRIMARY `C*#` cards, which `to_kpf1` fills from `CATALOG_RECORD`).
 - **DRP provenance is stamped at read** onto RECEIPT (`KPF0.from_fits` → `_stamp_wmko_tracking`, not
   `to_kpf1`): `DRPVERNO`/`DRPSTATU`/`PROGID`/`KOAID`/`ORIGID`. It rides RECEIPT forward, with `DRPSTATU`
   advanced per module. `ORIGID` (the original L0 obs_id) is also how L1/L2/L4 recover `self.obs_id` on
@@ -196,8 +197,9 @@ keyword defs.
 
 **Each registered keyword has one home extension** (the registry `Extension` column) that `set_keyword`
 routes to: **PRIMARY** (EPRV keywords), **QUALITY_CONTROL** (QC flags + `ISGOOD`, read-noise,
-calibration ages, DiagL2 metrics), **RECEIPT** (DRP provenance, applied flags, calibration paths), the
-**barycentric** L2 extensions, and **RV1–RV5** (L4 per-orderlet `CCD{1,2}RV<sfx>`). The one exception to
+calibration ages, DiagL2 metrics), **RECEIPT** (DRP provenance, applied flags, calibration paths),
+**CATALOG_RECORD** (the L0 `WMKOCR`/`GAIACR`/`SIMBADCR` presence flags), the **barycentric** L2
+extensions, and **RV1–RV5** (L4 per-orderlet `CCD{1,2}RV<sfx>`). The one exception to
 *PRIMARY holds EPRV keywords only* is the L4 SCI-combined RV keywords `CCD{1,2}RV`/`CCD{1,2}ERV` —
 KPF-registered yet homed on PRIMARY, since they are the pipeline's final RV measurements and belong
 beside the EPRV `RV`/`RVERR`. Masters register their PRIMARY keywords in per-master-type registries and
@@ -289,8 +291,8 @@ independent of `--jobs`, cores, or RAM, because masters stacking degrades with t
 concurrent jobs (OS memory-mapping contention) rather than with compute or memory pressure — so do
 **not** swap in a cores- or RAM-derived cap. Both orchestrators also **stagger** their subprocess
 launches (`_LAUNCH_INTERVAL`): masters by 5.0 s to desync the I/O-heavy read phase each build opens,
-science by 1.0 s to rate-limit the SIMBAD/Gaia catalog queries the per-frame L0 pointing QC fires at
-startup (rationale in each module's comment). These caps and intervals were tuned empirically on
+science by 1.0 s to rate-limit the SIMBAD/Gaia catalog queries `AstroQuery` fires per frame at startup
+(rationale in each module's comment). These caps and intervals were tuned empirically on
 Caltech's shrek server — heuristics, not definitive values; re-confirm against a real run before
 changing them.
 

--- a/docs/dev/KPF_VNEXT_ARCHITECTURE.md
+++ b/docs/dev/KPF_VNEXT_ARCHITECTURE.md
@@ -177,6 +177,8 @@ The architecture invariants:
 - **`QUALITY_CONTROL` + `RECEIPT` propagate L0→L1→L2→L4** card-by-card (`KPFDataModel._forward_headers`)
   as an **append-only history**; only `ISGOOD` (the running QC aggregate — see *QC flags*)
   changes per level.
+- **`CATALOG_RECORD` (AstroQuery's resolved catalog rows + presence flags) also passes through
+  L0→L1→L2→L4**, and `to_kpf1` overlays its merged `kpf-drp` row onto the PRIMARY `C*#` cards.
 - **Structural header validation lives in the checkpoints layer** (`Checkpoint.unregistered_keywords`),
   not in QC or `to_kpfN`: every card on a registry-governed extension must be a registered keyword or a
   structural card, else it raises.

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -79,12 +79,11 @@ class KPFDataModel(RVDataModel):
         The ``to_kpfN`` converters set ``obs_id`` directly, so this only fills the
         from_fits path.
 
-        CATALOG_RECORD is normalized here for every level: AstroQuery stores missing
-        floats as NaN, but astropy's FITS reader returns them masked, and a masked
-        cell is not NaN (``np.isnan`` on one is falsy), so a missing-value check
-        would read it as present. Filling back to NaN makes a table just built and
-        one read from disk behave identically. It belongs at this chokepoint rather
-        than in each ``_read`` because L2/L4 read through rvdata's readers.
+        CATALOG_RECORD is normalized here for every level: astropy's FITS reader
+        returns a missing (NaN) cell masked, and a masked cell is not NaN
+        (``np.isnan`` on one is falsy), so a missing-value check would read it as
+        present. This sits at the chokepoint rather than in each ``_read`` because
+        L2/L4 read through rvdata's readers.
         """
         logger.info("reading %s from %s", cls.__name__, fn)
         obj = super().from_fits(fn, instrument=instrument, **kwargs)

--- a/kpfpipe/data_models/base.py
+++ b/kpfpipe/data_models/base.py
@@ -78,11 +78,21 @@ class KPFDataModel(RVDataModel):
         obs_id from the ORIGID provenance card instead (see ``_obs_id_from_receipt``).
         The ``to_kpfN`` converters set ``obs_id`` directly, so this only fills the
         from_fits path.
+
+        CATALOG_RECORD is normalized here for every level: AstroQuery stores missing
+        floats as NaN, but astropy's FITS reader returns them masked, and a masked
+        cell is not NaN (``np.isnan`` on one is falsy), so a missing-value check
+        would read it as present. Filling back to NaN makes a table just built and
+        one read from disk behave identically. It belongs at this chokepoint rather
+        than in each ``_read`` because L2/L4 read through rvdata's readers.
         """
         logger.info("reading %s from %s", cls.__name__, fn)
         obj = super().from_fits(fn, instrument=instrument, **kwargs)
         if getattr(obj, "obs_id", None) is None:
             obj.obs_id = obj._obs_id_from_receipt()
+        table = obj.data.get("CATALOG_RECORD")
+        if table is not None and getattr(table, "has_masked_values", False):
+            obj.set_data("CATALOG_RECORD", table.filled(np.nan))
         return obj
 
     def _obs_id_from_receipt(self):

--- a/kpfpipe/data_models/config/L0-extensions.csv
+++ b/kpfpipe/data_models/config/L0-extensions.csv
@@ -18,3 +18,4 @@ HDU,Name,DataType,Required,Description
 16,RECEIPT,BinTableHDU,True,Processing history
 17,DRP_CONFIG,BinTableHDU,False,Pipeline config as a 2-column table (key = value)
 18,QUALITY_CONTROL,BinTableHDU,True,Quality-control booleans and diagnostic metrics
+19,CATALOG_RECORD,BinTableHDU,True,External catalog astrometry (Gaia/SIMBAD/DCS) resolved by AstroQuery

--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -14,3 +14,6 @@ OBJOFF,Pointing offset from OBJECT (SIMBAD) position (arcsec),QUALITY_CONTROL,fl
 GAIAOFF,Pointing offset from GAIAID position (arcsec),QUALITY_CONTROL,float,DiagL0
 NOTJUNK,QC: obs_id not in junk list,QUALITY_CONTROL,int,QCL0
 ISGOOD,QC: aggregate pass/fail,QUALITY_CONTROL,int,QC
+WMKOCR,Catalog record present for DCS/TCS target,CATALOG_RECORD,int,AstroQuery
+GAIACR,Catalog record present for Gaia DR3 source,CATALOG_RECORD,int,AstroQuery
+SIMBADCR,Catalog record present for SIMBAD object,CATALOG_RECORD,int,AstroQuery

--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -4,13 +4,13 @@ KOAID,KOA archive ID (DRP-RUN-19),RECEIPT,str,KPF0.from_fits
 PROGID,WMKO program ID (DRP-RUN-19),RECEIPT,str,KPF0.from_fits
 DRPVERNO,Pipeline version (DRP-RUN-11; EPRV equivalent is DRPTAG),RECEIPT,str,KPF0.from_fits
 DRPSTATU,DRP reduction status (DRP-RUN-20),RECEIPT,str,KPF0.from_fits
-WMKOCR,Catalog record present for DCS/TCS target,CATALOG_RECORD,int,KPF0.from_fits
+WMKOCR,Catalog record present for DCS/TCS target,CATALOG_RECORD,int,AstroQuery
 GAIACR,Catalog record present for Gaia DR3 source,CATALOG_RECORD,int,AstroQuery
 SIMBADCR,Catalog record present for SIMBAD object,CATALOG_RECORD,int,AstroQuery
 DATAPRL0,QC: GREEN/RED amp extensions present/non-empty,QUALITY_CONTROL,int,QCL0
 KWRDPRL0,QC: required L0 PRIMARY keywords present,QUALITY_CONTROL,int,QCL0
 EXPTIMOK,"QC: EXPTIME finite/non-neg, matches ELAPSED",QUALITY_CONTROL,int,QCL0
-DATTIMOK,QC: Dates/times consistent (DATE-BEG/MID/END/ELAPSED),QUALITY_CONTROL,int,QCL0
+DATTIMOK,QC: Dates/times consistent (DATE-BEG/MID/END),QUALITY_CONTROL,int,QCL0
 RADECOK,QC: pointing consistent with target/catalog RA/DEC,QUALITY_CONTROL,int,QCL0
 CATLOGOK,QC: catalog epoch/equinox/rv/parallax/PM in physical range,QUALITY_CONTROL,int,QCL0
 TARGOFF,Pointing offset from DCS target (arcsec),QUALITY_CONTROL,float,DiagL0

--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -12,6 +12,7 @@ KWRDPRL0,QC: required L0 PRIMARY keywords present,QUALITY_CONTROL,int,QCL0
 EXPTIMOK,"QC: EXPTIME finite/non-neg, matches ELAPSED",QUALITY_CONTROL,int,QCL0
 DATTIMOK,QC: Dates/times consistent (DATE-BEG/MID/END/ELAPSED),QUALITY_CONTROL,int,QCL0
 RADECOK,QC: pointing consistent with target/catalog RA/DEC,QUALITY_CONTROL,int,QCL0
+CATLOGOK,QC: catalog epoch/equinox/rv/parallax/PM in physical range,QUALITY_CONTROL,int,QCL0
 TARGOFF,Pointing offset from DCS target (arcsec),QUALITY_CONTROL,float,DiagL0
 OBJOFF,Pointing offset from OBJECT (SIMBAD) position (arcsec),QUALITY_CONTROL,float,DiagL0
 GAIAOFF,Pointing offset from GAIAID position (arcsec),QUALITY_CONTROL,float,DiagL0

--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -4,6 +4,9 @@ KOAID,KOA archive ID (DRP-RUN-19),RECEIPT,str,KPF0.from_fits
 PROGID,WMKO program ID (DRP-RUN-19),RECEIPT,str,KPF0.from_fits
 DRPVERNO,Pipeline version (DRP-RUN-11; EPRV equivalent is DRPTAG),RECEIPT,str,KPF0.from_fits
 DRPSTATU,DRP reduction status (DRP-RUN-20),RECEIPT,str,KPF0.from_fits
+WMKOCR,Catalog record present for DCS/TCS target,CATALOG_RECORD,int,KPF0.from_fits
+GAIACR,Catalog record present for Gaia DR3 source,CATALOG_RECORD,int,AstroQuery
+SIMBADCR,Catalog record present for SIMBAD object,CATALOG_RECORD,int,AstroQuery
 DATAPRL0,QC: GREEN/RED amp extensions present/non-empty,QUALITY_CONTROL,int,QCL0
 KWRDPRL0,QC: required L0 PRIMARY keywords present,QUALITY_CONTROL,int,QCL0
 EXPTIMOK,"QC: EXPTIME finite/non-neg, matches ELAPSED",QUALITY_CONTROL,int,QCL0
@@ -14,6 +17,3 @@ OBJOFF,Pointing offset from OBJECT (SIMBAD) position (arcsec),QUALITY_CONTROL,fl
 GAIAOFF,Pointing offset from GAIAID position (arcsec),QUALITY_CONTROL,float,DiagL0
 NOTJUNK,QC: obs_id not in junk list,QUALITY_CONTROL,int,QCL0
 ISGOOD,QC: aggregate pass/fail,QUALITY_CONTROL,int,QC
-WMKOCR,Catalog record present for DCS/TCS target,CATALOG_RECORD,int,AstroQuery
-GAIACR,Catalog record present for Gaia DR3 source,CATALOG_RECORD,int,AstroQuery
-SIMBADCR,Catalog record present for SIMBAD object,CATALOG_RECORD,int,AstroQuery

--- a/kpfpipe/data_models/config/L1-extensions.csv
+++ b/kpfpipe/data_models/config/L1-extensions.csv
@@ -12,3 +12,4 @@ HDU,Name,DataType,Required,Description
 10,DRP_CONFIG,BinTableHDU,False,Pipeline config as a 2-column table (key = value)
 11,INSTRUMENT_HEADER,ImageHDU,False,Verbatim raw instrument (L0) PRIMARY header
 12,QUALITY_CONTROL,BinTableHDU,True,Quality-control booleans and diagnostic metrics
+13,CATALOG_RECORD,BinTableHDU,False,External catalog astrometry (Gaia/SIMBAD/DCS) resolved by AstroQuery

--- a/kpfpipe/data_models/config/L2-headers.csv
+++ b/kpfpipe/data_models/config/L2-headers.csv
@@ -1,5 +1,4 @@
 Keyword,Description,Extension,DataType,PopulatedBy
-ASTRSRC,Astrometry source used for barycentric correction,RECEIPT,str,BarycentricCorrection
 CCD1BJD,GREEN photon-weighted mid-time [BJD_TDB],BJD_TDB,float,BarycentricCorrection
 CCD2BJD,RED photon-weighted mid-time [BJD_TDB],BJD_TDB,float,BarycentricCorrection
 CCD1BKMS,GREEN barycentric velocity [km/s],BARYCORR_KMS,float,BarycentricCorrection

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -47,6 +47,7 @@ import importlib.resources
 import logging
 from types import MappingProxyType
 
+import numpy as np
 import pandas as pd
 from rvdata.core.models.definitions import (
     LEVEL2_PRIMARY_KEYWORDS,
@@ -66,8 +67,13 @@ _kpf_pipe_cfg = importlib.resources.files("kpfpipe.data_models.config")
 _NUMORDER = int(DETECTOR["norder"]["GREEN"]) + int(DETECTOR["norder"]["RED"])
 
 # Number of traces/orderlets (SKY, SCI1-3, CAL); the numbered per-orderlet
-# extensions CCF#/RV#/CCF_VAR# run 1.._NUMTRACES.
-_NUMTRACES = len(pd.read_csv(_kpf_pipe_cfg / "trace-map.csv"))
+# extensions CCF#/RV#/CCF_VAR# run 1.._NUMTRACES. _SCI_TRACES holds just the
+# science-fiber indices, the fibers the catalog C*# overlay targets.
+_TRACE_MAP = pd.read_csv(_kpf_pipe_cfg / "trace-map.csv")
+_NUMTRACES = len(_TRACE_MAP)
+_SCI_TRACES = tuple(
+    _TRACE_MAP.loc[_TRACE_MAP["Fiber"].isin({"SCI1", "SCI2", "SCI3"}), "Trace"]
+)
 
 # EPRV-standard compliance is pinned to the installed rv-data-standard release
 # (environment.yml pins it exactly): EPRVTAG is its version ("v0.4.0"), VOCLASS
@@ -116,13 +122,12 @@ class KeywordRegistry:
         "JD_UTC": None,
     }
 
-    # rvdata's header_map numbers per-trace keywords CAL-first (trace 1=CAL .. 5=SKY),
-    # the stale translator convention; KPF is SKY-first (1=SKY .. 5=CAL, per the
-    # EPRV frame; see trace-map.csv). These are the fiber-indexed families
-    # whose STANDARD index _load_header_map realigns 1<->5. NOT here (also end in 1/5
-    # but not fiber-indexed): EXSNR/EXSNRW (wavelength band 452/852nm), DQLVL, T*.
-    _FIBER_INDEXED_BASES = (
-        "TRACE",
+    # Per-fiber catalog C*# keyword bases. On the SCI fibers these are populated by
+    # the CATALOG_RECORD overlay in KPF0.to_kpf1 (the merged canonical astrometry),
+    # not by the raw TARG*/GAIAID header_map mapping; _load_header_map blanks those
+    # SCI source cells so the overlay is the sole writer and, absent a canonical row,
+    # the cards stay empty. SKY(1)/CAL(5) keep their header_map defaults.
+    _CATALOG_BASES = (
         "CSRC",
         "CID",
         "CRA",
@@ -137,6 +142,14 @@ class KeywordRegistry:
         "CCLR",
         "CLSRC",
     )
+
+    # rvdata's header_map numbers per-trace keywords CAL-first (trace 1=CAL .. 5=SKY),
+    # the stale translator convention; KPF is SKY-first (1=SKY .. 5=CAL, per the
+    # EPRV frame; see trace-map.csv). These are the fiber-indexed families (TRACE plus
+    # the catalog bases) whose STANDARD index _load_header_map realigns 1<->5. NOT here
+    # (also end in 1/5 but not fiber-indexed): EXSNR/EXSNRW (wavelength band
+    # 452/852nm), DQLVL, T*.
+    _FIBER_INDEXED_BASES = ("TRACE", *_CATALOG_BASES)
 
     # STANDARD keys rvdata's header_map.csv maps but KPF deliberately does not
     # register (parallactic angle, not carried on KPF products). Dropped silently;
@@ -290,6 +303,18 @@ class KeywordRegistry:
             self._DEFAULT_OVERRIDES.keys()
         )
         self.header_map = raw[keep].reset_index(drop=True)
+
+        # The SCI-fiber catalog C*# cards come from the CATALOG_RECORD overlay in
+        # KPF0.to_kpf1, not from the raw TARG*/GAIAID mapping: blank their INSTRUMENT
+        # and DEFAULT so _map_header emits nothing and the overlay is the sole writer.
+        # SKY(1)/CAL(5) are untouched (they keep their header_map defaults).
+        sci_catalog_keys = {
+            f"{base}{i}" for base in self._CATALOG_BASES for i in _SCI_TRACES
+        }
+        overlay = (
+            self.header_map["STANDARD"].astype(str).str.strip().isin(sci_catalog_keys)
+        )
+        self.header_map.loc[overlay, ["INSTRUMENT", "DEFAULT"]] = np.nan
 
     def is_structural(self, key):
         """True for a FITS structural / bookkeeping card (never a registered keyword).

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -67,11 +67,12 @@ _kpf_pipe_cfg = importlib.resources.files("kpfpipe.data_models.config")
 _NUMORDER = int(DETECTOR["norder"]["GREEN"]) + int(DETECTOR["norder"]["RED"])
 
 # Number of traces/orderlets (SKY, SCI1-3, CAL); the numbered per-orderlet
-# extensions CCF#/RV#/CCF_VAR# run 1.._NUMTRACES. _SCI_TRACES holds just the
-# science-fiber indices, the fibers the catalog C*# overlay targets.
+# extensions CCF#/RV#/CCF_VAR# run 1.._NUMTRACES. SCI_TRACES holds just the
+# science-fiber indices, the fibers the catalog C*# overlay targets -- the single
+# definition, imported by level0 rather than re-derived there.
 _TRACE_MAP = pd.read_csv(_kpf_pipe_cfg / "trace-map.csv")
 _NUMTRACES = len(_TRACE_MAP)
-_SCI_TRACES = tuple(
+SCI_TRACES = tuple(
     _TRACE_MAP.loc[_TRACE_MAP["Fiber"].isin({"SCI1", "SCI2", "SCI3"}), "Trace"]
 )
 
@@ -123,9 +124,8 @@ class KeywordRegistry:
     }
 
     # Per-fiber catalog C*# keyword bases. On the SCI fibers these come from the
-    # CATALOG_RECORD overlay in KPF0.to_kpf1, not the raw TARG*/GAIAID mapping --
-    # _load_header_map blanks those SCI source cells so the overlay is the sole
-    # writer. SKY(1)/CAL(5) keep their header_map defaults.
+    # CATALOG_RECORD overlay in KPF0.to_kpf1, not the raw TARG*/GAIAID mapping;
+    # SKY(1)/CAL(5) keep their header_map defaults.
     _CATALOG_BASES = (
         "CSRC",
         "CID",
@@ -303,11 +303,10 @@ class KeywordRegistry:
         )
         self.header_map = raw[keep].reset_index(drop=True)
 
-        # Blank the SCI-fiber catalog C*# INSTRUMENT/DEFAULT source cells so
-        # _map_header emits nothing and the CATALOG_RECORD overlay (KPF0.to_kpf1) is
-        # their sole writer; SKY(1)/CAL(5) keep their header_map defaults.
+        # Blank the SCI-fiber catalog source cells so _map_header emits nothing and
+        # the CATALOG_RECORD overlay is their sole writer.
         sci_catalog_keys = {
-            f"{base}{i}" for base in self._CATALOG_BASES for i in _SCI_TRACES
+            f"{base}{i}" for base in self._CATALOG_BASES for i in SCI_TRACES
         }
         overlay = (
             self.header_map["STANDARD"].astype(str).str.strip().isin(sci_catalog_keys)

--- a/kpfpipe/data_models/keyword_registry.py
+++ b/kpfpipe/data_models/keyword_registry.py
@@ -122,11 +122,10 @@ class KeywordRegistry:
         "JD_UTC": None,
     }
 
-    # Per-fiber catalog C*# keyword bases. On the SCI fibers these are populated by
-    # the CATALOG_RECORD overlay in KPF0.to_kpf1 (the merged canonical astrometry),
-    # not by the raw TARG*/GAIAID header_map mapping; _load_header_map blanks those
-    # SCI source cells so the overlay is the sole writer and, absent a canonical row,
-    # the cards stay empty. SKY(1)/CAL(5) keep their header_map defaults.
+    # Per-fiber catalog C*# keyword bases. On the SCI fibers these come from the
+    # CATALOG_RECORD overlay in KPF0.to_kpf1, not the raw TARG*/GAIAID mapping --
+    # _load_header_map blanks those SCI source cells so the overlay is the sole
+    # writer. SKY(1)/CAL(5) keep their header_map defaults.
     _CATALOG_BASES = (
         "CSRC",
         "CID",
@@ -304,10 +303,9 @@ class KeywordRegistry:
         )
         self.header_map = raw[keep].reset_index(drop=True)
 
-        # The SCI-fiber catalog C*# cards come from the CATALOG_RECORD overlay in
-        # KPF0.to_kpf1, not from the raw TARG*/GAIAID mapping: blank their INSTRUMENT
-        # and DEFAULT so _map_header emits nothing and the overlay is the sole writer.
-        # SKY(1)/CAL(5) are untouched (they keep their header_map defaults).
+        # Blank the SCI-fiber catalog C*# INSTRUMENT/DEFAULT source cells so
+        # _map_header emits nothing and the CATALOG_RECORD overlay (KPF0.to_kpf1) is
+        # their sole writer; SKY(1)/CAL(5) keep their header_map defaults.
         sci_catalog_keys = {
             f"{base}{i}" for base in self._CATALOG_BASES for i in _SCI_TRACES
         }

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -31,6 +31,13 @@ _config_path = importlib.resources.files("kpfpipe.data_models.config")
 _L0_EXTENSIONS = pd.read_csv(_config_path / "L0-extensions.csv")
 _KNOWN_L0_EXTENSIONS = set(_L0_EXTENSIONS["Name"].tolist())
 
+# Science-fiber trace indices; the fibers the catalog C*# overlay in to_kpf1
+# targets (SKY/CAL keep their header_map defaults).
+_TRACE_MAP = pd.read_csv(_config_path / "trace-map.csv")
+_SCI_TRACES = tuple(
+    _TRACE_MAP.loc[_TRACE_MAP["Fiber"].isin({"SCI1", "SCI2", "SCI3"}), "Trace"]
+)
+
 # WMKO-native L0 filename: KP.YYYYMMDD.NNNNN.NN.fits (the obs_id plus .fits).
 _L0_FILENAME_PATTERN = re.compile(r"KP\.\d{8}\.\d{5}\.\d{2}\.fits")
 
@@ -46,9 +53,9 @@ _DRPSTATU_DEFAULT = "File ingested into KPF-DRP"
 # intrinsic to the coordinates and never sourced separately), 'plx_src' (parallax),
 # 'rv_src' (rv). For a plain source row each provenance label is the row's own
 # 'source'; the merged row names whichever source won each block (or "" when none
-# supplied it). Every source
-# is sanitized to the EPRV C*# PRIMARY format so to_kpf1 can copy cells straight onto
-# the catalog cards: RA/Dec are sexagesimal strings (RA hour-angle 'h:m:s', Dec deg
+# supplied it). Every source is sanitized to the EPRV C*# PRIMARY format so to_kpf1
+# can copy cells straight onto the catalog cards: RA/Dec are sexagesimal strings
+# (RA hour-angle 'h:m:s', Dec deg
 # 'd:m:s', ICRS), proper motion is arcsec/yr (RA incl. cos Dec), parallax mas, RV
 # km/s, epoch/equinox in Julian years. Float columns hold NaN where a value is
 # missing; string columns (RA/Dec included) hold "".
@@ -400,6 +407,74 @@ class KPF0(KPFDataModel):
             )
         return out
 
+    # CATALOG_RECORD canonical column -> EPRV C*# keyword base. The row is stored in
+    # EPRV C*# format already, so the overlay is a direct copy (no conversion).
+    _CATALOG_CARD_BASES = {
+        "object": "CID",
+        "radec_src": "CSRC",
+        "ra": "CRA",
+        "dec": "CDEC",
+        "pmra": "CPMR",
+        "pmdec": "CPMD",
+        "parallax": "CPLX",
+        "rv": "CRV",
+        "epoch": "CEPCH",
+        "equinox": "CEQNX",
+    }
+
+    def _catalog_primary_cards(self):
+        """Map the merged CATALOG_RECORD 'kpf-drp' row onto the SCI-fiber C*# cards.
+
+        Returns ``{C-keyword: value}`` for every science fiber (SCI1-3, see
+        ``_SCI_TRACES``), a direct copy of the canonical row's already-EPRV-format
+        cells. Returns ``{}`` -- leaving the SCI C*# cards blank -- when there is no
+        usable canonical astrometry (no CATALOG_RECORD data, no 'kpf-drp' row, or an
+        empty RA/Dec). A per-card missing value (NaN float / "" string, e.g. a target
+        with no measured parallax or rv) is skipped so that card stays blank rather
+        than carrying 'nan'. Emits a WARNING when the canonical astrometry landing on
+        PRIMARY was assembled from more than one catalog (position/parallax/rv from
+        different sources), so the C*# block is not internally single-source.
+        """
+        table = self.data.get("CATALOG_RECORD")
+        if table is None or not table.colnames:
+            return {}
+        match = table[table["source"] == "kpf-drp"]
+        if len(match) == 0:
+            return {}
+        row = match[0]
+        if str(row["ra"]).strip() == "" or str(row["dec"]).strip() == "":
+            return {}
+
+        provenance = {
+            str(row[col]).strip()
+            for col in ("radec_src", "plx_src", "rv_src")
+            if str(row[col]).strip()
+        }
+        if len(provenance) > 1:
+            logger.warning(
+                "PRIMARY catalog keywords assembled from mixed sources "
+                "(radec=%s, parallax=%s, rv=%s); C*# astrometry is not "
+                "internally single-source",
+                row["radec_src"],
+                str(row["plx_src"]) or '""',
+                str(row["rv_src"]) or '""',
+            )
+
+        cards = {}
+        for col, base in self._CATALOG_CARD_BASES.items():
+            value = row[col]
+            if col in _CATALOG_STR_COLUMNS:
+                if str(value).strip() == "":
+                    continue
+                value = str(value)
+            else:
+                if np.isnan(value):
+                    continue
+                value = float(value)
+            for i in _SCI_TRACES:
+                cards[f"{base}{i}"] = value
+        return cards
+
     def to_kpf1(self):
         """Create a KPF1 scaffold from this L0, carrying over headers and
         pass-through extensions.
@@ -420,6 +495,13 @@ class KPF0(KPFDataModel):
         # L0 PRIMARY verbatim into the immutable INSTRUMENT_HEADER.
         if "PRIMARY" in self.headers:
             for key, value in self._map_header().items():
+                kpf1.headers["PRIMARY"][key] = value
+
+            # Overlay the merged canonical astrometry (CATALOG_RECORD 'kpf-drp' row)
+            # onto the SCI-fiber EPRV C*# cards -- the sole writer of those cards
+            # (their raw TARG*/GAIAID mapping is neutralized in the header_map). Empty
+            # when there is no canonical row, leaving the seeded cards blank.
+            for key, value in self._catalog_primary_cards().items():
                 kpf1.headers["PRIMARY"][key] = value
 
             if "INSTRUMENT_HEADER" not in kpf1.extensions:

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -278,6 +278,8 @@ class KPF0(KPFDataModel):
         "z": "CZ",
         "epoch": "CEPCH",
         "equinox": "CEQNX",
+        "color": "CCLR",
+        "color_name": "CCLRN",
     }
 
     def _catalog_primary_cards(self):

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -290,19 +290,21 @@ class KPF0(KPFDataModel):
         was assembled from more than one catalog (position/parallax/rv from different
         sources), so the C*# block is not internally single-source.
 
-        Requires that AstroQuery has already populated CATALOG_RECORD -- its sole
-        writer, which always emits the 'kpf-drp' row with a resolved position. An empty
-        CATALOG_RECORD therefore means AstroQuery has not run: mandatory for a science
-        frame (IMTYPE 'Object'), which raises ``ValueError``; expected-absent for a
-        calibration (no target), which yields ``{}`` (SCI C*# cards left blank).
+        AstroQuery is the sole writer of CATALOG_RECORD, always emitting the 'kpf-drp'
+        row with a resolved position. An empty CATALOG_RECORD therefore means AstroQuery
+        has not run: on a science frame (IMTYPE 'Object') this yields ``{}`` with a
+        WARNING (the SCI C*# cards stay blank, so BarycentricCorrection and
+        CrossCorrelation will fail downstream); on a calibration (no target) it yields
+        ``{}`` silently.
         """
         table = self.data["CATALOG_RECORD"]
         if not table.colnames:
             imtype = self.headers["PRIMARY"].get("IMTYPE")
             if str(imtype).strip().lower() == "object":
-                raise ValueError(
-                    "CATALOG_RECORD is empty; run AstroQuery before to_kpf1 "
-                    "(science frames require resolved target astrometry)"
+                logger.warning(
+                    "CATALOG_RECORD is empty for a science frame; AstroQuery has not "
+                    "run, so the SCI C*# astrometry cards are left blank -- "
+                    "BarycentricCorrection and CrossCorrelation will fail downstream"
                 )
             return {}
 
@@ -361,9 +363,10 @@ class KPF0(KPFDataModel):
 
             # Overlay the merged canonical astrometry (CATALOG_RECORD 'kpf-drp' row)
             # onto the SCI-fiber EPRV C*# cards -- the sole writer of those cards (their
-            # raw TARG*/GAIAID mapping is neutralized in the header_map). Assumes
-            # AstroQuery has run: raises for a science frame whose CATALOG_RECORD is
-            # empty; blank (cards left unset) for a calibration frame.
+            # raw TARG*/GAIAID mapping is neutralized in the header_map). When
+            # AstroQuery has not run the cards are left blank: with a WARNING for a
+            # science frame (BarycentricCorrection/CrossCorrelation then fail),
+            # silently for a calibration frame.
             for key, value in self._catalog_primary_cards().items():
                 kpf1.headers["PRIMARY"][key] = value
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -12,8 +12,6 @@ import re
 
 import numpy as np
 import pandas as pd
-from astropy import units as u
-from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from rvdata.core.models.definitions import BASE_RECEIPT_COLUMNS
@@ -44,50 +42,6 @@ _L0_FILENAME_PATTERN = re.compile(r"KP\.\d{8}\.\d{5}\.\d{2}\.fits")
 # Initial DRPSTATU value on the L1 EPRV PRIMARY, before any pipeline module runs.
 # Each module overwrites it via the receipt_add_entry override (see base.py).
 _DRPSTATU_DEFAULT = "File ingested into KPF-DRP"
-
-# Schema of the CATALOG_RECORD BinTable extension: one row per resolved source
-# (wmko/gaia/simbad) plus the merged 'kpf-drp' canonical row. Columns: 'source' (the
-# nominal source this row came from), 'object' (the target name supplied to the
-# query), and three provenance labels naming the source each value block was taken
-# from -- 'radec_src' (ra/dec/pmra/pmdec plus their frame/epoch/equinox, which are
-# intrinsic to the coordinates and never sourced separately), 'plx_src' (parallax),
-# 'rv_src' (rv). For a plain source row each provenance label is the row's own
-# 'source'; the merged row names whichever source won each block (or "" when none
-# supplied it). Every source is sanitized to the EPRV C*# PRIMARY format so to_kpf1
-# can copy cells straight onto the catalog cards: RA/Dec are sexagesimal strings
-# (RA hour-angle 'h:m:s', Dec deg
-# 'd:m:s', ICRS), proper motion is arcsec/yr (RA incl. cos Dec), parallax mas, RV
-# km/s, epoch/equinox in Julian years. Float columns hold NaN where a value is
-# missing; string columns (RA/Dec included) hold "".
-_CATALOG_COLUMNS = (
-    "source",
-    "object",
-    "radec_src",
-    "plx_src",
-    "rv_src",
-    "ra",
-    "dec",
-    "pmra",
-    "pmdec",
-    "parallax",
-    "rv",
-    "frame",
-    "epoch",
-    "equinox",
-)
-_CATALOG_STR_COLUMNS = frozenset(
-    {"source", "object", "radec_src", "plx_src", "rv_src", "frame", "ra", "dec"}
-)
-_CATALOG_UNITS = {
-    "pmra": u.arcsec / u.yr,
-    "pmdec": u.arcsec / u.yr,
-    "parallax": u.mas,
-    "rv": u.km / u.s,
-    "epoch": u.yr,
-    "equinox": u.yr,
-}
-# Presence flag written to the CATALOG_RECORD header per source (int 0/1).
-_CATALOG_FLAGS = {"wmko": "WMKOCR", "gaia": "GAIACR", "simbad": "SIMBADCR"}
 
 
 class KPF0(KPFDataModel):
@@ -122,9 +76,6 @@ class KPF0(KPFDataModel):
         self.obs_id = get_obs_id(self.filename)
         if "PRIMARY" in self.headers:
             self._stamp_wmko_tracking()
-            # Populate the native (telescope-side) wmko row of CATALOG_RECORD from
-            # the raw TARG* astrometry.
-            self.set_catalog_record("wmko", self._wmko_catalog_record())
 
     def _stamp_wmko_tracking(self):
         """Stamp WMKO DRP-RUN provenance onto the L0 RECEIPT at read time.
@@ -154,100 +105,6 @@ class KPF0(KPFDataModel):
             )
             progname = "UNKNOWN"
         self.set_keyword("PROGID", progname)
-
-    def _wmko_catalog_record(self):
-        """Build the native WMKO/DCS target record from L0 PRIMARY TARG*.
-
-        Telescope-side astrometry (no external query), sanitized to the EPRV C*#
-        format: TARGRA/TARGDEC sexagesimal reformatted to the canonical RA
-        hour-angle / Dec deg 'h:m:s' strings; TARGPMRA time-s/yr -> arcsec/yr
-        (x15 cos Dec), TARGPMDC already arcsec/yr; TARGFRAM FK5 J2000 relabeled
-        ICRS (the ~23 mas frame tie is negligible). Returns None -- so the frame
-        gets WMKOCR=0 -- when there is no target pointing (TARGRA absent, e.g. a
-        calibration) or the TARG* astrometry cannot be parsed (warned, never
-        raised, so a malformed file still loads). Well-formedness is gated
-        downstream by QCL0 (RADECOK), not here.
-        """
-        primary = self.headers["PRIMARY"]
-        if primary.get("TARGRA") is None:
-            return None
-        try:
-            ra = Angle(primary["TARGRA"], unit=u.hourangle)
-            dec = Angle(primary["TARGDEC"], unit=u.deg)
-            pmra, pmdec = primary.get("TARGPMRA"), primary.get("TARGPMDC")
-            return {
-                "object": primary.get("OBJECT"),
-                "ra": ra.to_string(unit=u.hourangle, sep=":", pad=True, precision=4),
-                "dec": dec.to_string(
-                    unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
-                ),
-                "pmra": None if pmra is None else pmra * 15.0 * np.cos(dec.radian),
-                "pmdec": None if pmdec is None else pmdec,
-                "parallax": primary.get("TARGPLAX"),
-                "rv": primary.get("TARGRADV"),
-                "frame": "icrs",
-                "epoch": primary.get("TARGEPOC"),
-                "equinox": primary.get("TARGEQUI"),
-            }
-        except Exception as exc:
-            logger.warning(
-                "could not build wmko CATALOG_RECORD from L0 PRIMARY TARG* "
-                "(%s: %s); left empty",
-                type(exc).__name__,
-                exc,
-            )
-            return None
-
-    def set_catalog_record(self, source, record):
-        """Upsert one source's row into the CATALOG_RECORD extension + set its flag.
-
-        The single writer for CATALOG_RECORD, shared by the read path (``wmko``),
-        AstroQuery (``gaia``/``simbad`` and the merged ``kpf-drp`` row). ``record`` is a
-        canonical record dict (the _CATALOG_COLUMNS fields minus ``source``) or None.
-        The three provenance labels (``radec_src``/``plx_src``/``rv_src``) default to
-        ``source`` when the record omits them (a source row's values are its own); the
-        merged row supplies each explicitly. Existing rows for other sources are
-        preserved (upsert), so callers add their row independently. A None record clears
-        the source's flag and writes no row; otherwise the row is (re)written and the
-        flag set to 1. A source without a registered presence flag (e.g. ``kpf-drp``,
-        which must always be present) writes no flag keyword. Missing floats become NaN,
-        missing strings "".
-        """
-        table = self.data["CATALOG_RECORD"]
-        rows = {}
-        if table.colnames:
-            for row in table:
-                rows[str(row["source"])] = {
-                    name: row[name] for name in _CATALOG_COLUMNS
-                }
-        if record is None:
-            rows.pop(source, None)
-        else:
-            rows[source] = {
-                "source": source,
-                "radec_src": source,
-                "plx_src": source,
-                "rv_src": source,
-                **record,
-            }
-
-        ordered = list(rows.values())
-        new_table = Table()
-        for name in _CATALOG_COLUMNS:
-            if name in _CATALOG_STR_COLUMNS:
-                new_table[name] = np.array(
-                    ["" if r[name] is None else r[name] for r in ordered], dtype=str
-                )
-            else:
-                new_table[name] = np.array(
-                    [np.nan if r[name] is None else r[name] for r in ordered],
-                    dtype=float,
-                )
-                new_table[name].unit = _CATALOG_UNITS[name]
-        self.set_data("CATALOG_RECORD", new_table)
-        flag = _CATALOG_FLAGS.get(source)
-        if flag is not None:
-            self.set_keyword(flag, 1 if record is not None else 0)
 
     def _read(self, hdul):
         """Read all extensions from an L0 FITS HDUList.
@@ -427,23 +284,29 @@ class KPF0(KPFDataModel):
 
         Returns ``{C-keyword: value}`` for every science fiber (SCI1-3, see
         ``_SCI_TRACES``), a direct copy of the canonical row's already-EPRV-format
-        cells. Returns ``{}`` -- leaving the SCI C*# cards blank -- when there is no
-        usable canonical astrometry (no CATALOG_RECORD data, no 'kpf-drp' row, or an
-        empty RA/Dec). A per-card missing value (NaN float / "" string, e.g. a target
-        with no measured parallax or rv) is skipped so that card stays blank rather
-        than carrying 'nan'. Emits a WARNING when the canonical astrometry landing on
-        PRIMARY was assembled from more than one catalog (position/parallax/rv from
-        different sources), so the C*# block is not internally single-source.
+        cells. A per-card missing value (NaN float / "" string, e.g. a target with no
+        measured parallax or rv) is skipped so that card stays blank rather than
+        carrying 'nan'. Emits a WARNING when the canonical astrometry landing on PRIMARY
+        was assembled from more than one catalog (position/parallax/rv from different
+        sources), so the C*# block is not internally single-source.
+
+        Requires that AstroQuery has already populated CATALOG_RECORD -- its sole
+        writer, which always emits the 'kpf-drp' row with a resolved position. An empty
+        CATALOG_RECORD therefore means AstroQuery has not run: mandatory for a science
+        frame (IMTYPE 'Object'), which raises ``ValueError``; expected-absent for a
+        calibration (no target), which yields ``{}`` (SCI C*# cards left blank).
         """
-        table = self.data.get("CATALOG_RECORD")
-        if table is None or not table.colnames:
+        table = self.data["CATALOG_RECORD"]
+        if not table.colnames:
+            imtype = self.headers["PRIMARY"].get("IMTYPE")
+            if str(imtype).strip().lower() == "object":
+                raise ValueError(
+                    "CATALOG_RECORD is empty; run AstroQuery before to_kpf1 "
+                    "(science frames require resolved target astrometry)"
+                )
             return {}
-        match = table[table["source"] == "kpf-drp"]
-        if len(match) == 0:
-            return {}
-        row = match[0]
-        if str(row["ra"]).strip() == "" or str(row["dec"]).strip() == "":
-            return {}
+
+        row = table[table["source"] == "kpf-drp"][0]
 
         provenance = {
             str(row[col]).strip()
@@ -463,10 +326,9 @@ class KPF0(KPFDataModel):
         cards = {}
         for col, base in self._CATALOG_CARD_BASES.items():
             value = row[col]
-            if col in _CATALOG_STR_COLUMNS:
-                if str(value).strip() == "":
+            if isinstance(value, str):
+                if value.strip() == "":
                     continue
-                value = str(value)
             else:
                 if np.isnan(value):
                     continue
@@ -498,9 +360,10 @@ class KPF0(KPFDataModel):
                 kpf1.headers["PRIMARY"][key] = value
 
             # Overlay the merged canonical astrometry (CATALOG_RECORD 'kpf-drp' row)
-            # onto the SCI-fiber EPRV C*# cards -- the sole writer of those cards
-            # (their raw TARG*/GAIAID mapping is neutralized in the header_map). Empty
-            # when there is no canonical row, leaving the seeded cards blank.
+            # onto the SCI-fiber EPRV C*# cards -- the sole writer of those cards (their
+            # raw TARG*/GAIAID mapping is neutralized in the header_map). Assumes
+            # AstroQuery has run: raises for a science frame whose CATALOG_RECORD is
+            # empty; blank (cards left unset) for a calibration frame.
             for key, value in self._catalog_primary_cards().items():
                 kpf1.headers["PRIMARY"][key] = value
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -39,16 +39,25 @@ _L0_FILENAME_PATTERN = re.compile(r"KP\.\d{8}\.\d{5}\.\d{2}\.fits")
 _DRPSTATU_DEFAULT = "File ingested into KPF-DRP"
 
 # Schema of the CATALOG_RECORD BinTable extension: one row per resolved source
-# (wmko/gaia/simbad) plus the merged 'kpf-drp' canonical row, carrying the record
-# fields plus a leading 'source' label and 'astr_src' (the source label whose
-# astrometry supplied this row's position block -- itself for a source row, the
-# merge base for the canonical row). Float columns hold NaN where a value is
-# missing; string columns hold "". Units document the canonical schema (deg, mas/yr
-# incl. cos Dec, mas, km/s, jyear).
+# (wmko/gaia/simbad) plus the merged 'kpf-drp' canonical row. Columns: 'source' (the
+# nominal source this row came from), 'object' (the target name supplied to the
+# query), and three provenance labels naming the source each value block was taken
+# from -- 'radec_src' (ra/dec/pmra/pmdec plus their frame/epoch/equinox, which are
+# intrinsic to the coordinates and never sourced separately), 'plx_src' (parallax),
+# 'rv_src' (rv). For a plain source row each provenance label is the row's own
+# 'source'; the merged row names whichever source won each block (or "" when none
+# supplied it). Every source
+# is sanitized to the EPRV C*# PRIMARY format so to_kpf1 can copy cells straight onto
+# the catalog cards: RA/Dec are sexagesimal strings (RA hour-angle 'h:m:s', Dec deg
+# 'd:m:s', ICRS), proper motion is arcsec/yr (RA incl. cos Dec), parallax mas, RV
+# km/s, epoch/equinox in Julian years. Float columns hold NaN where a value is
+# missing; string columns (RA/Dec included) hold "".
 _CATALOG_COLUMNS = (
     "source",
-    "source_id",
-    "astr_src",
+    "object",
+    "radec_src",
+    "plx_src",
+    "rv_src",
     "ra",
     "dec",
     "pmra",
@@ -59,12 +68,12 @@ _CATALOG_COLUMNS = (
     "epoch",
     "equinox",
 )
-_CATALOG_STR_COLUMNS = frozenset({"source", "source_id", "astr_src", "frame"})
+_CATALOG_STR_COLUMNS = frozenset(
+    {"source", "object", "radec_src", "plx_src", "rv_src", "frame", "ra", "dec"}
+)
 _CATALOG_UNITS = {
-    "ra": u.deg,
-    "dec": u.deg,
-    "pmra": u.mas / u.yr,
-    "pmdec": u.mas / u.yr,
+    "pmra": u.arcsec / u.yr,
+    "pmdec": u.arcsec / u.yr,
     "parallax": u.mas,
     "rv": u.km / u.s,
     "epoch": u.yr,
@@ -142,11 +151,12 @@ class KPF0(KPFDataModel):
     def _wmko_catalog_record(self):
         """Build the native WMKO/DCS target record from L0 PRIMARY TARG*.
 
-        Telescope-side astrometry (no external query), converted to the canonical
-        schema: TARGRA/TARGDEC sexagesimal (hourangle / deg) -> deg; TARGPMRA s/yr
-        and TARGPMDC arcsec/yr -> mas/yr; TARGFRAM FK5 J2000 relabeled ICRS (the
-        ~23 mas frame tie is negligible). Returns None -- so the frame gets
-        WMKOCR=0 -- when there is no target pointing (TARGRA absent, e.g. a
+        Telescope-side astrometry (no external query), sanitized to the EPRV C*#
+        format: TARGRA/TARGDEC sexagesimal reformatted to the canonical RA
+        hour-angle / Dec deg 'h:m:s' strings; TARGPMRA time-s/yr -> arcsec/yr
+        (x15 cos Dec), TARGPMDC already arcsec/yr; TARGFRAM FK5 J2000 relabeled
+        ICRS (the ~23 mas frame tie is negligible). Returns None -- so the frame
+        gets WMKOCR=0 -- when there is no target pointing (TARGRA absent, e.g. a
         calibration) or the TARG* astrometry cannot be parsed (warned, never
         raised, so a malformed file still loads). Well-formedness is gated
         downstream by QCL0 (RADECOK), not here.
@@ -155,16 +165,17 @@ class KPF0(KPFDataModel):
         if primary.get("TARGRA") is None:
             return None
         try:
-            dec = Angle(primary["TARGDEC"], unit=u.deg).deg
+            ra = Angle(primary["TARGRA"], unit=u.hourangle)
+            dec = Angle(primary["TARGDEC"], unit=u.deg)
             pmra, pmdec = primary.get("TARGPMRA"), primary.get("TARGPMDC")
             return {
-                "source_id": primary.get("OBJECT"),
-                "ra": Angle(primary["TARGRA"], unit=u.hourangle).to(u.deg).value,
-                "dec": dec,
-                "pmra": None
-                if pmra is None
-                else pmra * 15.0 * np.cos(np.radians(dec)) * 1e3,
-                "pmdec": None if pmdec is None else pmdec * 1e3,
+                "object": primary.get("OBJECT"),
+                "ra": ra.to_string(unit=u.hourangle, sep=":", pad=True, precision=4),
+                "dec": dec.to_string(
+                    unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
+                ),
+                "pmra": None if pmra is None else pmra * 15.0 * np.cos(dec.radian),
+                "pmdec": None if pmdec is None else pmdec,
                 "parallax": primary.get("TARGPLAX"),
                 "rv": primary.get("TARGRADV"),
                 "frame": "icrs",
@@ -186,13 +197,14 @@ class KPF0(KPFDataModel):
         The single writer for CATALOG_RECORD, shared by the read path (``wmko``),
         AstroQuery (``gaia``/``simbad`` and the merged ``kpf-drp`` row). ``record`` is a
         canonical record dict (the _CATALOG_COLUMNS fields minus ``source``) or None.
-        ``astr_src`` defaults to ``source`` when the record omits it (a source row's
-        position is its own); the merged row supplies its base's label explicitly.
-        Existing rows for other sources are preserved (upsert), so callers add their row
-        independently. A None record clears the source's flag and writes no row;
-        otherwise the row is (re)written and the flag set to 1. A source without a
-        registered presence flag (e.g. ``kpf-drp``, which must always be present) writes
-        no flag keyword. Missing floats become NaN, missing strings "".
+        The three provenance labels (``radec_src``/``plx_src``/``rv_src``) default to
+        ``source`` when the record omits them (a source row's values are its own); the
+        merged row supplies each explicitly. Existing rows for other sources are
+        preserved (upsert), so callers add their row independently. A None record clears
+        the source's flag and writes no row; otherwise the row is (re)written and the
+        flag set to 1. A source without a registered presence flag (e.g. ``kpf-drp``,
+        which must always be present) writes no flag keyword. Missing floats become NaN,
+        missing strings "".
         """
         table = self.data["CATALOG_RECORD"]
         rows = {}
@@ -204,7 +216,13 @@ class KPF0(KPFDataModel):
         if record is None:
             rows.pop(source, None)
         else:
-            rows[source] = {"source": source, "astr_src": source, **record}
+            rows[source] = {
+                "source": source,
+                "radec_src": source,
+                "plx_src": source,
+                "rv_src": source,
+                **record,
+            }
 
         ordered = list(rows.values())
         new_table = Table()

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -19,6 +19,7 @@ from rvdata.core.tools.headers import parse_value_to_datatype
 
 from kpfpipe import __version__
 from kpfpipe.data_models.base import KPFDataModel
+from kpfpipe.data_models.keyword_registry import SCI_TRACES
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.utils.io import kpf_filename
 from kpfpipe.utils.kpf import get_obs_id
@@ -28,13 +29,6 @@ logger = logging.getLogger(__name__)
 _config_path = importlib.resources.files("kpfpipe.data_models.config")
 _L0_EXTENSIONS = pd.read_csv(_config_path / "L0-extensions.csv")
 _KNOWN_L0_EXTENSIONS = set(_L0_EXTENSIONS["Name"].tolist())
-
-# Science-fiber trace indices; the fibers the catalog C*# overlay in to_kpf1
-# targets (SKY/CAL keep their header_map defaults).
-_TRACE_MAP = pd.read_csv(_config_path / "trace-map.csv")
-_SCI_TRACES = tuple(
-    _TRACE_MAP.loc[_TRACE_MAP["Fiber"].isin({"SCI1", "SCI2", "SCI3"}), "Trace"]
-)
 
 # WMKO-native L0 filename: KP.YYYYMMDD.NNNNN.NN.fits (the obs_id plus .fits).
 _L0_FILENAME_PATTERN = re.compile(r"KP\.\d{8}\.\d{5}\.\d{2}\.fits")
@@ -133,7 +127,6 @@ class KPF0(KPFDataModel):
                         )
                     self.create_extension(ext_name, fits_type)
 
-            # Payload decode, by name first (bespoke) then by type (generic).
             if ext_name == "PRIMARY":
                 pass
             elif ext_name == "RECEIPT":
@@ -282,17 +275,13 @@ class KPF0(KPFDataModel):
     def _catalog_primary_cards(self):
         """Map the merged CATALOG_RECORD 'kpf-drp' row onto the SCI-fiber C*# cards.
 
-        Returns ``{C-keyword: value}`` for every science fiber (SCI1-3, see
-        ``_SCI_TRACES``) -- a direct copy of the canonical row's already-EPRV-format
-        cells, skipping any card whose value is missing (NaN / "") so it stays blank
-        rather than carrying 'nan'. Warns when the canonical astrometry was assembled
-        from more than one catalog (position/parallax/rv from different sources), so
-        the C*# block is not internally single-source.
-
-        AstroQuery is the sole writer of CATALOG_RECORD, so an empty table means it has
-        not run: on a science frame (IMTYPE 'Object') this returns ``{}`` with a WARNING
-        (the blank cards then fail BarycentricCorrection/CrossCorrelation downstream);
-        on a calibration it returns ``{}`` silently.
+        Returns ``{C-keyword: value}`` for every science fiber (``SCI_TRACES``) -- a
+        direct copy of the canonical row's already-EPRV-format cells, skipping any
+        missing value (NaN / "") so the card stays blank rather than carrying 'nan'.
+        Warns when the canonical astrometry was assembled from more than one catalog,
+        and when an empty table on a science frame (IMTYPE 'Object') shows AstroQuery
+        never ran -- the blank cards then fail BarycentricCorrection and
+        CrossCorrelation downstream.
         """
         table = self.data["CATALOG_RECORD"]
         if not table.colnames:
@@ -332,7 +321,7 @@ class KPF0(KPFDataModel):
                 if np.isnan(value):
                     continue
                 value = float(value)
-            for i in _SCI_TRACES:
+            for i in SCI_TRACES:
                 cards[f"{base}{i}"] = value
         return cards
 
@@ -359,9 +348,8 @@ class KPF0(KPFDataModel):
             for key, value in self._map_header().items():
                 kpf1.headers["PRIMARY"][key] = value
 
-            # Overlay the merged canonical astrometry (CATALOG_RECORD 'kpf-drp' row)
-            # onto the SCI-fiber EPRV C*# cards -- their sole writer (the raw
-            # TARG*/GAIAID mapping is neutralized in the header_map).
+            # Overlay the canonical astrometry onto the SCI-fiber C*# cards -- their
+            # sole writer (the raw TARG*/GAIAID mapping is blanked in the header_map).
             for key, value in self._catalog_primary_cards().items():
                 kpf1.headers["PRIMARY"][key] = value
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -133,6 +133,7 @@ class KPF0(KPFDataModel):
                         )
                     self.create_extension(ext_name, fits_type)
 
+            # Payload decode, by name first (bespoke) then by type (generic).
             if ext_name == "PRIMARY":
                 pass
             elif ext_name == "RECEIPT":
@@ -145,11 +146,6 @@ class KPF0(KPFDataModel):
                     all_cols = df.columns.union(receipt_columns, sort=False)
                     df = df.reindex(columns=all_cols).fillna("")
                 self.receipt = df
-            elif ext_name == "CATALOG_RECORD":
-                # astropy reads NaN float cells back as masked; fill to NaN so
-                # consumers see one missing-value sentinel regardless of whether the
-                # table was just built by AstroQuery or round-tripped through FITS.
-                self.set_data(ext_name, Table.read(hdu).filled(np.nan))
             elif fits_type == "ImageHDU":
                 # np.array (not asarray) materializes the memmapped HDU into RAM
                 # before from_fits closes the file; a view would dangle afterward.
@@ -214,6 +210,7 @@ class KPF0(KPFDataModel):
         "EXPMETER_SKY",
         "TELEMETRY",
         "DRP_CONFIG",
+        "CATALOG_RECORD",
     ]
 
     def _map_header(self):
@@ -349,9 +346,10 @@ class KPF0(KPFDataModel):
         at read) and reaches L1 via the header forward below.
 
         Returns a KPF1 with EPRV PRIMARY, INSTRUMENT_HEADER, pass-through
-        extensions (CA_HK, EXPMETER_SCI/SKY, TELEMETRY, DRP_CONFIG), receipt, and
-        obs_id copied over. GREEN_CCD, GREEN_VAR, RED_CCD, RED_VAR are created
-        empty -- the caller (image assembly) fills those in.
+        extensions (CA_HK, EXPMETER_SCI/SKY, TELEMETRY, DRP_CONFIG,
+        CATALOG_RECORD), receipt, and obs_id copied over. GREEN_CCD, GREEN_VAR,
+        RED_CCD, RED_VAR are created empty -- the caller (image assembly) fills
+        those in.
         """
         kpf1 = KPF1()
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -275,6 +275,7 @@ class KPF0(KPFDataModel):
         "pmdec": "CPMD",
         "parallax": "CPLX",
         "rv": "CRV",
+        "z": "CZ",
         "epoch": "CEPCH",
         "equinox": "CEQNX",
     }

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -286,19 +286,16 @@ class KPF0(KPFDataModel):
         """Map the merged CATALOG_RECORD 'kpf-drp' row onto the SCI-fiber C*# cards.
 
         Returns ``{C-keyword: value}`` for every science fiber (SCI1-3, see
-        ``_SCI_TRACES``), a direct copy of the canonical row's already-EPRV-format
-        cells. A per-card missing value (NaN float / "" string, e.g. a target with no
-        measured parallax or rv) is skipped so that card stays blank rather than
-        carrying 'nan'. Emits a WARNING when the canonical astrometry landing on PRIMARY
-        was assembled from more than one catalog (position/parallax/rv from different
-        sources), so the C*# block is not internally single-source.
+        ``_SCI_TRACES``) -- a direct copy of the canonical row's already-EPRV-format
+        cells, skipping any card whose value is missing (NaN / "") so it stays blank
+        rather than carrying 'nan'. Warns when the canonical astrometry was assembled
+        from more than one catalog (position/parallax/rv from different sources), so
+        the C*# block is not internally single-source.
 
-        AstroQuery is the sole writer of CATALOG_RECORD, always emitting the 'kpf-drp'
-        row with a resolved position. An empty CATALOG_RECORD therefore means AstroQuery
-        has not run: on a science frame (IMTYPE 'Object') this yields ``{}`` with a
-        WARNING (the SCI C*# cards stay blank, so BarycentricCorrection and
-        CrossCorrelation will fail downstream); on a calibration (no target) it yields
-        ``{}`` silently.
+        AstroQuery is the sole writer of CATALOG_RECORD, so an empty table means it has
+        not run: on a science frame (IMTYPE 'Object') this returns ``{}`` with a WARNING
+        (the blank cards then fail BarycentricCorrection/CrossCorrelation downstream);
+        on a calibration it returns ``{}`` silently.
         """
         table = self.data["CATALOG_RECORD"]
         if not table.colnames:
@@ -365,11 +362,8 @@ class KPF0(KPFDataModel):
                 kpf1.headers["PRIMARY"][key] = value
 
             # Overlay the merged canonical astrometry (CATALOG_RECORD 'kpf-drp' row)
-            # onto the SCI-fiber EPRV C*# cards -- the sole writer of those cards (their
-            # raw TARG*/GAIAID mapping is neutralized in the header_map). When
-            # AstroQuery has not run the cards are left blank: with a WARNING for a
-            # science frame (BarycentricCorrection/CrossCorrelation then fail),
-            # silently for a calibration frame.
+            # onto the SCI-fiber EPRV C*# cards -- their sole writer (the raw
+            # TARG*/GAIAID mapping is neutralized in the header_map).
             for key, value in self._catalog_primary_cards().items():
                 kpf1.headers["PRIMARY"][key] = value
 

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -138,6 +138,11 @@ class KPF0(KPFDataModel):
                     all_cols = df.columns.union(receipt_columns, sort=False)
                     df = df.reindex(columns=all_cols).fillna("")
                 self.receipt = df
+            elif ext_name == "CATALOG_RECORD":
+                # astropy reads NaN float cells back as masked; fill to NaN so
+                # consumers see one missing-value sentinel regardless of whether the
+                # table was just built by AstroQuery or round-tripped through FITS.
+                self.set_data(ext_name, Table.read(hdu).filled(np.nan))
             elif fits_type == "ImageHDU":
                 # np.array (not asarray) materializes the memmapped HDU into RAM
                 # before from_fits closes the file; a view would dangle afterward.

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -12,6 +12,8 @@ import re
 
 import numpy as np
 import pandas as pd
+from astropy import units as u
+from astropy.coordinates import Angle
 from astropy.io import fits
 from astropy.table import Table
 from rvdata.core.models.definitions import BASE_RECEIPT_COLUMNS
@@ -35,6 +37,37 @@ _L0_FILENAME_PATTERN = re.compile(r"KP\.\d{8}\.\d{5}\.\d{2}\.fits")
 # Initial DRPSTATU value on the L1 EPRV PRIMARY, before any pipeline module runs.
 # Each module overwrites it via the receipt_add_entry override (see base.py).
 _DRPSTATU_DEFAULT = "File ingested into KPF-DRP"
+
+# Schema of the CATALOG_RECORD BinTable extension: one row per resolved source
+# (wmko/gaia/simbad), carrying the canonical record fields plus a leading 'source'
+# label. Float columns hold NaN where a value is missing; string columns hold "".
+# Units document the canonical schema (deg, mas/yr incl. cos Dec, mas, km/s, jyear).
+_CATALOG_COLUMNS = (
+    "source",
+    "source_id",
+    "ra",
+    "dec",
+    "pmra",
+    "pmdec",
+    "parallax",
+    "rv",
+    "frame",
+    "epoch",
+    "equinox",
+)
+_CATALOG_STR_COLUMNS = frozenset({"source", "source_id", "frame"})
+_CATALOG_UNITS = {
+    "ra": u.deg,
+    "dec": u.deg,
+    "pmra": u.mas / u.yr,
+    "pmdec": u.mas / u.yr,
+    "parallax": u.mas,
+    "rv": u.km / u.s,
+    "epoch": u.yr,
+    "equinox": u.yr,
+}
+# Presence flag written to the CATALOG_RECORD header per source (int 0/1).
+_CATALOG_FLAGS = {"wmko": "WMKOCR", "gaia": "GAIACR", "simbad": "SIMBADCR"}
 
 
 class KPF0(KPFDataModel):
@@ -69,6 +102,9 @@ class KPF0(KPFDataModel):
         self.obs_id = get_obs_id(self.filename)
         if "PRIMARY" in self.headers:
             self._stamp_wmko_tracking()
+            # Populate the native (telescope-side) wmko row of CATALOG_RECORD from
+            # the raw TARG* astrometry.
+            self.set_catalog_record("wmko", self._wmko_catalog_record())
 
     def _stamp_wmko_tracking(self):
         """Stamp WMKO DRP-RUN provenance onto the L0 RECEIPT at read time.
@@ -98,6 +134,86 @@ class KPF0(KPFDataModel):
             )
             progname = "UNKNOWN"
         self.set_keyword("PROGID", progname)
+
+    def _wmko_catalog_record(self):
+        """Build the native WMKO/DCS target record from L0 PRIMARY TARG*.
+
+        Telescope-side astrometry (no external query), converted to the canonical
+        schema: TARGRA/TARGDEC sexagesimal (hourangle / deg) -> deg; TARGPMRA s/yr
+        and TARGPMDC arcsec/yr -> mas/yr; TARGFRAM FK5 J2000 relabeled ICRS (the
+        ~23 mas frame tie is negligible). Returns None -- so the frame gets
+        WMKOCR=0 -- when there is no target pointing (TARGRA absent, e.g. a
+        calibration) or the TARG* astrometry cannot be parsed (warned, never
+        raised, so a malformed file still loads). Well-formedness is gated
+        downstream by QCL0 (RADECOK), not here.
+        """
+        primary = self.headers["PRIMARY"]
+        if primary.get("TARGRA") is None:
+            return None
+        try:
+            dec = Angle(primary["TARGDEC"], unit=u.deg).deg
+            pmra, pmdec = primary.get("TARGPMRA"), primary.get("TARGPMDC")
+            return {
+                "source_id": primary.get("OBJECT"),
+                "ra": Angle(primary["TARGRA"], unit=u.hourangle).to(u.deg).value,
+                "dec": dec,
+                "pmra": None
+                if pmra is None
+                else pmra * 15.0 * np.cos(np.radians(dec)) * 1e3,
+                "pmdec": None if pmdec is None else pmdec * 1e3,
+                "parallax": primary.get("TARGPLAX"),
+                "rv": primary.get("TARGRADV"),
+                "frame": "icrs",
+                "epoch": primary.get("TARGEPOC"),
+                "equinox": primary.get("TARGEQUI"),
+            }
+        except Exception as exc:
+            logger.warning(
+                "could not build wmko CATALOG_RECORD from L0 PRIMARY TARG* "
+                "(%s: %s); left empty",
+                type(exc).__name__,
+                exc,
+            )
+            return None
+
+    def set_catalog_record(self, source, record):
+        """Upsert one source's row into the CATALOG_RECORD extension + set its flag.
+
+        The single writer for CATALOG_RECORD, shared by the read path (``wmko``) and
+        AstroQuery (``gaia``/``simbad``). ``record`` is a canonical record dict (the
+        _CATALOG_COLUMNS fields minus ``source``) or None. Existing rows for other
+        sources are preserved (upsert), so callers add their row independently. A
+        None record clears the source's flag and writes no row; otherwise the row is
+        (re)written and the flag set to 1. Missing floats become NaN, missing strings
+        "".
+        """
+        table = self.data["CATALOG_RECORD"]
+        rows = {}
+        if table.colnames:
+            for row in table:
+                rows[str(row["source"])] = {
+                    name: row[name] for name in _CATALOG_COLUMNS
+                }
+        if record is None:
+            rows.pop(source, None)
+        else:
+            rows[source] = {"source": source, **record}
+
+        ordered = list(rows.values())
+        new_table = Table()
+        for name in _CATALOG_COLUMNS:
+            if name in _CATALOG_STR_COLUMNS:
+                new_table[name] = np.array(
+                    ["" if r[name] is None else r[name] for r in ordered], dtype=str
+                )
+            else:
+                new_table[name] = np.array(
+                    [np.nan if r[name] is None else r[name] for r in ordered],
+                    dtype=float,
+                )
+                new_table[name].unit = _CATALOG_UNITS[name]
+        self.set_data("CATALOG_RECORD", new_table)
+        self.set_keyword(_CATALOG_FLAGS[source], 1 if record is not None else 0)
 
     def _read(self, hdul):
         """Read all extensions from an L0 FITS HDUList.

--- a/kpfpipe/data_models/level0.py
+++ b/kpfpipe/data_models/level0.py
@@ -39,12 +39,16 @@ _L0_FILENAME_PATTERN = re.compile(r"KP\.\d{8}\.\d{5}\.\d{2}\.fits")
 _DRPSTATU_DEFAULT = "File ingested into KPF-DRP"
 
 # Schema of the CATALOG_RECORD BinTable extension: one row per resolved source
-# (wmko/gaia/simbad), carrying the canonical record fields plus a leading 'source'
-# label. Float columns hold NaN where a value is missing; string columns hold "".
-# Units document the canonical schema (deg, mas/yr incl. cos Dec, mas, km/s, jyear).
+# (wmko/gaia/simbad) plus the merged 'kpf-drp' canonical row, carrying the record
+# fields plus a leading 'source' label and 'astr_src' (the source label whose
+# astrometry supplied this row's position block -- itself for a source row, the
+# merge base for the canonical row). Float columns hold NaN where a value is
+# missing; string columns hold "". Units document the canonical schema (deg, mas/yr
+# incl. cos Dec, mas, km/s, jyear).
 _CATALOG_COLUMNS = (
     "source",
     "source_id",
+    "astr_src",
     "ra",
     "dec",
     "pmra",
@@ -55,7 +59,7 @@ _CATALOG_COLUMNS = (
     "epoch",
     "equinox",
 )
-_CATALOG_STR_COLUMNS = frozenset({"source", "source_id", "frame"})
+_CATALOG_STR_COLUMNS = frozenset({"source", "source_id", "astr_src", "frame"})
 _CATALOG_UNITS = {
     "ra": u.deg,
     "dec": u.deg,
@@ -179,13 +183,16 @@ class KPF0(KPFDataModel):
     def set_catalog_record(self, source, record):
         """Upsert one source's row into the CATALOG_RECORD extension + set its flag.
 
-        The single writer for CATALOG_RECORD, shared by the read path (``wmko``) and
-        AstroQuery (``gaia``/``simbad``). ``record`` is a canonical record dict (the
-        _CATALOG_COLUMNS fields minus ``source``) or None. Existing rows for other
-        sources are preserved (upsert), so callers add their row independently. A
-        None record clears the source's flag and writes no row; otherwise the row is
-        (re)written and the flag set to 1. Missing floats become NaN, missing strings
-        "".
+        The single writer for CATALOG_RECORD, shared by the read path (``wmko``),
+        AstroQuery (``gaia``/``simbad`` and the merged ``kpf-drp`` row). ``record`` is a
+        canonical record dict (the _CATALOG_COLUMNS fields minus ``source``) or None.
+        ``astr_src`` defaults to ``source`` when the record omits it (a source row's
+        position is its own); the merged row supplies its base's label explicitly.
+        Existing rows for other sources are preserved (upsert), so callers add their row
+        independently. A None record clears the source's flag and writes no row;
+        otherwise the row is (re)written and the flag set to 1. A source without a
+        registered presence flag (e.g. ``kpf-drp``, which must always be present) writes
+        no flag keyword. Missing floats become NaN, missing strings "".
         """
         table = self.data["CATALOG_RECORD"]
         rows = {}
@@ -197,7 +204,7 @@ class KPF0(KPFDataModel):
         if record is None:
             rows.pop(source, None)
         else:
-            rows[source] = {"source": source, **record}
+            rows[source] = {"source": source, "astr_src": source, **record}
 
         ordered = list(rows.values())
         new_table = Table()
@@ -213,7 +220,9 @@ class KPF0(KPFDataModel):
                 )
                 new_table[name].unit = _CATALOG_UNITS[name]
         self.set_data("CATALOG_RECORD", new_table)
-        self.set_keyword(_CATALOG_FLAGS[source], 1 if record is not None else 0)
+        flag = _CATALOG_FLAGS.get(source)
+        if flag is not None:
+            self.set_keyword(flag, 1 if record is not None else 0)
 
     def _read(self, hdul):
         """Read all extensions from an L0 FITS HDUList.

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -99,7 +99,6 @@ class KPF1(KPFDataModel):
                         )
                     self.create_extension(ext_name, fits_type)
 
-            # Payload decode, by name first (bespoke) then by type (generic).
             if ext_name == "PRIMARY":
                 pass
             elif ext_name == "RECEIPT":

--- a/kpfpipe/data_models/level1.py
+++ b/kpfpipe/data_models/level1.py
@@ -99,6 +99,7 @@ class KPF1(KPFDataModel):
                         )
                     self.create_extension(ext_name, fits_type)
 
+            # Payload decode, by name first (bespoke) then by type (generic).
             if ext_name == "PRIMARY":
                 pass
             elif ext_name == "RECEIPT":
@@ -176,6 +177,7 @@ class KPF1(KPFDataModel):
     _L1_TO_L2_PASSTHROUGH = {
         "TELEMETRY": "TELEMETRY",
         "EXPMETER_SCI": "EXPMETER",
+        "CATALOG_RECORD": "CATALOG_RECORD",
     }
 
     def to_kpf2(self):
@@ -184,9 +186,10 @@ class KPF1(KPFDataModel):
 
         The L1 PRIMARY is already EPRV-standard (converted in KPF0.to_kpf1), so
         the PRIMARY and INSTRUMENT_HEADER headers are a pure pass-through. Pass-
-        through extensions (TELEMETRY, EXPMETER_SCI->EXPMETER) and KPF-friendly
-        aliases (e.g. SCI2_FLUX -> TRACE3_FLUX) are handled below. Trace arrays
-        are created empty -- the caller (spectral extraction) fills those in.
+        through extensions (TELEMETRY, EXPMETER_SCI->EXPMETER, CATALOG_RECORD) and
+        KPF-friendly aliases (e.g. SCI2_FLUX -> TRACE3_FLUX) are handled below.
+        Trace arrays are created empty -- the caller (spectral extraction) fills
+        those in.
         """
         kpf2 = KPF2()
 

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -22,13 +22,20 @@ from kpfpipe.data_models.base import KPFDataModel, keyword_registry
 from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.utils.io import kpf_filename
 
-# Make rvdata's RV2._read aware of KPF's QUALITY_CONTROL extension so an L2
-# written with it reads back (KPF2.__init__ creates the empty extension).
+# Make rvdata's RV2._read aware of KPF's QUALITY_CONTROL and CATALOG_RECORD
+# extensions so an L2 written with them reads back (KPF2.__init__ creates the empty
+# extensions).
 keyword_registry.register_rvdata_extension(
     LEVEL2_EXTENSIONS,
     "QUALITY_CONTROL",
     "BinTableHDU",
     "Quality-control booleans and diagnostic metrics",
+)
+keyword_registry.register_rvdata_extension(
+    LEVEL2_EXTENSIONS,
+    "CATALOG_RECORD",
+    "BinTableHDU",
+    "External catalog astrometry (Gaia/SIMBAD/DCS) resolved by AstroQuery",
 )
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
@@ -170,14 +177,15 @@ class KPF2(KPFDataModel, RV2):
         # ANCILLARY_SPECTRUM (Ca H&K) as an ImageHDU, but we keep it a BinTableHDU
         # placeholder for now -- Ca H&K extraction is WIP and existing L2/master
         # products encode it as BinTableHDU, so flipping the type breaks reading
-        # them back (a deliberate EPRV deviation). QUALITY_CONTROL is
-        # created here (L2 has no extensions CSV); RECEIPT and barycentric/RV#
-        # already exist via RV2.
+        # them back (a deliberate EPRV deviation). QUALITY_CONTROL and
+        # CATALOG_RECORD are created here (L2 has no extensions CSV); RECEIPT and
+        # barycentric/RV# already exist via RV2.
         for ext, ext_type in [
             ("ANCILLARY_SPECTRUM", "BinTableHDU"),
             ("EXPMETER", "BinTableHDU"),
             ("TELEMETRY", "BinTableHDU"),
             ("QUALITY_CONTROL", "BinTableHDU"),
+            ("CATALOG_RECORD", "BinTableHDU"),
         ]:
             if ext not in self.extensions:
                 self.create_extension(ext, ext_type)
@@ -238,19 +246,30 @@ class KPF2(KPFDataModel, RV2):
         """
         Create a KPF4 scaffold from this KPF2, carrying over headers and receipt.
 
-        Returns a KPF4 with PRIMARY header keywords forwarded from L2,
-        and the receipt chain preserved. RV and CCF data extensions are
-        created but empty -- the caller (RV computation) fills those in.
+        Returns a KPF4 with PRIMARY header keywords forwarded from L2, the
+        CATALOG_RECORD pass-through extension, and the receipt chain preserved. RV
+        and CCF data extensions are created but empty -- the caller (RV
+        computation) fills those in.
         """
         kpf4 = KPF4()
 
-        # Forward PRIMARY, INSTRUMENT_HEADER, QUALITY_CONTROL, and RECEIPT
-        # card-by-card, mirroring to_kpf2: PRIMARY overlays onto kpf4's EPRV seed
-        # (native wins), the rest are verbatim copies. The receipt *table*
-        # propagates separately via the copy below.
+        # Forward PRIMARY, INSTRUMENT_HEADER, QUALITY_CONTROL, CATALOG_RECORD, and
+        # RECEIPT card-by-card, mirroring to_kpf2: PRIMARY overlays onto kpf4's EPRV
+        # seed (native wins), the rest are verbatim copies. The receipt *table*
+        # propagates separately via the copy below; CATALOG_RECORD's table is copied
+        # with its header, since its rows (not just the presence flags) carry forward.
         self._forward_headers(
-            kpf4, ("PRIMARY", "INSTRUMENT_HEADER", "QUALITY_CONTROL", "RECEIPT")
+            kpf4,
+            (
+                "PRIMARY",
+                "INSTRUMENT_HEADER",
+                "QUALITY_CONTROL",
+                "CATALOG_RECORD",
+                "RECEIPT",
+            ),
         )
+        if self.data.get("CATALOG_RECORD") is not None:
+            kpf4.set_data("CATALOG_RECORD", self.data["CATALOG_RECORD"])
 
         if self.receipt is not None and not self.receipt.empty:
             kpf4.receipt = self.receipt.copy()

--- a/kpfpipe/data_models/level2.py
+++ b/kpfpipe/data_models/level2.py
@@ -256,8 +256,8 @@ class KPF2(KPFDataModel, RV2):
         # Forward PRIMARY, INSTRUMENT_HEADER, QUALITY_CONTROL, CATALOG_RECORD, and
         # RECEIPT card-by-card, mirroring to_kpf2: PRIMARY overlays onto kpf4's EPRV
         # seed (native wins), the rest are verbatim copies. The receipt *table*
-        # propagates separately via the copy below; CATALOG_RECORD's table is copied
-        # with its header, since its rows (not just the presence flags) carry forward.
+        # propagates separately via the copy below, as does CATALOG_RECORD's table --
+        # its rows, not just the presence flags, carry forward.
         self._forward_headers(
             kpf4,
             (

--- a/kpfpipe/data_models/level4.py
+++ b/kpfpipe/data_models/level4.py
@@ -22,13 +22,20 @@ from kpfpipe.data_models.aliased_dict import AliasedOrderedDict
 from kpfpipe.data_models.base import KPFDataModel, keyword_registry
 from kpfpipe.utils.io import kpf_filename
 
-# Make rvdata's RV4._read aware of KPF's QUALITY_CONTROL extension so an L4
-# written with it reads back (QCL4 is planned; this keeps the read forward-safe).
+# Make rvdata's RV4._read aware of KPF's QUALITY_CONTROL and CATALOG_RECORD
+# extensions so an L4 written with them reads back (QCL4 is planned; this keeps the
+# read forward-safe).
 keyword_registry.register_rvdata_extension(
     LEVEL4_EXTENSIONS,
     "QUALITY_CONTROL",
     "BinTableHDU",
     "Quality-control booleans and diagnostic metrics",
+)
+keyword_registry.register_rvdata_extension(
+    LEVEL4_EXTENSIONS,
+    "CATALOG_RECORD",
+    "BinTableHDU",
+    "External catalog astrometry (Gaia/SIMBAD/DCS) resolved by AstroQuery",
 )
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
@@ -177,9 +184,11 @@ class KPF4(KPFDataModel, RV4):
         # QUALITY_CONTROL holds the accumulated QC booleans + diagnostics metrics
         # propagated from L0/L1/L2 (RV4 does not create it; registered into
         # rvdata's LEVEL4_EXTENSIONS above so a written L4 reads back). Mirrors
-        # KPF2.__init__; to_kpf4 forwards the L2 header onto it.
-        if "QUALITY_CONTROL" not in self.extensions:
-            self.create_extension("QUALITY_CONTROL", "BinTableHDU")
+        # KPF2.__init__; to_kpf4 forwards the L2 header onto it. CATALOG_RECORD is
+        # the same story: created empty here, filled by to_kpf4's pass-through.
+        for ext in ("QUALITY_CONTROL", "CATALOG_RECORD"):
+            if ext not in self.extensions:
+                self.create_extension(ext, "BinTableHDU")
 
         # Replace plain OrderedDicts with alias-aware versions
         self.extensions = AliasedOrderedDict.from_ordered_dict(self.extensions)

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -161,7 +161,6 @@ class KPFMasterL2(KPFMasterModel, KPF2):
                         )
                     self.create_extension(ext_name, fits_type)
 
-            # Payload decode, by name first (bespoke) then by type (generic).
             if ext_name == "PRIMARY":
                 pass
             elif ext_name == "RECEIPT":

--- a/kpfpipe/data_models/masters/level2.py
+++ b/kpfpipe/data_models/masters/level2.py
@@ -161,6 +161,7 @@ class KPFMasterL2(KPFMasterModel, KPF2):
                         )
                     self.create_extension(ext_name, fits_type)
 
+            # Payload decode, by name first (bespoke) then by type (generic).
             if ext_name == "PRIMARY":
                 pass
             elif ext_name == "RECEIPT":

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -3,19 +3,18 @@ KPF AstroQuery module.
 
 Consolidates the pipeline's external astronomical-catalog lookups into a single
 L0-stage module. Given a raw L0 science frame, it resolves the target's astrometry
-from Gaia (by GAIAID, whose release prefix picks the data release queried) and
-SIMBAD (by OBJECT), builds the telescope-native
-``wmko`` row from the L0 PRIMARY ``TARG*`` astrometry (no query), merges them into a
-canonical ``kpf-drp`` row, and writes all four rows to the L0 ``CATALOG_RECORD``
-extension with the ``WMKOCR``/``GAIACR``/``SIMBADCR`` presence flags. AstroQuery is
-the extension's sole populator.
+from Gaia (by GAIAID, whose release prefix picks the data release queried) and SIMBAD
+(by OBJECT), builds the telescope-native ``wmko`` row from the L0 PRIMARY ``TARG*``
+astrometry (no query), merges them into a canonical ``kpf-drp`` row, and writes all
+four rows to the L0 ``CATALOG_RECORD`` extension with the
+``WMKOCR``/``GAIACR``/``SIMBADCR`` presence flags.
 
-CATALOG_RECORD bridges an ordering problem: the results ultimately belong on the
-EPRV PRIMARY catalog keywords (``C*#``), but the WMKO -> EPRV PRIMARY conversion does
-not happen until ``KPF0.to_kpf1()`` downstream, which overlays the merged record onto
-those cards. AstroQuery never modifies the L0 PRIMARY header. All rows share one
-schema in the EPRV C*# PRIMARY format (see ``_CATALOG_COLUMNS``), so ``to_kpf1`` can
-copy cells straight onto the catalog cards.
+CATALOG_RECORD bridges an ordering problem: the results ultimately belong on the EPRV
+PRIMARY catalog keywords (``C*#``), but that conversion does not happen until
+``KPF0.to_kpf1()`` downstream, which overlays the merged record onto those cards.
+AstroQuery never modifies the L0 PRIMARY header. All rows share one schema in the EPRV
+C*# PRIMARY format (see ``_CATALOG_COLUMNS``), so ``to_kpf1`` can copy cells straight
+onto the catalog cards.
 """
 
 import logging
@@ -39,16 +38,19 @@ _DEFAULTS = {
     **DEFAULTS,
     "do_gaia_query": True,
     "do_simbad_query": True,
-    "use_wmko_tcs": True,
+    "astrometry_priority": ("gaia", "simbad"),
 }
 
-# The astrometric block the merge takes whole from one source: one fit -- proper
-# motion is meaningless without the parallax it was measured against -- plus the frame/
-# epoch that qualify the coordinates. equinox and rv are handled separately.
+# Sources that can supply a CATALOG_RECORD row, highest catalog priority first.
+_SOURCES = ("gaia", "simbad", "wmko")
+
+# The astrometric block the merge takes whole from one source: proper motion is
+# meaningless without the parallax it was measured against, and both need the
+# frame/epoch that qualify the coordinates. equinox and rv are handled separately.
 _ASTROMETRY = ("ra", "dec", "pmra", "pmdec", "parallax", "epoch", "frame")
 
-# Column units each catalog result is expected to carry, verified before its values
-# are trusted so a silent upstream schema change fails loudly (see _verify_units).
+# Expected result units, verified by _verify_units so a silent upstream schema
+# change fails loudly.
 _GAIA_UNITS = {
     "ra": u.deg,
     "dec": u.deg,
@@ -72,8 +74,8 @@ _SIMBAD_UNITS = {
 }
 
 # Queryable Gaia release -> its gaia_source table, newest last. DR1 and EDR3 are
-# excluded (no radial_velocity or BP/RP photometry, and superseded, respectively). Add
-# DR4 and DR5 here once they publish; until then they are neither probed nor accepted.
+# excluded (no radial_velocity or BP/RP photometry, and superseded, respectively).
+# A release absent here is neither probed nor accepted.
 _GAIA_TABLES = {
     "DR2": "gaiadr2.gaia_source",
     "DR3": "gaiadr3.gaia_source",
@@ -83,10 +85,10 @@ _GAIA_TABLES = {
 # source (wmko/gaia/simbad) plus the merged 'kpf-drp' row. radec_src/plx_src/rv_src
 # name the source each value block came from -- its own for a source row, the winner
 # (or "" if none) for the merged row. Values are in the EPRV C*# PRIMARY format: RA/Dec
-# sexagesimal strings (ICRS), PM arcsec/yr (RA incl. cos Dec), parallax mas, rv km/s, z
-# the redshift derived from rv, epoch/equinox Julian years. color is a color index and
-# color_name labels it (Gaia "Gaia BP-RP", SIMBAD "B-V", WMKO "G-J"), both blank when a
-# magnitude is missing. Missing floats -> NaN, strings -> "".
+# sexagesimal strings (ICRS), PM [arcsec/yr] (RA incl. cos Dec), parallax [mas], rv
+# [km/s], z the redshift derived from rv, epoch/equinox [Julian yr]. color is a color
+# index and color_name labels it (Gaia "Gaia BP-RP", SIMBAD "B-V", WMKO "G-J"), both
+# blank when a magnitude is missing. Missing floats -> NaN, strings -> "".
 _CATALOG_COLUMNS = (
     "source",
     "object",
@@ -131,8 +133,8 @@ _CATALOG_UNITS = {
     "equinox": u.yr,
     "color": u.mag,
 }
-# Presence flag written to the CATALOG_RECORD header per source (int 0/1). DiagL0 keeps
-# its own local mirror (the DiagL0 convention of not importing this schema).
+# Per-source presence flag written to the CATALOG_RECORD header (int 0/1). DiagL0
+# keeps its own local mirror rather than importing this schema.
 _CATALOG_FLAGS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
 
 
@@ -140,23 +142,21 @@ class AstroQuery:
     """
     Resolve target astrometry from external catalogs and write it to an L0.
 
-    Runs the two external catalog queries (Gaia by GAIAID, SIMBAD by OBJECT),
-    builds the native ``wmko`` row from the L0 PRIMARY ``TARG*`` astrometry, and writes
-    all three rows to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV
-    ``C*#`` catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). Only
-    science frames are supported: the constructor raises on a non-``Object`` IMTYPE (a
-    calibration). Fail-soft otherwise: a missing GAIAID/OBJECT or a failed network
-    lookup yields a ``None`` record rather than an error.
+    Runs the two external catalog queries (Gaia by GAIAID, SIMBAD by OBJECT), builds
+    the native ``wmko`` row from the L0 PRIMARY ``TARG*`` astrometry, and writes all
+    three rows to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV ``C*#``
+    catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). Only science
+    frames are supported: the constructor raises on a non-``Object`` IMTYPE. Fail-soft
+    otherwise -- a missing GAIAID/OBJECT or a failed lookup yields a ``None`` record.
 
     Parameters
     ----------
     l0_obj : KPF0
         Raw L0 science frame (IMTYPE ``Object``). Its PRIMARY header (IMTYPE, GAIAID,
-        OBJECT, TARG*) is read but never modified; the resolved catalog data is written
-        to the L0 ``CATALOG_RECORD`` extension.
+        OBJECT, TARG*) is read but never modified.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: do_gaia_query, do_simbad_query,
-        use_wmko_tcs.
+        astrometry_priority.
     """
 
     def __init__(self, l0_obj, config=None):
@@ -181,6 +181,8 @@ class AstroQuery:
         for k, v in _DEFAULTS.items():
             setattr(self, k, params.get(k, v))
 
+        self._validate_priority()
+
         self._wmko = None  # native WMKO record; set by read_wmko_header()
         self._gaia = None  # Gaia DR3 record; set by query_gaia()
         self._simbad = None  # SIMBAD record; set by query_simbad()
@@ -191,15 +193,34 @@ class AstroQuery:
     # Private helpers
     # ------------------------------------------------------------------
 
+    def _validate_priority(self):
+        """Reject an astrometry_priority naming an unknown or no source.
+
+        Caught at construction rather than at the merge, where an unknown name would
+        read as "that source had no record" and silently demote the position.
+
+        Raises
+        ------
+        ValueError
+            ``astrometry_priority`` is empty or names a source outside ``_SOURCES``.
+        """
+        self.astrometry_priority = tuple(self.astrometry_priority)
+        unknown = [s for s in self.astrometry_priority if s not in _SOURCES]
+        if unknown or not self.astrometry_priority:
+            raise ValueError(
+                f"astrometry_priority={list(self.astrometry_priority)} must be a "
+                f"non-empty ordered subset of {list(_SOURCES)}"
+                + (f"; unknown source(s) {unknown}" if unknown else "")
+            )
+
     def _gaia_source(self):
         """``(release, source_id)`` from L0 GAIAID, or None if absent/unusable.
 
         GAIAID names the release its id belongs to (e.g. 'DR3 12345'), which selects
-        the queried table -- a source_id denotes different stars across releases, so
-        the prefix is honored rather than discarded. ``release`` is None for a bare id
-        with no prefix, which ``_resolve_gaia_release`` then identifies against the
-        archive. Returns None when GAIAID is absent or blank, the trailing token is not
-        all digits, or the release is one this module cannot query (``_GAIA_TABLES``).
+        the queried table -- a source_id denotes different stars across releases, so the
+        prefix is honored rather than discarded. ``release`` is None for a bare id, left
+        for ``_resolve_gaia_release``. None when GAIAID is absent or blank, the trailing
+        token is not all digits, or the release is not in ``_GAIA_TABLES``.
         """
         raw = self.l0_obj.headers["PRIMARY"].get("GAIAID")
         if raw is None:
@@ -216,11 +237,12 @@ class AstroQuery:
     def _resolve_gaia_release(self, source_id):
         """The newest Gaia release whose gaia_source contains ``source_id``.
 
-        For a bare GAIAID only: rather than assume a release, probe the archive and
-        take the newest one that holds the id, since the same source_id denotes
-        different stars in different releases. A probe that fails is skipped rather
-        than aborting the search, so an unresolvable id still raises rather than being
-        mistaken for a resolved one.
+        For a bare GAIAID only: rather than assume a release, probe the archive and take
+        the newest one holding the id, since the same source_id denotes different stars
+        in different releases. Every release in ``_GAIA_TABLES`` is published, so a
+        failed probe means something is genuinely wrong: it warns and falls through to
+        an older release, which may hold a different star under that id. An id no
+        release holds raises rather than being mistaken for a resolved one.
 
         Parameters
         ----------
@@ -247,8 +269,9 @@ class AstroQuery:
                     lambda q=query: Gaia.launch_job(q).get_results(), f"Gaia {release}"
                 )
             except Exception as e:
-                logger.debug(
-                    "could not probe Gaia %s for source_id %s (%s: %s); skipping it",
+                logger.warning(
+                    "could not probe Gaia %s for source_id %s (%s: %s); falling "
+                    "through to an older release, which may denote a different star",
                     release,
                     source_id,
                     type(e).__name__,
@@ -297,9 +320,8 @@ class AstroQuery:
     def _redshift(rv_kms):
         """Relativistic redshift z for a catalog rv [km/s], or None if rv is missing.
 
-        Derived (see ``kpfpipe.utils.astro.compute_redshift``), carried on the record
-        so ``to_kpf1`` can overlay it onto the EPRV ``CZ#`` card without a consumer
-        recomputing it. Dimensionless.
+        Dimensionless, and carried on the record so ``to_kpf1`` can overlay it onto the
+        EPRV ``CZ#`` card without a consumer recomputing it.
         """
         if rv_kms is None:
             return None
@@ -309,9 +331,8 @@ class AstroQuery:
     def _color(blue_mag, red_mag, name):
         """The (color, color_name) pair for a bluer-minus-redder magnitude difference.
 
-        Returns ``(blue_mag - red_mag, name)``, or ``(None, None)`` when either
-        magnitude is missing -- a color index needs both, and pairing the value with
-        its label keeps a blank color from carrying an orphan name.
+        ``(None, None)`` when either magnitude is missing -- a color index needs both,
+        and dropping the label with it avoids a blank color carrying an orphan name.
         """
         if blue_mag is None or red_mag is None:
             return None, None
@@ -321,9 +342,9 @@ class AstroQuery:
     def _sexagesimal_radec(coord):
         """ICRS SkyCoord -> the EPRV C*# sexagesimal (ra, dec) strings.
 
-        The single formatter for the canonical colon-separated 'h:m:s' cards (RA
-        hour-angle, Dec deg), so a precision/padding change lands in one place.
-        astropy's combined hmsdms already pads and signs; we just split the two axes.
+        The single formatter for the colon-separated 'h:m:s' cards (RA hour-angle, Dec
+        deg), so a precision change lands in one place. astropy's hmsdms already pads
+        and signs both axes; this only splits them.
         """
         return tuple(coord.to_string("hmsdms", sep=":", precision=4).split())
 
@@ -331,9 +352,8 @@ class AstroQuery:
     def _verify_units(table, expected, source):
         """Verify a query result's column units before its values are trusted.
 
-        Guards the canonical-unit assumption: raises ``ValueError`` if any
-        expected column is missing or carries a unit other than the one the
-        record schema assumes, so a silent catalog schema change fails loudly.
+        Raises ``ValueError`` if an expected column is missing or carries a unit other
+        than the record schema assumes, so a silent catalog schema change fails loudly.
         """
         mismatched = {}
         for col, want in expected.items():
@@ -351,14 +371,11 @@ class AstroQuery:
     def _write_catalog_record(self, source, record):
         """Upsert one source's row into the L0 CATALOG_RECORD extension.
 
-        The sole writer for CATALOG_RECORD (``wmko``/``gaia``/``simbad`` and the merged
-        ``kpf-drp`` row). ``record`` is a canonical record dict or None; a None record
-        drops the source's row, otherwise the row is (re)written. Provenance labels
-        (``radec_src``/``plx_src``/``rv_src``) default to ``source`` when the record
-        omits them (a source row's values are its own); the merged row supplies them
-        explicitly. Other sources' rows are preserved (upsert). Missing floats become
-        NaN, strings "". The matching presence flags are headers, so ``_set_headers``
-        writes them once at the end of perform.
+        The sole writer for CATALOG_RECORD. A ``None`` ``record`` drops the source's
+        row, otherwise it is (re)written; other sources' rows are preserved (upsert).
+        Provenance labels (``radec_src``/``plx_src``/``rv_src``) default to ``source``,
+        since a source row's values are its own; the merged row supplies them
+        explicitly. Missing floats become NaN, strings "".
         """
         l0 = self.l0_obj
         table = l0.data["CATALOG_RECORD"]
@@ -405,16 +422,13 @@ class AstroQuery:
         """Query Gaia for the target's ICRS astrometry, or None (fail-soft).
 
         The release named in GAIAID selects the queried table (``_GAIA_TABLES``), so a
-        DR2 id is never looked up among DR3 source_ids; a bare id with no release is
-        warned about and identified against the archive by ``_resolve_gaia_release``.
-        Returns None (warned) when GAIAID yields no usable release/source_id, when the
-        lookup fails (after the transient-failure retries in ``retry_request``), or
-        when the source is not found. Raises ValueError if a bare id matches no
-        queryable release, or if the result's column units differ from the assumed
-        canonical schema (deg, mas/yr, mas, km/s, epoch in Julian years, BP/RP
-        magnitudes in mag; ICRS) -- the schema is shared across the supported
-        releases, so a release that breaks it fails loudly.
-        Whether it runs at all is gated upstream in perform by ``do_gaia_query``.
+        DR2 id is never looked up among DR3 source_ids; a bare id is identified against
+        the archive by ``_resolve_gaia_release``. Returns None (warned) when GAIAID
+        yields no usable release/source_id, when the lookup fails after the
+        ``retry_request`` retries, or when the source is not found. Raises ValueError
+        if a bare id matches no queryable release, or if the result's column units
+        differ from the schema shared by the supported releases (deg, mas/yr, mas,
+        km/s, Julian yr, mag; ICRS). Gated in perform by ``do_gaia_query``.
         """
         source = self._gaia_source()
         if source is None:
@@ -480,8 +494,7 @@ class AstroQuery:
             "parallax": self._scalar(row["parallax"]),
             "rv": self._scalar(row["radial_velocity"]),
             # frame/equinox are definitional, not queried: every Gaia release is ICRS
-            # (Gaia-CRF) with no equinox -- 2000.0 is the J2000 convention EPRV's
-            # Required CEQNX# demands. Only epoch (ref_epoch) is a real query output.
+            # (Gaia-CRF) with no equinox, and 2000.0 satisfies EPRV's required CEQNX#.
             "frame": "icrs",
             "epoch": self._scalar(row["ref_epoch"]),
             "equinox": 2000.0,
@@ -495,14 +508,12 @@ class AstroQuery:
     def query_simbad(self):
         """Query SIMBAD for the OBJECT's ICRS J2000 astrometry, or None (fail-soft).
 
-        Returns None when L0 has no OBJECT name, or when the lookup fails (after the
-        transient-failure retries in ``retry_request``) / resolves nothing (warned,
-        not raised). Raises ValueError if the result's column units differ from the
-        assumed schema. Column schema is the
-        astroquery 0.4.11 lowercase form (ra/dec deg, pmra/pmdec mas/yr, plx_value
-        mas, rvz_radvel km/s); the Johnson B/V magnitude columns come back unlabeled
-        (unit None) and form the B-V color. Whether it runs at all is gated upstream
-        in perform by ``do_simbad_query``.
+        Returns None (warned, not raised) when L0 has no OBJECT name, or when the
+        lookup fails after the ``retry_request`` retries or resolves nothing. Raises
+        ValueError if the result's column units differ from the assumed schema: the
+        astroquery 0.4.11 lowercase form (ra/dec deg, pmra/pmdec mas/yr, plx_value mas,
+        rvz_radvel km/s), where the Johnson B/V magnitudes come back unlabeled (unit
+        None) and form the B-V color. Gated in perform by ``do_simbad_query``.
         """
         name = self._simbad_resolvable_name()
         if name is None:
@@ -548,10 +559,9 @@ class AstroQuery:
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["plx_value"]),
             "rv": self._scalar(row["rvz_radvel"]),
-            # frame/epoch/equinox are definitional here, not queried: astroquery's
-            # SIMBAD returns basic ra/dec as ICRS J2000, with no per-object
-            # frame/epoch/equinox to read (unlike Gaia's real ref_epoch). equinox 2000.0
-            # satisfies EPRV's Required CEQNX#.
+            # frame/epoch/equinox are definitional, not queried: astroquery's SIMBAD
+            # returns basic ra/dec as ICRS J2000 with no per-object frame/epoch/equinox
+            # to read, and 2000.0 satisfies EPRV's required CEQNX#.
             "frame": "icrs",
             "epoch": 2000.0,
             "equinox": 2000.0,
@@ -566,15 +576,13 @@ class AstroQuery:
         """Read the native WMKO/DCS astrometry from L0 PRIMARY TARG*, or None.
 
         The telescope-side counterpart to query_gaia/query_simbad: no query, just the
-        raw TARG* pointing sanitized to the EPRV C*# format (TARGPMRA time-s/yr ->
-        arcsec/yr via x15 cos Dec; TARGPMDC already arcsec/yr) and rotated from its
-        native FK5 (J2000) to ICRS, so all three sources share one frame. KPF pointing
-        is always FK5, so a non-FK5 TARGFRAM (absent included) raises rather than being
-        coerced -- a wrong frame would corrupt the barycentric correction. The G-J color
-        comes straight off PRIMARY (GAIAMAG - 2MASSMAG), no frame handling. Returns None
-        (WMKOCR=0) when there is no pointing (TARGRA absent) or the TARG* astrometry
-        cannot be parsed (warned, never raised). Gated upstream in perform by
-        ``use_wmko_tcs``.
+        raw TARG* pointing sanitized to the EPRV C*# format and rotated from its native
+        FK5 (J2000) to ICRS, so all three sources share one frame. KPF pointing is
+        always FK5, so a non-FK5 or absent TARGFRAM raises rather than being coerced --
+        a wrong frame would corrupt the barycentric correction. Returns None (WMKOCR=0,
+        warned) when TARGRA is absent or the TARG* astrometry cannot be parsed. Always
+        run: TARGOFF needs this row even when ``astrometry_priority`` bars wmko from
+        anchoring the position.
         """
         primary = self.l0_obj.headers["PRIMARY"]
         if primary.get("TARGRA") is None:
@@ -595,10 +603,9 @@ class AstroQuery:
             )
             equinox = self._scalar(primary.get("TARGEQUI"))
 
-            # Rotate the native FK5 pointing to ICRS: position always, proper motion too
-            # when both components are present (TARGPMRA time-s/yr -> arcsec/yr via x15
-            # cos Dec first; a lone component is meaningless under rotation). Rotation
-            # carries no time propagation, so epoch is unchanged.
+            # Rotate the native FK5 pointing to ICRS (no time propagation, so epoch is
+            # unchanged); proper motion only when both components are present, since a
+            # lone one is meaningless under rotation. TARGPMRA time-s/yr -> arcsec/yr.
             fk5 = FK5(
                 equinox="J2000" if equinox is None else Time(equinox, format="jyear")
             )
@@ -645,40 +652,40 @@ class AstroQuery:
     def merge_catalog_records(self):
         """Merge the built source records into the canonical ``kpf-drp`` row.
 
-        Consumes the in-memory gaia/simbad/wmko records this instance just built
-        (``None`` for a source that was toggled off or resolved nothing), in priority
-        order gaia > simbad > wmko. The canonical record is the highest-priority source
-        that supplies a complete astrometric solution -- ra/dec/pmra/pmdec/parallax plus
-        the frame, epoch, and equinox that make them meaningful -- taken whole, since
-        those fields are one measurement and must not be spliced across catalogs. Its rv
-        rides along; when that source has none (Gaia commonly lacks radial_velocity), rv
-        falls back to the telescope TARGRADV on PRIMARY (not borrowed from a lower-
-        priority catalog). ``color``/``color_name`` ride along from the base source;
-        if it carries none, the highest-priority catalog that has a color supplies it
-        with a mixed-catalog warning (a color index is independent of the astrometry),
-        or blank when no source has one. ``radec_src``/``plx_src`` name the astrometric
-        source; ``rv_src`` names the rv source ("wmko" for the TARGRADV fallback, ""
-        when nothing supplied).
+        Consumes the in-memory gaia/simbad/wmko records (``None`` for a source toggled
+        off or unresolved). Only a source named in ``astrometry_priority`` may anchor
+        the position, in that order, and it supplies the astrometric solution --
+        ra/dec/pmra/pmdec/parallax plus the frame, epoch and equinox that qualify them
+        -- whole, since those fields are one measurement and must not be spliced across
+        catalogs. Sources left out of the priority still get their row written and their
+        offsets diagnosed; they simply cannot become the base. Its rv rides along; when
+        that source has none (Gaia commonly lacks radial_velocity) rv falls back to the
+        telescope TARGRADV on PRIMARY, never to another catalog. ``color`` and
+        ``color_name`` also ride along, but a base source without a color borrows one
+        from any built row, with a mixed-catalog warning. ``radec_src``/``plx_src`` name
+        the astrometric source, ``rv_src`` the rv source ("wmko" for the TARGRADV
+        fallback, "" when nothing supplied).
 
-        Raises ``ValueError`` when no source supplies a complete ra/dec/pmra/pmdec/
-        parallax/epoch block -- without a position there is nothing to correct, so it
-        must fail loudly. rv is optional, left missing when neither the astrometric
-        source nor TARGRADV supplies it.
+        Raises ``ValueError`` when no permitted source supplies a complete block --
+        without a position there is nothing to correct, and silently demoting to a
+        source the operator excluded is exactly what the priority exists to prevent. rv
+        is optional, left missing when neither the astrometric source nor TARGRADV
+        supplies it.
         """
-        # Assemble candidates in priority order (a source with no record is None).
-        candidates = []
-        for source, record in (
-            ("gaia", self._gaia),
-            ("simbad", self._simbad),
-            ("wmko", self._wmko),
-        ):
-            if record is not None:
-                candidates.append((source, record))
+        candidates = [
+            (source, getattr(self, f"_{source}"))
+            for source in _SOURCES
+            if getattr(self, f"_{source}") is not None
+        ]
 
-        # First source with a complete block wins; a present-but-incomplete
-        # higher-priority source is demoted with an auditable warning.
+        # Only a source named in astrometry_priority may anchor the position, in that
+        # order; the first with a complete block wins and an incomplete one ahead of it
+        # is demoted with an auditable warning.
         base_source, base_record = None, None
-        for source, record in candidates:
+        for source in self.astrometry_priority:
+            record = getattr(self, f"_{source}")
+            if record is None:
+                continue
             missing = [field for field in _ASTROMETRY if record[field] is None]
             if not missing:
                 base_source, base_record = source, record
@@ -693,12 +700,13 @@ class AstroQuery:
             available = [source for source, _ in candidates]
             raise ValueError(
                 f"cannot build a canonical astrometry position for "
-                f"{self.l0_obj.obs_id or 'unknown'}: no source supplies a complete "
-                f"ra/dec/pmra/pmdec/parallax/epoch block (have {available})"
+                f"{self.l0_obj.obs_id or 'unknown'}: no source in astrometry_priority "
+                f"{list(self.astrometry_priority)} supplies a complete "
+                f"ra/dec/pmra/pmdec/parallax/epoch block (rows built: {available})"
             )
 
         # rv from the base source, else telescope TARGRADV off PRIMARY -- independent of
-        # use_wmko_tcs (which gates only the wmko position row).
+        # astrometry_priority, which governs only the position.
         rv_value = base_record["rv"]
         rv_source = base_source
         if rv_value is None:
@@ -711,9 +719,8 @@ class AstroQuery:
                     rv_value,
                 )
 
-        # color/color_name from the base source; if it has none, borrow the highest-
-        # priority catalog that does. A color index is independent of the astrometry,
-        # so a mixed source is acceptable but flagged (mirrors the rv fallback).
+        # A color index is independent of the astrometry, so borrowing one from another
+        # catalog when the base source has none is acceptable, but flagged.
         color = base_record["color"]
         color_name = base_record["color_name"]
         if color is None:
@@ -770,57 +777,61 @@ class AstroQuery:
     def _set_headers(self, l0_obj):
         """Sole place this module writes headers; reads instance attributes.
 
-        One presence flag per queryable source: 1 when that source resolved a record,
-        0 when it did not -- absent, gated off, or failed alike, since a consumer
-        cannot act on the difference. All three are always written, so a flag missing
-        from CATALOG_RECORD means AstroQuery never ran (what DiagL0 warns on). The
-        merged ``kpf-drp`` row has no flag; merge_catalog_records raises instead.
+        One presence flag per queryable source: 1 when it resolved a record, 0
+        otherwise -- absent, gated off and failed are alike, since a consumer cannot
+        act on the difference. All three are written together, so a missing flag means
+        AstroQuery did not complete (what DiagL0 warns on). The merged ``kpf-drp`` row
+        has no flag; merge_catalog_records raises instead.
         """
-        for source, record in (
-            ("wmko", self._wmko),
-            ("gaia", self._gaia),
-            ("simbad", self._simbad),
-        ):
+        for source in _SOURCES:
+            record = getattr(self, f"_{source}")
             l0_obj.set_keyword(_CATALOG_FLAGS[source], 1 if record is not None else 0)
 
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, *, do_gaia_query=None, do_simbad_query=None, use_wmko_tcs=None):
+    def perform(
+        self, *, do_gaia_query=None, do_simbad_query=None, astrometry_priority=None
+    ):
         """
         Resolve external catalog astrometry and write it to the L0.
 
         Parameters
         ----------
-        do_gaia_query, do_simbad_query, use_wmko_tcs : bool, optional
-            Override the configured source toggles for this call.
+        do_gaia_query, do_simbad_query : bool, optional
+            Override the configured catalog-query toggles for this call.
+        astrometry_priority : sequence of str, optional
+            Override which sources may anchor the merged position, highest first.
 
         Returns
         -------
         l0_obj : KPF0
-            The input L0 (PRIMARY unchanged), now with its ``wmko``/``gaia``/``simbad``
-            rows and the merged ``kpf-drp`` row written to the ``CATALOG_RECORD``
-            extension, and an 'astro_query' receipt entry. Unusually for a pipeline
-            module this returns an L0, not the next level -- AstroQuery runs before
-            assembly.
+            The input L0 (PRIMARY unchanged), with the ``wmko``/``gaia``/``simbad`` and
+            merged ``kpf-drp`` rows written to ``CATALOG_RECORD``, plus an 'astro_query'
+            receipt entry. Unusually for a pipeline module this returns an L0, not the
+            next level -- AstroQuery runs before assembly.
+
+        Raises
+        ------
+        ValueError
+            No source named in ``astrometry_priority`` supplied a complete astrometric
+            block.
         """
         if do_gaia_query is not None:
             self.do_gaia_query = do_gaia_query
         if do_simbad_query is not None:
             self.do_simbad_query = do_simbad_query
-        if use_wmko_tcs is not None:
-            self.use_wmko_tcs = use_wmko_tcs
+        if astrometry_priority is not None:
+            self.astrometry_priority = astrometry_priority
+            self._validate_priority()
 
-        # Gate each source: a toggled-off source is neither queried nor built. Each
-        # method that runs writes its own CATALOG_RECORD row.
-        self._wmko = self.read_wmko_header() if self.use_wmko_tcs else None
+        self._wmko = self.read_wmko_header()
         self._gaia = self.query_gaia() if self.do_gaia_query else None
         self._simbad = self.query_simbad() if self.do_simbad_query else None
 
-        # Merge the source rows into the canonical kpf-drp row; raises if no complete
-        # position can be assembled.
         self.merge_catalog_records()
+
         self._set_headers(self.l0_obj)
         self._track_info()
         self.l0_obj.receipt_add_entry("astro_query", "", "PASS")

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -1,0 +1,306 @@
+"""
+KPF AstroQuery module.
+
+Consolidates every external astronomical-catalog lookup the pipeline needs into
+a single L0-stage module. Given a raw L0 frame, it resolves the target's
+astrometry from Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), and snapshots the
+DCS/TCS target astrometry already on the raw header, then hands all three back on
+a lightweight ``catalog_info`` dict attached to the L0 object.
+
+The dict is the bridge across an ordering problem: the query results ultimately
+belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO -> EPRV
+PRIMARY conversion does not happen until ``KPF0.to_kpf1()`` downstream. Rather
+than write headers here, AstroQuery tracks the queried quantities on the L0 and
+lets ``to_kpf1()`` overlay them onto the L1 PRIMARY (a follow-up integration).
+
+AstroQuery never modifies the L0 PRIMARY header -- that header is a pure
+pass-through to INSTRUMENT_HEADER. Values are stored raw, in each source's native
+units; unit conversion, per-fiber fan-out, and derived quantities (offsets,
+redshift) are the jobs of the downstream consumers, not this module.
+"""
+
+import logging
+
+import numpy as np
+from astroquery.gaia import Gaia
+from astroquery.simbad import Simbad
+
+from kpfpipe import DEFAULTS
+from kpfpipe.utils.config import ConfigHandler
+
+logger = logging.getLogger(__name__)
+
+_DEFAULTS = {
+    **DEFAULTS,
+    "use_gaia": True,
+    "use_simbad": True,
+}
+
+# WMKO/DCS target-astrometry cards on the raw L0 PRIMARY, snapshotted verbatim
+# (native units) into the 'wmko' record. Consumers apply the unit conventions
+# (e.g. TARGPMRA is time-seconds/yr) exactly as BarycentricCorrection/DiagL0 do.
+_WMKO_KEYS = {
+    "ra": "TARGRA",
+    "dec": "TARGDEC",
+    "pmra": "TARGPMRA",
+    "pmdec": "TARGPMDC",
+    "parallax": "TARGPLAX",
+    "frame": "TARGFRAM",
+    "epoch": "TARGEPOC",
+    "equinox": "TARGEQUI",
+    "rv": "TARGRADV",
+}
+
+
+class AstroQuery:
+    """
+    Resolve target astrometry from external catalogs and attach it to an L0.
+
+    Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT)
+    plus a verbatim snapshot of the DCS/TCS ``TARG*`` astrometry, and deposits all
+    three on ``l0_obj.catalog_info`` for downstream use (EPRV ``C*#`` catalog
+    keywords, DiagL0 pointing offsets, BarycentricCorrection). Fail-soft: a frame
+    with no GAIAID/OBJECT (e.g. a calibration) or a failed network lookup yields a
+    ``None`` record rather than an error.
+
+    Parameters
+    ----------
+    l0_obj : KPF0
+        Raw L0 frame. Its PRIMARY header (GAIAID, OBJECT, TARG*) is read but never
+        modified; the resolved catalog data is attached as ``l0_obj.catalog_info``.
+    config : None | dict | ConfigHandler
+        Module configuration. Recognized keys: use_gaia, use_simbad.
+    """
+
+    def __init__(self, l0_obj, config=None):
+        self.l0_obj = l0_obj
+
+        if config is None:
+            params = {}
+        elif isinstance(config, dict):
+            params = config
+        elif isinstance(config, ConfigHandler):
+            params = config.get_params(["DATA_DIRS", "TRACES", "MODULE_ASTRO_QUERY"])
+        else:
+            raise TypeError("config must be None, dict, or ConfigHandler")
+
+        for k, v in _DEFAULTS.items():
+            setattr(self, k, params.get(k, v))
+
+        self._gaia = None  # Gaia DR3 record; set by query_gaia()
+        self._simbad = None  # SIMBAD record; set by query_simbad()
+        self._wmko = None  # DCS/TCS TARG* record; set by read_wmko_target()
+        self._info = None
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _gaia_source_id(self):
+        """Digit-only Gaia DR3 id from L0 GAIAID, or None if absent/malformed.
+
+        GAIAID may arrive as a prefixed string (e.g. 'Gaia DR3 12345'); take the
+        trailing token and require it to be all digits.
+        """
+        primary = self.l0_obj.headers.get("PRIMARY")
+        raw = primary.get("GAIAID") if primary is not None else None
+        if raw is None:
+            return None
+        token = str(raw).strip().split()[-1] if str(raw).strip() else ""
+        return token if token.isdigit() else None
+
+    def _object_name(self):
+        """SIMBAD-resolvable name from L0 PRIMARY OBJECT, or None if absent.
+
+        KPF OBJECT for standard stars is a bare HD number (e.g. '10700') that
+        SIMBAD resolves only with an 'HD ' prefix; named targets pass through.
+        """
+        primary = self.l0_obj.headers.get("PRIMARY")
+        obj = primary.get("OBJECT") if primary is not None else None
+        if obj is None:
+            return None
+        obj = str(obj).strip()
+        if not obj:
+            return None
+        return f"HD {obj}" if obj.isdigit() else obj
+
+    @staticmethod
+    def _scalar(value):
+        """Coerce a catalog cell to a plain float, or None if missing/masked/NaN.
+
+        astroquery returns masked columns; a star without a measured RV or
+        parallax comes back masked, which must become a clean None in the record.
+        """
+        if value is None or value is np.ma.masked:
+            return None
+        try:
+            f = float(value)
+        except (TypeError, ValueError):
+            return None
+        return None if np.isnan(f) else f
+
+    # ------------------------------------------------------------------
+    # Algorithm steps
+    # ------------------------------------------------------------------
+
+    def read_wmko_target(self):
+        """Snapshot the DCS/TCS ``TARG*`` target astrometry from L0 PRIMARY.
+
+        Returns the raw header values (native units, no conversion) keyed by the
+        record schema, or None when the frame carries no target pointing (TARGRA
+        absent -- e.g. a calibration frame).
+        """
+        primary = self.l0_obj.headers.get("PRIMARY")
+        if primary is None or primary.get("TARGRA") is None:
+            return None
+        return {field: primary.get(card) for field, card in _WMKO_KEYS.items()}
+
+    def query_gaia(self):
+        """Query Gaia DR3 for the target's ICRS astrometry, or None (fail-soft).
+
+        Returns None when disabled, when L0 GAIAID yields no usable source_id, or
+        when the lookup fails (warned, not raised). Values are Gaia-native: deg,
+        mas/yr, mas, km/s, and ref_epoch in Julian years.
+        """
+        if not self.use_gaia:
+            return None
+        gaia_id = self._gaia_source_id()
+        if gaia_id is None:
+            logger.debug("no usable GAIAID on L0 PRIMARY; skipping Gaia query")
+            return None
+        query = f"""
+        SELECT ra, dec, pmra, pmdec, parallax, radial_velocity, ref_epoch
+        FROM gaiadr3.gaia_source
+        WHERE source_id = {gaia_id}
+        """
+        logger.info("querying Gaia DR3 for source_id %s", gaia_id)
+        try:
+            row = Gaia.launch_job(query).get_results()[0]
+        except Exception as e:
+            logger.warning("Gaia query failed (%s: %s); skipping", type(e).__name__, e)
+            return None
+        return {
+            "source_id": gaia_id,
+            "ra": self._scalar(row["ra"]),
+            "dec": self._scalar(row["dec"]),
+            "pmra": self._scalar(row["pmra"]),
+            "pmdec": self._scalar(row["pmdec"]),
+            "parallax": self._scalar(row["parallax"]),
+            "rv": self._scalar(row["radial_velocity"]),
+            "ref_epoch": self._scalar(row["ref_epoch"]),
+        }
+
+    def query_simbad(self):
+        """Query SIMBAD for the OBJECT's ICRS J2000 astrometry, or None (fail-soft).
+
+        Returns None when disabled, when L0 has no OBJECT name, or when the lookup
+        fails / resolves nothing (warned, not raised). Column schema is the
+        astroquery 0.4.11 lowercase form (ra/dec deg, pmra/pmdec mas/yr, plx_value
+        mas, rvz_radvel km/s).
+        """
+        if not self.use_simbad:
+            return None
+        name = self._object_name()
+        if name is None:
+            logger.debug("no OBJECT name on L0 PRIMARY; skipping SIMBAD query")
+            return None
+        logger.info("querying SIMBAD for %r", name)
+        try:
+            simbad = Simbad()
+            simbad.add_votable_fields("pmra", "pmdec", "plx", "rvz_radvel")
+            result = simbad.query_object(name)
+        except Exception as e:
+            logger.warning(
+                "SIMBAD query failed (%s: %s); skipping", type(e).__name__, e
+            )
+            return None
+        if result is None or len(result) == 0:
+            logger.warning("SIMBAD returned no match for %r; skipping", name)
+            return None
+        row = result[0]
+        return {
+            "name": name,
+            "ra": self._scalar(row["ra"]),
+            "dec": self._scalar(row["dec"]),
+            "pmra": self._scalar(row["pmra"]),
+            "pmdec": self._scalar(row["pmdec"]),
+            "parallax": self._scalar(row["plx_value"]),
+            "rv": self._scalar(row["rvz_radvel"]),
+            "epoch": 2000.0,
+        }
+
+    # ------------------------------------------------------------------
+    # Private helpers - module execution
+    # ------------------------------------------------------------------
+
+    def _track_info(self):
+        """Build and cache the info() summary text from instance attributes."""
+        gaia = self._gaia["source_id"] if self._gaia else "n/a"
+        simbad = self._simbad["name"] if self._simbad else "n/a"
+        wmko = "resolved" if self._wmko else "n/a"
+        lines = [
+            "AstroQuery",
+            f"  obs_id:  {self.l0_obj.obs_id or 'unknown'}",
+            f"  Gaia DR3:  {gaia}",
+            f"  SIMBAD:    {simbad}",
+            f"  WMKO/DCS:  {wmko}",
+        ]
+        self._info = "\n\n" + "\n".join(lines) + "\n\n"
+
+    def _attach_catalog_info(self, l0_obj):
+        """Deposit the resolved catalog records on ``l0_obj.catalog_info``.
+
+        The module's sole output site (analogous to ``_set_headers`` on a
+        transform module). No header is written: the L0 PRIMARY is an immutable
+        pass-through to INSTRUMENT_HEADER, and the EPRV ``C*#`` keywords live on
+        the L1 PRIMARY, which ``KPF0.to_kpf1()`` builds downstream from this dict.
+        """
+        l0_obj.catalog_info = {
+            "gaia": self._gaia,
+            "simbad": self._simbad,
+            "wmko": self._wmko,
+        }
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def perform(self, *, use_gaia=None, use_simbad=None):
+        """
+        Resolve external catalog astrometry and attach it to the L0.
+
+        Parameters
+        ----------
+        use_gaia, use_simbad : bool, optional
+            Override the configured query toggles for this call.
+
+        Returns
+        -------
+        l0_obj : KPF0
+            The input L0 (PRIMARY unchanged), now carrying ``catalog_info`` with
+            the ``gaia`` / ``simbad`` / ``wmko`` records (each a dict or None), and
+            an 'astro_query' receipt entry. Unusually for a pipeline module this
+            returns an L0, not the next level -- AstroQuery runs before assembly.
+        """
+        if use_gaia is not None:
+            self.use_gaia = use_gaia
+        if use_simbad is not None:
+            self.use_simbad = use_simbad
+
+        self._wmko = self.read_wmko_target()
+        self._gaia = self.query_gaia()
+        self._simbad = self.query_simbad()
+
+        self._attach_catalog_info(self.l0_obj)
+        self._track_info()
+        self.l0_obj.receipt_add_entry("astro_query", "", "PASS")
+
+        logger.info("%s", self._info)
+        return self.l0_obj
+
+    def info(self):
+        """Print a summary of the resolved catalog astrometry."""
+        if self._info is None:
+            print(f"{type(self).__name__}: perform() has not been called")
+        else:
+            print(self._info)

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -423,7 +423,9 @@ class AstroQuery:
         logger.info("querying SIMBAD for %r", name)
         try:
             simbad = Simbad()
-            simbad.add_votable_fields("pmra", "pmdec", "plx", "rvz_radvel", "B", "V")
+            simbad.add_votable_fields(
+                "pmra", "pmdec", "plx_value", "rvz_radvel", "B", "V"
+            )
             result = simbad.query_object(name)
         except Exception as e:
             logger.warning(

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -5,7 +5,7 @@ Consolidates every external astronomical-catalog lookup the pipeline needs into
 a single L0-stage module. Given a raw L0 frame, it resolves the target's
 astrometry from Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), and snapshots the
 DCS/TCS target astrometry already on the raw header, then hands all three back on
-a lightweight ``catalog_info`` dict attached to the L0 object.
+a lightweight ``catalog_query`` dict attached to the L0 object.
 
 The dict is the bridge across an ordering problem: the query results ultimately
 belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO -> EPRV
@@ -45,10 +45,10 @@ _WMKO_KEYS = {
     "pmra": "TARGPMRA",
     "pmdec": "TARGPMDC",
     "parallax": "TARGPLAX",
+    "rv": "TARGRADV",
     "frame": "TARGFRAM",
     "epoch": "TARGEPOC",
     "equinox": "TARGEQUI",
-    "rv": "TARGRADV",
 }
 
 
@@ -58,7 +58,7 @@ class AstroQuery:
 
     Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT)
     plus a verbatim snapshot of the DCS/TCS ``TARG*`` astrometry, and deposits all
-    three on ``l0_obj.catalog_info`` for downstream use (EPRV ``C*#`` catalog
+    three on ``l0_obj.catalog_query`` for downstream use (EPRV ``C*#`` catalog
     keywords, DiagL0 pointing offsets, BarycentricCorrection). Fail-soft: a frame
     with no GAIAID/OBJECT (e.g. a calibration) or a failed network lookup yields a
     ``None`` record rather than an error.
@@ -67,7 +67,7 @@ class AstroQuery:
     ----------
     l0_obj : KPF0
         Raw L0 frame. Its PRIMARY header (GAIAID, OBJECT, TARG*) is read but never
-        modified; the resolved catalog data is attached as ``l0_obj.catalog_info``.
+        modified; the resolved catalog data is attached as ``l0_obj.catalog_query``.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: use_gaia, use_simbad.
     """
@@ -153,7 +153,9 @@ class AstroQuery:
         primary = self.l0_obj.headers.get("PRIMARY")
         if primary is None or primary.get("TARGRA") is None:
             return None
-        return {field: primary.get(card) for field, card in _WMKO_KEYS.items()}
+        record = {"source_id": primary.get("OBJECT")}
+        record.update({field: primary.get(card) for field, card in _WMKO_KEYS.items()})
+        return record
 
     def query_gaia(self):
         """Query Gaia DR3 for the target's ICRS astrometry, or None (fail-soft).
@@ -187,7 +189,9 @@ class AstroQuery:
             "pmdec": self._scalar(row["pmdec"]),
             "parallax": self._scalar(row["parallax"]),
             "rv": self._scalar(row["radial_velocity"]),
-            "ref_epoch": self._scalar(row["ref_epoch"]),
+            "frame": "icrs",
+            "epoch": self._scalar(row["ref_epoch"]),
+            "equinox": 2000.0,
         }
 
     def query_simbad(self):
@@ -219,14 +223,16 @@ class AstroQuery:
             return None
         row = result[0]
         return {
-            "name": name,
+            "source_id": name,
             "ra": self._scalar(row["ra"]),
             "dec": self._scalar(row["dec"]),
             "pmra": self._scalar(row["pmra"]),
             "pmdec": self._scalar(row["pmdec"]),
             "parallax": self._scalar(row["plx_value"]),
             "rv": self._scalar(row["rvz_radvel"]),
+            "frame": "icrs",
             "epoch": 2000.0,
+            "equinox": 2000.0,
         }
 
     # ------------------------------------------------------------------
@@ -236,7 +242,7 @@ class AstroQuery:
     def _track_info(self):
         """Build and cache the info() summary text from instance attributes."""
         gaia = self._gaia["source_id"] if self._gaia else "n/a"
-        simbad = self._simbad["name"] if self._simbad else "n/a"
+        simbad = self._simbad["source_id"] if self._simbad else "n/a"
         wmko = "resolved" if self._wmko else "n/a"
         lines = [
             "AstroQuery",
@@ -247,15 +253,15 @@ class AstroQuery:
         ]
         self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
-    def _attach_catalog_info(self, l0_obj):
-        """Deposit the resolved catalog records on ``l0_obj.catalog_info``.
+    def _attach_catalog_query(self, l0_obj):
+        """Deposit the resolved catalog records on ``l0_obj.catalog_query``.
 
         The module's sole output site (analogous to ``_set_headers`` on a
         transform module). No header is written: the L0 PRIMARY is an immutable
         pass-through to INSTRUMENT_HEADER, and the EPRV ``C*#`` keywords live on
         the L1 PRIMARY, which ``KPF0.to_kpf1()`` builds downstream from this dict.
         """
-        l0_obj.catalog_info = {
+        l0_obj.catalog_query = {
             "gaia": self._gaia,
             "simbad": self._simbad,
             "wmko": self._wmko,
@@ -277,7 +283,7 @@ class AstroQuery:
         Returns
         -------
         l0_obj : KPF0
-            The input L0 (PRIMARY unchanged), now carrying ``catalog_info`` with
+            The input L0 (PRIMARY unchanged), now carrying ``catalog_query`` with
             the ``gaia`` / ``simbad`` / ``wmko`` records (each a dict or None), and
             an 'astro_query' receipt entry. Unusually for a pipeline module this
             returns an L0, not the next level -- AstroQuery runs before assembly.
@@ -291,7 +297,7 @@ class AstroQuery:
         self._gaia = self.query_gaia()
         self._simbad = self.query_simbad()
 
-        self._attach_catalog_info(self.l0_obj)
+        self._attach_catalog_query(self.l0_obj)
         self._track_info()
         self.l0_obj.receipt_add_entry("astro_query", "", "PASS")
 

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -191,7 +191,7 @@ class AstroQuery:
         surprise so a silent DCS format change cannot corrupt the record.
         """
         frame = primary.get("TARGFRAM")
-        equinox = self._scalar(primary.get("TARGEQUI"))
+        equinox = primary.get("TARGEQUI")
         ra, dec = primary.get("TARGRA"), primary.get("TARGDEC")
         problems = []
         if not (isinstance(frame, str) and frame.strip().upper() == _WMKO_FRAME):
@@ -230,8 +230,8 @@ class AstroQuery:
             return None
         self._verify_wmko_format(primary)
         dec_deg = Angle(primary["TARGDEC"], unit=u.deg).deg
-        pmra = self._scalar(primary.get("TARGPMRA"))
-        pmdec = self._scalar(primary.get("TARGPMDC"))
+        pmra = primary.get("TARGPMRA")
+        pmdec = primary.get("TARGPMDC")
         record = {
             "source_id": primary.get("OBJECT"),
             "ra": Angle(primary["TARGRA"], unit=u.hourangle).to(u.deg).value,
@@ -240,11 +240,11 @@ class AstroQuery:
             if pmra is None
             else pmra * 15.0 * np.cos(np.radians(dec_deg)) * 1e3,
             "pmdec": None if pmdec is None else pmdec * 1e3,
-            "parallax": self._scalar(primary.get("TARGPLAX")),
-            "rv": self._scalar(primary.get("TARGRADV")),
+            "parallax": primary.get("TARGPLAX"),
+            "rv": primary.get("TARGRADV"),
             "frame": "icrs",
-            "epoch": self._scalar(primary.get("TARGEPOC")),
-            "equinox": self._scalar(primary.get("TARGEQUI")),
+            "epoch": primary.get("TARGEPOC"),
+            "equinox": primary.get("TARGEQUI"),
         }
         logger.info("successfully built record for wmko")
         return record

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -28,8 +28,9 @@ import logging
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import Angle
+from astropy.coordinates import FK5, ICRS, Angle, SkyCoord
 from astropy.table import Table
+from astropy.time import Time
 from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
@@ -456,10 +457,11 @@ class AstroQuery:
         query, just the raw TARG* pointing, sanitized to the EPRV C*# format --
         TARGRA/TARGDEC sexagesimal reformatted to the canonical RA hour-angle / Dec
         deg 'h:m:s' strings; TARGPMRA time-s/yr -> arcsec/yr (x15 cos Dec), TARGPMDC
-        already arcsec/yr; TARGFRAM stored as the record's true astropy frame (its
-        lowercase form, 'fk5'), never relabeled -- downstream SkyCoord performs any
-        FK5->ICRS conversion. KPF pointing is always FK5 (J2000), so a TARGFRAM that is
-        not FK5 (absent included) raises rather than being coerced: a wrong frame would
+        already arcsec/yr. The native FK5 (J2000) pointing is then rotated to ICRS
+        here via astropy's tested SkyCoord machinery, so all three CATALOG_RECORD
+        sources share one frame (Gaia/SIMBAD are already ICRS) and nothing downstream
+        has to track fk5. KPF pointing is always FK5, so a TARGFRAM that is not FK5
+        (absent included) raises rather than being coerced -- a wrong frame would
         silently corrupt the barycentric correction. Returns None -- so the frame gets
         WMKOCR=0 -- when there is no target pointing (TARGRA absent) or the TARG*
         astrometry cannot be parsed (warned, never raised, so a malformed file still
@@ -479,19 +481,40 @@ class AstroQuery:
             ra = Angle(primary["TARGRA"], unit=u.hourangle)
             dec = Angle(primary["TARGDEC"], unit=u.deg)
             pmra, pmdec = primary.get("TARGPMRA"), primary.get("TARGPMDC")
+            equinox = primary.get("TARGEQUI")
+
+            # Rotate the native FK5 pointing to ICRS via SkyCoord. Position always;
+            # proper motion too when both components are present (TARGPMRA time-s/yr
+            # -> on-sky arcsec/yr via x15 cos Dec first -- a single component has no
+            # meaning under the rotation, so it is both-or-neither). A frame rotation
+            # carries no time propagation, so epoch is unchanged; parallax/RV are
+            # rotation-invariant and pass through untouched.
+            fk5 = FK5(
+                equinox="J2000" if equinox is None else Time(equinox, format="jyear")
+            )
+            components = {"ra": ra, "dec": dec, "frame": fk5}
+            has_pm = pmra is not None and pmdec is not None
+            if has_pm:
+                cosdec = np.cos(dec.radian)
+                components["pm_ra_cosdec"] = pmra * 15.0 * cosdec * u.arcsec / u.yr
+                components["pm_dec"] = pmdec * u.arcsec / u.yr
+            icrs = SkyCoord(**components).transform_to(ICRS())
+
             record = {
                 "object": primary.get("OBJECT"),
-                "ra": ra.to_string(unit=u.hourangle, sep=":", pad=True, precision=4),
-                "dec": dec.to_string(
+                "ra": icrs.ra.to_string(
+                    unit=u.hourangle, sep=":", pad=True, precision=4
+                ),
+                "dec": icrs.dec.to_string(
                     unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
                 ),
-                "pmra": None if pmra is None else pmra * 15.0 * np.cos(dec.radian),
-                "pmdec": None if pmdec is None else pmdec,
+                "pmra": icrs.pm_ra_cosdec.to_value(u.arcsec / u.yr) if has_pm else None,
+                "pmdec": icrs.pm_dec.to_value(u.arcsec / u.yr) if has_pm else None,
                 "parallax": primary.get("TARGPLAX"),
                 "rv": primary.get("TARGRADV"),
-                "frame": targfram.lower(),
+                "frame": "icrs",
                 "epoch": primary.get("TARGEPOC"),
-                "equinox": primary.get("TARGEQUI"),
+                "equinox": 2000.0,
             }
         except Exception as exc:
             logger.warning(

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -1,12 +1,12 @@
 """
 KPF AstroQuery module.
 
-Consolidates every external astronomical-catalog lookup the pipeline needs into
-a single L0-stage module. Given a raw L0 frame, it resolves the target's
-astrometry from Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), and snapshots the
-DCS/TCS target astrometry already on the raw header, then writes all three to the
-L0 ``CATALOG_RECORD`` extension -- a BinTable with one row per resolved source and
-``WMKOCR``/``GAIACR``/``SIMBADCR`` presence flags on its header.
+Consolidates the pipeline's external astronomical-catalog lookups into a single
+L0-stage module. Given a raw L0 frame, it resolves the target's astrometry from
+Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT) and writes those two rows to the L0
+``CATALOG_RECORD`` extension via ``KPF0.set_catalog_record``, setting the
+``GAIACR``/``SIMBADCR`` presence flags. The third (``wmko``) row is telescope-native
+(no query) and is populated by ``KPF0`` at read time, not here.
 
 The extension is the bridge across an ordering problem: the query results
 ultimately belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO ->
@@ -15,7 +15,7 @@ than write PRIMARY here, AstroQuery records the queried quantities on the L0 and
 lets ``to_kpf1()`` overlay them onto the L1 PRIMARY (a follow-up integration).
 
 AstroQuery never modifies the L0 PRIMARY header -- that header is a pure
-pass-through to INSTRUMENT_HEADER. The three records share one schema and one set
+pass-through to INSTRUMENT_HEADER. All three records share one schema and one set
 of units and reference frame, so a consumer reads any source identically: ICRS,
 RA/Dec in degrees, proper motion in mas/yr (RA including cos(Dec)), parallax in
 mas, RV in km/s, epoch/equinox in Julian years. Per-fiber fan-out and derived
@@ -26,8 +26,6 @@ import logging
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import Angle
-from astropy.table import Table
 from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
@@ -63,61 +61,25 @@ _SIMBAD_UNITS = {
     "rvz_radvel": u.km / u.s,
 }
 
-# The DCS TARG* astrometry format the wmko conversion assumes (verified before use).
-_WMKO_FRAME = "FK5"
-_WMKO_EQUINOX = 2000.0
-
-# Schema of the CATALOG_RECORD BinTable extension: one row per resolved source,
-# carrying the canonical record fields plus a leading 'source' label. Float columns
-# hold NaN where a value is missing; string columns hold "". Units document the
-# canonical schema (deg, mas/yr incl. cos Dec, mas, km/s, Julian years).
-_CATALOG_COLUMNS = (
-    "source",
-    "source_id",
-    "ra",
-    "dec",
-    "pmra",
-    "pmdec",
-    "parallax",
-    "rv",
-    "frame",
-    "epoch",
-    "equinox",
-)
-_CATALOG_STR_COLUMNS = frozenset({"source", "source_id", "frame"})
-_CATALOG_UNITS = {
-    "ra": u.deg,
-    "dec": u.deg,
-    "pmra": u.mas / u.yr,
-    "pmdec": u.mas / u.yr,
-    "parallax": u.mas,
-    "rv": u.km / u.s,
-    "epoch": u.yr,
-    "equinox": u.yr,
-}
-# Presence flag written to the CATALOG_RECORD header per source (int 0/1).
-_CATALOG_FLAGS = {"wmko": "WMKOCR", "gaia": "GAIACR", "simbad": "SIMBADCR"}
-
 
 class AstroQuery:
     """
-    Resolve target astrometry from external catalogs and attach it to an L0.
+    Resolve target astrometry from external catalogs and write it to an L0.
 
-    Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT)
-    plus a verbatim snapshot of the DCS/TCS ``TARG*`` astrometry, and writes all
-    three to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV ``C*#``
-    catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). Only science
-    frames
-    are supported: the constructor raises on a non-``Object`` IMTYPE (a calibration).
-    Fail-soft otherwise: a missing GAIAID/OBJECT or a failed network lookup yields a
-    ``None`` record rather than an error.
+    Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT) and
+    writes their rows to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV
+    ``C*#`` catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). The
+    native ``wmko`` row is populated by ``KPF0`` at read time, not here. Only science
+    frames are supported: the constructor raises on a non-``Object`` IMTYPE (a
+    calibration). Fail-soft otherwise: a missing GAIAID/OBJECT or a failed network
+    lookup yields a ``None`` record rather than an error.
 
     Parameters
     ----------
     l0_obj : KPF0
         Raw L0 science frame (IMTYPE ``Object``). Its PRIMARY header (IMTYPE, GAIAID,
-        OBJECT, TARG*) is read but never modified; the resolved catalog data is
-        written to the L0 ``CATALOG_RECORD`` extension.
+        OBJECT) is read but never modified; the resolved catalog data is written to
+        the L0 ``CATALOG_RECORD`` extension via ``set_catalog_record``.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: use_gaia, use_simbad.
     """
@@ -146,7 +108,6 @@ class AstroQuery:
 
         self._gaia = None  # Gaia DR3 record; set by query_gaia()
         self._simbad = None  # SIMBAD record; set by query_simbad()
-        self._wmko = None  # DCS/TCS TARG* record; set by read_wmko_target()
         self._info = None
 
     # ------------------------------------------------------------------
@@ -215,73 +176,9 @@ class AstroQuery:
                 "assumptions must be revalidated before use."
             )
 
-    def _verify_wmko_format(self, primary):
-        """Verify the DCS TARG* astrometry is in the assumed input format.
-
-        The wmko conversion assumes FK5 J2000 with sexagesimal TARGRA/TARGDEC
-        (hourangle/deg), TARGPMRA in s/yr and TARGPMDC in arcsec/yr. The pm units
-        are not encoded in the header, but the frame, equinox, and sexagesimal
-        coordinate format are -- verify those and raise ``ValueError`` on any
-        surprise so a silent DCS format change cannot corrupt the record.
-        """
-        frame = primary.get("TARGFRAM")
-        equinox = primary.get("TARGEQUI")
-        ra, dec = primary.get("TARGRA"), primary.get("TARGDEC")
-        problems = []
-        if not (isinstance(frame, str) and frame.strip().upper() == _WMKO_FRAME):
-            problems.append(f"TARGFRAM={frame!r} (expected {_WMKO_FRAME!r})")
-        if equinox != _WMKO_EQUINOX:
-            problems.append(f"TARGEQUI={equinox!r} (expected {_WMKO_EQUINOX})")
-        if not (
-            isinstance(ra, str) and ":" in ra and isinstance(dec, str) and ":" in dec
-        ):
-            problems.append(f"TARGRA/TARGDEC not sexagesimal ({ra!r}, {dec!r})")
-        if problems:
-            raise ValueError(
-                "unexpected WMKO/DCS astrometry format: "
-                + "; ".join(problems)
-                + "; AstroQuery assumes FK5 J2000 sexagesimal input. Verify the DCS "
-                "header format before proceeding."
-            )
-
     # ------------------------------------------------------------------
     # Algorithm steps
     # ------------------------------------------------------------------
-
-    def read_wmko_target(self):
-        """Read the DCS/TCS ``TARG*`` target astrometry from L0 PRIMARY.
-
-        Converts the native DCS values to the canonical schema (RA/Dec degrees,
-        proper motion mas/yr, ICRS): TARGRA/TARGDEC are sexagesimal (hourangle /
-        deg); TARGPMRA is time-seconds/yr (-> mas/yr via x15 cos(Dec)) and TARGPMDC
-        is arcsec/yr (-> mas/yr). TARGFRAM is FK5 J2000, relabeled ICRS (the ~23 mas
-        frame tie is negligible for this fallback record). Returns None when the
-        frame carries no target pointing (TARGRA absent -- e.g. a calibration).
-        """
-        primary = self.l0_obj.headers["PRIMARY"]
-        if primary.get("TARGRA") is None:
-            logger.warning("no TARGRA on L0 PRIMARY; WMKO/DCS astrometry unavailable")
-            return None
-        self._verify_wmko_format(primary)
-        dec_deg = Angle(primary["TARGDEC"], unit=u.deg).deg
-        pmra = primary.get("TARGPMRA")
-        pmdec = primary.get("TARGPMDC")
-        record = {
-            "source_id": primary.get("OBJECT"),
-            "ra": Angle(primary["TARGRA"], unit=u.hourangle).to(u.deg).value,
-            "dec": dec_deg,
-            "pmra": None
-            if pmra is None
-            else pmra * 15.0 * np.cos(np.radians(dec_deg)) * 1e3,
-            "pmdec": None if pmdec is None else pmdec * 1e3,
-            "parallax": primary.get("TARGPLAX"),
-            "rv": primary.get("TARGRADV"),
-            "frame": "icrs",
-            "epoch": primary.get("TARGEPOC"),
-            "equinox": primary.get("TARGEQUI"),
-        }
-        logger.info("successfully built record for wmko")
-        return record
 
     def query_gaia(self):
         """Query Gaia DR3 for the target's ICRS astrometry, or None (fail-soft).
@@ -396,45 +293,13 @@ class AstroQuery:
         """Build and cache the info() summary text from instance attributes."""
         gaia = self._gaia["source_id"] if self._gaia else "n/a"
         simbad = self._simbad["source_id"] if self._simbad else "n/a"
-        wmko = "resolved" if self._wmko else "n/a"
         lines = [
             "AstroQuery",
             f"  obs_id:  {self.l0_obj.obs_id or 'unknown'}",
             f"  Gaia DR3:  {gaia}",
             f"  SIMBAD:    {simbad}",
-            f"  WMKO/DCS:  {wmko}",
         ]
         self._info = "\n\n" + "\n".join(lines) + "\n\n"
-
-    def _attach_catalog_record(self, l0_obj):
-        """Write the resolved catalog records to the CATALOG_RECORD extension.
-
-        The module's sole output site (analogous to ``_set_headers`` on a transform
-        module). Builds a BinTable with one row per resolved source (canonical ICRS
-        schema; missing floats -> NaN, missing source_id -> "") and sets the
-        WMKOCR/GAIACR/SIMBADCR presence flags on the extension header. The L0 PRIMARY
-        is never touched -- the EPRV ``C*#`` keywords are built later in
-        ``KPF0.to_kpf1()``; this extension is the L0-stage bridge to that step.
-        """
-        records = {"wmko": self._wmko, "gaia": self._gaia, "simbad": self._simbad}
-        rows = [
-            {"source": src, **rec} for src, rec in records.items() if rec is not None
-        ]
-        table = Table()
-        for name in _CATALOG_COLUMNS:
-            if name in _CATALOG_STR_COLUMNS:
-                table[name] = np.array(
-                    ["" if r[name] is None else r[name] for r in rows], dtype=str
-                )
-            else:
-                table[name] = np.array(
-                    [np.nan if r[name] is None else r[name] for r in rows], dtype=float
-                )
-                table[name].unit = _CATALOG_UNITS[name]
-        l0_obj.set_data("CATALOG_RECORD", table)
-
-        for source, keyword in _CATALOG_FLAGS.items():
-            l0_obj.set_keyword(keyword, 1 if records[source] is not None else 0)
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -442,7 +307,7 @@ class AstroQuery:
 
     def perform(self, *, use_gaia=None, use_simbad=None):
         """
-        Resolve external catalog astrometry and attach it to the L0.
+        Resolve external catalog astrometry and write it to the L0.
 
         Parameters
         ----------
@@ -452,9 +317,9 @@ class AstroQuery:
         Returns
         -------
         l0_obj : KPF0
-            The input L0 (PRIMARY unchanged), now carrying the ``CATALOG_RECORD``
-            extension (one row per resolved source, with WMKOCR/GAIACR/SIMBADCR
-            presence flags) and an 'astro_query' receipt entry. Unusually for a
+            The input L0 (PRIMARY unchanged), now with its ``gaia``/``simbad`` rows
+            written to the ``CATALOG_RECORD`` extension (the ``wmko`` row is native,
+            populated at read) and an 'astro_query' receipt entry. Unusually for a
             pipeline module this returns an L0, not the next level -- AstroQuery
             runs before assembly.
         """
@@ -463,11 +328,11 @@ class AstroQuery:
         if use_simbad is not None:
             self.use_simbad = use_simbad
 
-        self._wmko = self.read_wmko_target()
         self._gaia = self.query_gaia()
         self._simbad = self.query_simbad()
 
-        self._attach_catalog_record(self.l0_obj)
+        self.l0_obj.set_catalog_record("gaia", self._gaia)
+        self.l0_obj.set_catalog_record("simbad", self._simbad)
         self._track_info()
         self.l0_obj.receipt_add_entry("astro_query", "", "PASS")
 

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -19,7 +19,8 @@ AstroQuery never modifies the L0 PRIMARY header (a pure pass-through to
 INSTRUMENT_HEADER). All three source rows and the merged ``kpf-drp`` row share one
 schema in the EPRV C*# PRIMARY format (see ``_CATALOG_COLUMNS``), so a consumer reads
 any source identically and ``to_kpf1`` can copy cells straight onto the catalog cards.
-Per-fiber fan-out and derived quantities (offsets, redshift) are downstream jobs.
+The redshift z (``CZ#``) is derived from rv here and rides along in the record; per-
+fiber fan-out and pointing offsets remain downstream jobs.
 """
 
 import logging
@@ -33,6 +34,7 @@ from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
 from kpfpipe import DEFAULTS
+from kpfpipe.utils.astro import compute_redshift
 from kpfpipe.utils.config import ConfigHandler
 
 logger = logging.getLogger(__name__)
@@ -79,8 +81,9 @@ _SIMBAD_UNITS = {
 # value block (position, parallax, rv) came from -- its own 'source' for a plain source
 # row, the winning source (or "" if none) for the merged row. Values are in the EPRV
 # C*# PRIMARY format: RA/Dec sexagesimal strings (RA hour-angle, Dec deg, ICRS), PM
-# arcsec/yr (RA incl. cos Dec), parallax mas, rv km/s, epoch/equinox Julian years.
-# Missing floats -> NaN, missing strings -> "".
+# arcsec/yr (RA incl. cos Dec), parallax mas, rv km/s, z the dimensionless relativistic
+# redshift derived from rv, epoch/equinox Julian years. Missing floats -> NaN, missing
+# strings -> "".
 _CATALOG_COLUMNS = (
     "source",
     "object",
@@ -93,6 +96,7 @@ _CATALOG_COLUMNS = (
     "pmdec",
     "parallax",
     "rv",
+    "z",
     "frame",
     "epoch",
     "equinox",
@@ -107,6 +111,7 @@ _CATALOG_UNITS = {
     "pmdec": u.arcsec / u.yr,
     "parallax": u.mas,
     "rv": u.km / u.s,
+    "z": u.dimensionless_unscaled,
     "epoch": u.yr,
     "equinox": u.yr,
 }
@@ -212,6 +217,18 @@ class AstroQuery:
         return None if np.isnan(f) else f
 
     @staticmethod
+    def _redshift(rv_kms):
+        """Relativistic redshift z for a catalog rv [km/s], or None if rv is missing.
+
+        Derived (see ``kpfpipe.utils.astro.compute_redshift``), carried on the record
+        so ``to_kpf1`` can overlay it onto the EPRV ``CZ#`` card without a consumer
+        recomputing it. Dimensionless.
+        """
+        if rv_kms is None:
+            return None
+        return float(compute_redshift(rv_kms * u.km / u.s))
+
+    @staticmethod
     def _sexagesimal_radec(coord):
         """ICRS SkyCoord -> the EPRV C*# sexagesimal (ra, dec) strings.
 
@@ -264,13 +281,15 @@ class AstroQuery:
         if record is None:
             rows.pop(source, None)
         else:
-            rows[source] = {
+            row = {
                 "source": source,
                 "radec_src": source,
                 "plx_src": source,
                 "rv_src": source,
                 **record,
             }
+            row["z"] = self._redshift(row["rv"])
+            rows[source] = row
 
         ordered = list(rows.values())
         new_table = Table()

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -3,10 +3,11 @@ KPF AstroQuery module.
 
 Consolidates the pipeline's external astronomical-catalog lookups into a single
 L0-stage module. Given a raw L0 frame, it resolves the target's astrometry from
-Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT) and writes those two rows to the L0
-``CATALOG_RECORD`` extension via ``KPF0.set_catalog_record``, setting the
-``GAIACR``/``SIMBADCR`` presence flags. The third (``wmko``) row is telescope-native
-(no query) and is populated by ``KPF0`` at read time, not here.
+Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), builds the telescope-native ``wmko``
+row from the L0 PRIMARY ``TARG*`` astrometry (no query), and writes all three rows
+to the L0 ``CATALOG_RECORD`` extension, setting the ``WMKOCR``/``GAIACR``/``SIMBADCR``
+presence flags. ``KPF0.read`` leaves ``CATALOG_RECORD`` empty; AstroQuery is its sole
+populator.
 
 The extension is the bridge across an ordering problem: the query results
 ultimately belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO ->
@@ -28,6 +29,7 @@ import logging
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
+from astropy.table import Table
 from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
@@ -45,11 +47,8 @@ _DEFAULTS = {
 
 # Source-merge configuration for the canonical ``kpf-drp`` row. Priority order
 # (highest first) governs which source supplies the coherent position block and,
-# independently, the parallax and RV. _PRESENCE_FLAGS maps each source to its
-# CATALOG_RECORD header flag (a local mirror of level0._CATALOG_FLAGS, matching the
-# DiagL0 convention of not importing the private schema).
+# independently, the parallax and RV.
 _MERGE_PRIORITY = ("gaia", "simbad", "wmko")
-_PRESENCE_FLAGS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
 # The position block is taken together from one source so ra/dec/PM and their frame
 # and reference epoch stay internally consistent -- a frame or epoch from a different
 # source than the coordinates would be meaningless. equinox rides with the same base
@@ -92,16 +91,62 @@ _SIMBAD_UNITS = {
     "rvz_radvel": u.km / u.s,
 }
 
+# CATALOG_RECORD extension write schema. AstroQuery is the sole populator: one row per
+# resolved source (wmko/gaia/simbad) plus the merged 'kpf-drp' canonical row. Columns:
+# 'source' (the row's nominal source), 'object' (the target name supplied to the
+# query), three provenance labels naming the source each value block came from --
+# 'radec_src' (ra/dec/pmra/pmdec plus their frame/epoch/equinox, intrinsic to the
+# coordinates and never sourced separately), 'plx_src' (parallax), 'rv_src' (rv) --
+# then the values. For a plain source row each provenance label is the row's own
+# 'source'; the merged row names whichever source won each block (or "" when none
+# supplied it). Every source is sanitized to the EPRV C*# PRIMARY format so
+# KPF0.to_kpf1 can copy cells straight onto the catalog cards: RA/Dec sexagesimal
+# strings (RA hour-angle 'h:m:s', Dec deg 'd:m:s', ICRS), proper motion arcsec/yr (RA
+# incl. cos Dec), parallax mas, RV km/s, epoch/equinox in Julian years. Float columns
+# hold NaN where a value is missing; string columns (RA/Dec included) hold "".
+_CATALOG_COLUMNS = (
+    "source",
+    "object",
+    "radec_src",
+    "plx_src",
+    "rv_src",
+    "ra",
+    "dec",
+    "pmra",
+    "pmdec",
+    "parallax",
+    "rv",
+    "frame",
+    "epoch",
+    "equinox",
+)
+_CATALOG_STR_COLUMNS = frozenset(
+    {"source", "object", "radec_src", "plx_src", "rv_src", "frame", "ra", "dec"}
+)
+
+# RA / DEC are sexagesimal strings, so not subject to astropy unit conversion
+_CATALOG_UNITS = {
+    "pmra": u.arcsec / u.yr,
+    "pmdec": u.arcsec / u.yr,
+    "parallax": u.mas,
+    "rv": u.km / u.s,
+    "epoch": u.yr,
+    "equinox": u.yr,
+}
+# Presence flag written to the CATALOG_RECORD header per source (int 0/1). DiagL0 keeps
+# its own local mirror (the DiagL0 convention of not importing this schema).
+_CATALOG_FLAGS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
+
 
 class AstroQuery:
     """
     Resolve target astrometry from external catalogs and write it to an L0.
 
-    Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT) and
-    writes their rows to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV
-    ``C*#`` catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). The
-    native ``wmko`` row is populated by ``KPF0`` at read time, not here. Only science
-    frames are supported: the constructor raises on a non-``Object`` IMTYPE (a
+    Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT),
+    builds the native ``wmko`` row from the L0 PRIMARY ``TARG*`` astrometry, and writes
+    all three rows to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV
+    ``C*#`` catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). Only
+    science frames are supported: the constructor raises on a non-``Object`` IMTYPE (a
     calibration). Fail-soft otherwise: a missing GAIAID/OBJECT or a failed network
     lookup yields a ``None`` record rather than an error.
 
@@ -109,8 +154,8 @@ class AstroQuery:
     ----------
     l0_obj : KPF0
         Raw L0 science frame (IMTYPE ``Object``). Its PRIMARY header (IMTYPE, GAIAID,
-        OBJECT) is read but never modified; the resolved catalog data is written to
-        the L0 ``CATALOG_RECORD`` extension via ``set_catalog_record``.
+        OBJECT, TARG*) is read but never modified; the resolved catalog data is written
+        to the L0 ``CATALOG_RECORD`` extension.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: use_gaia, use_simbad.
     """
@@ -137,6 +182,7 @@ class AstroQuery:
         for k, v in _DEFAULTS.items():
             setattr(self, k, params.get(k, v))
 
+        self._wmko = None  # native WMKO record; set by read_wmko_header()
         self._gaia = None  # Gaia DR3 record; set by query_gaia()
         self._simbad = None  # SIMBAD record; set by query_simbad()
         self._canonical = None  # merged kpf-drp record; set by merge_catalog_records()
@@ -207,6 +253,57 @@ class AstroQuery:
                 f"{expected}. The catalog schema may have changed; AstroQuery's unit "
                 "assumptions must be revalidated before use."
             )
+
+    def _write_catalog_record(self, source, record):
+        """Upsert one source's row into the L0 CATALOG_RECORD extension + set its flag.
+
+        The single writer for CATALOG_RECORD (``wmko``/``gaia``/``simbad`` and the
+        merged ``kpf-drp`` row). ``record`` is a canonical record dict (the
+        _CATALOG_COLUMNS fields minus ``source``) or None. The three provenance labels
+        (``radec_src``/``plx_src``/``rv_src``) default to ``source`` when the record
+        omits them (a source row's values are its own); the merged row supplies each
+        explicitly. Existing rows for other sources are preserved (upsert). A None
+        record clears the source's flag and writes no row; otherwise the row is
+        (re)written and the flag set to 1. A source without a registered presence flag
+        (e.g. ``kpf-drp``, which must always be present) writes no flag keyword. Missing
+        floats become NaN, missing strings "".
+        """
+        l0 = self.l0_obj
+        table = l0.data["CATALOG_RECORD"]
+        rows = {}
+        if table.colnames:
+            for row in table:
+                rows[str(row["source"])] = {
+                    name: row[name] for name in _CATALOG_COLUMNS
+                }
+        if record is None:
+            rows.pop(source, None)
+        else:
+            rows[source] = {
+                "source": source,
+                "radec_src": source,
+                "plx_src": source,
+                "rv_src": source,
+                **record,
+            }
+
+        ordered = list(rows.values())
+        new_table = Table()
+        for name in _CATALOG_COLUMNS:
+            if name in _CATALOG_STR_COLUMNS:
+                new_table[name] = np.array(
+                    ["" if r[name] is None else r[name] for r in ordered], dtype=str
+                )
+            else:
+                new_table[name] = np.array(
+                    [np.nan if r[name] is None else r[name] for r in ordered],
+                    dtype=float,
+                )
+                new_table[name].unit = _CATALOG_UNITS[name]
+        l0.set_data("CATALOG_RECORD", new_table)
+        flag = _CATALOG_FLAGS.get(source)
+        if flag is not None:
+            l0.set_keyword(flag, 1 if record is not None else 0)
 
     # ------------------------------------------------------------------
     # Algorithm steps
@@ -341,6 +438,51 @@ class AstroQuery:
         logger.info("successfully built record for simbad")
         return record
 
+    def read_wmko_header(self):
+        """Read the native WMKO/DCS astrometry from L0 PRIMARY TARG*, or None.
+
+        The telescope-side counterpart to query_gaia/query_simbad: no external
+        query, just the raw TARG* pointing, sanitized to the EPRV C*# format --
+        TARGRA/TARGDEC sexagesimal reformatted to the canonical RA hour-angle / Dec
+        deg 'h:m:s' strings; TARGPMRA time-s/yr -> arcsec/yr (x15 cos Dec), TARGPMDC
+        already arcsec/yr; TARGFRAM FK5 J2000 relabeled ICRS (the ~23 mas frame tie is
+        negligible). Returns None -- so the frame gets WMKOCR=0 -- when there is no
+        target pointing (TARGRA absent) or the TARG* astrometry cannot be parsed
+        (warned, never raised, so a malformed file still loads). Well-formedness is
+        gated downstream by QCL0 (RADECOK), not here.
+        """
+        primary = self.l0_obj.headers["PRIMARY"]
+        if primary.get("TARGRA") is None:
+            return None
+        try:
+            ra = Angle(primary["TARGRA"], unit=u.hourangle)
+            dec = Angle(primary["TARGDEC"], unit=u.deg)
+            pmra, pmdec = primary.get("TARGPMRA"), primary.get("TARGPMDC")
+            record = {
+                "object": primary.get("OBJECT"),
+                "ra": ra.to_string(unit=u.hourangle, sep=":", pad=True, precision=4),
+                "dec": dec.to_string(
+                    unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
+                ),
+                "pmra": None if pmra is None else pmra * 15.0 * np.cos(dec.radian),
+                "pmdec": None if pmdec is None else pmdec,
+                "parallax": primary.get("TARGPLAX"),
+                "rv": primary.get("TARGRADV"),
+                "frame": "icrs",
+                "epoch": primary.get("TARGEPOC"),
+                "equinox": primary.get("TARGEQUI"),
+            }
+        except Exception as exc:
+            logger.warning(
+                "could not build wmko CATALOG_RECORD from L0 PRIMARY TARG* "
+                "(%s: %s); left empty",
+                type(exc).__name__,
+                exc,
+            )
+            return None
+        logger.info("successfully built record for wmko")
+        return record
+
     def _read_catalog_row(self, table, source):
         """Read one CATALOG_RECORD row into a record dict, or None if absent.
 
@@ -393,7 +535,7 @@ class AstroQuery:
         for source in _MERGE_PRIORITY:
             if not getattr(self, f"use_{source}"):
                 continue
-            if not header.get(_PRESENCE_FLAGS[source]):
+            if not header.get(_CATALOG_FLAGS[source]):
                 continue
             record = self._read_catalog_row(table, source)
             if record is not None:
@@ -463,7 +605,7 @@ class AstroQuery:
             "equinox": base_record["equinox"],
         }
         self._canonical = record
-        self.l0_obj.set_catalog_record("kpf-drp", record)
+        self._write_catalog_record("kpf-drp", record)
         return record
 
     # ------------------------------------------------------------------
@@ -500,22 +642,26 @@ class AstroQuery:
         Returns
         -------
         l0_obj : KPF0
-            The input L0 (PRIMARY unchanged), now with its ``gaia``/``simbad`` rows
-            written to the ``CATALOG_RECORD`` extension (the ``wmko`` row is native,
-            populated at read) and an 'astro_query' receipt entry. Unusually for a
-            pipeline module this returns an L0, not the next level -- AstroQuery
-            runs before assembly.
+            The input L0 (PRIMARY unchanged), now with its ``wmko``/``gaia``/``simbad``
+            rows and the merged ``kpf-drp`` row written to the ``CATALOG_RECORD``
+            extension, and an 'astro_query' receipt entry. Unusually for a pipeline
+            module this returns an L0, not the next level -- AstroQuery runs before
+            assembly.
         """
         if use_gaia is not None:
             self.use_gaia = use_gaia
         if use_simbad is not None:
             self.use_simbad = use_simbad
 
+        self._wmko = self.read_wmko_header()
         self._gaia = self.query_gaia()
         self._simbad = self.query_simbad()
 
-        self.l0_obj.set_catalog_record("gaia", self._gaia)
-        self.l0_obj.set_catalog_record("simbad", self._simbad)
+        # Write all three source rows (wmko is native, built from L0 PRIMARY TARG*;
+        # gaia/simbad from the queries above); KPF0.read leaves CATALOG_RECORD empty.
+        self._write_catalog_record("wmko", self._wmko)
+        self._write_catalog_record("gaia", self._gaia)
+        self._write_catalog_record("simbad", self._simbad)
         # Merge the source rows (gaia/simbad/wmko) into the canonical kpf-drp row that
         # downstream (to_kpf1 C*#, barycentric correction) consumes. Raises if a
         # complete set cannot be assembled.

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -14,14 +14,18 @@ than write headers here, AstroQuery tracks the queried quantities on the L0 and
 lets ``to_kpf1()`` overlay them onto the L1 PRIMARY (a follow-up integration).
 
 AstroQuery never modifies the L0 PRIMARY header -- that header is a pure
-pass-through to INSTRUMENT_HEADER. Values are stored raw, in each source's native
-units; unit conversion, per-fiber fan-out, and derived quantities (offsets,
-redshift) are the jobs of the downstream consumers, not this module.
+pass-through to INSTRUMENT_HEADER. The three records share one schema and one set
+of units and reference frame, so a consumer reads any source identically: ICRS,
+RA/Dec in degrees, proper motion in mas/yr (RA including cos(Dec)), parallax in
+mas, RV in km/s, epoch/equinox in Julian years. Per-fiber fan-out and derived
+quantities (offsets, redshift) remain the jobs of downstream consumers.
 """
 
 import logging
 
+import astropy.units as u
 import numpy as np
+from astropy.coordinates import Angle
 from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
@@ -36,20 +40,30 @@ _DEFAULTS = {
     "use_simbad": True,
 }
 
-# WMKO/DCS target-astrometry cards on the raw L0 PRIMARY, snapshotted verbatim
-# (native units) into the 'wmko' record. Consumers apply the unit conventions
-# (e.g. TARGPMRA is time-seconds/yr) exactly as BarycentricCorrection/DiagL0 do.
-_WMKO_KEYS = {
-    "ra": "TARGRA",
-    "dec": "TARGDEC",
-    "pmra": "TARGPMRA",
-    "pmdec": "TARGPMDC",
-    "parallax": "TARGPLAX",
-    "rv": "TARGRADV",
-    "frame": "TARGFRAM",
-    "epoch": "TARGEPOC",
-    "equinox": "TARGEQUI",
+# Column units AstroQuery assumes for each catalog result, verified before the
+# values are trusted so a silent upstream schema change fails loudly instead of
+# corrupting the record.
+_GAIA_UNITS = {
+    "ra": u.deg,
+    "dec": u.deg,
+    "pmra": u.mas / u.yr,
+    "pmdec": u.mas / u.yr,
+    "parallax": u.mas,
+    "radial_velocity": u.km / u.s,
+    "ref_epoch": u.yr,
 }
+_SIMBAD_UNITS = {
+    "ra": u.deg,
+    "dec": u.deg,
+    "pmra": u.mas / u.yr,
+    "pmdec": u.mas / u.yr,
+    "plx_value": u.mas,
+    "rvz_radvel": u.km / u.s,
+}
+
+# The DCS TARG* astrometry format the wmko conversion assumes (verified before use).
+_WMKO_FRAME = "FK5"
+_WMKO_EQUINOX = 2000.0
 
 
 class AstroQuery:
@@ -108,7 +122,7 @@ class AstroQuery:
         token = str(raw).strip().split()[-1] if str(raw).strip() else ""
         return token if token.isdigit() else None
 
-    def _object_name(self):
+    def _simbad_resolvable_name(self):
         """SIMBAD-resolvable name from L0 PRIMARY OBJECT, or None if absent.
 
         KPF OBJECT for standard stars is a bare HD number (e.g. '10700') that
@@ -137,32 +151,102 @@ class AstroQuery:
             return None
         return None if np.isnan(f) else f
 
+    @staticmethod
+    def _verify_units(table, expected, source):
+        """Verify a query result's column units before its values are trusted.
+
+        Guards the canonical-unit assumption: raises ``ValueError`` if any
+        expected column is missing or carries a unit other than the one the
+        record schema assumes, so a silent catalog schema change fails loudly.
+        """
+        mismatched = {}
+        for col, want in expected.items():
+            if col not in table.colnames:
+                mismatched[col] = "MISSING"
+            elif table[col].unit != want:
+                mismatched[col] = table[col].unit
+        if mismatched:
+            raise ValueError(
+                f"{source} returned unexpected column units {mismatched}; expected "
+                f"{expected}. The catalog schema may have changed; AstroQuery's unit "
+                "assumptions must be revalidated before use."
+            )
+
+    def _verify_wmko_format(self, primary):
+        """Verify the DCS TARG* astrometry is in the assumed input format.
+
+        The wmko conversion assumes FK5 J2000 with sexagesimal TARGRA/TARGDEC
+        (hourangle/deg), TARGPMRA in s/yr and TARGPMDC in arcsec/yr. The pm units
+        are not encoded in the header, but the frame, equinox, and sexagesimal
+        coordinate format are -- verify those and raise ``ValueError`` on any
+        surprise so a silent DCS format change cannot corrupt the record.
+        """
+        frame = primary.get("TARGFRAM")
+        equinox = self._scalar(primary.get("TARGEQUI"))
+        ra, dec = primary.get("TARGRA"), primary.get("TARGDEC")
+        problems = []
+        if not (isinstance(frame, str) and frame.strip().upper() == _WMKO_FRAME):
+            problems.append(f"TARGFRAM={frame!r} (expected {_WMKO_FRAME!r})")
+        if equinox != _WMKO_EQUINOX:
+            problems.append(f"TARGEQUI={equinox!r} (expected {_WMKO_EQUINOX})")
+        if not (
+            isinstance(ra, str) and ":" in ra and isinstance(dec, str) and ":" in dec
+        ):
+            problems.append(f"TARGRA/TARGDEC not sexagesimal ({ra!r}, {dec!r})")
+        if problems:
+            raise ValueError(
+                "unexpected WMKO/DCS astrometry format: "
+                + "; ".join(problems)
+                + "; AstroQuery assumes FK5 J2000 sexagesimal input. Verify the DCS "
+                "header format before proceeding."
+            )
+
     # ------------------------------------------------------------------
     # Algorithm steps
     # ------------------------------------------------------------------
 
     def read_wmko_target(self):
-        """Snapshot the DCS/TCS ``TARG*`` target astrometry from L0 PRIMARY.
+        """Read the DCS/TCS ``TARG*`` target astrometry from L0 PRIMARY.
 
-        Returns the raw header values (native units, no conversion) keyed by the
-        record schema, or None when the frame carries no target pointing (TARGRA
-        absent -- e.g. a calibration frame).
+        Converts the native DCS values to the canonical schema (RA/Dec degrees,
+        proper motion mas/yr, ICRS): TARGRA/TARGDEC are sexagesimal (hourangle /
+        deg); TARGPMRA is time-seconds/yr (-> mas/yr via x15 cos(Dec)) and TARGPMDC
+        is arcsec/yr (-> mas/yr). TARGFRAM is FK5 J2000, relabeled ICRS (the ~23 mas
+        frame tie is negligible for this fallback record). Returns None when the
+        frame carries no target pointing (TARGRA absent -- e.g. a calibration).
         """
         primary = self.l0_obj.headers["PRIMARY"]
         if primary.get("TARGRA") is None:
             logger.warning("no TARGRA on L0 PRIMARY; WMKO/DCS astrometry unavailable")
             return None
-        record = {"source_id": primary.get("OBJECT")}
-        record.update({field: primary.get(card) for field, card in _WMKO_KEYS.items()})
+        self._verify_wmko_format(primary)
+        dec_deg = Angle(primary["TARGDEC"], unit=u.deg).deg
+        pmra = self._scalar(primary.get("TARGPMRA"))
+        pmdec = self._scalar(primary.get("TARGPMDC"))
+        record = {
+            "source_id": primary.get("OBJECT"),
+            "ra": Angle(primary["TARGRA"], unit=u.hourangle).to(u.deg).value,
+            "dec": dec_deg,
+            "pmra": None
+            if pmra is None
+            else pmra * 15.0 * np.cos(np.radians(dec_deg)) * 1e3,
+            "pmdec": None if pmdec is None else pmdec * 1e3,
+            "parallax": self._scalar(primary.get("TARGPLAX")),
+            "rv": self._scalar(primary.get("TARGRADV")),
+            "frame": "icrs",
+            "epoch": self._scalar(primary.get("TARGEPOC")),
+            "equinox": self._scalar(primary.get("TARGEQUI")),
+        }
         logger.info("successfully built record for wmko")
         return record
 
     def query_gaia(self):
         """Query Gaia DR3 for the target's ICRS astrometry, or None (fail-soft).
 
-        Returns None when disabled, when L0 GAIAID yields no usable source_id, or
-        when the lookup fails (warned, not raised). Values are Gaia-native: deg,
-        mas/yr, mas, km/s, and ref_epoch in Julian years.
+        Returns None (warned) when disabled, when GAIAID yields no usable
+        source_id, when the lookup fails, or when the source is not found. Raises
+        ValueError if the result's column units differ from the assumed canonical
+        schema (deg, mas/yr, mas, km/s, epoch in Julian years; ICRS).
         """
         if not self.use_gaia:
             return None
@@ -179,7 +263,7 @@ class AstroQuery:
         """
         logger.info("querying Gaia DR3 for source_id %s", gaia_id)
         try:
-            row = Gaia.launch_job(query).get_results()[0]
+            results = Gaia.launch_job(query).get_results()
         except Exception as e:
             logger.warning(
                 "Gaia query failed (%s: %s); Gaia astrometry unavailable",
@@ -187,6 +271,14 @@ class AstroQuery:
                 e,
             )
             return None
+        if len(results) == 0:
+            logger.warning(
+                "Gaia returned no match for source_id %s; Gaia astrometry unavailable",
+                gaia_id,
+            )
+            return None
+        self._verify_units(results, _GAIA_UNITS, "Gaia DR3")
+        row = results[0]
         record = {
             "source_id": gaia_id,
             "ra": self._scalar(row["ra"]),
@@ -206,13 +298,14 @@ class AstroQuery:
         """Query SIMBAD for the OBJECT's ICRS J2000 astrometry, or None (fail-soft).
 
         Returns None when disabled, when L0 has no OBJECT name, or when the lookup
-        fails / resolves nothing (warned, not raised). Column schema is the
+        fails / resolves nothing (warned, not raised). Raises ValueError if the
+        result's column units differ from the assumed schema. Column schema is the
         astroquery 0.4.11 lowercase form (ra/dec deg, pmra/pmdec mas/yr, plx_value
         mas, rvz_radvel km/s).
         """
         if not self.use_simbad:
             return None
-        name = self._object_name()
+        name = self._simbad_resolvable_name()
         if name is None:
             logger.warning(
                 "no OBJECT name on L0 PRIMARY; SIMBAD astrometry unavailable"
@@ -235,6 +328,7 @@ class AstroQuery:
                 "SIMBAD returned no match for %r; SIMBAD astrometry unavailable", name
             )
             return None
+        self._verify_units(result, _SIMBAD_UNITS, "SIMBAD")
         row = result[0]
         record = {
             "source_id": name,

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -102,8 +102,7 @@ class AstroQuery:
         GAIAID may arrive as a prefixed string (e.g. 'Gaia DR3 12345'); take the
         trailing token and require it to be all digits.
         """
-        primary = self.l0_obj.headers.get("PRIMARY")
-        raw = primary.get("GAIAID") if primary is not None else None
+        raw = self.l0_obj.headers["PRIMARY"].get("GAIAID")
         if raw is None:
             return None
         token = str(raw).strip().split()[-1] if str(raw).strip() else ""
@@ -115,8 +114,7 @@ class AstroQuery:
         KPF OBJECT for standard stars is a bare HD number (e.g. '10700') that
         SIMBAD resolves only with an 'HD ' prefix; named targets pass through.
         """
-        primary = self.l0_obj.headers.get("PRIMARY")
-        obj = primary.get("OBJECT") if primary is not None else None
+        obj = self.l0_obj.headers["PRIMARY"].get("OBJECT")
         if obj is None:
             return None
         obj = str(obj).strip()
@@ -150,11 +148,13 @@ class AstroQuery:
         record schema, or None when the frame carries no target pointing (TARGRA
         absent -- e.g. a calibration frame).
         """
-        primary = self.l0_obj.headers.get("PRIMARY")
-        if primary is None or primary.get("TARGRA") is None:
+        primary = self.l0_obj.headers["PRIMARY"]
+        if primary.get("TARGRA") is None:
+            logger.warning("no TARGRA on L0 PRIMARY; WMKO/DCS astrometry unavailable")
             return None
         record = {"source_id": primary.get("OBJECT")}
         record.update({field: primary.get(card) for field, card in _WMKO_KEYS.items()})
+        logger.info("successfully built record for wmko")
         return record
 
     def query_gaia(self):
@@ -168,7 +168,9 @@ class AstroQuery:
             return None
         gaia_id = self._gaia_source_id()
         if gaia_id is None:
-            logger.debug("no usable GAIAID on L0 PRIMARY; skipping Gaia query")
+            logger.warning(
+                "no usable GAIAID on L0 PRIMARY; Gaia astrometry unavailable"
+            )
             return None
         query = f"""
         SELECT ra, dec, pmra, pmdec, parallax, radial_velocity, ref_epoch
@@ -179,9 +181,13 @@ class AstroQuery:
         try:
             row = Gaia.launch_job(query).get_results()[0]
         except Exception as e:
-            logger.warning("Gaia query failed (%s: %s); skipping", type(e).__name__, e)
+            logger.warning(
+                "Gaia query failed (%s: %s); Gaia astrometry unavailable",
+                type(e).__name__,
+                e,
+            )
             return None
-        return {
+        record = {
             "source_id": gaia_id,
             "ra": self._scalar(row["ra"]),
             "dec": self._scalar(row["dec"]),
@@ -193,6 +199,8 @@ class AstroQuery:
             "epoch": self._scalar(row["ref_epoch"]),
             "equinox": 2000.0,
         }
+        logger.info("successfully built record for gaia")
+        return record
 
     def query_simbad(self):
         """Query SIMBAD for the OBJECT's ICRS J2000 astrometry, or None (fail-soft).
@@ -206,7 +214,9 @@ class AstroQuery:
             return None
         name = self._object_name()
         if name is None:
-            logger.debug("no OBJECT name on L0 PRIMARY; skipping SIMBAD query")
+            logger.warning(
+                "no OBJECT name on L0 PRIMARY; SIMBAD astrometry unavailable"
+            )
             return None
         logger.info("querying SIMBAD for %r", name)
         try:
@@ -215,14 +225,18 @@ class AstroQuery:
             result = simbad.query_object(name)
         except Exception as e:
             logger.warning(
-                "SIMBAD query failed (%s: %s); skipping", type(e).__name__, e
+                "SIMBAD query failed (%s: %s); SIMBAD astrometry unavailable",
+                type(e).__name__,
+                e,
             )
             return None
         if result is None or len(result) == 0:
-            logger.warning("SIMBAD returned no match for %r; skipping", name)
+            logger.warning(
+                "SIMBAD returned no match for %r; SIMBAD astrometry unavailable", name
+            )
             return None
         row = result[0]
-        return {
+        record = {
             "source_id": name,
             "ra": self._scalar(row["ra"]),
             "dec": self._scalar(row["dec"]),
@@ -234,6 +248,8 @@ class AstroQuery:
             "epoch": 2000.0,
             "equinox": 2000.0,
         }
+        logger.info("successfully built record for simbad")
+        return record
 
     # ------------------------------------------------------------------
     # Private helpers - module execution

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -65,6 +65,8 @@ _GAIA_UNITS = {
     "parallax": u.mas,
     "radial_velocity": u.km / u.s,
     "ref_epoch": u.yr,
+    "phot_bp_mean_mag": u.mag,
+    "phot_rp_mean_mag": u.mag,
 }
 _SIMBAD_UNITS = {
     "ra": u.deg,
@@ -73,6 +75,8 @@ _SIMBAD_UNITS = {
     "pmdec": u.mas / u.yr,
     "plx_value": u.mas,
     "rvz_radvel": u.km / u.s,
+    "B": None,
+    "V": None,
 }
 
 # CATALOG_RECORD write schema (AstroQuery is the sole populator): one row per resolved
@@ -82,8 +86,11 @@ _SIMBAD_UNITS = {
 # row, the winning source (or "" if none) for the merged row. Values are in the EPRV
 # C*# PRIMARY format: RA/Dec sexagesimal strings (RA hour-angle, Dec deg, ICRS), PM
 # arcsec/yr (RA incl. cos Dec), parallax mas, rv km/s, z the dimensionless relativistic
-# redshift derived from rv, epoch/equinox Julian years. Missing floats -> NaN, missing
-# strings -> "".
+# redshift derived from rv, epoch/equinox Julian years. color is a photometric color
+# index (a magnitude difference, mag) and color_name labels which one, differing by
+# source: Gaia "Gaia BP-RP" (G_BP - G_RP), SIMBAD "B-V" (Johnson B - V), WMKO "G-J"
+# (GAIAMAG - 2MASSMAG); both blank when the source lacks a needed magnitude. Missing
+# floats -> NaN, strings -> "".
 _CATALOG_COLUMNS = (
     "source",
     "object",
@@ -100,9 +107,21 @@ _CATALOG_COLUMNS = (
     "frame",
     "epoch",
     "equinox",
+    "color",
+    "color_name",
 )
 _CATALOG_STR_COLUMNS = frozenset(
-    {"source", "object", "radec_src", "plx_src", "rv_src", "frame", "ra", "dec"}
+    {
+        "source",
+        "object",
+        "radec_src",
+        "plx_src",
+        "rv_src",
+        "frame",
+        "ra",
+        "dec",
+        "color_name",
+    }
 )
 
 # RA / DEC are sexagesimal strings, so not subject to astropy unit conversion
@@ -114,6 +133,7 @@ _CATALOG_UNITS = {
     "z": u.dimensionless_unscaled,
     "epoch": u.yr,
     "equinox": u.yr,
+    "color": u.mag,
 }
 # Presence flag written to the CATALOG_RECORD header per source (int 0/1). DiagL0 keeps
 # its own local mirror (the DiagL0 convention of not importing this schema).
@@ -229,6 +249,18 @@ class AstroQuery:
         return float(compute_redshift(rv_kms * u.km / u.s))
 
     @staticmethod
+    def _color(blue_mag, red_mag, name):
+        """The (color, color_name) pair for a bluer-minus-redder magnitude difference.
+
+        Returns ``(blue_mag - red_mag, name)``, or ``(None, None)`` when either
+        magnitude is missing -- a color index needs both, and pairing the value with
+        its label keeps a blank color from carrying an orphan name.
+        """
+        if blue_mag is None or red_mag is None:
+            return None, None
+        return blue_mag - red_mag, name
+
+    @staticmethod
     def _sexagesimal_radec(coord):
         """ICRS SkyCoord -> the EPRV C*# sexagesimal (ra, dec) strings.
 
@@ -296,11 +328,12 @@ class AstroQuery:
         for name in _CATALOG_COLUMNS:
             if name in _CATALOG_STR_COLUMNS:
                 new_table[name] = np.array(
-                    ["" if r[name] is None else r[name] for r in ordered], dtype=str
+                    ["" if r.get(name) is None else r.get(name) for r in ordered],
+                    dtype=str,
                 )
             else:
                 new_table[name] = np.array(
-                    [np.nan if r[name] is None else r[name] for r in ordered],
+                    [np.nan if r.get(name) is None else r.get(name) for r in ordered],
                     dtype=float,
                 )
                 new_table[name].unit = _CATALOG_UNITS[name]
@@ -319,8 +352,8 @@ class AstroQuery:
         Returns None (warned) when GAIAID yields no usable source_id, when the
         lookup fails, or when the source is not found. Raises ValueError if the
         result's column units differ from the assumed canonical schema (deg,
-        mas/yr, mas, km/s, epoch in Julian years; ICRS). Whether it runs at all is
-        gated upstream in perform by ``do_gaia_query``.
+        mas/yr, mas, km/s, epoch in Julian years, BP/RP magnitudes in mag; ICRS).
+        Whether it runs at all is gated upstream in perform by ``do_gaia_query``.
         """
         gaia_id = self._gaia_source_id()
         if gaia_id is None:
@@ -329,7 +362,8 @@ class AstroQuery:
             )
             return None
         query = f"""
-        SELECT ra, dec, pmra, pmdec, parallax, radial_velocity, ref_epoch
+        SELECT ra, dec, pmra, pmdec, parallax, radial_velocity, ref_epoch,
+               phot_bp_mean_mag, phot_rp_mean_mag
         FROM gaiadr3.gaia_source
         WHERE source_id = {gaia_id}
         """
@@ -358,6 +392,11 @@ class AstroQuery:
         ra_str, dec_str = self._sexagesimal_radec(
             SkyCoord(ra, dec, unit=u.deg, frame="icrs")
         )
+        color, color_name = self._color(
+            self._scalar(row["phot_bp_mean_mag"]),
+            self._scalar(row["phot_rp_mean_mag"]),
+            "Gaia BP-RP",
+        )
         record = {
             "object": gaia_id,
             "ra": ra_str,
@@ -372,6 +411,8 @@ class AstroQuery:
             "frame": "icrs",
             "epoch": self._scalar(row["ref_epoch"]),
             "equinox": 2000.0,
+            "color": color,
+            "color_name": color_name,
         }
         logger.info("successfully built record for gaia")
         self._write_catalog_record("gaia", record)
@@ -384,8 +425,9 @@ class AstroQuery:
         resolves nothing (warned, not raised). Raises ValueError if the result's
         column units differ from the assumed schema. Column schema is the
         astroquery 0.4.11 lowercase form (ra/dec deg, pmra/pmdec mas/yr, plx_value
-        mas, rvz_radvel km/s). Whether it runs at all is gated upstream in perform
-        by ``do_simbad_query``.
+        mas, rvz_radvel km/s); the Johnson B/V magnitude columns come back unlabeled
+        (unit None) and form the B-V color. Whether it runs at all is gated upstream
+        in perform by ``do_simbad_query``.
         """
         name = self._simbad_resolvable_name()
         if name is None:
@@ -396,7 +438,7 @@ class AstroQuery:
         logger.info("querying SIMBAD for %r", name)
         try:
             simbad = Simbad()
-            simbad.add_votable_fields("pmra", "pmdec", "plx", "rvz_radvel")
+            simbad.add_votable_fields("pmra", "pmdec", "plx", "rvz_radvel", "B", "V")
             result = simbad.query_object(name)
         except Exception as e:
             logger.warning(
@@ -419,6 +461,9 @@ class AstroQuery:
         ra_str, dec_str = self._sexagesimal_radec(
             SkyCoord(ra, dec, unit=u.deg, frame="icrs")
         )
+        color, color_name = self._color(
+            self._scalar(row["B"]), self._scalar(row["V"]), "B-V"
+        )
         record = {
             "object": name,
             "ra": ra_str,
@@ -434,6 +479,8 @@ class AstroQuery:
             "frame": "icrs",
             "epoch": 2000.0,
             "equinox": 2000.0,
+            "color": color,
+            "color_name": color_name,
         }
         logger.info("successfully built record for simbad")
         self._write_catalog_record("simbad", record)
@@ -447,7 +494,8 @@ class AstroQuery:
         arcsec/yr via x15 cos Dec; TARGPMDC already arcsec/yr) and rotated from its
         native FK5 (J2000) to ICRS, so all three sources share one frame. KPF pointing
         is always FK5, so a non-FK5 TARGFRAM (absent included) raises rather than being
-        coerced -- a wrong frame would corrupt the barycentric correction. Returns None
+        coerced -- a wrong frame would corrupt the barycentric correction. The G-J color
+        comes straight off PRIMARY (GAIAMAG - 2MASSMAG), no frame handling. Returns None
         (WMKOCR=0) when there is no pointing (TARGRA absent) or the TARG* astrometry
         cannot be parsed (warned, never raised). Gated upstream in perform by
         ``use_wmko_tcs``.
@@ -488,6 +536,11 @@ class AstroQuery:
             icrs = SkyCoord(**components).transform_to(ICRS())
 
             ra_str, dec_str = self._sexagesimal_radec(icrs)
+            color, color_name = self._color(
+                self._scalar(primary.get("GAIAMAG")),
+                self._scalar(primary.get("2MASSMAG")),
+                "G-J",
+            )
             record = {
                 "object": primary.get("OBJECT"),
                 "ra": ra_str,
@@ -499,6 +552,8 @@ class AstroQuery:
                 "frame": "icrs",
                 "epoch": self._scalar(primary.get("TARGEPOC")),
                 "equinox": 2000.0,
+                "color": color,
+                "color_name": color_name,
             }
         except Exception as exc:
             logger.warning(
@@ -523,9 +578,10 @@ class AstroQuery:
         those fields are one measurement and must not be spliced across catalogs. Its rv
         rides along; when that source has none (Gaia commonly lacks radial_velocity), rv
         falls back to the telescope TARGRADV on PRIMARY (not borrowed from a lower-
-        priority catalog). ``radec_src``/``plx_src`` name the astrometric source;
-        ``rv_src`` names the rv source ("wmko" for the TARGRADV fallback, "" when
-        nothing supplied it).
+        priority catalog). Its ``color``/``color_name`` ride along too (whichever the
+        base source carries, or blank). ``radec_src``/``plx_src`` name the astrometric
+        source; ``rv_src`` names the rv source ("wmko" for the TARGRADV fallback, ""
+        when nothing supplied).
 
         Raises ``ValueError`` when no source supplies a complete ra/dec/pmra/pmdec/
         parallax/epoch block -- without a position there is nothing to correct, so it
@@ -596,6 +652,8 @@ class AstroQuery:
             "frame": base_record["frame"],
             "epoch": base_record["epoch"],
             "equinox": base_record["equinox"],
+            "color": base_record["color"],
+            "color_name": base_record["color_name"],
         }
         self._canonical = record
         self._write_catalog_record("kpf-drp", record)

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -446,8 +446,11 @@ class AstroQuery:
         try:
             ra = Angle(primary["TARGRA"], unit=u.hourangle)
             dec = Angle(primary["TARGDEC"], unit=u.deg)
-            pmra, pmdec = primary.get("TARGPMRA"), primary.get("TARGPMDC")
-            equinox = primary.get("TARGEQUI")
+            pmra, pmdec = (
+                self._scalar(primary.get("TARGPMRA")),
+                self._scalar(primary.get("TARGPMDC")),
+            )
+            equinox = self._scalar(primary.get("TARGEQUI"))
 
             # Rotate the native FK5 pointing to ICRS. Position always; proper motion too
             # when both components are present (TARGPMRA time-s/yr -> arcsec/yr via x15
@@ -472,10 +475,10 @@ class AstroQuery:
                 "dec": dec_str,
                 "pmra": icrs.pm_ra_cosdec.to_value(u.arcsec / u.yr) if has_pm else None,
                 "pmdec": icrs.pm_dec.to_value(u.arcsec / u.yr) if has_pm else None,
-                "parallax": primary.get("TARGPLAX"),
-                "rv": primary.get("TARGRADV"),
+                "parallax": self._scalar(primary.get("TARGPLAX")),
+                "rv": self._scalar(primary.get("TARGRADV")),
                 "frame": "icrs",
-                "epoch": primary.get("TARGEPOC"),
+                "epoch": self._scalar(primary.get("TARGEPOC")),
                 "equinox": 2000.0,
             }
         except Exception as exc:

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -368,6 +368,11 @@ class AstroQuery:
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["parallax"]),
             "rv": self._scalar(row["radial_velocity"]),
+            # frame/equinox are catalog-definitional, not query columns: Gaia DR3
+            # astrometry is ICRS (Gaia-CRF3, aligned to ICRS) by construction, and
+            # ICRS carries no equinox -- 2000.0 is the J2000 convention the EPRV
+            # standard's Required CEQNX# demands. Only epoch is a real query output
+            # (ref_epoch, J2016.0 for DR3).
             "frame": "icrs",
             "epoch": self._scalar(row["ref_epoch"]),
             "equinox": 2000.0,
@@ -431,6 +436,12 @@ class AstroQuery:
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["plx_value"]),
             "rv": self._scalar(row["rvz_radvel"]),
+            # frame/epoch/equinox are all definitional here, not query columns:
+            # astroquery's SIMBAD returns basic ra/dec in ICRS at equinox and epoch
+            # J2000 by construction, with no per-object frame/epoch/equinox field to
+            # read. (Contrast query_gaia, whose epoch is the real ref_epoch column;
+            # SIMBAD's epoch is fixed at 2000.0 by the default output, not queried.)
+            # equinox 2000.0 satisfies the EPRV standard's Required CEQNX#.
             "frame": "icrs",
             "epoch": 2000.0,
             "equinox": 2000.0,

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -561,8 +561,10 @@ class AstroQuery:
         those fields are one measurement and must not be spliced across catalogs. Its rv
         rides along; when that source has none (Gaia commonly lacks radial_velocity), rv
         falls back to the telescope TARGRADV on PRIMARY (not borrowed from a lower-
-        priority catalog). Its ``color``/``color_name`` ride along too (whichever the
-        base source carries, or blank). ``radec_src``/``plx_src`` name the astrometric
+        priority catalog). ``color``/``color_name`` ride along from the base source;
+        if it carries none, the highest-priority catalog that has a color supplies it
+        with a mixed-catalog warning (a color index is independent of the astrometry),
+        or blank when no source has one. ``radec_src``/``plx_src`` name the astrometric
         source; ``rv_src`` names the rv source ("wmko" for the TARGRADV fallback, ""
         when nothing supplied).
 
@@ -617,6 +619,23 @@ class AstroQuery:
                     rv_value,
                 )
 
+        # color/color_name from the base source; if it has none, borrow the highest-
+        # priority catalog that does. A color index is independent of the astrometry,
+        # so a mixed source is acceptable but flagged (mirrors the rv fallback).
+        color = base_record["color"]
+        color_name = base_record["color_name"]
+        if color is None:
+            for source, candidate in candidates:
+                if candidate["color"] is not None:
+                    color, color_name = candidate["color"], candidate["color_name"]
+                    logger.warning(
+                        "%s astrometric base has no color; using the %s %s color",
+                        base_source,
+                        source,
+                        color_name,
+                    )
+                    break
+
         record = {
             "object": base_record["object"],
             "radec_src": base_source,
@@ -631,8 +650,8 @@ class AstroQuery:
             "frame": base_record["frame"],
             "epoch": base_record["epoch"],
             "equinox": base_record["equinox"],
-            "color": base_record["color"],
-            "color_name": base_record["color_name"],
+            "color": color,
+            "color_name": color_name,
         }
         self._canonical = record
         self._write_catalog_record("kpf-drp", record)

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -15,17 +15,19 @@ than write PRIMARY here, AstroQuery records the queried quantities on the L0 and
 lets ``to_kpf1()`` overlay them onto the L1 PRIMARY (a follow-up integration).
 
 AstroQuery never modifies the L0 PRIMARY header -- that header is a pure
-pass-through to INSTRUMENT_HEADER. All three records share one schema and one set
-of units and reference frame, so a consumer reads any source identically: ICRS,
-RA/Dec in degrees, proper motion in mas/yr (RA including cos(Dec)), parallax in
-mas, RV in km/s, epoch/equinox in Julian years. Per-fiber fan-out and derived
-quantities (offsets, redshift) remain the jobs of downstream consumers.
+pass-through to INSTRUMENT_HEADER. All three records share one schema, sanitized to
+the EPRV C*# PRIMARY format so a consumer reads any source identically and to_kpf1
+can copy cells straight onto the catalog cards: ICRS, RA/Dec as sexagesimal strings
+(RA hour-angle, Dec deg), proper motion in arcsec/yr (RA including cos(Dec)),
+parallax in mas, RV in km/s, epoch/equinox in Julian years. Per-fiber fan-out and
+derived quantities (offsets, redshift) remain the jobs of downstream consumers.
 """
 
 import logging
 
 import astropy.units as u
 import numpy as np
+from astropy.coordinates import Angle
 from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
@@ -48,12 +50,16 @@ _DEFAULTS = {
 # DiagL0 convention of not importing the private schema).
 _MERGE_PRIORITY = ("gaia", "simbad", "wmko")
 _PRESENCE_FLAGS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
-# The position block is taken together from one source so ra/dec/PM/epoch stay
-# internally consistent; parallax and rv are filled per-column.
-_POSITION_FIELDS = ("ra", "dec", "pmra", "pmdec", "epoch")
-_MERGE_STR_FIELDS = frozenset({"source_id", "frame"})
+# The position block is taken together from one source so ra/dec/PM and their frame
+# and reference epoch stay internally consistent -- a frame or epoch from a different
+# source than the coordinates would be meaningless. equinox rides with the same base
+# (an ICRS formality) but is not gated, so a WMKO base missing TARGEQUI still
+# qualifies. parallax and rv are the only per-column fills. All of frame/epoch/equinox
+# therefore share the row's radec_src provenance.
+_POSITION_FIELDS = ("ra", "dec", "pmra", "pmdec", "epoch", "frame")
+_MERGE_STR_FIELDS = frozenset({"object", "frame", "ra", "dec"})
 _MERGE_READ_FIELDS = (
-    "source_id",
+    "object",
     "ra",
     "dec",
     "pmra",
@@ -245,12 +251,24 @@ class AstroQuery:
             return None
         self._verify_units(results, _GAIA_UNITS, "Gaia DR3")
         row = results[0]
+        ra, dec = self._scalar(row["ra"]), self._scalar(row["dec"])
+        pmra, pmdec = self._scalar(row["pmra"]), self._scalar(row["pmdec"])
+        # Sanitize to the EPRV C*# format: RA/Dec deg -> sexagesimal (RA hour-angle,
+        # Dec deg); proper motion mas/yr -> arcsec/yr.
         record = {
-            "source_id": gaia_id,
-            "ra": self._scalar(row["ra"]),
-            "dec": self._scalar(row["dec"]),
-            "pmra": self._scalar(row["pmra"]),
-            "pmdec": self._scalar(row["pmdec"]),
+            "object": gaia_id,
+            "ra": None
+            if ra is None
+            else Angle(ra, u.deg).to_string(
+                unit=u.hourangle, sep=":", pad=True, precision=4
+            ),
+            "dec": None
+            if dec is None
+            else Angle(dec, u.deg).to_string(
+                unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
+            ),
+            "pmra": None if pmra is None else pmra / 1e3,
+            "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["parallax"]),
             "rv": self._scalar(row["radial_velocity"]),
             "frame": "icrs",
@@ -296,12 +314,24 @@ class AstroQuery:
             return None
         self._verify_units(result, _SIMBAD_UNITS, "SIMBAD")
         row = result[0]
+        ra, dec = self._scalar(row["ra"]), self._scalar(row["dec"])
+        pmra, pmdec = self._scalar(row["pmra"]), self._scalar(row["pmdec"])
+        # Sanitize to the EPRV C*# format: RA/Dec deg -> sexagesimal (RA hour-angle,
+        # Dec deg); proper motion mas/yr -> arcsec/yr.
         record = {
-            "source_id": name,
-            "ra": self._scalar(row["ra"]),
-            "dec": self._scalar(row["dec"]),
-            "pmra": self._scalar(row["pmra"]),
-            "pmdec": self._scalar(row["pmdec"]),
+            "object": name,
+            "ra": None
+            if ra is None
+            else Angle(ra, u.deg).to_string(
+                unit=u.hourangle, sep=":", pad=True, precision=4
+            ),
+            "dec": None
+            if dec is None
+            else Angle(dec, u.deg).to_string(
+                unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
+            ),
+            "pmra": None if pmra is None else pmra / 1e3,
+            "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["plx_value"]),
             "rv": self._scalar(row["rvz_radvel"]),
             "frame": "icrs",
@@ -336,12 +366,17 @@ class AstroQuery:
 
         Combines the ``gaia``/``simbad``/``wmko`` rows (each gated by its ``use_*``
         toggle and presence flag) into one canonical record, in ``_MERGE_PRIORITY``
-        order: the coherent position block (ra/dec/pmra/pmdec/epoch, plus frame/equinox)
-        is taken together from the highest-priority source that supplies it complete,
-        while parallax and rv are each filled independently from the highest-priority
-        source that has them. ``astr_src`` records the position source's label; an
-        optional parallax/rv borrowed from a different source is a DEBUG-level note
-        (Gaia commonly lacks radial_velocity, so this is routine, not an error).
+        order: the coherent position block -- ra/dec/pmra/pmdec, plus the frame, epoch,
+        and equinox that make them meaningful -- is taken together from the highest-
+        priority source that supplies it complete, while parallax and rv are each filled
+        independently from the highest-priority source that has them. frame, epoch, and
+        equinox are intrinsic to the coordinates (a frame or epoch from another source
+        would be inconsistent), so they always ride with the position, sharing radec_src
+        provenance rather than getting their own labels. The three provenance labels
+        record where each block came from -- ``radec_src`` (position + frame/epoch/
+        equinox), ``plx_src`` (parallax), ``rv_src`` (rv), each "" when nothing supplied
+        it; a parallax/rv borrowed from a different source than the position is a DEBUG
+        note (Gaia commonly lacks radial_velocity, so this is routine, not an error).
 
         Raises ``ValueError`` when a coherent position block (ra, dec, pmra, pmdec,
         epoch) cannot be assembled from the enabled sources -- without a position there
@@ -413,8 +448,10 @@ class AstroQuery:
             )
 
         record = {
-            "source_id": base_record["source_id"],
-            "astr_src": base_source,
+            "object": base_record["object"],
+            "radec_src": base_source,
+            "plx_src": parallax_source if parallax_source is not None else "",
+            "rv_src": rv_source if rv_source is not None else "",
             "ra": base_record["ra"],
             "dec": base_record["dec"],
             "pmra": base_record["pmra"],
@@ -435,9 +472,9 @@ class AstroQuery:
 
     def _track_info(self):
         """Build and cache the info() summary text from instance attributes."""
-        gaia = self._gaia["source_id"] if self._gaia else "n/a"
-        simbad = self._simbad["source_id"] if self._simbad else "n/a"
-        canonical = self._canonical["astr_src"] if self._canonical else "n/a"
+        gaia = self._gaia["object"] if self._gaia else "n/a"
+        simbad = self._simbad["object"] if self._simbad else "n/a"
+        canonical = self._canonical["radec_src"] if self._canonical else "n/a"
         lines = [
             "AstroQuery",
             f"  obs_id:  {self.l0_obj.obs_id or 'unknown'}",

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -30,6 +30,7 @@ from astroquery.simbad import Simbad
 from kpfpipe import DEFAULTS
 from kpfpipe.utils.astro import compute_redshift
 from kpfpipe.utils.config import ConfigHandler
+from kpfpipe.utils.network import retry_request
 
 logger = logging.getLogger(__name__)
 
@@ -336,9 +337,10 @@ class AstroQuery:
         """Query Gaia DR3 for the target's ICRS astrometry, or None (fail-soft).
 
         Returns None (warned) when GAIAID yields no usable source_id, when the
-        lookup fails, or when the source is not found. Raises ValueError if the
-        result's column units differ from the assumed canonical schema (deg,
-        mas/yr, mas, km/s, epoch in Julian years, BP/RP magnitudes in mag; ICRS).
+        lookup fails (after the transient-failure retries in ``retry_request``), or
+        when the source is not found. Raises ValueError if the result's column units
+        differ from the assumed canonical schema (deg, mas/yr, mas, km/s, epoch in
+        Julian years, BP/RP magnitudes in mag; ICRS).
         Whether it runs at all is gated upstream in perform by ``do_gaia_query``.
         """
         gaia_id = self._gaia_source_id()
@@ -355,7 +357,9 @@ class AstroQuery:
         """
         logger.info("querying Gaia DR3 for source_id %s", gaia_id)
         try:
-            results = Gaia.launch_job(query).get_results()
+            results = retry_request(
+                lambda: Gaia.launch_job(query).get_results(), "Gaia DR3"
+            )
         except Exception as e:
             logger.warning(
                 "Gaia query failed (%s: %s); Gaia astrometry unavailable",
@@ -406,9 +410,10 @@ class AstroQuery:
     def query_simbad(self):
         """Query SIMBAD for the OBJECT's ICRS J2000 astrometry, or None (fail-soft).
 
-        Returns None when L0 has no OBJECT name, or when the lookup fails /
-        resolves nothing (warned, not raised). Raises ValueError if the result's
-        column units differ from the assumed schema. Column schema is the
+        Returns None when L0 has no OBJECT name, or when the lookup fails (after the
+        transient-failure retries in ``retry_request``) / resolves nothing (warned,
+        not raised). Raises ValueError if the result's column units differ from the
+        assumed schema. Column schema is the
         astroquery 0.4.11 lowercase form (ra/dec deg, pmra/pmdec mas/yr, plx_value
         mas, rvz_radvel km/s); the Johnson B/V magnitude columns come back unlabeled
         (unit None) and form the B-V color. Whether it runs at all is gated upstream
@@ -426,7 +431,7 @@ class AstroQuery:
             simbad.add_votable_fields(
                 "pmra", "pmdec", "plx_value", "rvz_radvel", "B", "V"
             )
-            result = simbad.query_object(name)
+            result = retry_request(lambda: simbad.query_object(name), "SIMBAD")
         except Exception as e:
             logger.warning(
                 "SIMBAD query failed (%s: %s); SIMBAD astrometry unavailable",

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -15,13 +15,11 @@ EPRV PRIMARY conversion does not happen until ``KPF0.to_kpf1()`` downstream. Rat
 than write PRIMARY here, AstroQuery records the queried quantities on the L0 and
 lets ``to_kpf1()`` overlay them onto the L1 PRIMARY (a follow-up integration).
 
-AstroQuery never modifies the L0 PRIMARY header -- that header is a pure
-pass-through to INSTRUMENT_HEADER. All three records share one schema, sanitized to
-the EPRV C*# PRIMARY format so a consumer reads any source identically and to_kpf1
-can copy cells straight onto the catalog cards: ICRS, RA/Dec as sexagesimal strings
-(RA hour-angle, Dec deg), proper motion in arcsec/yr (RA including cos(Dec)),
-parallax in mas, RV in km/s, epoch/equinox in Julian years. Per-fiber fan-out and
-derived quantities (offsets, redshift) remain the jobs of downstream consumers.
+AstroQuery never modifies the L0 PRIMARY header (a pure pass-through to
+INSTRUMENT_HEADER). All three source rows and the merged ``kpf-drp`` row share one
+schema in the EPRV C*# PRIMARY format (see ``_CATALOG_COLUMNS``), so a consumer reads
+any source identically and ``to_kpf1`` can copy cells straight onto the catalog cards.
+Per-fiber fan-out and derived quantities (offsets, redshift) are downstream jobs.
 """
 
 import logging
@@ -46,13 +44,13 @@ _DEFAULTS = {
     "use_wmko_tcs": True,
 }
 
-# Fields that together make a coherent position block: the merge takes them from a
-# single source so ra/dec/PM and the frame/epoch that qualify them stay internally
-# consistent -- a frame or epoch from a different source than the coordinates would
-# be meaningless. equinox is not gated (an ICRS formality), so a WMKO base missing
-# TARGEQUI still qualifies; frame/epoch/equinox share the position's radec_src
-# provenance. Merge priority (highest first) is gaia > simbad > wmko.
-_POSITION_FIELDS = ("ra", "dec", "pmra", "pmdec", "epoch", "frame")
+# The astrometric block the merge takes whole from one source: ra/dec/pmra/pmdec/
+# parallax are one astrometric fit -- proper motion without the parallax it was measured
+# against is nearly meaningless -- plus the frame/epoch that qualify the coordinates.
+# equinox is not gated (an ICRS formality), so a WMKO base missing TARGEQUI still
+# qualifies. rv is handled separately (base source, else TARGRADV). Priority (highest
+# first): gaia > simbad > wmko.
+_ASTROMETRY = ("ra", "dec", "pmra", "pmdec", "parallax", "epoch", "frame")
 
 # Column units AstroQuery assumes for each catalog result, verified before the
 # values are trusted so a silent upstream schema change fails loudly instead of
@@ -75,19 +73,14 @@ _SIMBAD_UNITS = {
     "rvz_radvel": u.km / u.s,
 }
 
-# CATALOG_RECORD extension write schema. AstroQuery is the sole populator: one row per
-# resolved source (wmko/gaia/simbad) plus the merged 'kpf-drp' canonical row. Columns:
-# 'source' (the row's nominal source), 'object' (the target name supplied to the
-# query), three provenance labels naming the source each value block came from --
-# 'radec_src' (ra/dec/pmra/pmdec plus their frame/epoch/equinox, intrinsic to the
-# coordinates and never sourced separately), 'plx_src' (parallax), 'rv_src' (rv) --
-# then the values. For a plain source row each provenance label is the row's own
-# 'source'; the merged row names whichever source won each block (or "" when none
-# supplied it). Every source is sanitized to the EPRV C*# PRIMARY format so
-# KPF0.to_kpf1 can copy cells straight onto the catalog cards: RA/Dec sexagesimal
-# strings (RA hour-angle 'h:m:s', Dec deg 'd:m:s', ICRS), proper motion arcsec/yr (RA
-# incl. cos Dec), parallax mas, RV km/s, epoch/equinox in Julian years. Float columns
-# hold NaN where a value is missing; string columns (RA/Dec included) hold "".
+# CATALOG_RECORD write schema (AstroQuery is the sole populator): one row per resolved
+# source (wmko/gaia/simbad) plus the merged 'kpf-drp' row. 'source' labels the row,
+# 'object' is the queried target name, and radec_src/plx_src/rv_src name the source each
+# value block (position, parallax, rv) came from -- its own 'source' for a plain source
+# row, the winning source (or "" if none) for the merged row. Values are in the EPRV
+# C*# PRIMARY format: RA/Dec sexagesimal strings (RA hour-angle, Dec deg, ICRS), PM
+# arcsec/yr (RA incl. cos Dec), parallax mas, rv km/s, epoch/equinox Julian years.
+# Missing floats -> NaN, missing strings -> "".
 _CATALOG_COLUMNS = (
     "source",
     "object",
@@ -222,12 +215,9 @@ class AstroQuery:
     def _sexagesimal_radec(coord):
         """ICRS SkyCoord -> the EPRV C*# sexagesimal (ra, dec) strings.
 
-        The single formatter for the canonical colon-separated 'h:m:s' cards
-        (RA hour-angle, Dec deg) shared by every CATALOG_RECORD source, so a
-        precision/padding change lands in one place. astropy's combined hmsdms
-        already pads and signs; we just split the two axes back apart. RA/Dec are
-        basic quantities -- a coord that cannot be built from them raises upstream
-        rather than being papered over.
+        The single formatter for the canonical colon-separated 'h:m:s' cards (RA
+        hour-angle, Dec deg), so a precision/padding change lands in one place.
+        astropy's combined hmsdms already pads and signs; we just split the two axes.
         """
         return tuple(coord.to_string("hmsdms", sep=":", precision=4).split())
 
@@ -253,18 +243,15 @@ class AstroQuery:
             )
 
     def _write_catalog_record(self, source, record):
-        """Upsert one source's row into the L0 CATALOG_RECORD extension + set its flag.
+        """Upsert one source's row into the L0 CATALOG_RECORD extension, set its flag.
 
-        The single writer for CATALOG_RECORD (``wmko``/``gaia``/``simbad`` and the
-        merged ``kpf-drp`` row). ``record`` is a canonical record dict (the
-        _CATALOG_COLUMNS fields minus ``source``) or None. The three provenance labels
-        (``radec_src``/``plx_src``/``rv_src``) default to ``source`` when the record
-        omits them (a source row's values are its own); the merged row supplies each
-        explicitly. Existing rows for other sources are preserved (upsert). A None
-        record clears the source's flag and writes no row; otherwise the row is
-        (re)written and the flag set to 1. A source without a registered presence flag
-        (e.g. ``kpf-drp``, which must always be present) writes no flag keyword. Missing
-        floats become NaN, missing strings "".
+        The sole writer for CATALOG_RECORD (``wmko``/``gaia``/``simbad`` and the merged
+        ``kpf-drp`` row). ``record`` is a canonical record dict or None; a None record
+        drops the source's row and clears its flag, otherwise the row is (re)written and
+        the flag set to 1. Provenance labels (``radec_src``/``plx_src``/``rv_src``)
+        default to ``source`` when the record omits them (a source row's values are its
+        own); the merged row supplies them explicitly. Other sources' rows are preserved
+        (upsert). ``kpf-drp`` writes no flag. Missing floats become NaN, strings "".
         """
         l0 = self.l0_obj
         table = l0.data["CATALOG_RECORD"]
@@ -360,11 +347,9 @@ class AstroQuery:
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["parallax"]),
             "rv": self._scalar(row["radial_velocity"]),
-            # frame/equinox are catalog-definitional, not query columns: Gaia DR3
-            # astrometry is ICRS (Gaia-CRF3, aligned to ICRS) by construction, and
-            # ICRS carries no equinox -- 2000.0 is the J2000 convention the EPRV
-            # standard's Required CEQNX# demands. Only epoch is a real query output
-            # (ref_epoch, J2016.0 for DR3).
+            # frame/equinox are definitional, not queried: Gaia DR3 is ICRS (Gaia-CRF3)
+            # with no equinox -- 2000.0 is the J2000 convention EPRV's Required CEQNX#
+            # demands. Only epoch (ref_epoch, J2016.0 for DR3) is a real query output.
             "frame": "icrs",
             "epoch": self._scalar(row["ref_epoch"]),
             "equinox": 2000.0,
@@ -423,12 +408,10 @@ class AstroQuery:
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["plx_value"]),
             "rv": self._scalar(row["rvz_radvel"]),
-            # frame/epoch/equinox are all definitional here, not query columns:
-            # astroquery's SIMBAD returns basic ra/dec in ICRS at equinox and epoch
-            # J2000 by construction, with no per-object frame/epoch/equinox field to
-            # read. (Contrast query_gaia, whose epoch is the real ref_epoch column;
-            # SIMBAD's epoch is fixed at 2000.0 by the default output, not queried.)
-            # equinox 2000.0 satisfies the EPRV standard's Required CEQNX#.
+            # frame/epoch/equinox are definitional here, not queried: astroquery's
+            # SIMBAD returns basic ra/dec as ICRS J2000, with no per-object
+            # frame/epoch/equinox to read (unlike Gaia's real ref_epoch). equinox 2000.0
+            # satisfies EPRV's Required CEQNX#.
             "frame": "icrs",
             "epoch": 2000.0,
             "equinox": 2000.0,
@@ -440,20 +423,15 @@ class AstroQuery:
     def read_wmko_header(self):
         """Read the native WMKO/DCS astrometry from L0 PRIMARY TARG*, or None.
 
-        The telescope-side counterpart to query_gaia/query_simbad: no external
-        query, just the raw TARG* pointing, sanitized to the EPRV C*# format --
-        TARGRA/TARGDEC sexagesimal reformatted to the canonical RA hour-angle / Dec
-        deg 'h:m:s' strings; TARGPMRA time-s/yr -> arcsec/yr (x15 cos Dec), TARGPMDC
-        already arcsec/yr. The native FK5 (J2000) pointing is then rotated to ICRS
-        here via astropy's tested SkyCoord machinery, so all three CATALOG_RECORD
-        sources share one frame (Gaia/SIMBAD are already ICRS) and nothing downstream
-        has to track fk5. KPF pointing is always FK5, so a TARGFRAM that is not FK5
-        (absent included) raises rather than being coerced -- a wrong frame would
-        silently corrupt the barycentric correction. Returns None -- so the frame gets
-        WMKOCR=0 -- when there is no target pointing (TARGRA absent) or the TARG*
-        astrometry cannot be parsed (warned, never raised, so a malformed file still
-        loads). Well-formedness is gated downstream by QCL0 (RADECOK), not here.
-        Whether it runs at all is gated upstream in perform by ``use_wmko_tcs``.
+        The telescope-side counterpart to query_gaia/query_simbad: no query, just the
+        raw TARG* pointing sanitized to the EPRV C*# format (TARGPMRA time-s/yr ->
+        arcsec/yr via x15 cos Dec; TARGPMDC already arcsec/yr) and rotated from its
+        native FK5 (J2000) to ICRS, so all three sources share one frame. KPF pointing
+        is always FK5, so a non-FK5 TARGFRAM (absent included) raises rather than being
+        coerced -- a wrong frame would corrupt the barycentric correction. Returns None
+        (WMKOCR=0) when there is no pointing (TARGRA absent) or the TARG* astrometry
+        cannot be parsed (warned, never raised). Gated upstream in perform by
+        ``use_wmko_tcs``.
         """
         primary = self.l0_obj.headers["PRIMARY"]
         if primary.get("TARGRA") is None:
@@ -471,12 +449,11 @@ class AstroQuery:
             pmra, pmdec = primary.get("TARGPMRA"), primary.get("TARGPMDC")
             equinox = primary.get("TARGEQUI")
 
-            # Rotate the native FK5 pointing to ICRS via SkyCoord. Position always;
-            # proper motion too when both components are present (TARGPMRA time-s/yr
-            # -> on-sky arcsec/yr via x15 cos Dec first -- a single component has no
-            # meaning under the rotation, so it is both-or-neither). A frame rotation
-            # carries no time propagation, so epoch is unchanged; parallax/RV are
-            # rotation-invariant and pass through untouched.
+            # Rotate the native FK5 pointing to ICRS. Position always; proper motion too
+            # when both components are present (TARGPMRA time-s/yr -> arcsec/yr via x15
+            # cos Dec first; a lone component is meaningless under rotation, so it is
+            # both-or-neither). Rotation carries no time propagation, so epoch is
+            # unchanged; parallax/RV are rotation-invariant.
             fk5 = FK5(
                 equinox="J2000" if equinox is None else Time(equinox, format="jyear")
             )
@@ -518,92 +495,72 @@ class AstroQuery:
 
         Consumes the in-memory gaia/simbad/wmko records this instance just built
         (``None`` for a source that was toggled off or resolved nothing), in priority
-        order gaia > simbad > wmko: the coherent position block -- ra/dec/pmra/pmdec
-        plus the frame, epoch, and equinox that make them meaningful -- is taken
-        together from the highest-priority source that supplies it complete, while
-        parallax and rv are each filled independently from the highest-priority source
-        that has them. frame/epoch/equinox are intrinsic to the coordinates and ride
-        with the position under its ``radec_src`` provenance. The three provenance
-        labels record where each block came from -- ``radec_src`` (position),
-        ``plx_src`` (parallax), ``rv_src`` (rv), each "" when nothing supplied it; a
-        parallax/rv borrowed from a source other than the position is a routine DEBUG
-        note (Gaia commonly lacks radial_velocity).
+        order gaia > simbad > wmko. The canonical record is the highest-priority source
+        that supplies a complete astrometric solution -- ra/dec/pmra/pmdec/parallax plus
+        the frame, epoch, and equinox that make them meaningful -- taken whole, since
+        those fields are one measurement and must not be spliced across catalogs. Its rv
+        rides along; when that source has none (Gaia commonly lacks radial_velocity), rv
+        falls back to the telescope TARGRADV on PRIMARY (not borrowed from a lower-
+        priority catalog). ``radec_src``/``plx_src`` name the astrometric source;
+        ``rv_src`` names the rv source ("wmko" for the TARGRADV fallback, "" when
+        nothing supplied it).
 
         Raises ``ValueError`` when no source supplies a complete ra/dec/pmra/pmdec/
-        epoch block -- without a position there is nothing to correct, so it must fail
-        loudly. parallax and rv are optional, left missing when no source has them.
+        parallax/epoch block -- without a position there is nothing to correct, so it
+        must fail loudly. rv is optional, left missing when neither the astrometric
+        source nor TARGRADV supplies it.
         """
-        # The source records are ours, just built and schema-clean (missing cells are
-        # None), so consume them directly in priority order -- no re-read of the table
-        # we just wrote, and a toggled-off source is already None.
-        candidates = [
-            (source, record)
-            for source, record in (
-                ("gaia", self._gaia),
-                ("simbad", self._simbad),
-                ("wmko", self._wmko),
-            )
-            if record is not None
-        ]
+        # Our own records, just built and schema-clean; assemble in priority order (a
+        # source toggled off or that resolved nothing is already None).
+        candidates = []
+        for source, record in (
+            ("gaia", self._gaia),
+            ("simbad", self._simbad),
+            ("wmko", self._wmko),
+        ):
+            if record is not None:
+                candidates.append((source, record))
 
-        base = next(
-            (
-                (source, record)
-                for source, record in candidates
-                if all(record[f] is not None for f in _POSITION_FIELDS)
-            ),
-            None,
-        )
-        if base is None:
+        # Take the whole astrometric block from the first source that has it complete;
+        # raise if none does (without a position there is nothing to correct).
+        base_source, base_record = None, None
+        for source, record in candidates:
+            if all(record[field] is not None for field in _ASTROMETRY):
+                base_source, base_record = source, record
+                break
+        if base_record is None:
             available = [source for source, _ in candidates]
             raise ValueError(
                 f"cannot build a canonical astrometry position for "
                 f"{self.l0_obj.obs_id or 'unknown'}: no source supplies a complete "
-                f"ra/dec/pmra/pmdec/epoch block (have {available})"
+                f"ra/dec/pmra/pmdec/parallax/epoch block (have {available})"
             )
-        base_source, base_record = base
 
-        # parallax and rv are optional; take each from the highest-priority source
-        # that has it, or leave missing.
-        parallax_source, parallax_value = next(
-            (
-                (source, record["parallax"])
-                for source, record in candidates
-                if record["parallax"] is not None
-            ),
-            (None, None),
-        )
-        rv_source, rv_value = next(
-            (
-                (source, record["rv"])
-                for source, record in candidates
-                if record["rv"] is not None
-            ),
-            (None, None),
-        )
-
-        mixed = [
-            f"{field}={src}"
-            for field, src in (("parallax", parallax_source), ("rv", rv_source))
-            if src is not None and src != base_source
-        ]
-        if mixed:
-            logger.debug(
-                "canonical astrometry mixes sources: position=%s, %s",
-                base_source,
-                ", ".join(mixed),
-            )
+        # rv from the base source, else telescope TARGRADV off PRIMARY -- independent of
+        # use_wmko_tcs (which gates only the wmko position row) and already km/s, so no
+        # conversion.
+        rv_value = base_record["rv"]
+        rv_source = base_source
+        if rv_value is None:
+            rv_value = self._scalar(self.l0_obj.headers["PRIMARY"].get("TARGRADV"))
+            rv_source = "wmko" if rv_value is not None else ""
+            if rv_value is not None:
+                logger.warning(
+                    "no catalog supplied a radial velocity; falling back to the "
+                    "telescope TARGRADV=%s km/s from L0 PRIMARY",
+                    rv_value,
+                )
 
         record = {
             "object": base_record["object"],
             "radec_src": base_source,
-            "plx_src": parallax_source if parallax_source is not None else "",
-            "rv_src": rv_source if rv_source is not None else "",
+            "plx_src": base_source,
+            "rv_src": rv_source,
             "ra": base_record["ra"],
             "dec": base_record["dec"],
             "pmra": base_record["pmra"],
             "pmdec": base_record["pmdec"],
-            "parallax": parallax_value,
+            "parallax": base_record["parallax"],
             "rv": rv_value,
             "frame": base_record["frame"],
             "epoch": base_record["epoch"],

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -3,7 +3,8 @@ KPF AstroQuery module.
 
 Consolidates the pipeline's external astronomical-catalog lookups into a single
 L0-stage module. Given a raw L0 science frame, it resolves the target's astrometry
-from Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), builds the telescope-native
+from Gaia (by GAIAID, whose release prefix picks the data release queried) and
+SIMBAD (by OBJECT), builds the telescope-native
 ``wmko`` row from the L0 PRIMARY ``TARG*`` astrometry (no query), merges them into a
 canonical ``kpf-drp`` row, and writes all four rows to the L0 ``CATALOG_RECORD``
 extension with the ``WMKOCR``/``GAIACR``/``SIMBADCR`` presence flags. AstroQuery is
@@ -70,6 +71,14 @@ _SIMBAD_UNITS = {
     "V": None,
 }
 
+# Queryable Gaia release -> its gaia_source table, newest last. DR1 and EDR3 are
+# excluded (no radial_velocity or BP/RP photometry, and superseded, respectively). Add
+# DR4 and DR5 here once they publish; until then they are neither probed nor accepted.
+_GAIA_TABLES = {
+    "DR2": "gaiadr2.gaia_source",
+    "DR3": "gaiadr3.gaia_source",
+}
+
 # CATALOG_RECORD write schema (AstroQuery is the sole populator): one row per resolved
 # source (wmko/gaia/simbad) plus the merged 'kpf-drp' row. radec_src/plx_src/rv_src
 # name the source each value block came from -- its own for a source row, the winner
@@ -131,7 +140,7 @@ class AstroQuery:
     """
     Resolve target astrometry from external catalogs and write it to an L0.
 
-    Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT),
+    Runs the two external catalog queries (Gaia by GAIAID, SIMBAD by OBJECT),
     builds the native ``wmko`` row from the L0 PRIMARY ``TARG*`` astrometry, and writes
     all three rows to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV
     ``C*#`` catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). Only
@@ -182,17 +191,78 @@ class AstroQuery:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _gaia_source_id(self):
-        """Digit-only Gaia DR3 id from L0 GAIAID, or None if absent/malformed.
+    def _gaia_source(self):
+        """``(release, source_id)`` from L0 GAIAID, or None if absent/unusable.
 
-        GAIAID may arrive as a prefixed string (e.g. 'Gaia DR3 12345'); take the
-        trailing token and require it to be all digits.
+        GAIAID names the release its id belongs to (e.g. 'DR3 12345'), which selects
+        the queried table -- a source_id denotes different stars across releases, so
+        the prefix is honored rather than discarded. ``release`` is None for a bare id
+        with no prefix, which ``_resolve_gaia_release`` then identifies against the
+        archive. Returns None when GAIAID is absent or blank, the trailing token is not
+        all digits, or the release is one this module cannot query (``_GAIA_TABLES``).
         """
         raw = self.l0_obj.headers["PRIMARY"].get("GAIAID")
         if raw is None:
             return None
-        token = str(raw).strip().split()[-1] if str(raw).strip() else ""
-        return token if token.isdigit() else None
+        tokens = str(raw).strip().split()
+        if not tokens or not tokens[-1].isdigit():
+            return None
+        source_id = tokens[-1]
+        if len(tokens) == 1:
+            return None, source_id
+        release = tokens[-2].upper()
+        return (release, source_id) if release in _GAIA_TABLES else None
+
+    def _resolve_gaia_release(self, source_id):
+        """The newest Gaia release whose gaia_source contains ``source_id``.
+
+        For a bare GAIAID only: rather than assume a release, probe the archive and
+        take the newest one that holds the id, since the same source_id denotes
+        different stars in different releases. A probe that fails is skipped rather
+        than aborting the search, so an unresolvable id still raises rather than being
+        mistaken for a resolved one.
+
+        Parameters
+        ----------
+        source_id : str
+            Digit-only Gaia source_id, with no release prefix.
+
+        Returns
+        -------
+        str
+            The release key into ``_GAIA_TABLES``.
+
+        Raises
+        ------
+        ValueError
+            No queryable release contains ``source_id``.
+        """
+        for release in sorted(_GAIA_TABLES, reverse=True):
+            query = (
+                f"SELECT source_id FROM {_GAIA_TABLES[release]} "
+                f"WHERE source_id = {source_id}"
+            )
+            try:
+                found = retry_request(
+                    lambda q=query: Gaia.launch_job(q).get_results(), f"Gaia {release}"
+                )
+            except Exception as e:
+                logger.debug(
+                    "could not probe Gaia %s for source_id %s (%s: %s); skipping it",
+                    release,
+                    source_id,
+                    type(e).__name__,
+                    e,
+                )
+                continue
+            if len(found):
+                logger.warning("resolved bare GAIAID %s to Gaia %s", source_id, release)
+                return release
+        raise ValueError(
+            f"GAIAID {source_id} carries no data release and no queryable Gaia release "
+            f"({', '.join(sorted(_GAIA_TABLES))}) contains that source_id; refusing to "
+            "guess which release it belongs to."
+        )
 
     def _simbad_resolvable_name(self):
         """SIMBAD-resolvable name from L0 PRIMARY OBJECT, or None if absent.
@@ -332,31 +402,46 @@ class AstroQuery:
     # ------------------------------------------------------------------
 
     def query_gaia(self):
-        """Query Gaia DR3 for the target's ICRS astrometry, or None (fail-soft).
+        """Query Gaia for the target's ICRS astrometry, or None (fail-soft).
 
-        Returns None (warned) when GAIAID yields no usable source_id, when the
+        The release named in GAIAID selects the queried table (``_GAIA_TABLES``), so a
+        DR2 id is never looked up among DR3 source_ids; a bare id with no release is
+        warned about and identified against the archive by ``_resolve_gaia_release``.
+        Returns None (warned) when GAIAID yields no usable release/source_id, when the
         lookup fails (after the transient-failure retries in ``retry_request``), or
-        when the source is not found. Raises ValueError if the result's column units
-        differ from the assumed canonical schema (deg, mas/yr, mas, km/s, epoch in
-        Julian years, BP/RP magnitudes in mag; ICRS).
+        when the source is not found. Raises ValueError if a bare id matches no
+        queryable release, or if the result's column units differ from the assumed
+        canonical schema (deg, mas/yr, mas, km/s, epoch in Julian years, BP/RP
+        magnitudes in mag; ICRS) -- the schema is shared across the supported
+        releases, so a release that breaks it fails loudly.
         Whether it runs at all is gated upstream in perform by ``do_gaia_query``.
         """
-        gaia_id = self._gaia_source_id()
-        if gaia_id is None:
+        source = self._gaia_source()
+        if source is None:
             logger.warning(
-                "no usable GAIAID on L0 PRIMARY; Gaia astrometry unavailable"
+                "no usable GAIAID on L0 PRIMARY (%r); Gaia astrometry unavailable "
+                "(queryable releases: %s)",
+                self.l0_obj.headers["PRIMARY"].get("GAIAID"),
+                ", ".join(sorted(_GAIA_TABLES)),
             )
             return None
+        release, gaia_id = source
+        if release is None:
+            logger.warning(
+                "GAIAID %r carries no data release; querying Gaia to identify it",
+                self.l0_obj.headers["PRIMARY"].get("GAIAID"),
+            )
+            release = self._resolve_gaia_release(gaia_id)
         query = f"""
         SELECT ra, dec, pmra, pmdec, parallax, radial_velocity, ref_epoch,
                phot_bp_mean_mag, phot_rp_mean_mag
-        FROM gaiadr3.gaia_source
+        FROM {_GAIA_TABLES[release]}
         WHERE source_id = {gaia_id}
         """
-        logger.info("querying Gaia DR3 for source_id %s", gaia_id)
+        logger.info("querying Gaia %s for source_id %s", release, gaia_id)
         try:
             results = retry_request(
-                lambda: Gaia.launch_job(query).get_results(), "Gaia DR3"
+                lambda: Gaia.launch_job(query).get_results(), f"Gaia {release}"
             )
         except Exception as e:
             logger.warning(
@@ -367,11 +452,13 @@ class AstroQuery:
             return None
         if len(results) == 0:
             logger.warning(
-                "Gaia returned no match for source_id %s; Gaia astrometry unavailable",
+                "Gaia %s returned no match for source_id %s; Gaia astrometry "
+                "unavailable",
+                release,
                 gaia_id,
             )
             return None
-        self._verify_units(results, _GAIA_UNITS, "Gaia DR3")
+        self._verify_units(results, _GAIA_UNITS, f"Gaia {release}")
         row = results[0]
         ra, dec = self._scalar(row["ra"]), self._scalar(row["dec"])
         pmra, pmdec = self._scalar(row["pmra"]), self._scalar(row["pmdec"])
@@ -385,16 +472,16 @@ class AstroQuery:
             "Gaia BP-RP",
         )
         record = {
-            "object": gaia_id,
+            "object": f"Gaia {release} {gaia_id}",
             "ra": ra_str,
             "dec": dec_str,
             "pmra": None if pmra is None else pmra / 1e3,
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["parallax"]),
             "rv": self._scalar(row["radial_velocity"]),
-            # frame/equinox are definitional, not queried: Gaia DR3 is ICRS (Gaia-CRF3)
-            # with no equinox -- 2000.0 is the J2000 convention EPRV's Required CEQNX#
-            # demands. Only epoch (ref_epoch, J2016.0 for DR3) is a real query output.
+            # frame/equinox are definitional, not queried: every Gaia release is ICRS
+            # (Gaia-CRF) with no equinox -- 2000.0 is the J2000 convention EPRV's
+            # Required CEQNX# demands. Only epoch (ref_epoch) is a real query output.
             "frame": "icrs",
             "epoch": self._scalar(row["ref_epoch"]),
             "equinox": 2000.0,

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -279,15 +279,16 @@ class AstroQuery:
             )
 
     def _write_catalog_record(self, source, record):
-        """Upsert one source's row into the L0 CATALOG_RECORD extension, set its flag.
+        """Upsert one source's row into the L0 CATALOG_RECORD extension.
 
         The sole writer for CATALOG_RECORD (``wmko``/``gaia``/``simbad`` and the merged
         ``kpf-drp`` row). ``record`` is a canonical record dict or None; a None record
-        drops the source's row and clears its flag, otherwise the row is (re)written and
-        the flag set to 1. Provenance labels (``radec_src``/``plx_src``/``rv_src``)
-        default to ``source`` when the record omits them (a source row's values are its
-        own); the merged row supplies them explicitly. Other sources' rows are preserved
-        (upsert). ``kpf-drp`` writes no flag. Missing floats become NaN, strings "".
+        drops the source's row, otherwise the row is (re)written. Provenance labels
+        (``radec_src``/``plx_src``/``rv_src``) default to ``source`` when the record
+        omits them (a source row's values are its own); the merged row supplies them
+        explicitly. Other sources' rows are preserved (upsert). Missing floats become
+        NaN, strings "". The matching presence flags are headers, so ``_set_headers``
+        writes them once at the end of perform.
         """
         l0 = self.l0_obj
         table = l0.data["CATALOG_RECORD"]
@@ -325,9 +326,6 @@ class AstroQuery:
                 )
                 new_table[name].unit = _CATALOG_UNITS[name]
         l0.set_data("CATALOG_RECORD", new_table)
-        flag = _CATALOG_FLAGS.get(source)
-        if flag is not None:
-            l0.set_keyword(flag, 1 if record is not None else 0)
 
     # ------------------------------------------------------------------
     # Algorithm steps
@@ -682,6 +680,22 @@ class AstroQuery:
         ]
         self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
+    def _set_headers(self, l0_obj):
+        """Sole place this module writes headers; reads instance attributes.
+
+        One presence flag per queryable source: 1 when that source resolved a record,
+        0 when it did not -- absent, gated off, or failed alike, since a consumer
+        cannot act on the difference. All three are always written, so a flag missing
+        from CATALOG_RECORD means AstroQuery never ran (what DiagL0 warns on). The
+        merged ``kpf-drp`` row has no flag; merge_catalog_records raises instead.
+        """
+        for source, record in (
+            ("wmko", self._wmko),
+            ("gaia", self._gaia),
+            ("simbad", self._simbad),
+        ):
+            l0_obj.set_keyword(_CATALOG_FLAGS[source], 1 if record is not None else 0)
+
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
@@ -720,6 +734,7 @@ class AstroQuery:
         # Merge the source rows into the canonical kpf-drp row; raises if no complete
         # position can be assembled.
         self.merge_catalog_records()
+        self._set_headers(self.l0_obj)
         self._track_info()
         self.l0_obj.receipt_add_entry("astro_query", "", "PASS")
 

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -235,6 +235,19 @@ class AstroQuery:
         return None if np.isnan(f) else f
 
     @staticmethod
+    def _sexagesimal_radec(coord):
+        """ICRS SkyCoord -> the EPRV C*# sexagesimal (ra, dec) strings.
+
+        The single formatter for the canonical colon-separated 'h:m:s' cards
+        (RA hour-angle, Dec deg) shared by every CATALOG_RECORD source, so a
+        precision/padding change lands in one place. astropy's combined hmsdms
+        already pads and signs; we just split the two axes back apart. RA/Dec are
+        basic quantities -- a coord that cannot be built from them raises upstream
+        rather than being papered over.
+        """
+        return tuple(coord.to_string("hmsdms", sep=":", precision=4).split())
+
+    @staticmethod
     def _verify_units(table, expected, source):
         """Verify a query result's column units before its values are trusted.
 
@@ -353,18 +366,13 @@ class AstroQuery:
         pmra, pmdec = self._scalar(row["pmra"]), self._scalar(row["pmdec"])
         # Sanitize to the EPRV C*# format: RA/Dec deg -> sexagesimal (RA hour-angle,
         # Dec deg); proper motion mas/yr -> arcsec/yr.
+        ra_str, dec_str = self._sexagesimal_radec(
+            SkyCoord(ra, dec, unit=u.deg, frame="icrs")
+        )
         record = {
             "object": gaia_id,
-            "ra": None
-            if ra is None
-            else Angle(ra, u.deg).to_string(
-                unit=u.hourangle, sep=":", pad=True, precision=4
-            ),
-            "dec": None
-            if dec is None
-            else Angle(dec, u.deg).to_string(
-                unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
-            ),
+            "ra": ra_str,
+            "dec": dec_str,
             "pmra": None if pmra is None else pmra / 1e3,
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["parallax"]),
@@ -421,18 +429,13 @@ class AstroQuery:
         pmra, pmdec = self._scalar(row["pmra"]), self._scalar(row["pmdec"])
         # Sanitize to the EPRV C*# format: RA/Dec deg -> sexagesimal (RA hour-angle,
         # Dec deg); proper motion mas/yr -> arcsec/yr.
+        ra_str, dec_str = self._sexagesimal_radec(
+            SkyCoord(ra, dec, unit=u.deg, frame="icrs")
+        )
         record = {
             "object": name,
-            "ra": None
-            if ra is None
-            else Angle(ra, u.deg).to_string(
-                unit=u.hourangle, sep=":", pad=True, precision=4
-            ),
-            "dec": None
-            if dec is None
-            else Angle(dec, u.deg).to_string(
-                unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
-            ),
+            "ra": ra_str,
+            "dec": dec_str,
             "pmra": None if pmra is None else pmra / 1e3,
             "pmdec": None if pmdec is None else pmdec / 1e3,
             "parallax": self._scalar(row["plx_value"]),
@@ -500,14 +503,11 @@ class AstroQuery:
                 components["pm_dec"] = pmdec * u.arcsec / u.yr
             icrs = SkyCoord(**components).transform_to(ICRS())
 
+            ra_str, dec_str = self._sexagesimal_radec(icrs)
             record = {
                 "object": primary.get("OBJECT"),
-                "ra": icrs.ra.to_string(
-                    unit=u.hourangle, sep=":", pad=True, precision=4
-                ),
-                "dec": icrs.dec.to_string(
-                    unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
-                ),
+                "ra": ra_str,
+                "dec": dec_str,
                 "pmra": icrs.pm_ra_cosdec.to_value(u.arcsec / u.yr) if has_pm else None,
                 "pmdec": icrs.pm_dec.to_value(u.arcsec / u.yr) if has_pm else None,
                 "parallax": primary.get("TARGPLAX"),

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -73,21 +73,30 @@ class AstroQuery:
     Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT)
     plus a verbatim snapshot of the DCS/TCS ``TARG*`` astrometry, and deposits all
     three on ``l0_obj.catalog_query`` for downstream use (EPRV ``C*#`` catalog
-    keywords, DiagL0 pointing offsets, BarycentricCorrection). Fail-soft: a frame
-    with no GAIAID/OBJECT (e.g. a calibration) or a failed network lookup yields a
+    keywords, DiagL0 pointing offsets, BarycentricCorrection). Only science frames
+    are supported: the constructor raises on a non-``Object`` IMTYPE (a calibration).
+    Fail-soft otherwise: a missing GAIAID/OBJECT or a failed network lookup yields a
     ``None`` record rather than an error.
 
     Parameters
     ----------
     l0_obj : KPF0
-        Raw L0 frame. Its PRIMARY header (GAIAID, OBJECT, TARG*) is read but never
-        modified; the resolved catalog data is attached as ``l0_obj.catalog_query``.
+        Raw L0 science frame (IMTYPE ``Object``). Its PRIMARY header (IMTYPE, GAIAID,
+        OBJECT, TARG*) is read but never modified; the resolved catalog data is
+        attached as ``l0_obj.catalog_query``.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: use_gaia, use_simbad.
     """
 
     def __init__(self, l0_obj, config=None):
         self.l0_obj = l0_obj
+
+        imtype = l0_obj.headers["PRIMARY"].get("IMTYPE")
+        if str(imtype).strip().lower() != "object":
+            raise ValueError(
+                f"AstroQuery runs only on science frames (IMTYPE 'Object'); got "
+                f"IMTYPE={imtype!r}. It must not be called on a calibration frame."
+            )
 
         if config is None:
             params = {}

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -4,13 +4,14 @@ KPF AstroQuery module.
 Consolidates every external astronomical-catalog lookup the pipeline needs into
 a single L0-stage module. Given a raw L0 frame, it resolves the target's
 astrometry from Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), and snapshots the
-DCS/TCS target astrometry already on the raw header, then hands all three back on
-a lightweight ``catalog_record`` dict attached to the L0 object.
+DCS/TCS target astrometry already on the raw header, then writes all three to the
+L0 ``CATALOG_RECORD`` extension -- a BinTable with one row per resolved source and
+``WMKOCR``/``GAIACR``/``SIMBADCR`` presence flags on its header.
 
-The dict is the bridge across an ordering problem: the query results ultimately
-belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO -> EPRV
-PRIMARY conversion does not happen until ``KPF0.to_kpf1()`` downstream. Rather
-than write headers here, AstroQuery tracks the queried quantities on the L0 and
+The extension is the bridge across an ordering problem: the query results
+ultimately belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO ->
+EPRV PRIMARY conversion does not happen until ``KPF0.to_kpf1()`` downstream. Rather
+than write PRIMARY here, AstroQuery records the queried quantities on the L0 and
 lets ``to_kpf1()`` overlay them onto the L1 PRIMARY (a follow-up integration).
 
 AstroQuery never modifies the L0 PRIMARY header -- that header is a pure
@@ -26,6 +27,7 @@ import logging
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import Angle
+from astropy.table import Table
 from astroquery.gaia import Gaia
 from astroquery.simbad import Simbad
 
@@ -65,15 +67,47 @@ _SIMBAD_UNITS = {
 _WMKO_FRAME = "FK5"
 _WMKO_EQUINOX = 2000.0
 
+# Schema of the CATALOG_RECORD BinTable extension: one row per resolved source,
+# carrying the canonical record fields plus a leading 'source' label. Float columns
+# hold NaN where a value is missing; string columns hold "". Units document the
+# canonical schema (deg, mas/yr incl. cos Dec, mas, km/s, Julian years).
+_CATALOG_COLUMNS = (
+    "source",
+    "source_id",
+    "ra",
+    "dec",
+    "pmra",
+    "pmdec",
+    "parallax",
+    "rv",
+    "frame",
+    "epoch",
+    "equinox",
+)
+_CATALOG_STR_COLUMNS = frozenset({"source", "source_id", "frame"})
+_CATALOG_UNITS = {
+    "ra": u.deg,
+    "dec": u.deg,
+    "pmra": u.mas / u.yr,
+    "pmdec": u.mas / u.yr,
+    "parallax": u.mas,
+    "rv": u.km / u.s,
+    "epoch": u.yr,
+    "equinox": u.yr,
+}
+# Presence flag written to the CATALOG_RECORD header per source (int 0/1).
+_CATALOG_FLAGS = {"wmko": "WMKOCR", "gaia": "GAIACR", "simbad": "SIMBADCR"}
+
 
 class AstroQuery:
     """
     Resolve target astrometry from external catalogs and attach it to an L0.
 
     Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT)
-    plus a verbatim snapshot of the DCS/TCS ``TARG*`` astrometry, and deposits all
-    three on ``l0_obj.catalog_record`` for downstream use (EPRV ``C*#`` catalog
-    keywords, DiagL0 pointing offsets, BarycentricCorrection). Only science frames
+    plus a verbatim snapshot of the DCS/TCS ``TARG*`` astrometry, and writes all
+    three to the L0 ``CATALOG_RECORD`` extension for downstream use (EPRV ``C*#``
+    catalog keywords, DiagL0 pointing offsets, BarycentricCorrection). Only science
+    frames
     are supported: the constructor raises on a non-``Object`` IMTYPE (a calibration).
     Fail-soft otherwise: a missing GAIAID/OBJECT or a failed network lookup yields a
     ``None`` record rather than an error.
@@ -83,7 +117,7 @@ class AstroQuery:
     l0_obj : KPF0
         Raw L0 science frame (IMTYPE ``Object``). Its PRIMARY header (IMTYPE, GAIAID,
         OBJECT, TARG*) is read but never modified; the resolved catalog data is
-        attached as ``l0_obj.catalog_record``.
+        written to the L0 ``CATALOG_RECORD`` extension.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: use_gaia, use_simbad.
     """
@@ -373,18 +407,34 @@ class AstroQuery:
         self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
     def _attach_catalog_record(self, l0_obj):
-        """Deposit the resolved catalog records on ``l0_obj.catalog_record``.
+        """Write the resolved catalog records to the CATALOG_RECORD extension.
 
-        The module's sole output site (analogous to ``_set_headers`` on a
-        transform module). No header is written: the L0 PRIMARY is an immutable
-        pass-through to INSTRUMENT_HEADER, and the EPRV ``C*#`` keywords live on
-        the L1 PRIMARY, which ``KPF0.to_kpf1()`` builds downstream from this dict.
+        The module's sole output site (analogous to ``_set_headers`` on a transform
+        module). Builds a BinTable with one row per resolved source (canonical ICRS
+        schema; missing floats -> NaN, missing source_id -> "") and sets the
+        WMKOCR/GAIACR/SIMBADCR presence flags on the extension header. The L0 PRIMARY
+        is never touched -- the EPRV ``C*#`` keywords are built later in
+        ``KPF0.to_kpf1()``; this extension is the L0-stage bridge to that step.
         """
-        l0_obj.catalog_record = {
-            "gaia": self._gaia,
-            "simbad": self._simbad,
-            "wmko": self._wmko,
-        }
+        records = {"wmko": self._wmko, "gaia": self._gaia, "simbad": self._simbad}
+        rows = [
+            {"source": src, **rec} for src, rec in records.items() if rec is not None
+        ]
+        table = Table()
+        for name in _CATALOG_COLUMNS:
+            if name in _CATALOG_STR_COLUMNS:
+                table[name] = np.array(
+                    ["" if r[name] is None else r[name] for r in rows], dtype=str
+                )
+            else:
+                table[name] = np.array(
+                    [np.nan if r[name] is None else r[name] for r in rows], dtype=float
+                )
+                table[name].unit = _CATALOG_UNITS[name]
+        l0_obj.set_data("CATALOG_RECORD", table)
+
+        for source, keyword in _CATALOG_FLAGS.items():
+            l0_obj.set_keyword(keyword, 1 if records[source] is not None else 0)
 
     # ------------------------------------------------------------------
     # Public entry point
@@ -402,10 +452,11 @@ class AstroQuery:
         Returns
         -------
         l0_obj : KPF0
-            The input L0 (PRIMARY unchanged), now carrying ``catalog_record`` with
-            the ``gaia`` / ``simbad`` / ``wmko`` records (each a dict or None), and
-            an 'astro_query' receipt entry. Unusually for a pipeline module this
-            returns an L0, not the next level -- AstroQuery runs before assembly.
+            The input L0 (PRIMARY unchanged), now carrying the ``CATALOG_RECORD``
+            extension (one row per resolved source, with WMKOCR/GAIACR/SIMBADCR
+            presence flags) and an 'astro_query' receipt entry. Unusually for a
+            pipeline module this returns an L0, not the next level -- AstroQuery
+            runs before assembly.
         """
         if use_gaia is not None:
             self.use_gaia = use_gaia

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -445,15 +445,25 @@ class AstroQuery:
         query, just the raw TARG* pointing, sanitized to the EPRV C*# format --
         TARGRA/TARGDEC sexagesimal reformatted to the canonical RA hour-angle / Dec
         deg 'h:m:s' strings; TARGPMRA time-s/yr -> arcsec/yr (x15 cos Dec), TARGPMDC
-        already arcsec/yr; TARGFRAM FK5 J2000 relabeled ICRS (the ~23 mas frame tie is
-        negligible). Returns None -- so the frame gets WMKOCR=0 -- when there is no
-        target pointing (TARGRA absent) or the TARG* astrometry cannot be parsed
-        (warned, never raised, so a malformed file still loads). Well-formedness is
-        gated downstream by QCL0 (RADECOK), not here.
+        already arcsec/yr; TARGFRAM stored as the record's true astropy frame (its
+        lowercase form, 'fk5'), never relabeled -- downstream SkyCoord performs any
+        FK5->ICRS conversion. KPF pointing is always FK5 (J2000), so a TARGFRAM that is
+        not FK5 (absent included) raises rather than being coerced: a wrong frame would
+        silently corrupt the barycentric correction. Returns None -- so the frame gets
+        WMKOCR=0 -- when there is no target pointing (TARGRA absent) or the TARG*
+        astrometry cannot be parsed (warned, never raised, so a malformed file still
+        loads). Well-formedness is gated downstream by QCL0 (RADECOK), not here.
         """
         primary = self.l0_obj.headers["PRIMARY"]
         if primary.get("TARGRA") is None:
             return None
+        targfram = str(primary.get("TARGFRAM") or "").strip()
+        if targfram.upper() != "FK5":
+            raise ValueError(
+                f"unexpected TARGFRAM={primary.get('TARGFRAM')!r}; KPF pointing must "
+                "be 'FK5' (J2000). Refusing to guess the frame, which would corrupt "
+                "the barycentric correction."
+            )
         try:
             ra = Angle(primary["TARGRA"], unit=u.hourangle)
             dec = Angle(primary["TARGDEC"], unit=u.deg)
@@ -468,7 +478,7 @@ class AstroQuery:
                 "pmdec": None if pmdec is None else pmdec,
                 "parallax": primary.get("TARGPLAX"),
                 "rv": primary.get("TARGRADV"),
-                "frame": "icrs",
+                "frame": targfram.lower(),
                 "epoch": primary.get("TARGEPOC"),
                 "equinox": primary.get("TARGEQUI"),
             }

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -38,7 +38,32 @@ _DEFAULTS = {
     **DEFAULTS,
     "use_gaia": True,
     "use_simbad": True,
+    "use_wmko": True,
 }
+
+# Source-merge configuration for the canonical ``kpf-drp`` row. Priority order
+# (highest first) governs which source supplies the coherent position block and,
+# independently, the parallax and RV. _PRESENCE_FLAGS maps each source to its
+# CATALOG_RECORD header flag (a local mirror of level0._CATALOG_FLAGS, matching the
+# DiagL0 convention of not importing the private schema).
+_MERGE_PRIORITY = ("gaia", "simbad", "wmko")
+_PRESENCE_FLAGS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
+# The position block is taken together from one source so ra/dec/PM/epoch stay
+# internally consistent; parallax and rv are filled per-column.
+_POSITION_FIELDS = ("ra", "dec", "pmra", "pmdec", "epoch")
+_MERGE_STR_FIELDS = frozenset({"source_id", "frame"})
+_MERGE_READ_FIELDS = (
+    "source_id",
+    "ra",
+    "dec",
+    "pmra",
+    "pmdec",
+    "parallax",
+    "rv",
+    "frame",
+    "epoch",
+    "equinox",
+)
 
 # Column units AstroQuery assumes for each catalog result, verified before the
 # values are trusted so a silent upstream schema change fails loudly instead of
@@ -108,6 +133,7 @@ class AstroQuery:
 
         self._gaia = None  # Gaia DR3 record; set by query_gaia()
         self._simbad = None  # SIMBAD record; set by query_simbad()
+        self._canonical = None  # merged kpf-drp record; set by merge_catalog_records()
         self._info = None
 
     # ------------------------------------------------------------------
@@ -285,6 +311,124 @@ class AstroQuery:
         logger.info("successfully built record for simbad")
         return record
 
+    def _read_catalog_row(self, table, source):
+        """Read one CATALOG_RECORD row into a record dict, or None if absent.
+
+        Coerces the missing-value sentinels back to None (NaN floats, "" strings) so
+        the merge sees a single "missing" marker per cell regardless of source.
+        """
+        match = table[table["source"] == source]
+        if len(match) == 0:
+            return None
+        row = match[0]
+        record = {}
+        for name in _MERGE_READ_FIELDS:
+            value = row[name]
+            if name in _MERGE_STR_FIELDS:
+                record[name] = None if str(value) == "" else str(value)
+            else:
+                f = float(value)
+                record[name] = None if np.isnan(f) else f
+        return record
+
+    def merge_catalog_records(self):
+        """Merge the source rows into the canonical ``kpf-drp`` CATALOG_RECORD row.
+
+        Combines the ``gaia``/``simbad``/``wmko`` rows (each gated by its ``use_*``
+        toggle and presence flag) into one canonical record, in ``_MERGE_PRIORITY``
+        order: the coherent position block (ra/dec/pmra/pmdec/epoch, plus frame/equinox)
+        is taken together from the highest-priority source that supplies it complete,
+        while parallax and rv are each filled independently from the highest-priority
+        source that has them. ``astr_src`` records the position source's label; an
+        optional parallax/rv borrowed from a different source is a DEBUG-level note
+        (Gaia commonly lacks radial_velocity, so this is routine, not an error).
+
+        Raises ``ValueError`` when a coherent position block (ra, dec, pmra, pmdec,
+        epoch) cannot be assembled from the enabled sources -- without a position there
+        is nothing to correct, so its absence must fail loudly. parallax and rv are
+        optional: filled when any source has them, else left missing (NaN) for the
+        downstream consumer to default (as BarycentricCorrection already does).
+        """
+        table = self.l0_obj.data["CATALOG_RECORD"]
+        header = self.l0_obj.headers["CATALOG_RECORD"]
+
+        # Candidate (source_label, record) pairs in priority order, gated by toggle
+        # and presence flag.
+        candidates = []
+        for source in _MERGE_PRIORITY:
+            if not getattr(self, f"use_{source}"):
+                continue
+            if not header.get(_PRESENCE_FLAGS[source]):
+                continue
+            record = self._read_catalog_row(table, source)
+            if record is not None:
+                candidates.append((source, record))
+
+        base = next(
+            (
+                (source, record)
+                for source, record in candidates
+                if all(record[f] is not None for f in _POSITION_FIELDS)
+            ),
+            None,
+        )
+        if base is None:
+            enabled = [s for s in _MERGE_PRIORITY if getattr(self, f"use_{s}")]
+            raise ValueError(
+                f"cannot build a canonical astrometry position for "
+                f"{self.l0_obj.obs_id or 'unknown'}: missing ra/dec/pmra/pmdec/epoch "
+                f"across enabled sources {enabled}"
+            )
+        base_source, base_record = base
+
+        # parallax and rv are optional; take each from the highest-priority source
+        # that has it, or leave missing.
+        parallax_source, parallax_value = next(
+            (
+                (source, record["parallax"])
+                for source, record in candidates
+                if record["parallax"] is not None
+            ),
+            (None, None),
+        )
+        rv_source, rv_value = next(
+            (
+                (source, record["rv"])
+                for source, record in candidates
+                if record["rv"] is not None
+            ),
+            (None, None),
+        )
+
+        mixed = [
+            f"{field}={src}"
+            for field, src in (("parallax", parallax_source), ("rv", rv_source))
+            if src is not None and src != base_source
+        ]
+        if mixed:
+            logger.debug(
+                "canonical astrometry mixes sources: position=%s, %s",
+                base_source,
+                ", ".join(mixed),
+            )
+
+        record = {
+            "source_id": base_record["source_id"],
+            "astr_src": base_source,
+            "ra": base_record["ra"],
+            "dec": base_record["dec"],
+            "pmra": base_record["pmra"],
+            "pmdec": base_record["pmdec"],
+            "parallax": parallax_value,
+            "rv": rv_value,
+            "frame": base_record["frame"],
+            "epoch": base_record["epoch"],
+            "equinox": base_record["equinox"],
+        }
+        self._canonical = record
+        self.l0_obj.set_catalog_record("kpf-drp", record)
+        return record
+
     # ------------------------------------------------------------------
     # Private helpers - module execution
     # ------------------------------------------------------------------
@@ -293,11 +437,13 @@ class AstroQuery:
         """Build and cache the info() summary text from instance attributes."""
         gaia = self._gaia["source_id"] if self._gaia else "n/a"
         simbad = self._simbad["source_id"] if self._simbad else "n/a"
+        canonical = self._canonical["astr_src"] if self._canonical else "n/a"
         lines = [
             "AstroQuery",
             f"  obs_id:  {self.l0_obj.obs_id or 'unknown'}",
             f"  Gaia DR3:  {gaia}",
             f"  SIMBAD:    {simbad}",
+            f"  canonical position source:  {canonical}",
         ]
         self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
@@ -333,6 +479,10 @@ class AstroQuery:
 
         self.l0_obj.set_catalog_record("gaia", self._gaia)
         self.l0_obj.set_catalog_record("simbad", self._simbad)
+        # Merge the source rows (gaia/simbad/wmko) into the canonical kpf-drp row that
+        # downstream (to_kpf1 C*#, barycentric correction) consumes. Raises if a
+        # complete set cannot be assembled.
+        self.merge_catalog_records()
         self._track_info()
         self.l0_obj.receipt_add_entry("astro_query", "", "PASS")
 

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -525,12 +525,21 @@ class AstroQuery:
                 candidates.append((source, record))
 
         # Take the whole astrometric block from the first source that has it complete;
-        # raise if none does (without a position there is nothing to correct).
+        # raise if none does (without a position there is nothing to correct). A
+        # present-but-incomplete higher-priority source is demoted -- warn (naming the
+        # missing fields) so the fallback is auditable, not silent.
         base_source, base_record = None, None
         for source, record in candidates:
-            if all(record[field] is not None for field in _ASTROMETRY):
+            missing = [field for field in _ASTROMETRY if record[field] is None]
+            if not missing:
                 base_source, base_record = source, record
                 break
+            logger.warning(
+                "%s astrometry incomplete (missing %s); skipping it as the "
+                "astrometric base",
+                source,
+                ", ".join(missing),
+            )
         if base_record is None:
             available = [source for source, _ in candidates]
             raise ValueError(

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -2,25 +2,19 @@
 KPF AstroQuery module.
 
 Consolidates the pipeline's external astronomical-catalog lookups into a single
-L0-stage module. Given a raw L0 frame, it resolves the target's astrometry from
-Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), builds the telescope-native ``wmko``
-row from the L0 PRIMARY ``TARG*`` astrometry (no query), and writes all three rows
-to the L0 ``CATALOG_RECORD`` extension, setting the ``WMKOCR``/``GAIACR``/``SIMBADCR``
-presence flags. ``KPF0.read`` leaves ``CATALOG_RECORD`` empty; AstroQuery is its sole
-populator.
+L0-stage module. Given a raw L0 science frame, it resolves the target's astrometry
+from Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), builds the telescope-native
+``wmko`` row from the L0 PRIMARY ``TARG*`` astrometry (no query), merges them into a
+canonical ``kpf-drp`` row, and writes all four rows to the L0 ``CATALOG_RECORD``
+extension with the ``WMKOCR``/``GAIACR``/``SIMBADCR`` presence flags. AstroQuery is
+the extension's sole populator.
 
-The extension is the bridge across an ordering problem: the query results
-ultimately belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO ->
-EPRV PRIMARY conversion does not happen until ``KPF0.to_kpf1()`` downstream. Rather
-than write PRIMARY here, AstroQuery records the queried quantities on the L0 and
-lets ``to_kpf1()`` overlay them onto the L1 PRIMARY (a follow-up integration).
-
-AstroQuery never modifies the L0 PRIMARY header (a pure pass-through to
-INSTRUMENT_HEADER). All three source rows and the merged ``kpf-drp`` row share one
-schema in the EPRV C*# PRIMARY format (see ``_CATALOG_COLUMNS``), so a consumer reads
-any source identically and ``to_kpf1`` can copy cells straight onto the catalog cards.
-The redshift z (``CZ#``) is derived from rv here and rides along in the record; per-
-fiber fan-out and pointing offsets remain downstream jobs.
+CATALOG_RECORD bridges an ordering problem: the results ultimately belong on the
+EPRV PRIMARY catalog keywords (``C*#``), but the WMKO -> EPRV PRIMARY conversion does
+not happen until ``KPF0.to_kpf1()`` downstream, which overlays the merged record onto
+those cards. AstroQuery never modifies the L0 PRIMARY header. All rows share one
+schema in the EPRV C*# PRIMARY format (see ``_CATALOG_COLUMNS``), so ``to_kpf1`` can
+copy cells straight onto the catalog cards.
 """
 
 import logging
@@ -46,17 +40,13 @@ _DEFAULTS = {
     "use_wmko_tcs": True,
 }
 
-# The astrometric block the merge takes whole from one source: ra/dec/pmra/pmdec/
-# parallax are one astrometric fit -- proper motion without the parallax it was measured
-# against is nearly meaningless -- plus the frame/epoch that qualify the coordinates.
-# equinox is not gated (an ICRS formality), so a WMKO base missing TARGEQUI still
-# qualifies. rv is handled separately (base source, else TARGRADV). Priority (highest
-# first): gaia > simbad > wmko.
+# The astrometric block the merge takes whole from one source: one fit -- proper
+# motion is meaningless without the parallax it was measured against -- plus the frame/
+# epoch that qualify the coordinates. equinox and rv are handled separately.
 _ASTROMETRY = ("ra", "dec", "pmra", "pmdec", "parallax", "epoch", "frame")
 
-# Column units AstroQuery assumes for each catalog result, verified before the
-# values are trusted so a silent upstream schema change fails loudly instead of
-# corrupting the record.
+# Column units each catalog result is expected to carry, verified before its values
+# are trusted so a silent upstream schema change fails loudly (see _verify_units).
 _GAIA_UNITS = {
     "ra": u.deg,
     "dec": u.deg,
@@ -80,17 +70,13 @@ _SIMBAD_UNITS = {
 }
 
 # CATALOG_RECORD write schema (AstroQuery is the sole populator): one row per resolved
-# source (wmko/gaia/simbad) plus the merged 'kpf-drp' row. 'source' labels the row,
-# 'object' is the queried target name, and radec_src/plx_src/rv_src name the source each
-# value block (position, parallax, rv) came from -- its own 'source' for a plain source
-# row, the winning source (or "" if none) for the merged row. Values are in the EPRV
-# C*# PRIMARY format: RA/Dec sexagesimal strings (RA hour-angle, Dec deg, ICRS), PM
-# arcsec/yr (RA incl. cos Dec), parallax mas, rv km/s, z the dimensionless relativistic
-# redshift derived from rv, epoch/equinox Julian years. color is a photometric color
-# index (a magnitude difference, mag) and color_name labels which one, differing by
-# source: Gaia "Gaia BP-RP" (G_BP - G_RP), SIMBAD "B-V" (Johnson B - V), WMKO "G-J"
-# (GAIAMAG - 2MASSMAG); both blank when the source lacks a needed magnitude. Missing
-# floats -> NaN, strings -> "".
+# source (wmko/gaia/simbad) plus the merged 'kpf-drp' row. radec_src/plx_src/rv_src
+# name the source each value block came from -- its own for a source row, the winner
+# (or "" if none) for the merged row. Values are in the EPRV C*# PRIMARY format: RA/Dec
+# sexagesimal strings (ICRS), PM arcsec/yr (RA incl. cos Dec), parallax mas, rv km/s, z
+# the redshift derived from rv, epoch/equinox Julian years. color is a color index and
+# color_name labels it (Gaia "Gaia BP-RP", SIMBAD "B-V", WMKO "G-J"), both blank when a
+# magnitude is missing. Missing floats -> NaN, strings -> "".
 _CATALOG_COLUMNS = (
     "source",
     "object",
@@ -387,8 +373,7 @@ class AstroQuery:
         row = results[0]
         ra, dec = self._scalar(row["ra"]), self._scalar(row["dec"])
         pmra, pmdec = self._scalar(row["pmra"]), self._scalar(row["pmdec"])
-        # Sanitize to the EPRV C*# format: RA/Dec deg -> sexagesimal (RA hour-angle,
-        # Dec deg); proper motion mas/yr -> arcsec/yr.
+        # To the EPRV C*# format: deg -> sexagesimal; PM mas/yr -> arcsec/yr.
         ra_str, dec_str = self._sexagesimal_radec(
             SkyCoord(ra, dec, unit=u.deg, frame="icrs")
         )
@@ -456,8 +441,7 @@ class AstroQuery:
         row = result[0]
         ra, dec = self._scalar(row["ra"]), self._scalar(row["dec"])
         pmra, pmdec = self._scalar(row["pmra"]), self._scalar(row["pmdec"])
-        # Sanitize to the EPRV C*# format: RA/Dec deg -> sexagesimal (RA hour-angle,
-        # Dec deg); proper motion mas/yr -> arcsec/yr.
+        # To the EPRV C*# format: deg -> sexagesimal; PM mas/yr -> arcsec/yr.
         ra_str, dec_str = self._sexagesimal_radec(
             SkyCoord(ra, dec, unit=u.deg, frame="icrs")
         )
@@ -519,11 +503,10 @@ class AstroQuery:
             )
             equinox = self._scalar(primary.get("TARGEQUI"))
 
-            # Rotate the native FK5 pointing to ICRS. Position always; proper motion too
+            # Rotate the native FK5 pointing to ICRS: position always, proper motion too
             # when both components are present (TARGPMRA time-s/yr -> arcsec/yr via x15
-            # cos Dec first; a lone component is meaningless under rotation, so it is
-            # both-or-neither). Rotation carries no time propagation, so epoch is
-            # unchanged; parallax/RV are rotation-invariant.
+            # cos Dec first; a lone component is meaningless under rotation). Rotation
+            # carries no time propagation, so epoch is unchanged.
             fk5 = FK5(
                 equinox="J2000" if equinox is None else Time(equinox, format="jyear")
             )
@@ -588,8 +571,7 @@ class AstroQuery:
         must fail loudly. rv is optional, left missing when neither the astrometric
         source nor TARGRADV supplies it.
         """
-        # Our own records, just built and schema-clean; assemble in priority order (a
-        # source toggled off or that resolved nothing is already None).
+        # Assemble candidates in priority order (a source with no record is None).
         candidates = []
         for source, record in (
             ("gaia", self._gaia),
@@ -599,10 +581,8 @@ class AstroQuery:
             if record is not None:
                 candidates.append((source, record))
 
-        # Take the whole astrometric block from the first source that has it complete;
-        # raise if none does (without a position there is nothing to correct). A
-        # present-but-incomplete higher-priority source is demoted -- warn (naming the
-        # missing fields) so the fallback is auditable, not silent.
+        # First source with a complete block wins; a present-but-incomplete
+        # higher-priority source is demoted with an auditable warning.
         base_source, base_record = None, None
         for source, record in candidates:
             missing = [field for field in _ASTROMETRY if record[field] is None]
@@ -624,8 +604,7 @@ class AstroQuery:
             )
 
         # rv from the base source, else telescope TARGRADV off PRIMARY -- independent of
-        # use_wmko_tcs (which gates only the wmko position row) and already km/s, so no
-        # conversion.
+        # use_wmko_tcs (which gates only the wmko position row).
         rv_value = base_record["rv"]
         rv_source = base_source
         if rv_value is None:
@@ -706,16 +685,14 @@ class AstroQuery:
         if use_wmko_tcs is not None:
             self.use_wmko_tcs = use_wmko_tcs
 
-        # Each source is gated here: a toggled-off source is neither queried nor
-        # built, so its row stays absent. Each method that runs looks up its
-        # astrometry and writes its own CATALOG_RECORD row in one go.
+        # Gate each source: a toggled-off source is neither queried nor built. Each
+        # method that runs writes its own CATALOG_RECORD row.
         self._wmko = self.read_wmko_header() if self.use_wmko_tcs else None
         self._gaia = self.query_gaia() if self.do_gaia_query else None
         self._simbad = self.query_simbad() if self.do_simbad_query else None
 
-        # Merge the source rows (gaia/simbad/wmko) into the canonical kpf-drp row that
-        # downstream (to_kpf1 C*#, barycentric correction) consumes. Raises if a
-        # complete set cannot be assembled.
+        # Merge the source rows into the canonical kpf-drp row; raises if no complete
+        # position can be assembled.
         self.merge_catalog_records()
         self._track_info()
         self.l0_obj.receipt_add_entry("astro_query", "", "PASS")

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -41,35 +41,18 @@ logger = logging.getLogger(__name__)
 
 _DEFAULTS = {
     **DEFAULTS,
-    "use_gaia": True,
-    "use_simbad": True,
-    "use_wmko": True,
+    "do_gaia_query": True,
+    "do_simbad_query": True,
+    "use_wmko_tcs": True,
 }
 
-# Source-merge configuration for the canonical ``kpf-drp`` row. Priority order
-# (highest first) governs which source supplies the coherent position block and,
-# independently, the parallax and RV.
-_MERGE_PRIORITY = ("gaia", "simbad", "wmko")
-# The position block is taken together from one source so ra/dec/PM and their frame
-# and reference epoch stay internally consistent -- a frame or epoch from a different
-# source than the coordinates would be meaningless. equinox rides with the same base
-# (an ICRS formality) but is not gated, so a WMKO base missing TARGEQUI still
-# qualifies. parallax and rv are the only per-column fills. All of frame/epoch/equinox
-# therefore share the row's radec_src provenance.
+# Fields that together make a coherent position block: the merge takes them from a
+# single source so ra/dec/PM and the frame/epoch that qualify them stay internally
+# consistent -- a frame or epoch from a different source than the coordinates would
+# be meaningless. equinox is not gated (an ICRS formality), so a WMKO base missing
+# TARGEQUI still qualifies; frame/epoch/equinox share the position's radec_src
+# provenance. Merge priority (highest first) is gaia > simbad > wmko.
 _POSITION_FIELDS = ("ra", "dec", "pmra", "pmdec", "epoch", "frame")
-_MERGE_STR_FIELDS = frozenset({"object", "frame", "ra", "dec"})
-_MERGE_READ_FIELDS = (
-    "object",
-    "ra",
-    "dec",
-    "pmra",
-    "pmdec",
-    "parallax",
-    "rv",
-    "frame",
-    "epoch",
-    "equinox",
-)
 
 # Column units AstroQuery assumes for each catalog result, verified before the
 # values are trusted so a silent upstream schema change fails loudly instead of
@@ -158,7 +141,8 @@ class AstroQuery:
         OBJECT, TARG*) is read but never modified; the resolved catalog data is written
         to the L0 ``CATALOG_RECORD`` extension.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: use_gaia, use_simbad.
+        Module configuration. Recognized keys: do_gaia_query, do_simbad_query,
+        use_wmko_tcs.
     """
 
     def __init__(self, l0_obj, config=None):
@@ -326,13 +310,12 @@ class AstroQuery:
     def query_gaia(self):
         """Query Gaia DR3 for the target's ICRS astrometry, or None (fail-soft).
 
-        Returns None (warned) when disabled, when GAIAID yields no usable
-        source_id, when the lookup fails, or when the source is not found. Raises
-        ValueError if the result's column units differ from the assumed canonical
-        schema (deg, mas/yr, mas, km/s, epoch in Julian years; ICRS).
+        Returns None (warned) when GAIAID yields no usable source_id, when the
+        lookup fails, or when the source is not found. Raises ValueError if the
+        result's column units differ from the assumed canonical schema (deg,
+        mas/yr, mas, km/s, epoch in Julian years; ICRS). Whether it runs at all is
+        gated upstream in perform by ``do_gaia_query``.
         """
-        if not self.use_gaia:
-            return None
         gaia_id = self._gaia_source_id()
         if gaia_id is None:
             logger.warning(
@@ -387,19 +370,19 @@ class AstroQuery:
             "equinox": 2000.0,
         }
         logger.info("successfully built record for gaia")
+        self._write_catalog_record("gaia", record)
         return record
 
     def query_simbad(self):
         """Query SIMBAD for the OBJECT's ICRS J2000 astrometry, or None (fail-soft).
 
-        Returns None when disabled, when L0 has no OBJECT name, or when the lookup
-        fails / resolves nothing (warned, not raised). Raises ValueError if the
-        result's column units differ from the assumed schema. Column schema is the
+        Returns None when L0 has no OBJECT name, or when the lookup fails /
+        resolves nothing (warned, not raised). Raises ValueError if the result's
+        column units differ from the assumed schema. Column schema is the
         astroquery 0.4.11 lowercase form (ra/dec deg, pmra/pmdec mas/yr, plx_value
-        mas, rvz_radvel km/s).
+        mas, rvz_radvel km/s). Whether it runs at all is gated upstream in perform
+        by ``do_simbad_query``.
         """
-        if not self.use_simbad:
-            return None
         name = self._simbad_resolvable_name()
         if name is None:
             logger.warning(
@@ -451,6 +434,7 @@ class AstroQuery:
             "equinox": 2000.0,
         }
         logger.info("successfully built record for simbad")
+        self._write_catalog_record("simbad", record)
         return record
 
     def read_wmko_header(self):
@@ -469,6 +453,7 @@ class AstroQuery:
         WMKOCR=0 -- when there is no target pointing (TARGRA absent) or the TARG*
         astrometry cannot be parsed (warned, never raised, so a malformed file still
         loads). Well-formedness is gated downstream by QCL0 (RADECOK), not here.
+        Whether it runs at all is gated upstream in perform by ``use_wmko_tcs``.
         """
         primary = self.l0_obj.headers["PRIMARY"]
         if primary.get("TARGRA") is None:
@@ -524,66 +509,42 @@ class AstroQuery:
                 exc,
             )
             return None
-        logger.info("successfully built record for wmko")
-        return record
-
-    def _read_catalog_row(self, table, source):
-        """Read one CATALOG_RECORD row into a record dict, or None if absent.
-
-        Coerces the missing-value sentinels back to None (NaN floats, "" strings) so
-        the merge sees a single "missing" marker per cell regardless of source.
-        """
-        match = table[table["source"] == source]
-        if len(match) == 0:
-            return None
-        row = match[0]
-        record = {}
-        for name in _MERGE_READ_FIELDS:
-            value = row[name]
-            if name in _MERGE_STR_FIELDS:
-                record[name] = None if str(value) == "" else str(value)
-            else:
-                f = float(value)
-                record[name] = None if np.isnan(f) else f
+        logger.info("successfully built record for wmko-tcs")
+        self._write_catalog_record("wmko", record)
         return record
 
     def merge_catalog_records(self):
-        """Merge the source rows into the canonical ``kpf-drp`` CATALOG_RECORD row.
+        """Merge the built source records into the canonical ``kpf-drp`` row.
 
-        Combines the ``gaia``/``simbad``/``wmko`` rows (each gated by its ``use_*``
-        toggle and presence flag) into one canonical record, in ``_MERGE_PRIORITY``
-        order: the coherent position block -- ra/dec/pmra/pmdec, plus the frame, epoch,
-        and equinox that make them meaningful -- is taken together from the highest-
-        priority source that supplies it complete, while parallax and rv are each filled
-        independently from the highest-priority source that has them. frame, epoch, and
-        equinox are intrinsic to the coordinates (a frame or epoch from another source
-        would be inconsistent), so they always ride with the position, sharing radec_src
-        provenance rather than getting their own labels. The three provenance labels
-        record where each block came from -- ``radec_src`` (position + frame/epoch/
-        equinox), ``plx_src`` (parallax), ``rv_src`` (rv), each "" when nothing supplied
-        it; a parallax/rv borrowed from a different source than the position is a DEBUG
-        note (Gaia commonly lacks radial_velocity, so this is routine, not an error).
+        Consumes the in-memory gaia/simbad/wmko records this instance just built
+        (``None`` for a source that was toggled off or resolved nothing), in priority
+        order gaia > simbad > wmko: the coherent position block -- ra/dec/pmra/pmdec
+        plus the frame, epoch, and equinox that make them meaningful -- is taken
+        together from the highest-priority source that supplies it complete, while
+        parallax and rv are each filled independently from the highest-priority source
+        that has them. frame/epoch/equinox are intrinsic to the coordinates and ride
+        with the position under its ``radec_src`` provenance. The three provenance
+        labels record where each block came from -- ``radec_src`` (position),
+        ``plx_src`` (parallax), ``rv_src`` (rv), each "" when nothing supplied it; a
+        parallax/rv borrowed from a source other than the position is a routine DEBUG
+        note (Gaia commonly lacks radial_velocity).
 
-        Raises ``ValueError`` when a coherent position block (ra, dec, pmra, pmdec,
-        epoch) cannot be assembled from the enabled sources -- without a position there
-        is nothing to correct, so its absence must fail loudly. parallax and rv are
-        optional: filled when any source has them, else left missing (NaN) for the
-        downstream consumer to default (as BarycentricCorrection already does).
+        Raises ``ValueError`` when no source supplies a complete ra/dec/pmra/pmdec/
+        epoch block -- without a position there is nothing to correct, so it must fail
+        loudly. parallax and rv are optional, left missing when no source has them.
         """
-        table = self.l0_obj.data["CATALOG_RECORD"]
-        header = self.l0_obj.headers["CATALOG_RECORD"]
-
-        # Candidate (source_label, record) pairs in priority order, gated by toggle
-        # and presence flag.
-        candidates = []
-        for source in _MERGE_PRIORITY:
-            if not getattr(self, f"use_{source}"):
-                continue
-            if not header.get(_CATALOG_FLAGS[source]):
-                continue
-            record = self._read_catalog_row(table, source)
-            if record is not None:
-                candidates.append((source, record))
+        # The source records are ours, just built and schema-clean (missing cells are
+        # None), so consume them directly in priority order -- no re-read of the table
+        # we just wrote, and a toggled-off source is already None.
+        candidates = [
+            (source, record)
+            for source, record in (
+                ("gaia", self._gaia),
+                ("simbad", self._simbad),
+                ("wmko", self._wmko),
+            )
+            if record is not None
+        ]
 
         base = next(
             (
@@ -594,11 +555,11 @@ class AstroQuery:
             None,
         )
         if base is None:
-            enabled = [s for s in _MERGE_PRIORITY if getattr(self, f"use_{s}")]
+            available = [source for source, _ in candidates]
             raise ValueError(
                 f"cannot build a canonical astrometry position for "
-                f"{self.l0_obj.obs_id or 'unknown'}: missing ra/dec/pmra/pmdec/epoch "
-                f"across enabled sources {enabled}"
+                f"{self.l0_obj.obs_id or 'unknown'}: no source supplies a complete "
+                f"ra/dec/pmra/pmdec/epoch block (have {available})"
             )
         base_source, base_record = base
 
@@ -674,14 +635,14 @@ class AstroQuery:
     # Public entry point
     # ------------------------------------------------------------------
 
-    def perform(self, *, use_gaia=None, use_simbad=None):
+    def perform(self, *, do_gaia_query=None, do_simbad_query=None, use_wmko_tcs=None):
         """
         Resolve external catalog astrometry and write it to the L0.
 
         Parameters
         ----------
-        use_gaia, use_simbad : bool, optional
-            Override the configured query toggles for this call.
+        do_gaia_query, do_simbad_query, use_wmko_tcs : bool, optional
+            Override the configured source toggles for this call.
 
         Returns
         -------
@@ -692,20 +653,20 @@ class AstroQuery:
             module this returns an L0, not the next level -- AstroQuery runs before
             assembly.
         """
-        if use_gaia is not None:
-            self.use_gaia = use_gaia
-        if use_simbad is not None:
-            self.use_simbad = use_simbad
+        if do_gaia_query is not None:
+            self.do_gaia_query = do_gaia_query
+        if do_simbad_query is not None:
+            self.do_simbad_query = do_simbad_query
+        if use_wmko_tcs is not None:
+            self.use_wmko_tcs = use_wmko_tcs
 
-        self._wmko = self.read_wmko_header()
-        self._gaia = self.query_gaia()
-        self._simbad = self.query_simbad()
+        # Each source is gated here: a toggled-off source is neither queried nor
+        # built, so its row stays absent. Each method that runs looks up its
+        # astrometry and writes its own CATALOG_RECORD row in one go.
+        self._wmko = self.read_wmko_header() if self.use_wmko_tcs else None
+        self._gaia = self.query_gaia() if self.do_gaia_query else None
+        self._simbad = self.query_simbad() if self.do_simbad_query else None
 
-        # Write all three source rows (wmko is native, built from L0 PRIMARY TARG*;
-        # gaia/simbad from the queries above); KPF0.read leaves CATALOG_RECORD empty.
-        self._write_catalog_record("wmko", self._wmko)
-        self._write_catalog_record("gaia", self._gaia)
-        self._write_catalog_record("simbad", self._simbad)
         # Merge the source rows (gaia/simbad/wmko) into the canonical kpf-drp row that
         # downstream (to_kpf1 C*#, barycentric correction) consumes. Raises if a
         # complete set cannot be assembled.

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -5,7 +5,7 @@ Consolidates every external astronomical-catalog lookup the pipeline needs into
 a single L0-stage module. Given a raw L0 frame, it resolves the target's
 astrometry from Gaia DR3 (by GAIAID) and SIMBAD (by OBJECT), and snapshots the
 DCS/TCS target astrometry already on the raw header, then hands all three back on
-a lightweight ``catalog_query`` dict attached to the L0 object.
+a lightweight ``catalog_record`` dict attached to the L0 object.
 
 The dict is the bridge across an ordering problem: the query results ultimately
 belong on the EPRV PRIMARY catalog keywords (``C*#``), but the WMKO -> EPRV
@@ -72,7 +72,7 @@ class AstroQuery:
 
     Runs the two external catalog queries (Gaia DR3 by GAIAID, SIMBAD by OBJECT)
     plus a verbatim snapshot of the DCS/TCS ``TARG*`` astrometry, and deposits all
-    three on ``l0_obj.catalog_query`` for downstream use (EPRV ``C*#`` catalog
+    three on ``l0_obj.catalog_record`` for downstream use (EPRV ``C*#`` catalog
     keywords, DiagL0 pointing offsets, BarycentricCorrection). Only science frames
     are supported: the constructor raises on a non-``Object`` IMTYPE (a calibration).
     Fail-soft otherwise: a missing GAIAID/OBJECT or a failed network lookup yields a
@@ -83,7 +83,7 @@ class AstroQuery:
     l0_obj : KPF0
         Raw L0 science frame (IMTYPE ``Object``). Its PRIMARY header (IMTYPE, GAIAID,
         OBJECT, TARG*) is read but never modified; the resolved catalog data is
-        attached as ``l0_obj.catalog_query``.
+        attached as ``l0_obj.catalog_record``.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: use_gaia, use_simbad.
     """
@@ -372,15 +372,15 @@ class AstroQuery:
         ]
         self._info = "\n\n" + "\n".join(lines) + "\n\n"
 
-    def _attach_catalog_query(self, l0_obj):
-        """Deposit the resolved catalog records on ``l0_obj.catalog_query``.
+    def _attach_catalog_record(self, l0_obj):
+        """Deposit the resolved catalog records on ``l0_obj.catalog_record``.
 
         The module's sole output site (analogous to ``_set_headers`` on a
         transform module). No header is written: the L0 PRIMARY is an immutable
         pass-through to INSTRUMENT_HEADER, and the EPRV ``C*#`` keywords live on
         the L1 PRIMARY, which ``KPF0.to_kpf1()`` builds downstream from this dict.
         """
-        l0_obj.catalog_query = {
+        l0_obj.catalog_record = {
             "gaia": self._gaia,
             "simbad": self._simbad,
             "wmko": self._wmko,
@@ -402,7 +402,7 @@ class AstroQuery:
         Returns
         -------
         l0_obj : KPF0
-            The input L0 (PRIMARY unchanged), now carrying ``catalog_query`` with
+            The input L0 (PRIMARY unchanged), now carrying ``catalog_record`` with
             the ``gaia`` / ``simbad`` / ``wmko`` records (each a dict or None), and
             an 'astro_query' receipt entry. Unusually for a pipeline module this
             returns an L0, not the next level -- AstroQuery runs before assembly.
@@ -416,7 +416,7 @@ class AstroQuery:
         self._gaia = self.query_gaia()
         self._simbad = self.query_simbad()
 
-        self._attach_catalog_query(self.l0_obj)
+        self._attach_catalog_record(self.l0_obj)
         self._track_info()
         self.l0_obj.receipt_add_entry("astro_query", "", "PASS")
 

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -254,20 +254,20 @@ class BarycentricCorrection:
         return t_ext, f_ext
 
     def _compute_per_channel_flux_weighted_midpoint_time(
-        self, interpolate=True, extrapolate=True, fix_expmeter_outliers=True
+        self, interpolate=True, extrapolate=True, fix_outliers=True
     ):
         """
         Flux-weighted midpoint time per expmeter channel -> (w_em [Å], t_em [JD-UTC]).
 
         Optionally fills gaps between readings (``interpolate``), before/after the
         shutter window (``extrapolate``, using DATE-BEG/DATE-END), and replaces
-        outlier readings (``fix_expmeter_outliers``) before collapsing the time
-        axis to a flux-weighted mean per channel.
+        outlier readings (``fix_outliers``) before collapsing the time axis to a
+        flux-weighted mean per channel.
         """
         t_beg, t_mid, t_end = self._get_timestamps()
         w_em, f = self._get_normalized_flux()
 
-        if fix_expmeter_outliers:
+        if fix_outliers:
             f = self._fix_expmeter_outliers(f)
 
         # Cache boundary readings; f[0] and f[-1] get clobbered by later vstacks.
@@ -425,7 +425,7 @@ class BarycentricCorrection:
         output="orders",
         interpolate=True,
         extrapolate=True,
-        fix_expmeter_outliers=True,
+        fix_outliers=True,
         weight_percentile=90,
     ):
         """
@@ -450,7 +450,7 @@ class BarycentricCorrection:
             If True, estimate flux during gaps before the first or after the
             last expmeter reading, using DATE-BEG / DATE-END from
             INSTRUMENT_HEADER.
-        fix_expmeter_outliers : bool, optional
+        fix_outliers : bool, optional
             If True (default), detect and replace outlier expmeter readings.
         weight_percentile : float, optional
             Per-order SCI2 brightness percentile used to weight orders for the
@@ -480,12 +480,12 @@ class BarycentricCorrection:
 
         # Reuse the cached integration when the toggles match (perform() asks
         # for 'orders' then 'ccds').
-        key = (interpolate, extrapolate, fix_expmeter_outliers)
+        key = (interpolate, extrapolate, fix_outliers)
         if self._exposure_meter is None or self._exposure_meter[0] != key:
             w_em, t_em = self._compute_per_channel_flux_weighted_midpoint_time(
                 interpolate=interpolate,
                 extrapolate=extrapolate,
-                fix_expmeter_outliers=fix_expmeter_outliers,
+                fix_outliers=fix_outliers,
             )
             self._exposure_meter = (key, w_em, t_em)
         _, w_em, t_em = self._exposure_meter
@@ -556,8 +556,8 @@ class BarycentricCorrection:
     def compute_barycentric_correction(
         self,
         output="orders",
-        interpolate=True,
-        extrapolate=True,
+        interpolate_expmeter_flux=True,
+        extrapolate_expmeter_flux=True,
         fix_expmeter_outliers=True,
     ):
         """
@@ -573,8 +573,10 @@ class BarycentricCorrection:
         ----------
         output : {'expmeter', 'orders', 'ccds'}
             Binning level; forwarded to compute_flux_weighted_midpoint_times().
-        interpolate, extrapolate, fix_expmeter_outliers : bool, optional
-            Forwarded to compute_flux_weighted_midpoint_times().
+        interpolate_expmeter_flux, extrapolate_expmeter_flux, fix_expmeter_outliers
+                : bool, optional
+            Forwarded to compute_flux_weighted_midpoint_times() as its
+            ``interpolate`` / ``extrapolate`` / ``fix_outliers``.
 
         Returns
         -------
@@ -587,9 +589,9 @@ class BarycentricCorrection:
         """
         _, t_fwm = self.compute_flux_weighted_midpoint_times(
             output=output,
-            interpolate=interpolate,
-            extrapolate=extrapolate,
-            fix_expmeter_outliers=fix_expmeter_outliers,
+            interpolate=interpolate_expmeter_flux,
+            extrapolate=extrapolate_expmeter_flux,
+            fix_outliers=fix_expmeter_outliers,
         )
         astrometry = self._get_astrometry()
 
@@ -664,8 +666,8 @@ class BarycentricCorrection:
     def perform(
         self,
         *,
-        interpolate=True,
-        extrapolate=True,
+        interpolate_expmeter_flux=True,
+        extrapolate_expmeter_flux=True,
         fix_expmeter_outliers=True,
     ):
         """
@@ -673,9 +675,11 @@ class BarycentricCorrection:
 
         Parameters
         ----------
-        interpolate, extrapolate, fix_expmeter_outliers : bool, optional
-            Forwarded to compute_flux_weighted_midpoint_times(). See that
-            method for semantics.
+        interpolate_expmeter_flux, extrapolate_expmeter_flux, fix_expmeter_outliers
+                : bool, optional
+            Forwarded to compute_flux_weighted_midpoint_times() as its
+            ``interpolate`` / ``extrapolate`` / ``fix_outliers``. See that method
+            for semantics.
 
         Returns
         -------
@@ -685,8 +689,8 @@ class BarycentricCorrection:
             extension headers, and a 'barycentric_correction' receipt entry.
         """
         kwargs = dict(
-            interpolate=interpolate,
-            extrapolate=extrapolate,
+            interpolate_expmeter_flux=interpolate_expmeter_flux,
+            extrapolate_expmeter_flux=extrapolate_expmeter_flux,
             fix_expmeter_outliers=fix_expmeter_outliers,
         )
         bjd_tdb, bary_kms, bary_z = self.compute_barycentric_correction(

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -6,19 +6,21 @@ midpoint times and stores them on the L2 as BJD_TDB, BARYCORR_KMS, and
 BARYCORR_Z (per spectral order), plus per-CCD scalar summaries in the
 barycentric extension headers. Wavelength arrays are not modified.
 
+Target astrometry is read from the EPRV PRIMARY C*# catalog keywords, not queried:
+AstroQuery is the pipeline's sole external-catalog client, and KPF0.to_kpf1 overlays
+its merged canonical record onto those cards.
+
 Follows the barycentric-correction approach of Wright & Eastman (2014,
 barycorrpy) with the flux-weighted midpoint time of Butler et al. (1996).
 """
 
 import logging
-import re
 
 import astropy.units as u
 import numpy as np
-from astropy.coordinates import EarthLocation, SkyCoord
+from astropy.coordinates import Angle, EarthLocation
 from astropy.stats import mad_std
 from astropy.time import Time
-from astroquery.gaia import Gaia
 from barycorrpy import get_BC_vel, utc_tdb
 from scipy.interpolate import griddata
 from scipy.ndimage import gaussian_filter, median_filter
@@ -31,11 +33,17 @@ from kpfpipe.utils.stats import strictly_increasing
 
 logger = logging.getLogger(__name__)
 
-_DEFAULTS = {
-    **DEFAULTS,
-    "use_gaia_astrometry": True,
-    "use_wmko_fallback": False,
-}
+_DEFAULTS = {**DEFAULTS}
+
+# The PRIMARY C*# catalog cards are written identically to every science fiber
+# (SCI1-3 = traces 2-4); read SCI2, the reference fiber this module already uses for
+# SCI2_WAVE / SCI2_FLUX.
+_CATALOG_TRACE = 3
+
+# The position block the correction cannot proceed without. AstroQuery's merge refuses
+# to emit a canonical row without it, so an absent card means AstroQuery never ran (or
+# this is a calibration frame, which BarycentricCorrection must not be called on).
+_REQUIRED_CARDS = ("CRA", "CDEC", "CPMR", "CPMD", "CEPCH")
 
 
 class BarycentricCorrection:
@@ -44,19 +52,20 @@ class BarycentricCorrection:
 
     Derives the flux-weighted midpoint time per expmeter channel (EXPMETER_SCI),
     averages it over the channels within each spectral order's wavelength range
-    (SCI2_WAVE), resolves the target's astrometry (Gaia DR3, with a WMKO header
-    fallback), and calls barycorrpy to populate BJD_TDB / BARYCORR_KMS /
+    (SCI2_WAVE), reads the target's astrometry from the PRIMARY C*# catalog
+    keywords, and calls barycorrpy to populate BJD_TDB / BARYCORR_KMS /
     BARYCORR_Z. WAVE arrays are not modified.
 
     Parameters
     ----------
     l2_obj : KPF2
         Extracted L2 frame. Must have EXPMETER_SCI populated and SCI2_WAVE
-        populated by WavelengthCalibration. INSTRUMENT_HEADER (the preserved
-        L1 PRIMARY) must contain GAIAID, and DATE-BEG/DATE-END when extrapolating.
+        populated by WavelengthCalibration. PRIMARY must carry the SCI2 catalog
+        cards (CRA3/CDEC3/CPMR3/CPMD3/CEPCH3, written by AstroQuery via
+        KPF0.to_kpf1). INSTRUMENT_HEADER (the preserved L1 PRIMARY) must contain
+        DATE-BEG/DATE-END when extrapolating.
     config : None | dict | ConfigHandler
-        Module configuration. Recognized keys: use_gaia_astrometry,
-        use_wmko_fallback.
+        Module configuration. Recognizes no module-specific keys.
     """
 
     # WMKO site coordinates
@@ -88,10 +97,8 @@ class BarycentricCorrection:
         self._ccd_kms = None
         self._ccd_z = None
         self._exposure_meter = None  # (toggle_key, w_em, t_em)
-        self._skycoord = None  # cached Gaia DR3 SkyCoord
-        self._astrometry_source = (
-            None  # 'Gaia DR3' | 'WMKO header', set by _get_skycoord
-        )
+        self._astrometry = None  # cached barycorrpy kwargs, set by _get_astrometry
+        self._astrometry_source = None  # CSRC3 ('gaia'|'simbad'|'wmko'), same setter
 
     # ------------------------------------------------------------------
     # Private helpers -- exposure-meter handling
@@ -310,119 +317,81 @@ class BarycentricCorrection:
     # Private helpers -- barycorr handoffs
     # ------------------------------------------------------------------
 
-    def _gaia_astrometry(self):
+    def _get_astrometry(self):
         """
-        Query Gaia DR3 for the target's ICRS astrometry (cached SkyCoord).
+        Read the target astrometry off the PRIMARY C*# cards (cached).
 
-        source_id comes from GAIAID in INSTRUMENT_HEADER. Returns a SkyCoord
-        with proper motion and distance (from parallax) at the Gaia ref_epoch;
-        the network query runs once and is reused (one target per frame).
+        The cards carry AstroQuery's merged canonical record (see
+        ``KPF0._catalog_primary_cards``), already sanitized to one schema, so this is a
+        unit conversion into barycorrpy's argument set -- ra/dec [deg], pmra/pmdec
+        [mas/yr], px [mas], epoch [JD] -- and nothing else. The frame is ICRS: not
+        persisted as a card, but fixed by AstroQuery's construction, which rotates every
+        source into ICRS before writing.
+
+        AstroQuery persists catalog values faithfully, unphysical ones included, so the
+        physical sanitation belongs here: a missing or non-positive parallax (routine
+        for faint Gaia sources) becomes ``px=0``, barycorrpy's own no-parallax value.
+
+        Raises
+        ------
+        ValueError
+            If any of ``_REQUIRED_CARDS`` is absent or blank -- without a position
+            there is nothing to correct.
         """
-        if self._skycoord is None:
-            gaia_id_raw = self.l2_obj.headers["INSTRUMENT_HEADER"]["GAIAID"]
-            gaia_id = re.split(r"\s+", str(gaia_id_raw).strip())[-1]
-            if not gaia_id.isdigit():
-                raise ValueError(f"Gaia source_id must be all digits; got {gaia_id!r}")
-            query = f"""
-            SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
-            FROM gaiadr3.gaia_source
-            WHERE source_id = {gaia_id}
-            """
-            logger.info("querying Gaia DR3 for source_id %s", gaia_id)
-            job = Gaia.launch_job(query)
-            result = job.get_results()[0]
-
-            self._skycoord = SkyCoord(
-                ra=result["ra"] * u.deg,
-                dec=result["dec"] * u.deg,
-                pm_ra_cosdec=result["pmra"] * u.mas / u.yr,
-                pm_dec=result["pmdec"] * u.mas / u.yr,
-                distance=(1e3 / result["parallax"]) * u.pc,
-                obstime=Time(result["ref_epoch"], format="jyear"),
-                frame="icrs",
-            )
-        return self._skycoord
-
-    def _wmko_astrometry(self):
-        """
-        Build a SkyCoord from WMKO/DCS astrometry in INSTRUMENT_HEADER (fallback).
-
-        Unit gotchas: TARGPMRA is time-seconds/yr (-> mas/yr via x15 cos(dec));
-        TARGPLAX is mas (-> distance via 1e3/plax), matching the Gaia path.
-        """
-        inst = self.l2_obj.headers["INSTRUMENT_HEADER"]
-        pos = SkyCoord(inst["TARGRA"], inst["TARGDEC"], unit=(u.hourangle, u.deg))
-        pm_ra_cosdec = float(inst["TARGPMRA"]) * 15.0 * np.cos(pos.dec.rad) * 1e3
-        return SkyCoord(
-            ra=pos.ra,
-            dec=pos.dec,
-            pm_ra_cosdec=pm_ra_cosdec * u.mas / u.yr,
-            pm_dec=float(inst["TARGPMDC"]) * 1e3 * u.mas / u.yr,
-            distance=(1e3 / float(inst["TARGPLAX"])) * u.pc,
-            frame=str(inst["TARGFRAM"]).lower(),
-            obstime=Time(float(inst["TARGEPOC"]), format="jyear"),
-        )
-
-    def _get_skycoord(self):
-        """
-        Resolve target astrometry: Gaia DR3 first, then WMKO header fallback.
-
-        Each source is tried only if its config toggle is set. If neither
-        yields a SkyCoord, raises and surfaces the captured Gaia error so an
-        our-side vs Gaia-server-side failure stays distinguishable.
-        """
-        gaia_error = None
-        if self.use_gaia_astrometry:
-            try:
-                skycoord = self._gaia_astrometry()
-                self._astrometry_source = "Gaia DR3"
-                return skycoord
-            except Exception as e:
-                gaia_error = e
-        if self.use_wmko_fallback:
-            if gaia_error is not None:
-                logger.warning(
-                    "Gaia astrometry unavailable (%s: %s); "
-                    "using WMKO header astrometry",
-                    type(gaia_error).__name__,
-                    gaia_error,
+        if self._astrometry is None:
+            primary = self.l2_obj.headers["PRIMARY"]
+            cards = {
+                base: primary.get(f"{base}{_CATALOG_TRACE}") for base in _REQUIRED_CARDS
+            }
+            missing = [
+                f"{base}{_CATALOG_TRACE}"
+                for base, value in cards.items()
+                if value is None or str(value).strip() == ""
+            ]
+            if missing:
+                raise ValueError(
+                    f"no target astrometry on PRIMARY: {', '.join(missing)} "
+                    f"missing or blank; run AstroQuery on the L0 so the canonical "
+                    f"catalog record reaches the C*# cards"
                 )
-            self._astrometry_source = "WMKO header"
-            return self._wmko_astrometry()
-        raise ValueError(
-            "no target astrometry: Gaia "
-            + (
-                f"failed ({type(gaia_error).__name__}: {gaia_error})"
-                if gaia_error
-                else "disabled"
-            )
-            + ", WMKO fallback disabled"
-        )
+
+            # A parallax card is written only when the catalog measured one, and its
+            # value is the catalog's own (QC flags an unphysical one via CATLOGOK, but
+            # does not repair it).
+            parallax = primary.get(f"CPLX{_CATALOG_TRACE}")
+            try:
+                px = float(parallax)
+            except (TypeError, ValueError):
+                px = np.nan
+            if not np.isfinite(px) or px <= 0:
+                logger.warning(
+                    "CPLX%d=%s is missing or unusable; using px=0 (no parallax)",
+                    _CATALOG_TRACE,
+                    parallax,
+                )
+                px = 0.0
+
+            self._astrometry = {
+                "ra": Angle(cards["CRA"], unit=u.hourangle).deg,
+                "dec": Angle(cards["CDEC"], unit=u.deg).deg,
+                # C*# proper motion is arcsec/yr (RA incl. cos Dec); barycorrpy mas/yr.
+                "pmra": float(cards["CPMR"]) * 1e3,
+                "pmdec": float(cards["CPMD"]) * 1e3,
+                "px": px,
+                "epoch": Time(float(cards["CEPCH"]), format="jyear").jd,
+            }
+            self._astrometry_source = primary.get(f"CSRC{_CATALOG_TRACE}") or "unknown"
+        return self._astrometry
 
     @staticmethod
-    def _compute_barycorr(skycoord, obs_times, location, rv_mps=0.0):
+    def _compute_barycorr(astrometry, obs_times, location, rv_mps=0.0):
         """
         barycorrpy handoff -> (bc_vel_mps, bjd_tdb), each shape (n,).
 
-        ``rv_mps`` is the target's systemic RV so the BJD_TDB light-travel
-        correction accounts for stellar motion.
+        ``astrometry`` is the ICRS argument set from ``_get_astrometry``. ``rv_mps``
+        is the target's systemic RV so the BJD_TDB light-travel correction accounts
+        for stellar motion.
         """
-        icrs = skycoord.icrs
-        ra = icrs.ra.to(u.deg).value
-        dec = icrs.dec.to(u.deg).value
-        pmra = (
-            icrs.pm_ra_cosdec.to(u.mas / u.yr).value
-            if icrs.pm_ra_cosdec is not None
-            else 0.0
-        )
-        pmdec = icrs.pm_dec.to(u.mas / u.yr).value if icrs.pm_dec is not None else 0.0
-        px = (
-            (1 / icrs.distance.to(u.pc).value * 1e3)
-            if icrs.distance is not None
-            else 0.0
-        )
-        epoch = icrs.obstime.jd
-
         lat = location.lat.to(u.deg).value
         lon = location.lon.to(u.deg).value
         alt = location.height.to(u.m).value
@@ -431,29 +400,19 @@ class BarycentricCorrection:
 
         bc_vel, *_ = get_BC_vel(
             JDUTC=JDUTC,
-            ra=ra,
-            dec=dec,
             lat=lat,
             longi=lon,
             alt=alt,
-            pmra=pmra,
-            pmdec=pmdec,
-            px=px,
-            epoch=epoch,
             rv=rv_mps,
+            **astrometry,
         )
         bjd_tdb, *_ = utc_tdb.JDUTC_to_BJDTDB(
             JDUTC=JDUTC,
-            ra=ra,
-            dec=dec,
             lat=lat,
             longi=lon,
             alt=alt,
-            pmra=pmra,
-            pmdec=pmdec,
-            px=px,
-            epoch=epoch,
             rv=rv_mps,
+            **astrometry,
         )
         return np.asarray(bc_vel), np.asarray(bjd_tdb)
 
@@ -606,7 +565,7 @@ class BarycentricCorrection:
         time for each output bin.
 
         Mirrors compute_flux_weighted_midpoint_times: ``output`` selects the
-        binning. The per-channel integration and the Gaia astrometry are both
+        binning. The per-channel integration and the resolved astrometry are both
         cached, so calling this for 'orders' then 'ccds' does the heavy work
         once.
 
@@ -632,14 +591,16 @@ class BarycentricCorrection:
             extrapolate=extrapolate,
             fix_expmeter_outliers=fix_expmeter_outliers,
         )
-        skycoord = self._get_skycoord()
+        astrometry = self._get_astrometry()
 
-        # TARGRADV is in km/s; barycorrpy expects rv in m/s. Missing → 0.
-        inst = self.l2_obj.headers["INSTRUMENT_HEADER"]
-        rv_mps = float(inst.get("TARGRADV", 0.0) or 0.0) * 1000.0
+        # CRV# is in km/s; barycorrpy expects rv in m/s. Missing → 0. AstroQuery
+        # already falls back to the telescope TARGRADV when no catalog supplied an rv,
+        # so this card is the systemic RV whatever its provenance.
+        primary = self.l2_obj.headers["PRIMARY"]
+        rv_mps = float(primary.get(f"CRV{_CATALOG_TRACE}", 0.0) or 0.0) * 1000.0
 
         bc_vel_mps, bjd_tdb = self._compute_barycorr(
-            skycoord,
+            astrometry,
             t_fwm,
             self.KECK_LOCATION,
             rv_mps=rv_mps,
@@ -680,9 +641,8 @@ class BarycentricCorrection:
     def _set_headers(self, l2_obj):
         """Write the per-CCD summary keywords.
 
-        Reads self._ccd_bjd/_ccd_kms/_ccd_z and self._astrometry_source
-        (populated by perform()); set_keyword routes each to its registry home.
-        CCD1=GREEN, CCD2=RED.
+        Reads self._ccd_bjd/_ccd_kms/_ccd_z (populated by perform()); set_keyword
+        routes each to its registry home. CCD1=GREEN, CCD2=RED.
         """
         l2_obj.set_keyword("CCD1BJD", float(self._ccd_bjd[0]))
         l2_obj.set_keyword("CCD1BKMS", float(self._ccd_kms[0]))
@@ -690,7 +650,6 @@ class BarycentricCorrection:
         l2_obj.set_keyword("CCD2BJD", float(self._ccd_bjd[1]))
         l2_obj.set_keyword("CCD2BKMS", float(self._ccd_kms[1]))
         l2_obj.set_keyword("CCD2BZ", float(self._ccd_z[1]))
-        l2_obj.set_keyword("ASTRSRC", self._astrometry_source)
         # CTYPE1 names the single (spectral-order) axis of these 1-D per-order
         # arrays -- registered content, multi-homed across the three barycorr
         # extensions, so stamped directly (set_keyword can't route a multi-home
@@ -705,8 +664,6 @@ class BarycentricCorrection:
     def perform(
         self,
         *,
-        use_gaia_astrometry=None,
-        use_wmko_fallback=None,
         interpolate=True,
         extrapolate=True,
         fix_expmeter_outliers=True,
@@ -716,8 +673,6 @@ class BarycentricCorrection:
 
         Parameters
         ----------
-        use_gaia_astrometry, use_wmko_fallback : bool, optional
-            Override the configured astrometry-source toggles for this call.
         interpolate, extrapolate, fix_expmeter_outliers : bool, optional
             Forwarded to compute_flux_weighted_midpoint_times(). See that
             method for semantics.
@@ -727,14 +682,8 @@ class BarycentricCorrection:
         l2_obj : KPF2
             Input KPF2 with BJD_TDB / BARYCORR_KMS / BARYCORR_Z populated, the
             per-CCD CCD{1,2}BJD/BKMS/BZ summaries written to those same bary
-            extension headers, the astrometry source (ASTRSRC) written to
-            RECEIPT, and a 'barycentric_correction' receipt entry.
+            extension headers, and a 'barycentric_correction' receipt entry.
         """
-        if use_gaia_astrometry is not None:
-            self.use_gaia_astrometry = use_gaia_astrometry
-        if use_wmko_fallback is not None:
-            self.use_wmko_fallback = use_wmko_fallback
-
         kwargs = dict(
             interpolate=interpolate,
             extrapolate=extrapolate,

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -35,12 +35,10 @@ logger = logging.getLogger(__name__)
 
 _DEFAULTS = {**DEFAULTS}
 
-# The position block the correction cannot proceed without. AstroQuery's merge refuses
-# to emit a canonical row without it, so an absent card means AstroQuery never ran (or
-# this is a calibration frame, which BarycentricCorrection must not be called on).
-# The trailing 3 here and on the CPLX3/CSRC3/CRV3 reads below is the SCI2 trace: the
-# C*# cards are written identically to every science fiber (SCI1-3 = traces 2-4), and
-# SCI2 is the reference fiber this module already uses for SCI2_WAVE / SCI2_FLUX.
+# The position block the correction cannot proceed without; an absent card means
+# AstroQuery never ran. The trailing 3 (here and on CPLX3/CSRC3/CRV3 below) selects
+# the SCI2 trace: the C*# cards are written identically to every science fiber
+# (SCI1-3 = traces 2-4), and SCI2 is the fiber this module uses for SCI2_WAVE/FLUX.
 _REQUIRED_CARDS = ("CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3")
 
 
@@ -321,12 +319,10 @@ class BarycentricCorrection:
         """
         Convert a caller-supplied SkyCoord into barycorrpy's argument set.
 
-        The interactive escape hatch behind ``perform(skycoord=...)``: same output as
-        ``_get_astrometry``, sourced from the object instead of the header. Deliberately
-        unvalidated -- the SkyCoord is rotated to ICRS and read, and astropy raises on
-        its own if the object was built without the proper motion, distance, or obstime
-        the correction needs. No sanitation either: a caller passing explicit astrometry
-        is asking for exactly those numbers.
+        Backs ``perform(skycoord=...)``: same output as ``_get_astrometry``, sourced
+        from the object instead of the header. Unvalidated -- the SkyCoord is rotated to
+        ICRS and read, and astropy raises if it lacks the proper motion, distance, or
+        obstime the correction needs.
         """
         icrs = skycoord.icrs
         return {
@@ -374,9 +370,8 @@ class BarycentricCorrection:
                     f"catalog record reaches the C*# cards"
                 )
 
-            # A parallax card is written only when the catalog measured one, and its
-            # value is the catalog's own (QC flags an unphysical one via CATLOGOK, but
-            # does not repair it).
+            # The parallax card is the catalog's own value; QC flags an unphysical one
+            # via CATLOGOK but does not repair it, so sanitize here.
             parallax = primary.get("CPLX3")
             try:
                 px = float(parallax)
@@ -622,11 +617,20 @@ class BarycentricCorrection:
         else:
             astrometry = self._get_astrometry()
 
-        # CRV3 (SCI2 trace) is in km/s; barycorrpy expects rv in m/s. Missing → 0.
-        # AstroQuery already falls back to the telescope TARGRADV when no catalog
-        # supplied an rv, so this card is the systemic RV whatever its provenance.
+        # CRV3 (SCI2 trace) is in km/s; barycorrpy expects rv in m/s.
         primary = self.l2_obj.headers["PRIMARY"]
-        rv_mps = float(primary.get("CRV3", 0.0) or 0.0) * 1000.0
+        systemic_rv = primary.get("CRV3")
+        try:
+            rv_kms = float(systemic_rv)
+        except (TypeError, ValueError):
+            rv_kms = np.nan
+        if not np.isfinite(rv_kms):
+            logger.warning(
+                "CRV3=%s is missing or unusable; using rv=0 (no systemic RV)",
+                systemic_rv,
+            )
+            rv_kms = 0.0
+        rv_mps = rv_kms * 1000.0
 
         bc_vel_mps, bjd_tdb = self._compute_barycorr(
             astrometry,
@@ -709,12 +713,11 @@ class BarycentricCorrection:
             ``interpolate`` / ``extrapolate`` / ``fix_outliers``. See that method
             for semantics.
         skycoord : False | SkyCoord, optional
-            Astrometry override for interactive use: when given, the correction is
-            computed from this SkyCoord instead of the PRIMARY C*# cards, which stay
-            untouched. Lets a user retry with different astrometry on an L2 in hand,
-            rather than re-reducing from L0 to re-run AstroQuery. The production path
-            leaves this False. The SkyCoord is used as-is -- it must carry proper
-            motion, distance, and obstime, and astropy raises if it does not.
+            Astrometry override for interactive use: when given, the correction uses
+            this SkyCoord instead of the PRIMARY C*# cards, which stay untouched --
+            lets a user retry with different astrometry on an L2 in hand without
+            re-running AstroQuery from L0. Used as-is: it must carry proper motion,
+            distance, and obstime, and astropy raises if it does not.
 
         Returns
         -------

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -6,9 +6,8 @@ midpoint times and stores them on the L2 as BJD_TDB, BARYCORR_KMS, and
 BARYCORR_Z (per spectral order), plus per-CCD scalar summaries in the
 barycentric extension headers. Wavelength arrays are not modified.
 
-Target astrometry is read from the EPRV PRIMARY C*# catalog keywords, not queried:
-AstroQuery is the pipeline's sole external-catalog client, and KPF0.to_kpf1 overlays
-its merged canonical record onto those cards.
+Target astrometry is read from the PRIMARY C*# catalog cards, not queried --
+AstroQuery is the pipeline's sole external-catalog client.
 
 Follows the barycentric-correction approach of Wright & Eastman (2014,
 barycorrpy) with the flux-weighted midpoint time of Butler et al. (1996).
@@ -36,9 +35,8 @@ logger = logging.getLogger(__name__)
 _DEFAULTS = {**DEFAULTS}
 
 # The position block the correction cannot proceed without; an absent card means
-# AstroQuery never ran. The trailing 3 (here and on CPLX3/CSRC3/CRV3 below) selects
-# the SCI2 trace: the C*# cards are written identically to every science fiber
-# (SCI1-3 = traces 2-4), and SCI2 is the fiber this module uses for SCI2_WAVE/FLUX.
+# AstroQuery never ran. The trailing 3 (also CPLX3/CSRC3/CRV3) selects the SCI2
+# trace: the C*# cards are identical across science fibers (SCI1-3 = traces 2-4).
 _REQUIRED_CARDS = ("CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3")
 
 
@@ -57,10 +55,9 @@ class BarycentricCorrection:
     l2_obj : KPF2
         Extracted L2 frame. Must have EXPMETER_SCI populated and SCI2_WAVE
         populated by WavelengthCalibration. PRIMARY must carry the SCI2 catalog
-        cards (CRA3/CDEC3/CPMR3/CPMD3/CEPCH3, written by AstroQuery via
-        KPF0.to_kpf1), unless perform() is given a ``skycoord`` override.
-        INSTRUMENT_HEADER (the preserved L1 PRIMARY) must contain
-        DATE-BEG/DATE-END when extrapolating.
+        cards (CRA3/CDEC3/CPMR3/CPMD3/CEPCH3) unless perform() is given a
+        ``skycoord`` override. INSTRUMENT_HEADER (the preserved L1 PRIMARY) must
+        contain DATE-BEG/DATE-END when extrapolating.
     config : None | dict | ConfigHandler
         Module configuration. Recognizes no module-specific keys.
     """
@@ -319,10 +316,8 @@ class BarycentricCorrection:
         """
         Convert a caller-supplied SkyCoord into barycorrpy's argument set.
 
-        Backs ``perform(skycoord=...)``: same output as ``_get_astrometry``, sourced
-        from the object instead of the header. Unvalidated -- the SkyCoord is rotated to
-        ICRS and read, and astropy raises if it lacks the proper motion, distance, or
-        obstime the correction needs.
+        Backs ``perform(skycoord=...)``. Unvalidated -- the SkyCoord is rotated to
+        ICRS and read; astropy raises if it lacks proper motion, distance, or obstime.
         """
         icrs = skycoord.icrs
         return {
@@ -338,12 +333,10 @@ class BarycentricCorrection:
         """
         Read the target astrometry off the PRIMARY C*# cards (cached).
 
-        The cards carry AstroQuery's merged canonical record (see
-        ``KPF0._catalog_primary_cards``), already sanitized to one schema, so this is a
-        unit conversion into barycorrpy's argument set -- ra/dec [deg], pmra/pmdec
-        [mas/yr], px [mas], epoch [JD] -- and nothing else. The frame is ICRS: not
-        persisted as a card, but fixed by AstroQuery's construction, which rotates every
-        source into ICRS before writing.
+        The cards carry AstroQuery's merged canonical record, so this is only a unit
+        conversion into barycorrpy's argument set -- ra/dec [deg], pmra/pmdec [mas/yr],
+        px [mas], epoch [JD]. The frame is ICRS: not persisted as a card, but fixed by
+        AstroQuery, which rotates every source into ICRS before writing.
 
         AstroQuery persists catalog values faithfully, unphysical ones included, so the
         physical sanitation belongs here: a missing or non-positive parallax (routine
@@ -370,8 +363,7 @@ class BarycentricCorrection:
                     f"catalog record reaches the C*# cards"
                 )
 
-            # The parallax card is the catalog's own value; QC flags an unphysical one
-            # via CATLOGOK but does not repair it, so sanitize here.
+            # QC flags an unphysical parallax (CATLOGOK) but does not repair it.
             parallax = primary.get("CPLX3")
             try:
                 px = float(parallax)
@@ -610,8 +602,7 @@ class BarycentricCorrection:
             fix_outliers=fix_expmeter_outliers,
         )
         if skycoord:
-            # Caller-supplied astrometry: not cached onto self._astrometry, so a later
-            # call without skycoord still reads the header rather than this override.
+            # Not cached: a later call without skycoord still reads the header.
             astrometry = self._astrometry_from_skycoord(skycoord)
             self._astrometry_source = "user SkyCoord"
         else:
@@ -713,11 +704,10 @@ class BarycentricCorrection:
             ``interpolate`` / ``extrapolate`` / ``fix_outliers``. See that method
             for semantics.
         skycoord : False | SkyCoord, optional
-            Astrometry override for interactive use: when given, the correction uses
-            this SkyCoord instead of the PRIMARY C*# cards, which stay untouched --
-            lets a user retry with different astrometry on an L2 in hand without
-            re-running AstroQuery from L0. Used as-is: it must carry proper motion,
-            distance, and obstime, and astropy raises if it does not.
+            Astrometry override for interactive use: the correction uses this
+            SkyCoord instead of the PRIMARY C*# cards, which stay untouched. Used
+            as-is -- it must carry proper motion, distance, and obstime, and astropy
+            raises if it does not.
 
         Returns
         -------

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -62,7 +62,8 @@ class BarycentricCorrection:
         Extracted L2 frame. Must have EXPMETER_SCI populated and SCI2_WAVE
         populated by WavelengthCalibration. PRIMARY must carry the SCI2 catalog
         cards (CRA3/CDEC3/CPMR3/CPMD3/CEPCH3, written by AstroQuery via
-        KPF0.to_kpf1). INSTRUMENT_HEADER (the preserved L1 PRIMARY) must contain
+        KPF0.to_kpf1), unless perform() is given a ``skycoord`` override.
+        INSTRUMENT_HEADER (the preserved L1 PRIMARY) must contain
         DATE-BEG/DATE-END when extrapolating.
     config : None | dict | ConfigHandler
         Module configuration. Recognizes no module-specific keys.
@@ -317,6 +318,28 @@ class BarycentricCorrection:
     # Private helpers -- barycorr handoffs
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _astrometry_from_skycoord(skycoord):
+        """
+        Convert a caller-supplied SkyCoord into barycorrpy's argument set.
+
+        The interactive escape hatch behind ``perform(skycoord=...)``: same output as
+        ``_get_astrometry``, sourced from the object instead of the header. Deliberately
+        unvalidated -- the SkyCoord is rotated to ICRS and read, and astropy raises on
+        its own if the object was built without the proper motion, distance, or obstime
+        the correction needs. No sanitation either: a caller passing explicit astrometry
+        is asking for exactly those numbers.
+        """
+        icrs = skycoord.icrs
+        return {
+            "ra": icrs.ra.to_value(u.deg),
+            "dec": icrs.dec.to_value(u.deg),
+            "pmra": icrs.pm_ra_cosdec.to_value(u.mas / u.yr),
+            "pmdec": icrs.pm_dec.to_value(u.mas / u.yr),
+            "px": 1e3 / icrs.distance.to_value(u.pc),
+            "epoch": icrs.obstime.jd,
+        }
+
     def _get_astrometry(self):
         """
         Read the target astrometry off the PRIMARY C*# cards (cached).
@@ -559,6 +582,7 @@ class BarycentricCorrection:
         interpolate_expmeter_flux=True,
         extrapolate_expmeter_flux=True,
         fix_expmeter_outliers=True,
+        skycoord=False,
     ):
         """
         Compute the barycentric correction at the flux-weighted photon-midpoint
@@ -577,6 +601,8 @@ class BarycentricCorrection:
                 : bool, optional
             Forwarded to compute_flux_weighted_midpoint_times() as its
             ``interpolate`` / ``extrapolate`` / ``fix_outliers``.
+        skycoord : False | SkyCoord, optional
+            Use this astrometry instead of the PRIMARY C*# cards. See perform().
 
         Returns
         -------
@@ -593,7 +619,13 @@ class BarycentricCorrection:
             extrapolate=extrapolate_expmeter_flux,
             fix_outliers=fix_expmeter_outliers,
         )
-        astrometry = self._get_astrometry()
+        if skycoord:
+            # Caller-supplied astrometry: not cached onto self._astrometry, so a later
+            # call without skycoord still reads the header rather than this override.
+            astrometry = self._astrometry_from_skycoord(skycoord)
+            self._astrometry_source = "user SkyCoord"
+        else:
+            astrometry = self._get_astrometry()
 
         # CRV# is in km/s; barycorrpy expects rv in m/s. Missing → 0. AstroQuery
         # already falls back to the telescope TARGRADV when no catalog supplied an rv,
@@ -669,6 +701,7 @@ class BarycentricCorrection:
         interpolate_expmeter_flux=True,
         extrapolate_expmeter_flux=True,
         fix_expmeter_outliers=True,
+        skycoord=False,
     ):
         """
         Compute per-order barycentric correction and store it on the KPF2.
@@ -680,6 +713,13 @@ class BarycentricCorrection:
             Forwarded to compute_flux_weighted_midpoint_times() as its
             ``interpolate`` / ``extrapolate`` / ``fix_outliers``. See that method
             for semantics.
+        skycoord : False | SkyCoord, optional
+            Astrometry override for interactive use: when given, the correction is
+            computed from this SkyCoord instead of the PRIMARY C*# cards, which stay
+            untouched. Lets a user retry with different astrometry on an L2 in hand,
+            rather than re-reducing from L0 to re-run AstroQuery. The production path
+            leaves this False. The SkyCoord is used as-is -- it must carry proper
+            motion, distance, and obstime, and astropy raises if it does not.
 
         Returns
         -------
@@ -692,6 +732,7 @@ class BarycentricCorrection:
             interpolate_expmeter_flux=interpolate_expmeter_flux,
             extrapolate_expmeter_flux=extrapolate_expmeter_flux,
             fix_expmeter_outliers=fix_expmeter_outliers,
+            skycoord=skycoord,
         )
         bjd_tdb, bary_kms, bary_z = self.compute_barycentric_correction(
             output="orders", **kwargs

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -35,15 +35,13 @@ logger = logging.getLogger(__name__)
 
 _DEFAULTS = {**DEFAULTS}
 
-# The PRIMARY C*# catalog cards are written identically to every science fiber
-# (SCI1-3 = traces 2-4); read SCI2, the reference fiber this module already uses for
-# SCI2_WAVE / SCI2_FLUX.
-_CATALOG_TRACE = 3
-
 # The position block the correction cannot proceed without. AstroQuery's merge refuses
 # to emit a canonical row without it, so an absent card means AstroQuery never ran (or
 # this is a calibration frame, which BarycentricCorrection must not be called on).
-_REQUIRED_CARDS = ("CRA", "CDEC", "CPMR", "CPMD", "CEPCH")
+# The trailing 3 here and on the CPLX3/CSRC3/CRV3 reads below is the SCI2 trace: the
+# C*# cards are written identically to every science fiber (SCI1-3 = traces 2-4), and
+# SCI2 is the reference fiber this module already uses for SCI2_WAVE / SCI2_FLUX.
+_REQUIRED_CARDS = ("CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3")
 
 
 class BarycentricCorrection:
@@ -363,12 +361,10 @@ class BarycentricCorrection:
         """
         if self._astrometry is None:
             primary = self.l2_obj.headers["PRIMARY"]
-            cards = {
-                base: primary.get(f"{base}{_CATALOG_TRACE}") for base in _REQUIRED_CARDS
-            }
+            cards = {name: primary.get(name) for name in _REQUIRED_CARDS}
             missing = [
-                f"{base}{_CATALOG_TRACE}"
-                for base, value in cards.items()
+                name
+                for name, value in cards.items()
                 if value is None or str(value).strip() == ""
             ]
             if missing:
@@ -381,29 +377,28 @@ class BarycentricCorrection:
             # A parallax card is written only when the catalog measured one, and its
             # value is the catalog's own (QC flags an unphysical one via CATLOGOK, but
             # does not repair it).
-            parallax = primary.get(f"CPLX{_CATALOG_TRACE}")
+            parallax = primary.get("CPLX3")
             try:
                 px = float(parallax)
             except (TypeError, ValueError):
                 px = np.nan
             if not np.isfinite(px) or px <= 0:
                 logger.warning(
-                    "CPLX%d=%s is missing or unusable; using px=0 (no parallax)",
-                    _CATALOG_TRACE,
+                    "CPLX3=%s is missing or unusable; using px=0 (no parallax)",
                     parallax,
                 )
                 px = 0.0
 
             self._astrometry = {
-                "ra": Angle(cards["CRA"], unit=u.hourangle).deg,
-                "dec": Angle(cards["CDEC"], unit=u.deg).deg,
+                "ra": Angle(cards["CRA3"], unit=u.hourangle).deg,
+                "dec": Angle(cards["CDEC3"], unit=u.deg).deg,
                 # C*# proper motion is arcsec/yr (RA incl. cos Dec); barycorrpy mas/yr.
-                "pmra": float(cards["CPMR"]) * 1e3,
-                "pmdec": float(cards["CPMD"]) * 1e3,
+                "pmra": float(cards["CPMR3"]) * 1e3,
+                "pmdec": float(cards["CPMD3"]) * 1e3,
                 "px": px,
-                "epoch": Time(float(cards["CEPCH"]), format="jyear").jd,
+                "epoch": Time(float(cards["CEPCH3"]), format="jyear").jd,
             }
-            self._astrometry_source = primary.get(f"CSRC{_CATALOG_TRACE}") or "unknown"
+            self._astrometry_source = primary.get("CSRC3") or "unknown"
         return self._astrometry
 
     @staticmethod
@@ -627,11 +622,11 @@ class BarycentricCorrection:
         else:
             astrometry = self._get_astrometry()
 
-        # CRV# is in km/s; barycorrpy expects rv in m/s. Missing → 0. AstroQuery
-        # already falls back to the telescope TARGRADV when no catalog supplied an rv,
-        # so this card is the systemic RV whatever its provenance.
+        # CRV3 (SCI2 trace) is in km/s; barycorrpy expects rv in m/s. Missing → 0.
+        # AstroQuery already falls back to the telescope TARGRADV when no catalog
+        # supplied an rv, so this card is the systemic RV whatever its provenance.
         primary = self.l2_obj.headers["PRIMARY"]
-        rv_mps = float(primary.get(f"CRV{_CATALOG_TRACE}", 0.0) or 0.0) * 1000.0
+        rv_mps = float(primary.get("CRV3", 0.0) or 0.0) * 1000.0
 
         bc_vel_mps, bjd_tdb = self._compute_barycorr(
             astrometry,

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -212,13 +212,11 @@ class CrossCorrelation:
     def _get_systemic_rv(self):
         """Target systemic RV (PRIMARY CRV3) [km/s] -- the stellar CCF grid center.
 
-        CRV3 is AstroQuery's canonical catalog rv, overlaid onto the SCI fibers by
-        KPF0.to_kpf1, so the CCF grid centers on the same systemic velocity the
-        barycentric correction used. Raises rather than defaulting to 0: a grid
-        centered on the wrong velocity misses the star.
+        CRV3 is the canonical catalog rv, so the CCF grid centers on the same
+        systemic velocity the barycentric correction used. Raises rather than
+        defaulting to 0: a grid centered on the wrong velocity misses the star.
         """
-        # CRV3 is the SCI2 trace, the trace BarycentricCorrection reads; the C*#
-        # cards are written identically to all science fibers (traces 2-4).
+        # The C*# cards are written identically to all science fibers (traces 2-4).
         primary = self.l2_obj.headers.get("PRIMARY", {})
         try:
             star_rv = float(primary.get("CRV3"))

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -13,7 +13,7 @@ its illumination source (SCI-OBJ/SKY-OBJ/CAL-OBJ in INSTRUMENT_HEADER):
   +--------+-------------------------------------+----------+---------------------+
   | source | mask                                | barycorr | grid center         |
   +========+=====================================+==========+=====================+
-  | target | TARGTEFF-lookup                     | yes      | TARGRADV (systemic) |
+  | target | TARGTEFF-lookup                     | yes      | CRV3 (systemic)     |
   +--------+-------------------------------------+----------+---------------------+
   | sky    | G2_espresso (solar)                 | yes      | 0                   |
   +--------+-------------------------------------+----------+---------------------+
@@ -210,16 +210,30 @@ class CrossCorrelation:
         return row["DEFAULT_MASK"].iloc[0]
 
     def _get_systemic_rv(self):
-        """Target systemic RV (TARGRADV) [km/s] -- the stellar CCF grid center."""
-        inst = self.l2_obj.headers.get("INSTRUMENT_HEADER", {})
+        """Target systemic RV (PRIMARY CRV3) [km/s] -- the stellar CCF grid center.
+
+        CRV3 is AstroQuery's canonical catalog rv (the telescope TARGRADV is its own
+        last-resort fallback), overlaid onto the SCI fibers by KPF0.to_kpf1 -- so the
+        CCF grid is centered on the same systemic velocity the barycentric correction
+        used, rather than on the raw DCS value.
+
+        Raises rather than defaulting to 0: the grid center decides where the CCF dip
+        is searched for, so a window centered on the wrong velocity simply misses the
+        star.
+        """
+        # The 3 is the SCI2 trace: the C*# cards are written identically to every
+        # science fiber (SCI1-3 = traces 2-4), and SCI2 is the trace
+        # BarycentricCorrection reads, so both stages use the same systemic rv.
+        primary = self.l2_obj.headers.get("PRIMARY", {})
         try:
-            star_rv = float(inst.get("TARGRADV"))
+            star_rv = float(primary.get("CRV3"))
         except (TypeError, ValueError):
             star_rv = None
         if star_rv is None or not np.isfinite(star_rv):
             raise ValueError(
-                "target radial velocity (TARGRADV) not available in "
-                "INSTRUMENT_HEADER; cannot center the CCF velocity grid"
+                "target radial velocity (CRV3) not available on PRIMARY; cannot "
+                "center the CCF velocity grid. Run AstroQuery on the L0 so the "
+                "canonical catalog record reaches the C*# cards."
             )
         return star_rv
 
@@ -447,7 +461,7 @@ class CrossCorrelation:
         ValueError
             For a range of malformed or unusable inputs: an unrecognized or
             missing illumination keyword; a missing target effective temperature
-            (``TARGTEFF``) or radial velocity (``TARGRADV``) for a stellar fiber;
+            (``TARGTEFF``) or radial velocity (``CRV3``) for a stellar fiber;
             a required but unpopulated ``BARYCORR_Z``; a descending ``WAVE``
             array; or a ``clip_edge_pixels`` that removes every pixel of the order.
         RuntimeError

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -212,18 +212,13 @@ class CrossCorrelation:
     def _get_systemic_rv(self):
         """Target systemic RV (PRIMARY CRV3) [km/s] -- the stellar CCF grid center.
 
-        CRV3 is AstroQuery's canonical catalog rv (the telescope TARGRADV is its own
-        last-resort fallback), overlaid onto the SCI fibers by KPF0.to_kpf1 -- so the
-        CCF grid is centered on the same systemic velocity the barycentric correction
-        used, rather than on the raw DCS value.
-
-        Raises rather than defaulting to 0: the grid center decides where the CCF dip
-        is searched for, so a window centered on the wrong velocity simply misses the
-        star.
+        CRV3 is AstroQuery's canonical catalog rv, overlaid onto the SCI fibers by
+        KPF0.to_kpf1, so the CCF grid centers on the same systemic velocity the
+        barycentric correction used. Raises rather than defaulting to 0: a grid
+        centered on the wrong velocity misses the star.
         """
-        # The 3 is the SCI2 trace: the C*# cards are written identically to every
-        # science fiber (SCI1-3 = traces 2-4), and SCI2 is the trace
-        # BarycentricCorrection reads, so both stages use the same systemic rv.
+        # CRV3 is the SCI2 trace, the trace BarycentricCorrection reads; the C*#
+        # cards are written identically to all science fibers (traces 2-4).
         primary = self.l2_obj.headers.get("PRIMARY", {})
         try:
             star_rv = float(primary.get("CRV3"))

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -19,7 +19,7 @@ class DiagL0(Diagnostics):
     """Diagnostics for KPF Level 0 raw data products.
 
     The pointing-offset metrics compare the telescope pointing against the target
-    astrometry resolved upstream by AstroQuery and attached as ``l0.catalog_query``
+    astrometry resolved upstream by AstroQuery and attached as ``l0.catalog_record``
     (Gaia / SIMBAD / DCS, all in one canonical ICRS schema). When a source's
     astrometry is unavailable the offset is emitted present-but-empty (a valueless
     card) and a WARNING is logged -- diagnostics record what they can and leave
@@ -29,16 +29,16 @@ class DiagL0(Diagnostics):
     LEVEL = "L0"
 
     def _catalog_record(self, source):
-        """Usable ``catalog_query`` record for ``source``, or None with a WARNING.
+        """Usable ``catalog_record`` record for ``source``, or None with a WARNING.
 
-        Handles the three contingencies: AstroQuery not run (no ``catalog_query``),
+        Handles the three contingencies: AstroQuery not run (no ``catalog_record``),
         the source's record absent (lookup disabled/failed, or WMKO unavailable),
         or a record present but missing a field the offset needs.
         """
-        catalog = getattr(self.kpf_obj, "catalog_query", None)
+        catalog = getattr(self.kpf_obj, "catalog_record", None)
         if catalog is None:
             logger.warning(
-                "no catalog_query on L0 (run AstroQuery first); "
+                "no catalog_record on L0 (run AstroQuery first); "
                 "%s pointing offset unavailable",
                 source,
             )
@@ -46,20 +46,20 @@ class DiagL0(Diagnostics):
         rec = catalog.get(source)
         if rec is None:
             logger.warning(
-                "no %s astrometry in catalog_query; pointing offset unavailable",
+                "no %s astrometry in catalog_record; pointing offset unavailable",
                 source,
             )
             return None
         if any(rec.get(field) is None for field in _OFFSET_FIELDS):
             logger.warning(
-                "incomplete %s record in catalog_query; pointing offset unavailable",
+                "incomplete %s record in catalog_record; pointing offset unavailable",
                 source,
             )
             return None
         return rec
 
     def _record_skycoord(self, rec):
-        """ICRS SkyCoord from a ``catalog_query`` record (canonical units).
+        """ICRS SkyCoord from a ``catalog_record`` record (canonical units).
 
         AstroQuery normalizes every source ('gaia'/'simbad'/'wmko') to the same
         schema -- ICRS, RA/Dec deg, proper motion mas/yr (RA incl. cos Dec),

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -1,10 +1,18 @@
 """Diagnostics for KPF Level 0 (raw CCD) data products."""
 
+import logging
+
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
 
 from kpfpipe.quality_control.diagnostics.base import Diagnostics
+
+logger = logging.getLogger(__name__)
+
+# Record fields the pointing offset needs; a None in any of them (or a missing
+# record) makes the source unusable, and the offset is emitted present-but-empty.
+_OFFSET_FIELDS = ("ra", "dec", "pmra", "pmdec", "parallax", "epoch", "frame")
 
 
 class DiagL0(Diagnostics):
@@ -12,20 +20,51 @@ class DiagL0(Diagnostics):
 
     The pointing-offset metrics compare the telescope pointing against the target
     astrometry resolved upstream by AstroQuery and attached as ``l0.catalog_query``
-    (Gaia / SIMBAD / DCS, all in one canonical ICRS schema); DiagL0 assumes that
-    dict is present and fully populated.
+    (Gaia / SIMBAD / DCS, all in one canonical ICRS schema). When a source's
+    astrometry is unavailable the offset is emitted present-but-empty (a valueless
+    card) and a WARNING is logged -- diagnostics record what they can and leave
+    error-raising to the checkpoint layer.
     """
 
     LEVEL = "L0"
 
-    def _record_skycoord(self, source):
+    def _catalog_record(self, source):
+        """Usable ``catalog_query`` record for ``source``, or None with a WARNING.
+
+        Handles the three contingencies: AstroQuery not run (no ``catalog_query``),
+        the source's record absent (lookup disabled/failed, or WMKO unavailable),
+        or a record present but missing a field the offset needs.
+        """
+        catalog = getattr(self.kpf_obj, "catalog_query", None)
+        if catalog is None:
+            logger.warning(
+                "no catalog_query on L0 (run AstroQuery first); "
+                "%s pointing offset unavailable",
+                source,
+            )
+            return None
+        rec = catalog.get(source)
+        if rec is None:
+            logger.warning(
+                "no %s astrometry in catalog_query; pointing offset unavailable",
+                source,
+            )
+            return None
+        if any(rec.get(field) is None for field in _OFFSET_FIELDS):
+            logger.warning(
+                "incomplete %s record in catalog_query; pointing offset unavailable",
+                source,
+            )
+            return None
+        return rec
+
+    def _record_skycoord(self, rec):
         """ICRS SkyCoord from a ``catalog_query`` record (canonical units).
 
         AstroQuery normalizes every source ('gaia'/'simbad'/'wmko') to the same
         schema -- ICRS, RA/Dec deg, proper motion mas/yr (RA incl. cos Dec),
         parallax mas, epoch in Julian years -- so one builder serves all three.
         """
-        rec = self.kpf_obj.catalog_query[source]
         return SkyCoord(
             ra=rec["ra"] * u.deg,
             dec=rec["dec"] * u.deg,
@@ -48,11 +87,15 @@ class DiagL0(Diagnostics):
     def _offset(self, source):
         """Arcsec separation of the pointing from a catalog source at obs epoch.
 
-        The catalog position is propagated to the observation epoch (proper
-        motion) before the comparison, so the offset reflects where the source
-        actually sits at the time of the exposure.
+        Returns None (present-but-empty keyword) when the source astrometry is
+        unavailable; otherwise the catalog position is propagated to the
+        observation epoch (proper motion) before the comparison, so the offset
+        reflects where the source actually sits at the time of the exposure.
         """
-        coord = self._record_skycoord(source).apply_space_motion(
+        rec = self._catalog_record(source)
+        if rec is None:
+            return None
+        coord = self._record_skycoord(rec).apply_space_motion(
             new_obstime=self._obs_time()
         )
         return round(float(self._pointing().separation(coord).arcsec), 4)

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -2,6 +2,7 @@
 
 import logging
 
+import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
@@ -10,56 +11,64 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 logger = logging.getLogger(__name__)
 
-# Record fields the pointing offset needs; a None in any of them (or a missing
-# record) makes the source unusable, and the offset is emitted present-but-empty.
-_OFFSET_FIELDS = ("ra", "dec", "pmra", "pmdec", "parallax", "epoch", "frame")
+# Numeric record fields the pointing offset needs; a NaN in any (a missing
+# measurement) makes the source unusable, and the offset is emitted present-but-
+# empty. 'frame' is a fixed literal AstroQuery always sets, so it is not gated here.
+_OFFSET_FIELDS = ("ra", "dec", "pmra", "pmdec", "parallax", "epoch")
+
+# CATALOG_RECORD presence flag (int 0/1) per source, on the extension header.
+_FLAG_KEYWORDS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
 
 
 class DiagL0(Diagnostics):
     """Diagnostics for KPF Level 0 raw data products.
 
     The pointing-offset metrics compare the telescope pointing against the target
-    astrometry resolved upstream by AstroQuery and attached as ``l0.catalog_record``
-    (Gaia / SIMBAD / DCS, all in one canonical ICRS schema). When a source's
-    astrometry is unavailable the offset is emitted present-but-empty (a valueless
-    card) and a WARNING is logged -- diagnostics record what they can and leave
-    error-raising to the checkpoint layer.
+    astrometry resolved upstream by AstroQuery and written to the L0
+    ``CATALOG_RECORD`` extension (Gaia / SIMBAD / DCS, all in one canonical ICRS
+    schema). When a source's astrometry is unavailable the offset is emitted
+    present-but-empty (a valueless card) and a WARNING is logged -- diagnostics
+    record what they can and leave error-raising to the checkpoint layer.
     """
 
     LEVEL = "L0"
 
     def _catalog_record(self, source):
-        """Usable ``catalog_record`` record for ``source``, or None with a WARNING.
+        """The CATALOG_RECORD row for ``source``, or None with a WARNING.
 
-        Handles the three contingencies: AstroQuery not run (no ``catalog_record``),
-        the source's record absent (lookup disabled/failed, or WMKO unavailable),
-        or a record present but missing a field the offset needs.
+        Handles the three contingencies: AstroQuery not run (no presence flag on the
+        CATALOG_RECORD header), the source's record absent (flag 0 -- lookup
+        disabled/failed, or WMKO unavailable), or a record present but missing a
+        measurement the offset needs. The flag is written with the row, so flag 1
+        guarantees exactly one matching row.
         """
-        catalog = getattr(self.kpf_obj, "catalog_record", None)
-        if catalog is None:
+        hdr = self.kpf_obj.headers["CATALOG_RECORD"]
+        keyword = _FLAG_KEYWORDS[source]
+        if keyword not in hdr:
             logger.warning(
-                "no catalog_record on L0 (run AstroQuery first); "
+                "no CATALOG_RECORD flags on L0 (run AstroQuery first); "
                 "%s pointing offset unavailable",
                 source,
             )
             return None
-        rec = catalog.get(source)
-        if rec is None:
+        if not hdr[keyword]:
             logger.warning(
-                "no %s astrometry in catalog_record; pointing offset unavailable",
+                "no %s astrometry in CATALOG_RECORD; pointing offset unavailable",
                 source,
             )
             return None
-        if any(rec.get(field) is None for field in _OFFSET_FIELDS):
+        table = self.kpf_obj.data["CATALOG_RECORD"]
+        row = table[table["source"] == source][0]
+        if any(np.isnan(row[field]) for field in _OFFSET_FIELDS):
             logger.warning(
-                "incomplete %s record in catalog_record; pointing offset unavailable",
+                "incomplete %s record in CATALOG_RECORD; pointing offset unavailable",
                 source,
             )
             return None
-        return rec
+        return row
 
     def _record_skycoord(self, rec):
-        """ICRS SkyCoord from a ``catalog_record`` record (canonical units).
+        """ICRS SkyCoord from a CATALOG_RECORD record (canonical units).
 
         AstroQuery normalizes every source ('gaia'/'simbad'/'wmko') to the same
         schema -- ICRS, RA/Dec deg, proper motion mas/yr (RA incl. cos Dec),

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -94,15 +94,6 @@ class DiagL0(Diagnostics):
             frame=str(rec["frame"]),
         )
 
-    def _pointing(self):
-        """Telescope pointing SkyCoord from L0 PRIMARY RA/DEC (sexagesimal h/deg)."""
-        hdr = self.kpf_obj.headers["PRIMARY"]
-        return SkyCoord(hdr["RA"], hdr["DEC"], unit=(u.hourangle, u.deg))
-
-    def _obs_time(self):
-        """Observation epoch (Time) from L0 PRIMARY MJD-OBS, for PM propagation."""
-        return Time(float(self.kpf_obj.headers["PRIMARY"]["MJD-OBS"]), format="mjd")
-
     def _offset(self, source):
         """Arcsec separation of the pointing from a catalog source at obs epoch.
 
@@ -117,10 +108,11 @@ class DiagL0(Diagnostics):
         if rec is None:
             return None
         try:
-            coord = self._record_skycoord(rec).apply_space_motion(
-                new_obstime=self._obs_time()
-            )
-            return round(float(self._pointing().separation(coord).arcsec), 4)
+            hdr = self.kpf_obj.headers["PRIMARY"]
+            pointing = SkyCoord(hdr["RA"], hdr["DEC"], unit=(u.hourangle, u.deg))
+            obs_time = Time(float(hdr["MJD-OBS"]), format="mjd")
+            coord = self._record_skycoord(rec).apply_space_motion(new_obstime=obs_time)
+            return round(float(pointing.separation(coord).arcsec), 4)
         except Exception as exc:
             logger.warning(
                 "could not compute %s pointing offset (%s: %s); emitting empty",

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -11,11 +11,9 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 logger = logging.getLogger(__name__)
 
-# Fields the pointing offset requires: RA/Dec (position) and epoch (the propagation
-# baseline). A record missing either is unusable, so its offset is emitted present-
-# but-empty. Proper motion and parallax are optional -- when absent they fall back to
-# zero for the offset only (see _record_skycoord), leaving CATALOG_RECORD untouched.
-# RA/Dec are sexagesimal strings, epoch a float.
+# Fields the pointing offset requires: position, and epoch as the propagation
+# baseline. A record missing either is unusable, so its offset is emitted present-
+# but-empty. Proper motion and parallax are optional (see _record_skycoord).
 _OFFSET_STR_FIELDS = ("ra", "dec")
 _OFFSET_REQUIRED_NUM_FIELDS = ("epoch",)
 
@@ -27,9 +25,9 @@ class DiagL0(Diagnostics):
     """Diagnostics for KPF Level 0 raw data products.
 
     The pointing-offset metrics compare the telescope pointing against the target
-    astrometry AstroQuery resolves into the L0 ``CATALOG_RECORD`` extension (Gaia /
-    SIMBAD / DCS, one canonical ICRS schema). An unavailable source yields a
-    present-but-empty offset and a WARNING -- error-raising is the checkpoint's job.
+    astrometry AstroQuery resolves into the L0 ``CATALOG_RECORD`` extension. An
+    unavailable source yields a present-but-empty offset and a WARNING --
+    error-raising is the checkpoint's job.
     """
 
     LEVEL = "L0"

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -11,12 +11,13 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 logger = logging.getLogger(__name__)
 
-# Record fields the pointing offset needs; an incomplete one (empty RA/Dec string,
-# NaN measurement, or non-positive parallax -- routine for faint Gaia sources) makes
-# the source unusable, so its offset is emitted present-but-empty. RA/Dec are
-# sexagesimal strings, the rest floats.
+# Fields the pointing offset requires: RA/Dec (position) and epoch (the propagation
+# baseline). A record missing either is unusable, so its offset is emitted present-
+# but-empty. Proper motion and parallax are optional -- when absent they fall back to
+# zero for the offset only (see _record_skycoord), leaving CATALOG_RECORD untouched.
+# RA/Dec are sexagesimal strings, epoch a float.
 _OFFSET_STR_FIELDS = ("ra", "dec")
-_OFFSET_NUM_FIELDS = ("pmra", "pmdec", "parallax", "epoch")
+_OFFSET_REQUIRED_NUM_FIELDS = ("epoch",)
 
 # CATALOG_RECORD presence flag (int 0/1) per source, on the extension header.
 _CATALOG_FLAGS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
@@ -37,9 +38,8 @@ class DiagL0(Diagnostics):
         """The CATALOG_RECORD row for ``source``, or None with a WARNING.
 
         Returns None when AstroQuery has not run (no presence flag), the source's
-        record is absent (flag 0), or a present record is missing a measurement the
-        offset needs. The flag is written with the row, so flag 1 guarantees exactly
-        one matching row.
+        record is absent (flag 0), or a present record lacks a position or epoch. The
+        flag is written with the row, so flag 1 guarantees exactly one matching row.
         """
         hdr = self.kpf_obj.headers["CATALOG_RECORD"]
         keyword = _CATALOG_FLAGS[source]
@@ -58,14 +58,13 @@ class DiagL0(Diagnostics):
             return None
         table = self.kpf_obj.data["CATALOG_RECORD"]
         row = table[table["source"] == source][0]
-        missing = (
-            any(str(row[field]).strip() == "" for field in _OFFSET_STR_FIELDS)
-            or any(np.isnan(row[field]) for field in _OFFSET_NUM_FIELDS)
-            or float(row["parallax"]) <= 0
-        )
+        missing = any(
+            str(row[field]).strip() == "" for field in _OFFSET_STR_FIELDS
+        ) or any(np.isnan(row[field]) for field in _OFFSET_REQUIRED_NUM_FIELDS)
         if missing:
             logger.warning(
-                "incomplete %s record in CATALOG_RECORD; pointing offset unavailable",
+                "incomplete %s record in CATALOG_RECORD (no position or epoch); "
+                "pointing offset unavailable",
                 source,
             )
             return None
@@ -76,18 +75,34 @@ class DiagL0(Diagnostics):
 
         The canonical schema all three sources share: RA/Dec sexagesimal strings
         (RA hour-angle, Dec deg), proper motion arcsec/yr (RA incl. cos Dec),
-        parallax mas, epoch in Julian years.
+        parallax mas, epoch in Julian years. Proper motion and parallax fall back to
+        zero (no motion, no distance) when the record omits them -- for this offset
+        only; the CATALOG_RECORD values are left untouched.
         """
-        return SkyCoord(
-            ra=rec["ra"],
-            dec=rec["dec"],
-            unit=(u.hourangle, u.deg),
-            pm_ra_cosdec=float(rec["pmra"]) * u.arcsec / u.yr,
-            pm_dec=float(rec["pmdec"]) * u.arcsec / u.yr,
-            distance=(1e3 / float(rec["parallax"])) * u.pc,
-            obstime=Time(float(rec["epoch"]), format="jyear"),
-            frame=str(rec["frame"]),
-        )
+        pmra, pmdec = float(rec["pmra"]), float(rec["pmdec"])
+        parallax = float(rec["parallax"])
+        pm_missing = np.isnan(pmra) or np.isnan(pmdec)
+        plx_missing = np.isnan(parallax) or parallax <= 0
+        if pm_missing or plx_missing:
+            logger.debug(
+                "%s record missing %s; using PM=0, parallax=0 for the offset",
+                rec["source"],
+                " and ".join(
+                    n for n, m in (("PM", pm_missing), ("parallax", plx_missing)) if m
+                ),
+            )
+        kwargs = {
+            "ra": rec["ra"],
+            "dec": rec["dec"],
+            "unit": (u.hourangle, u.deg),
+            "pm_ra_cosdec": (0.0 if pm_missing else pmra) * u.arcsec / u.yr,
+            "pm_dec": (0.0 if pm_missing else pmdec) * u.arcsec / u.yr,
+            "obstime": Time(float(rec["epoch"]), format="jyear"),
+            "frame": str(rec["frame"]),
+        }
+        if not plx_missing:
+            kwargs["distance"] = (1e3 / parallax) * u.pc
+        return SkyCoord(**kwargs)
 
     def _offset(self, source):
         """Arcsec separation of the pointing from a catalog source at obs epoch.

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -11,11 +11,10 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 logger = logging.getLogger(__name__)
 
-# Record fields the pointing offset needs; a missing one (an empty RA/Dec string, a
-# NaN measurement, or a non-positive parallax -- routine for faint Gaia sources)
-# makes the source unusable, and the offset is emitted present-but-empty. RA/Dec are
-# sexagesimal strings (EPRV C*# format), the rest floats. 'frame' is a fixed literal
-# AstroQuery always sets, so it is not gated here.
+# Record fields the pointing offset needs; an incomplete one (empty RA/Dec string,
+# NaN measurement, or non-positive parallax -- routine for faint Gaia sources) makes
+# the source unusable, so its offset is emitted present-but-empty. RA/Dec are
+# sexagesimal strings, the rest floats.
 _OFFSET_STR_FIELDS = ("ra", "dec")
 _OFFSET_NUM_FIELDS = ("pmra", "pmdec", "parallax", "epoch")
 
@@ -27,11 +26,9 @@ class DiagL0(Diagnostics):
     """Diagnostics for KPF Level 0 raw data products.
 
     The pointing-offset metrics compare the telescope pointing against the target
-    astrometry resolved upstream by AstroQuery and written to the L0
-    ``CATALOG_RECORD`` extension (Gaia / SIMBAD / DCS, all in one canonical ICRS
-    schema). When a source's astrometry is unavailable the offset is emitted
-    present-but-empty (a valueless card) and a WARNING is logged -- diagnostics
-    record what they can and leave error-raising to the checkpoint layer.
+    astrometry AstroQuery resolves into the L0 ``CATALOG_RECORD`` extension (Gaia /
+    SIMBAD / DCS, one canonical ICRS schema). An unavailable source yields a
+    present-but-empty offset and a WARNING -- error-raising is the checkpoint's job.
     """
 
     LEVEL = "L0"
@@ -39,11 +36,10 @@ class DiagL0(Diagnostics):
     def _catalog_record(self, source):
         """The CATALOG_RECORD row for ``source``, or None with a WARNING.
 
-        Handles the three contingencies: AstroQuery not run (no presence flag on the
-        CATALOG_RECORD header), the source's record absent (flag 0 -- lookup
-        disabled/failed, or WMKO unavailable), or a record present but missing a
-        measurement the offset needs. The flag is written with the row, so flag 1
-        guarantees exactly one matching row.
+        Returns None when AstroQuery has not run (no presence flag), the source's
+        record is absent (flag 0), or a present record is missing a measurement the
+        offset needs. The flag is written with the row, so flag 1 guarantees exactly
+        one matching row.
         """
         hdr = self.kpf_obj.headers["CATALOG_RECORD"]
         keyword = _CATALOG_FLAGS[source]
@@ -76,12 +72,11 @@ class DiagL0(Diagnostics):
         return row
 
     def _record_skycoord(self, rec):
-        """ICRS SkyCoord from a CATALOG_RECORD record (EPRV C*# format).
+        """ICRS SkyCoord from a CATALOG_RECORD record.
 
-        Every source ('gaia'/'simbad'/'wmko') is sanitized to the same schema --
-        ICRS, RA/Dec sexagesimal strings (RA hour-angle, Dec deg), proper motion
-        arcsec/yr (RA incl. cos Dec), parallax mas, epoch in Julian years -- so one
-        builder serves all three.
+        The canonical schema all three sources share: RA/Dec sexagesimal strings
+        (RA hour-angle, Dec deg), proper motion arcsec/yr (RA incl. cos Dec),
+        parallax mas, epoch in Julian years.
         """
         return SkyCoord(
             ra=rec["ra"],
@@ -97,12 +92,10 @@ class DiagL0(Diagnostics):
     def _offset(self, source):
         """Arcsec separation of the pointing from a catalog source at obs epoch.
 
-        Returns None (present-but-empty keyword) when the source astrometry is
-        unavailable; otherwise the catalog position is propagated to the
-        observation epoch (proper motion) before the comparison, so the offset
-        reflects where the source actually sits at the time of the exposure. Any
-        residual malformed astrometry (e.g. an unparseable epoch) is caught and
-        emitted empty rather than raised -- error-raising is the checkpoint's job.
+        Returns None (present-but-empty) when the source astrometry is unavailable
+        or malformed (an unparseable value is caught and emitted empty, not raised);
+        otherwise the catalog position is proper-motion propagated to the obs epoch
+        before the comparison.
         """
         rec = self._catalog_record(source)
         if rec is None:

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -11,10 +11,12 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 logger = logging.getLogger(__name__)
 
-# Numeric record fields the pointing offset needs; a NaN in any (a missing
-# measurement) makes the source unusable, and the offset is emitted present-but-
-# empty. 'frame' is a fixed literal AstroQuery always sets, so it is not gated here.
-_OFFSET_FIELDS = ("ra", "dec", "pmra", "pmdec", "parallax", "epoch")
+# Record fields the pointing offset needs; a missing one (an empty RA/Dec string or
+# a NaN measurement) makes the source unusable, and the offset is emitted present-
+# but-empty. RA/Dec are sexagesimal strings (EPRV C*# format), the rest floats.
+# 'frame' is a fixed literal AstroQuery always sets, so it is not gated here.
+_OFFSET_STR_FIELDS = ("ra", "dec")
+_OFFSET_NUM_FIELDS = ("pmra", "pmdec", "parallax", "epoch")
 
 # CATALOG_RECORD presence flag (int 0/1) per source, on the extension header.
 _FLAG_KEYWORDS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
@@ -59,7 +61,10 @@ class DiagL0(Diagnostics):
             return None
         table = self.kpf_obj.data["CATALOG_RECORD"]
         row = table[table["source"] == source][0]
-        if any(np.isnan(row[field]) for field in _OFFSET_FIELDS):
+        missing = any(
+            str(row[field]).strip() == "" for field in _OFFSET_STR_FIELDS
+        ) or any(np.isnan(row[field]) for field in _OFFSET_NUM_FIELDS)
+        if missing:
             logger.warning(
                 "incomplete %s record in CATALOG_RECORD; pointing offset unavailable",
                 source,
@@ -68,20 +73,22 @@ class DiagL0(Diagnostics):
         return row
 
     def _record_skycoord(self, rec):
-        """ICRS SkyCoord from a CATALOG_RECORD record (canonical units).
+        """ICRS SkyCoord from a CATALOG_RECORD record (EPRV C*# format).
 
-        AstroQuery normalizes every source ('gaia'/'simbad'/'wmko') to the same
-        schema -- ICRS, RA/Dec deg, proper motion mas/yr (RA incl. cos Dec),
-        parallax mas, epoch in Julian years -- so one builder serves all three.
+        Every source ('gaia'/'simbad'/'wmko') is sanitized to the same schema --
+        ICRS, RA/Dec sexagesimal strings (RA hour-angle, Dec deg), proper motion
+        arcsec/yr (RA incl. cos Dec), parallax mas, epoch in Julian years -- so one
+        builder serves all three.
         """
         return SkyCoord(
-            ra=rec["ra"] * u.deg,
-            dec=rec["dec"] * u.deg,
-            pm_ra_cosdec=rec["pmra"] * u.mas / u.yr,
-            pm_dec=rec["pmdec"] * u.mas / u.yr,
-            distance=(1e3 / rec["parallax"]) * u.pc,
-            obstime=Time(rec["epoch"], format="jyear"),
-            frame=rec["frame"],
+            ra=rec["ra"],
+            dec=rec["dec"],
+            unit=(u.hourangle, u.deg),
+            pm_ra_cosdec=float(rec["pmra"]) * u.arcsec / u.yr,
+            pm_dec=float(rec["pmdec"]) * u.arcsec / u.yr,
+            distance=(1e3 / float(rec["parallax"])) * u.pc,
+            obstime=Time(float(rec["epoch"]), format="jyear"),
+            frame=str(rec["frame"]),
         )
 
     def _pointing(self):

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -1,130 +1,39 @@
 """Diagnostics for KPF Level 0 (raw CCD) data products."""
 
-import logging
-import re
-
-import numpy as np
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 from astropy.time import Time
-from astroquery.gaia import Gaia
-from astroquery.simbad import Simbad
 
 from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
-logger = logging.getLogger(__name__)
-
 
 class DiagL0(Diagnostics):
-    """Diagnostics for KPF Level 0 raw data products."""
+    """Diagnostics for KPF Level 0 raw data products.
+
+    The pointing-offset metrics compare the telescope pointing against the target
+    astrometry resolved upstream by AstroQuery and attached as ``l0.catalog_query``
+    (Gaia / SIMBAD / DCS, all in one canonical ICRS schema); DiagL0 assumes that
+    dict is present and fully populated.
+    """
 
     LEVEL = "L0"
 
-    # Keys each metric needs; absent -> metric is N/A for that frame (skip).
-    _POINTING_KEYS = ("RA", "DEC", "MJD-OBS")
-    _TARGET_KEYS = (
-        "TARGRA",
-        "TARGDEC",
-        "TARGPMRA",
-        "TARGPMDC",
-        "TARGPLAX",
-        "TARGFRAM",
-        "TARGEPOC",
-    )
+    def _record_skycoord(self, source):
+        """ICRS SkyCoord from a ``catalog_query`` record (canonical units).
 
-    @staticmethod
-    def _present(hdr, keys):
-        """True if every key in ``keys`` is present and non-None in ``hdr``."""
-        return all(hdr.get(k) is not None for k in keys)
-
-    # Astrometry helpers reproduced from BarycentricCorrection._gaia_astrometry /
-    # ._wmko_astrometry (there they read INSTRUMENT_HEADER; at L0 the natives are
-    # on PRIMARY). The two copies are kept in sync by hand.
-
-    def _gaia_source_id(self):
-        """Digit-only Gaia DR3 id from L0 GAIAID, or None if absent/malformed."""
-        raw = self.kpf_obj.headers["PRIMARY"].get("GAIAID")
-        if raw is None:
-            return None
-        token = re.split(r"\s+", str(raw).strip())[-1]
-        return token if token.isdigit() else None
-
-    def _gaia_astrometry(self):
-        """Gaia DR3 SkyCoord (ICRS, PM+distance, Gaia epoch) for the L0 GAIAID."""
-        gaia_id = self._gaia_source_id()
-        if gaia_id is None:
-            raise ValueError("no usable Gaia source id in L0 PRIMARY GAIAID")
-        query = f"""
-        SELECT ra, dec, pmra, pmdec, parallax, ref_epoch
-        FROM gaiadr3.gaia_source
-        WHERE source_id = {gaia_id}
+        AstroQuery normalizes every source ('gaia'/'simbad'/'wmko') to the same
+        schema -- ICRS, RA/Dec deg, proper motion mas/yr (RA incl. cos Dec),
+        parallax mas, epoch in Julian years -- so one builder serves all three.
         """
-        result = Gaia.launch_job(query).get_results()[0]
+        rec = self.kpf_obj.catalog_query[source]
         return SkyCoord(
-            ra=result["ra"] * u.deg,
-            dec=result["dec"] * u.deg,
-            pm_ra_cosdec=result["pmra"] * u.mas / u.yr,
-            pm_dec=result["pmdec"] * u.mas / u.yr,
-            distance=(1e3 / result["parallax"]) * u.pc,
-            obstime=Time(result["ref_epoch"], format="jyear"),
-            frame="icrs",
-        )
-
-    def _wmko_astrometry(self):
-        """WMKO/DCS target SkyCoord from L0 PRIMARY TARG* astrometry.
-
-        TARGPMRA is s/yr (-> mas/yr via x15 cos(dec)); TARGPLAX is mas (-> pc).
-        """
-        hdr = self.kpf_obj.headers["PRIMARY"]
-        pos = SkyCoord(hdr["TARGRA"], hdr["TARGDEC"], unit=(u.hourangle, u.deg))
-        pm_ra_cosdec = float(hdr["TARGPMRA"]) * 15.0 * np.cos(pos.dec.rad) * 1e3
-        return SkyCoord(
-            ra=pos.ra,
-            dec=pos.dec,
-            pm_ra_cosdec=pm_ra_cosdec * u.mas / u.yr,
-            pm_dec=float(hdr["TARGPMDC"]) * 1e3 * u.mas / u.yr,
-            distance=(1e3 / float(hdr["TARGPLAX"])) * u.pc,
-            frame=str(hdr["TARGFRAM"]).lower(),
-            obstime=Time(float(hdr["TARGEPOC"]), format="jyear"),
-        )
-
-    def _object_name(self):
-        """SIMBAD-resolvable name from L0 PRIMARY OBJECT, or None if absent.
-
-        KPF OBJECT for standard stars is a bare HD number (e.g. '10700') that
-        SIMBAD resolves only with an 'HD ' prefix; named targets pass through.
-        """
-        obj = self.kpf_obj.headers["PRIMARY"].get("OBJECT")
-        if obj is None:
-            return None
-        obj = str(obj).strip()
-        if not obj:
-            return None
-        return f"HD {obj}" if obj.isdigit() else obj
-
-    def _simbad_astrometry(self):
-        """SIMBAD SkyCoord (ICRS J2000, PM+distance) for the L0 OBJECT name.
-
-        SIMBAD reports ICRS coordinates at epoch J2000.0; column names are the
-        astroquery 0.4.11 lowercase schema (ra/dec in deg, pmra/pmdec, plx_value).
-        """
-        name = self._object_name()
-        if name is None:
-            raise ValueError("no OBJECT name in L0 PRIMARY header")
-        simbad = Simbad()
-        simbad.add_votable_fields("pmra", "pmdec", "plx")
-        result = simbad.query_object(name)
-        if result is None or len(result) == 0:
-            raise ValueError(f"SIMBAD returned no match for {name!r}")
-        row = result[0]
-        return SkyCoord(
-            ra=row["ra"] * u.deg,
-            dec=row["dec"] * u.deg,
-            pm_ra_cosdec=row["pmra"] * u.mas / u.yr,
-            pm_dec=row["pmdec"] * u.mas / u.yr,
-            distance=(1e3 / row["plx_value"]) * u.pc,
-            obstime=Time(2000.0, format="jyear"),
-            frame="icrs",
+            ra=rec["ra"] * u.deg,
+            dec=rec["dec"] * u.deg,
+            pm_ra_cosdec=rec["pmra"] * u.mas / u.yr,
+            pm_dec=rec["pmdec"] * u.mas / u.yr,
+            distance=(1e3 / rec["parallax"]) * u.pc,
+            obstime=Time(rec["epoch"], format="jyear"),
+            frame=rec["frame"],
         )
 
     def _pointing(self):
@@ -136,68 +45,32 @@ class DiagL0(Diagnostics):
         """Observation epoch (Time) from L0 PRIMARY MJD-OBS, for PM propagation."""
         return Time(float(self.kpf_obj.headers["PRIMARY"]["MJD-OBS"]), format="mjd")
 
-    def gaia_ra_dec_offset(self):
-        """GAIAOFF: arcsec, RA/DEC pointing vs GAIAID position at obs epoch.
+    def _offset(self, source):
+        """Arcsec separation of the pointing from a catalog source at obs epoch.
 
-        Skipped when the frame has no pointing or no usable GAIAID; a Gaia
-        network/lookup failure warns and skips (fail-soft).
+        The catalog position is propagated to the observation epoch (proper
+        motion) before the comparison, so the offset reflects where the source
+        actually sits at the time of the exposure.
         """
-        hdr = self.kpf_obj.headers["PRIMARY"]
-        if (
-            not self._present(hdr, self._POINTING_KEYS)
-            or self._gaia_source_id() is None
-        ):
-            return {}
-        try:
-            gaia = self._gaia_astrometry().apply_space_motion(
-                new_obstime=self._obs_time()
-            )
-        except Exception as e:
-            logger.warning(
-                "GAIAOFF skipped: Gaia lookup failed (%s: %s)", type(e).__name__, e
-            )
-            return {}
-        sep = float(self._pointing().separation(gaia).arcsec)
-        return self._tag(GAIAOFF=round(sep, 4))
+        coord = self._record_skycoord(source).apply_space_motion(
+            new_obstime=self._obs_time()
+        )
+        return round(float(self._pointing().separation(coord).arcsec), 4)
+
+    def gaia_ra_dec_offset(self):
+        """GAIAOFF: arcsec, RA/DEC pointing vs Gaia catalog position at obs epoch."""
+        return self._tag(GAIAOFF=self._offset("gaia"))
 
     gaia_ra_dec_offset._diag_name = "gaia_ra_dec_offset"
 
     def target_ra_dec_offset(self):
-        """TARGOFF: arcsec, RA/DEC pointing vs TARGRA/DEC target at obs epoch.
-
-        Skipped when the frame has no pointing or no DCS target (e.g. a
-        calibration frame).
-        """
-        hdr = self.kpf_obj.headers["PRIMARY"]
-        if not self._present(hdr, self._POINTING_KEYS + self._TARGET_KEYS):
-            return {}
-        target = self._wmko_astrometry().apply_space_motion(
-            new_obstime=self._obs_time()
-        )
-        sep = float(self._pointing().separation(target).arcsec)
-        return self._tag(TARGOFF=round(sep, 4))
+        """TARGOFF: arcsec, RA/DEC pointing vs DCS target position at obs epoch."""
+        return self._tag(TARGOFF=self._offset("wmko"))
 
     target_ra_dec_offset._diag_name = "target_ra_dec_offset"
 
     def object_ra_dec_offset(self):
-        """OBJOFF: arcsec, RA/DEC pointing vs SIMBAD(OBJECT) position at obs epoch.
-
-        Skipped when the frame has no pointing or no OBJECT name; a SIMBAD
-        network/lookup failure (or an unresolvable name) warns and skips.
-        """
-        hdr = self.kpf_obj.headers["PRIMARY"]
-        if not self._present(hdr, self._POINTING_KEYS) or self._object_name() is None:
-            return {}
-        try:
-            obj = self._simbad_astrometry().apply_space_motion(
-                new_obstime=self._obs_time()
-            )
-        except Exception as e:
-            logger.warning(
-                "OBJOFF skipped: SIMBAD lookup failed (%s: %s)", type(e).__name__, e
-            )
-            return {}
-        sep = float(self._pointing().separation(obj).arcsec)
-        return self._tag(OBJOFF=round(sep, 4))
+        """OBJOFF: arcsec, RA/DEC pointing vs SIMBAD(OBJECT) position at obs epoch."""
+        return self._tag(OBJOFF=self._offset("simbad"))
 
     object_ra_dec_offset._diag_name = "object_ra_dec_offset"

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -11,10 +11,11 @@ from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
 logger = logging.getLogger(__name__)
 
-# Record fields the pointing offset needs; a missing one (an empty RA/Dec string or
-# a NaN measurement) makes the source unusable, and the offset is emitted present-
-# but-empty. RA/Dec are sexagesimal strings (EPRV C*# format), the rest floats.
-# 'frame' is a fixed literal AstroQuery always sets, so it is not gated here.
+# Record fields the pointing offset needs; a missing one (an empty RA/Dec string, a
+# NaN measurement, or a non-positive parallax -- routine for faint Gaia sources)
+# makes the source unusable, and the offset is emitted present-but-empty. RA/Dec are
+# sexagesimal strings (EPRV C*# format), the rest floats. 'frame' is a fixed literal
+# AstroQuery always sets, so it is not gated here.
 _OFFSET_STR_FIELDS = ("ra", "dec")
 _OFFSET_NUM_FIELDS = ("pmra", "pmdec", "parallax", "epoch")
 
@@ -61,9 +62,11 @@ class DiagL0(Diagnostics):
             return None
         table = self.kpf_obj.data["CATALOG_RECORD"]
         row = table[table["source"] == source][0]
-        missing = any(
-            str(row[field]).strip() == "" for field in _OFFSET_STR_FIELDS
-        ) or any(np.isnan(row[field]) for field in _OFFSET_NUM_FIELDS)
+        missing = (
+            any(str(row[field]).strip() == "" for field in _OFFSET_STR_FIELDS)
+            or any(np.isnan(row[field]) for field in _OFFSET_NUM_FIELDS)
+            or float(row["parallax"]) <= 0
+        )
         if missing:
             logger.warning(
                 "incomplete %s record in CATALOG_RECORD; pointing offset unavailable",
@@ -106,15 +109,26 @@ class DiagL0(Diagnostics):
         Returns None (present-but-empty keyword) when the source astrometry is
         unavailable; otherwise the catalog position is propagated to the
         observation epoch (proper motion) before the comparison, so the offset
-        reflects where the source actually sits at the time of the exposure.
+        reflects where the source actually sits at the time of the exposure. Any
+        residual malformed astrometry (e.g. an unparseable epoch) is caught and
+        emitted empty rather than raised -- error-raising is the checkpoint's job.
         """
         rec = self._catalog_record(source)
         if rec is None:
             return None
-        coord = self._record_skycoord(rec).apply_space_motion(
-            new_obstime=self._obs_time()
-        )
-        return round(float(self._pointing().separation(coord).arcsec), 4)
+        try:
+            coord = self._record_skycoord(rec).apply_space_motion(
+                new_obstime=self._obs_time()
+            )
+            return round(float(self._pointing().separation(coord).arcsec), 4)
+        except Exception as exc:
+            logger.warning(
+                "could not compute %s pointing offset (%s: %s); emitting empty",
+                source,
+                type(exc).__name__,
+                exc,
+            )
+            return None
 
     def gaia_ra_dec_offset(self):
         """GAIAOFF: arcsec, RA/DEC pointing vs Gaia catalog position at obs epoch."""

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -38,8 +38,9 @@ class DiagL0(Diagnostics):
         """The CATALOG_RECORD row for ``source``, or None with a WARNING.
 
         Returns None when AstroQuery has not run (no presence flag), the source's
-        record is absent (flag 0), or a present record lacks a position or epoch. The
-        flag is written with the row, so flag 1 guarantees exactly one matching row.
+        record is absent (flag 0), or a present record lacks a position or epoch.
+        AstroQuery writes every flag alongside the rows it wrote, so flag 1
+        guarantees exactly one matching row.
         """
         hdr = self.kpf_obj.headers["CATALOG_RECORD"]
         keyword = _CATALOG_FLAGS[source]

--- a/kpfpipe/quality_control/diagnostics/level0.py
+++ b/kpfpipe/quality_control/diagnostics/level0.py
@@ -19,7 +19,7 @@ _OFFSET_STR_FIELDS = ("ra", "dec")
 _OFFSET_NUM_FIELDS = ("pmra", "pmdec", "parallax", "epoch")
 
 # CATALOG_RECORD presence flag (int 0/1) per source, on the extension header.
-_FLAG_KEYWORDS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
+_CATALOG_FLAGS = {"gaia": "GAIACR", "simbad": "SIMBADCR", "wmko": "WMKOCR"}
 
 
 class DiagL0(Diagnostics):
@@ -45,7 +45,7 @@ class DiagL0(Diagnostics):
         guarantees exactly one matching row.
         """
         hdr = self.kpf_obj.headers["CATALOG_RECORD"]
-        keyword = _FLAG_KEYWORDS[source]
+        keyword = _CATALOG_FLAGS[source]
         if keyword not in hdr:
             logger.warning(
                 "no CATALOG_RECORD flags on L0 (run AstroQuery first); "

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -28,9 +28,16 @@ class QC:
 
     @staticmethod
     def _hdr_float(hdr, key):
-        """Return float value for a header key, or None if absent."""
-        val = hdr.get(key)
-        return None if val is None else float(val)
+        """Return float value for a header key, or None if absent/empty/non-numeric.
+
+        A present-but-empty (valueless) card and an absent key both read back as
+        None (which ``float`` rejects); a stray non-numeric value is caught too, so
+        a check reading the key degrades gracefully rather than raising.
+        """
+        try:
+            return float(hdr.get(key))
+        except (TypeError, ValueError):
+            return None
 
     @staticmethod
     def _hdr_bool(hdr, key):

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -30,10 +30,9 @@ class QC:
     def _hdr_float(hdr, key):
         """Return float value for a header key, or None if the card is absent/empty.
 
-        A present-but-empty (valueless) card and an absent key both read back as
-        None (which ``float`` rejects with TypeError), so a check reading the key
-        degrades gracefully. A present-but-non-numeric value is malformed, not
-        missing: it raises ValueError, which ``QC.run`` surfaces (fail loud).
+        An absent or valueless card reads back as None (``float`` raises TypeError),
+        degrading gracefully. A present-but-non-numeric value is malformed: the
+        ValueError propagates for ``QC.run`` to surface (fail loud).
         """
         try:
             return float(hdr.get(key))

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -30,9 +30,8 @@ class QC:
     def _hdr_float(hdr, key):
         """Return float value for a header key, or None if the card is absent/empty.
 
-        An absent or valueless card reads back as None (``float`` raises TypeError),
-        degrading gracefully. A present-but-non-numeric value is malformed: the
-        ValueError propagates for ``QC.run`` to surface (fail loud).
+        A present-but-non-numeric value is malformed, so its ValueError propagates
+        for ``QC.run`` to surface (fail loud).
         """
         try:
             return float(hdr.get(key))

--- a/kpfpipe/quality_control/qc_flags/base.py
+++ b/kpfpipe/quality_control/qc_flags/base.py
@@ -28,15 +28,16 @@ class QC:
 
     @staticmethod
     def _hdr_float(hdr, key):
-        """Return float value for a header key, or None if absent/empty/non-numeric.
+        """Return float value for a header key, or None if the card is absent/empty.
 
         A present-but-empty (valueless) card and an absent key both read back as
-        None (which ``float`` rejects); a stray non-numeric value is caught too, so
-        a check reading the key degrades gracefully rather than raising.
+        None (which ``float`` rejects with TypeError), so a check reading the key
+        degrades gracefully. A present-but-non-numeric value is malformed, not
+        missing: it raises ValueError, which ``QC.run`` surfaces (fail loud).
         """
         try:
             return float(hdr.get(key))
-        except (TypeError, ValueError):
+        except TypeError:
             return None
 
     @staticmethod

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -138,14 +138,17 @@ class QCL0(QC):
     def radec_consistent(self):
         """Pointing agrees with the target and catalog positions.
 
-        Thresholds the DiagL0 offsets on QUALITY_CONTROL: TARGOFF < 1", and the
-        catalog cross-matches OBJOFF/GAIAOFF < 5" (a loose bound, since the loaded
-        pointing coordinates are not Gaia/SIMBAD-derived). Each offset is checked
-        only when present, so a frame with no pointing (e.g. a calibration frame)
-        or a skipped catalog lookup passes.
+        TARGOFF (pointing vs the DCS target) is internal telescope-pointing
+        consistency and is required: an empty value (astrometry unavailable) or
+        one >= 1" fails. OBJOFF/GAIAOFF are external catalog cross-matches with a
+        looser 5" bound, checked only when present-and-valued, so a disabled or
+        failed Gaia/SIMBAD lookup passes.
         """
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
-        for key, limit in (("TARGOFF", 1.0), ("OBJOFF", 5.0), ("GAIAOFF", 5.0)):
+        targoff = self._hdr_float(hdr, "TARGOFF")
+        if targoff is None or targoff >= 1.0:
+            return False
+        for key, limit in (("OBJOFF", 5.0), ("GAIAOFF", 5.0)):
             val = self._hdr_float(hdr, key)
             if val is not None and val >= limit:
                 return False

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -16,14 +16,12 @@ _SUPPORTED_NAMP = (2, 4)  # valid KPF readout modes (see ImageAssembly.count_amp
 _TIME_TOL_S = 0.1  # DATE-END - DATE-BEG vs ELAPSED tolerance (v2.12 quality_control.py)
 
 # Physical-range bounds for the canonical CATALOG_RECORD astrometry, ported from the
-# v2.12 quality_control.py good_TARG_headers L0 checks. epoch/equinox are Julian years,
-# rv km/s, parallax mas, proper motion arcsec/yr. The epoch/equinox window is
-# exclusive-low / inclusive-high (1950 < x <= 2050), matching legacy. Two vNext
-# additions to the legacy value bounds, both justified by our source being Gaia (not the
-# DCS TARG* header) and both feeding the barycentric correction: the parallax LOWER
-# bound (a negative Gaia parallax is routine and would be a negative distance), and the
-# proper-motion bound (legacy had it but left it commented out for unit uncertainty --
-# moot here, where PM is canonical arcsec/yr; the highest-PM star is ~10.4"/yr).
+# v2.12 quality_control.py good_TARG_headers L0 checks. The epoch/equinox window is
+# exclusive-low / inclusive-high (1950 < x <= 2050), matching legacy. Two are vNext
+# additions justified by our Gaia source (both feed the barycentric correction): the
+# parallax LOWER bound (a negative Gaia parallax is routine, and gives a negative
+# distance), and the proper-motion bound (canonical arcsec/yr here; highest real PM
+# is ~10.4"/yr).
 _EPOCH_RANGE = (1950.0, 2050.0)
 _MAX_ABS_RV = 350.0  # km/s (Chubak et al. 2012, arXiv:1207.6212, Fig. 8)
 _PARALLAX_RANGE = (0.0, 1000.0)  # mas; 0 < plx < 1000 (> 0 and < 1 arcsec)
@@ -172,18 +170,14 @@ class QCL0(QC):
         """Canonical CATALOG_RECORD astrometry values are physically plausible.
 
         Ports the v2.12 good_TARG_headers range checks onto the merged ``kpf-drp``
-        row AstroQuery resolves (the astrometry that feeds the barycentric
-        correction), not the raw WMKO TARG* keywords. Each field is checked only when
-        present: epoch/equinox in (1950, 2050] Julian years, |rv| <= 350 km/s,
-        parallax in (0, 1000) mas, and |pmra|/|pmdec| <= 15 arcsec/yr. The parallax
-        lower bound and the PM bound are vNext additions justified by our Gaia source
-        (see the module bounds comment); both would otherwise corrupt the barycentric
-        correction (negative distance / wrong obs-epoch position).
+        row AstroQuery resolves (the astrometry feeding the barycentric correction),
+        not the raw WMKO TARG* keywords. Each field is checked only when present:
+        epoch/equinox in (1950, 2050] Julian years, |rv| <= 350 km/s, parallax in
+        (0, 1000) mas, |pmra|/|pmdec| <= 15 arcsec/yr. The parallax lower bound and
+        the PM bound are vNext additions (see the module bounds comment).
 
-        Passes when there is no ``kpf-drp`` row -- a calibration frame carries no
-        target astrometry, and this is value sanity, not a presence check (a science
-        frame's missing astrometry is caught upstream: AstroQuery raises at merge,
-        to_kpf1 on an empty Object record).
+        Passes when there is no ``kpf-drp`` row: this is value sanity, not a presence
+        check -- a science frame's missing astrometry is caught upstream.
         """
         table = self.kpf_obj.data["CATALOG_RECORD"]
         match = table[table["source"] == "kpf-drp"] if table.colnames else table

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -83,8 +83,7 @@ class QCL0(QC):
         Ports v2.12 ``L2_datetime``. At L0 the raw instrument times live on the
         WMKO-native PRIMARY (the header later snapshotted verbatim into
         INSTRUMENT_HEADER at to_kpf1); the 0/1 flag then propagates downstream
-        on QUALITY_CONTROL. ELAPSED consistency is validated in exptime_sane
-        (EXPTIMOK), so it is not repeated here.
+        on QUALITY_CONTROL.
         """
         hdr = self.kpf_obj.headers["PRIMARY"]
         beg, mid, end = (

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -15,13 +15,11 @@ _AMPS_PER_CHIP = 4  # GREEN_AMP1..4 / RED_AMP1..4 (only a subset is read out)
 _SUPPORTED_NAMP = (2, 4)  # valid KPF readout modes (see ImageAssembly.count_amplifiers)
 _TIME_TOL_S = 0.1  # DATE-END - DATE-BEG vs ELAPSED tolerance (v2.12 quality_control.py)
 
-# Physical-range bounds for the canonical CATALOG_RECORD astrometry, ported from the
-# v2.12 quality_control.py good_TARG_headers L0 checks. The epoch/equinox window is
-# exclusive-low / inclusive-high (1950 < x <= 2050), matching legacy. Two are vNext
-# additions justified by our Gaia source (both feed the barycentric correction): the
-# parallax LOWER bound (a negative Gaia parallax is routine, and gives a negative
-# distance), and the proper-motion bound (canonical arcsec/yr here; highest real PM
-# is ~10.4"/yr).
+# Physical-range bounds for the canonical CATALOG_RECORD astrometry, ported from
+# v2.12 good_TARG_headers. The epoch/equinox window is exclusive-low, matching
+# legacy. The parallax lower bound and the PM bound are vNext additions for our Gaia
+# source: a negative Gaia parallax is routine and gives a negative distance, and the
+# highest real PM is ~10.4 arcsec/yr.
 _EPOCH_RANGE = (1950.0, 2050.0)
 _MAX_ABS_RV = 350.0  # km/s (Chubak et al. 2012, arXiv:1207.6212, Fig. 8)
 _PARALLAX_RANGE = (0.0, 1000.0)  # mas; 0 < plx < 1000 (> 0 and < 1 arcsec)
@@ -172,11 +170,10 @@ class QCL0(QC):
         row AstroQuery resolves (the astrometry feeding the barycentric correction),
         not the raw WMKO TARG* keywords. Each field is checked only when present:
         epoch/equinox in (1950, 2050] Julian years, |rv| <= 350 km/s, parallax in
-        (0, 1000) mas, |pmra|/|pmdec| <= 15 arcsec/yr. The parallax lower bound and
-        the PM bound are vNext additions (see the module bounds comment).
+        (0, 1000) mas, |pmra|/|pmdec| <= 15 arcsec/yr.
 
         Passes when there is no ``kpf-drp`` row: this is value sanity, not a presence
-        check -- a science frame's missing astrometry is caught upstream.
+        check.
         """
         table = self.kpf_obj.data["CATALOG_RECORD"]
         match = table[table["source"] == "kpf-drp"] if table.colnames else table

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -15,6 +15,20 @@ _AMPS_PER_CHIP = 4  # GREEN_AMP1..4 / RED_AMP1..4 (only a subset is read out)
 _SUPPORTED_NAMP = (2, 4)  # valid KPF readout modes (see ImageAssembly.count_amplifiers)
 _TIME_TOL_S = 0.1  # DATE-END - DATE-BEG vs ELAPSED tolerance (v2.12 quality_control.py)
 
+# Physical-range bounds for the canonical CATALOG_RECORD astrometry, ported from the
+# v2.12 quality_control.py good_TARG_headers L0 checks. epoch/equinox are Julian years,
+# rv km/s, parallax mas, proper motion arcsec/yr. The epoch/equinox window is
+# exclusive-low / inclusive-high (1950 < x <= 2050), matching legacy. Two vNext
+# additions to the legacy value bounds, both justified by our source being Gaia (not the
+# DCS TARG* header) and both feeding the barycentric correction: the parallax LOWER
+# bound (a negative Gaia parallax is routine and would be a negative distance), and the
+# proper-motion bound (legacy had it but left it commented out for unit uncertainty --
+# moot here, where PM is canonical arcsec/yr; the highest-PM star is ~10.4"/yr).
+_EPOCH_RANGE = (1950.0, 2050.0)
+_MAX_ABS_RV = 350.0  # km/s (Chubak et al. 2012, arXiv:1207.6212, Fig. 8)
+_PARALLAX_RANGE = (0.0, 1000.0)  # mas; 0 < plx < 1000 (> 0 and < 1 arcsec)
+_MAX_ABS_PM = 15.0  # arcsec/yr, per component
+
 
 def _parse_iso(value):
     """Parse an ISO-8601 datetime string, or None if missing/unparseable."""
@@ -66,13 +80,13 @@ class QCL0(QC):
     header_keywords_present._qc_key = "KWRDPRL0"
 
     def times_consistent(self):
-        """DATE-BEG < DATE-MID < DATE-END and |(END-BEG) - ELAPSED| < 0.1 s.
+        """DATE-BEG <= DATE-MID <= DATE-END.
 
         Ports v2.12 ``L2_datetime``. At L0 the raw instrument times live on the
         WMKO-native PRIMARY (the header later snapshotted verbatim into
         INSTRUMENT_HEADER at to_kpf1); the 0/1 flag then propagates downstream
-        on QUALITY_CONTROL. Passes the duration check when ELAPSED is absent --
-        only the present cards are checked.
+        on QUALITY_CONTROL. ELAPSED consistency is validated in exptime_sane
+        (EXPTIMOK), so it is not repeated here.
         """
         hdr = self.kpf_obj.headers["PRIMARY"]
         beg, mid, end = (
@@ -80,15 +94,7 @@ class QCL0(QC):
         )
         if beg is None or mid is None or end is None:
             return False
-        if not (beg <= mid <= end):
-            return False
-        elapsed = self._hdr_float(hdr, "ELAPSED")
-        if (
-            elapsed is not None
-            and abs((end - beg).total_seconds() - elapsed) > _TIME_TOL_S
-        ):
-            return False
-        return True
+        return beg <= mid <= end
 
     times_consistent._qc_key = "DATTIMOK"
 
@@ -155,3 +161,49 @@ class QCL0(QC):
         return True
 
     radec_consistent._qc_key = "RADECOK"
+
+    @staticmethod
+    def _row_float(row, field):
+        """A CATALOG_RECORD numeric cell as float, or None for an absent (NaN) one."""
+        value = float(row[field])
+        return None if np.isnan(value) else value
+
+    def catalog_values_sane(self):
+        """Canonical CATALOG_RECORD astrometry values are physically plausible.
+
+        Ports the v2.12 good_TARG_headers range checks onto the merged ``kpf-drp``
+        row AstroQuery resolves (the astrometry that feeds the barycentric
+        correction), not the raw WMKO TARG* keywords. Each field is checked only when
+        present: epoch/equinox in (1950, 2050] Julian years, |rv| <= 350 km/s,
+        parallax in (0, 1000) mas, and |pmra|/|pmdec| <= 15 arcsec/yr. The parallax
+        lower bound and the PM bound are vNext additions justified by our Gaia source
+        (see the module bounds comment); both would otherwise corrupt the barycentric
+        correction (negative distance / wrong obs-epoch position).
+
+        Passes when there is no ``kpf-drp`` row -- a calibration frame carries no
+        target astrometry, and this is value sanity, not a presence check (a science
+        frame's missing astrometry is caught upstream: AstroQuery raises at merge,
+        to_kpf1 on an empty Object record).
+        """
+        table = self.kpf_obj.data["CATALOG_RECORD"]
+        match = table[table["source"] == "kpf-drp"] if table.colnames else table
+        if not len(match):
+            return True
+        row = match[0]
+        for field in ("epoch", "equinox"):
+            val = self._row_float(row, field)
+            if val is not None and not (_EPOCH_RANGE[0] < val <= _EPOCH_RANGE[1]):
+                return False
+        rv = self._row_float(row, "rv")
+        if rv is not None and abs(rv) > _MAX_ABS_RV:
+            return False
+        plax = self._row_float(row, "parallax")
+        if plax is not None and not (_PARALLAX_RANGE[0] < plax < _PARALLAX_RANGE[1]):
+            return False
+        for field in ("pmra", "pmdec"):
+            pm = self._row_float(row, field)
+            if pm is not None and abs(pm) > _MAX_ABS_PM:
+                return False
+        return True
+
+    catalog_values_sane._qc_key = "CATLOGOK"

--- a/kpfpipe/utils/network.py
+++ b/kpfpipe/utils/network.py
@@ -1,0 +1,72 @@
+"""Network helpers for the pipeline's calls out to external services."""
+
+import logging
+import random
+import time
+
+from astroquery.exceptions import RemoteServiceError
+from astroquery.exceptions import TimeoutError as AstroqueryTimeoutError
+from pyvo.dal import DALServiceError
+
+logger = logging.getLogger(__name__)
+
+# Nominal seconds to wait before each retry; len() sets the retry count, so a call
+# is attempted len(_RETRY_WAITS) + 1 times (~44 s of waiting worst case).
+_RETRY_WAITS = (1.0, 3.0, 10.0, 30.0)
+
+# Transient failures worth another attempt. OSError covers the builtin
+# ConnectionError/TimeoutError and every requests exception (RequestException
+# subclasses OSError). pyvo's DALServiceError is a service/transport failure; its
+# sibling DALQueryError -- a malformed query -- is deliberately absent, as is every
+# other exception, so a bad ADQL query or an unknown object fails at once instead of
+# burning the full backoff.
+_RETRYABLE = (OSError, AstroqueryTimeoutError, RemoteServiceError, DALServiceError)
+
+
+def retry_request(func, description):
+    """Call ``func``, retrying transient network failures with backoff.
+
+    ``description`` names the service in the retry warnings (e.g. "Gaia DR3").
+    Waits follow ``_RETRY_WAITS`` with equal jitter. A non-transient exception, or
+    the last attempt's exception, propagates to the caller unchanged -- the
+    AstroQuery callers turn that into their existing fail-soft warning + None.
+
+    Note there is no per-attempt timeout: astroquery 0.4.11 exposes no socket
+    timeout for either client (``Gaia.launch_job`` takes none and its TAP transport
+    builds an ``http.client`` connection without one; SIMBAD's ``timeout`` is a
+    server-side execution duration), so a hung connection is not bounded here.
+
+    Parameters
+    ----------
+    func : callable
+        Zero-argument callable performing the request.
+    description : str
+        Service name used in the retry log messages.
+
+    Returns
+    -------
+    object
+        Whatever ``func`` returns.
+
+    Raises
+    ------
+    Exception
+        Whatever ``func`` raises, once retries are exhausted or immediately if the
+        failure is not transient.
+    """
+    for wait in _RETRY_WAITS:
+        try:
+            return func()
+        except _RETRYABLE as e:
+            # Equal jitter -- half the nominal wait plus a random half -- so parallel
+            # workers that failed together do not retry in lockstep.
+            delay = wait / 2 + random.uniform(0, wait / 2)
+            logger.warning(
+                "%s request failed (%s: %s); retrying in %.1f s",
+                description,
+                type(e).__name__,
+                e,
+                delay,
+            )
+            time.sleep(delay)
+    return func()

--- a/kpfpipe/utils/network.py
+++ b/kpfpipe/utils/network.py
@@ -16,25 +16,23 @@ _RETRY_WAITS = (1.0, 3.0, 10.0, 30.0)
 
 # Transient failures worth another attempt. OSError covers the builtin
 # ConnectionError/TimeoutError and every requests exception (RequestException
-# subclasses OSError). pyvo's DALServiceError is a service/transport failure; its
-# sibling DALQueryError -- a malformed query -- is deliberately absent, as is every
-# other exception, so a bad ADQL query or an unknown object fails at once instead of
-# burning the full backoff.
+# subclasses OSError); DALServiceError is a pyvo service/transport failure. Its
+# sibling DALQueryError -- a malformed query -- is deliberately absent, so a bad ADQL
+# query or an unknown object fails at once instead of burning the full backoff.
 _RETRYABLE = (OSError, AstroqueryTimeoutError, RemoteServiceError, DALServiceError)
 
 
 def retry_request(func, description):
     """Call ``func``, retrying transient network failures with backoff.
 
-    ``description`` names the service in the retry warnings (e.g. "Gaia DR3").
-    Waits follow ``_RETRY_WAITS`` with equal jitter. A non-transient exception, or
-    the last attempt's exception, propagates to the caller unchanged -- the
-    AstroQuery callers turn that into their existing fail-soft warning + None.
+    Waits follow ``_RETRY_WAITS`` with equal jitter. A non-transient exception, or the
+    last attempt's, propagates to the caller unchanged -- the AstroQuery callers turn
+    that into their fail-soft warning + None.
 
-    Note there is no per-attempt timeout: astroquery 0.4.11 exposes no socket
-    timeout for either client (``Gaia.launch_job`` takes none and its TAP transport
-    builds an ``http.client`` connection without one; SIMBAD's ``timeout`` is a
-    server-side execution duration), so a hung connection is not bounded here.
+    There is no per-attempt timeout: astroquery 0.4.11 exposes no socket timeout for
+    either client (``Gaia.launch_job`` takes none and its TAP transport builds an
+    ``http.client`` connection without one; SIMBAD's ``timeout`` is a server-side
+    execution duration), so a hung connection is not bounded here.
 
     Parameters
     ----------

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -58,8 +58,8 @@ def main(config, args):
     l0 = KPF0.from_fits(kpf_filepath(obs_id, "L0", data_root=data_root_in))
 
     # Consolidate external-catalog lookups up front: resolve Gaia/SIMBAD astrometry
-    # into l0's CATALOG_RECORD extension (the native wmko row is already populated at
-    # read) for the L0 diagnostics (and, later, barycentric correction) to consume.
+    # (plus the native wmko row read off PRIMARY TARG*) into l0's CATALOG_RECORD
+    # extension for the L0 diagnostics and the barycentric correction to consume.
     logger.info("resolving catalog astrometry for %s", obs_id)
     astro_query = AstroQuery(l0, config)
     l0 = astro_query.perform()

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -58,7 +58,7 @@ def main(config, args):
     l0 = KPF0.from_fits(kpf_filepath(obs_id, "L0", data_root=data_root_in))
 
     # Consolidate external-catalog lookups up front: resolve target astrometry
-    # (Gaia/SIMBAD + DCS snapshot) onto l0.catalog_query for the L0 diagnostics
+    # (Gaia/SIMBAD + DCS snapshot) onto l0.catalog_record for the L0 diagnostics
     # (and, later, barycentric correction) to consume.
     logger.info("resolving catalog astrometry for %s", obs_id)
     astro_query = AstroQuery(l0, config)

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -57,9 +57,8 @@ def main(config, args):
 
     l0 = KPF0.from_fits(kpf_filepath(obs_id, "L0", data_root=data_root_in))
 
-    # Consolidate external-catalog lookups up front: resolve Gaia/SIMBAD astrometry
-    # (plus the native wmko row read off PRIMARY TARG*) into l0's CATALOG_RECORD
-    # extension for the L0 diagnostics and the barycentric correction to consume.
+    # Resolve Gaia/SIMBAD astrometry (plus the native wmko row off PRIMARY TARG*) into
+    # l0's CATALOG_RECORD, for the L0 diagnostics and barycentric correction to consume.
     logger.info("resolving catalog astrometry for %s", obs_id)
     astro_query = AstroQuery(l0, config)
     l0 = astro_query.perform()

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -57,9 +57,9 @@ def main(config, args):
 
     l0 = KPF0.from_fits(kpf_filepath(obs_id, "L0", data_root=data_root_in))
 
-    # Consolidate external-catalog lookups up front: resolve target astrometry
-    # (Gaia/SIMBAD + DCS snapshot) into l0's CATALOG_RECORD extension for the L0
-    # diagnostics (and, later, barycentric correction) to consume.
+    # Consolidate external-catalog lookups up front: resolve Gaia/SIMBAD astrometry
+    # into l0's CATALOG_RECORD extension (the native wmko row is already populated at
+    # read) for the L0 diagnostics (and, later, barycentric correction) to consume.
     logger.info("resolving catalog astrometry for %s", obs_id)
     astro_query = AstroQuery(l0, config)
     l0 = astro_query.perform()

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -58,8 +58,8 @@ def main(config, args):
     l0 = KPF0.from_fits(kpf_filepath(obs_id, "L0", data_root=data_root_in))
 
     # Consolidate external-catalog lookups up front: resolve target astrometry
-    # (Gaia/SIMBAD + DCS snapshot) onto l0.catalog_record for the L0 diagnostics
-    # (and, later, barycentric correction) to consume.
+    # (Gaia/SIMBAD + DCS snapshot) into l0's CATALOG_RECORD extension for the L0
+    # diagnostics (and, later, barycentric correction) to consume.
     logger.info("resolving catalog astrometry for %s", obs_id)
     astro_query = AstroQuery(l0, config)
     l0 = astro_query.perform()

--- a/recipes/kpf_drp_science.py
+++ b/recipes/kpf_drp_science.py
@@ -14,6 +14,7 @@ import logging
 import time
 
 from kpfpipe.data_models import KPF0
+from kpfpipe.modules.astro_query import AstroQuery
 from kpfpipe.modules.barycentric_correction import BarycentricCorrection
 from kpfpipe.modules.calibration_association import CalibrationAssociation
 from kpfpipe.modules.cross_correlation import CrossCorrelation
@@ -55,6 +56,13 @@ def main(config, args):
     data_root_science = data_dirs["KPF_SCIENCE_OUTPUT"]
 
     l0 = KPF0.from_fits(kpf_filepath(obs_id, "L0", data_root=data_root_in))
+
+    # Consolidate external-catalog lookups up front: resolve target astrometry
+    # (Gaia/SIMBAD + DCS snapshot) onto l0.catalog_query for the L0 diagnostics
+    # (and, later, barycentric correction) to consume.
+    logger.info("resolving catalog astrometry for %s", obs_id)
+    astro_query = AstroQuery(l0, config)
+    l0 = astro_query.perform()
 
     # Generate L0 quicklook plots
     logger.info("generating L0 quicklook plots for %s", obs_id)

--- a/scripts/processing/_dispatch.py
+++ b/scripts/processing/_dispatch.py
@@ -78,8 +78,8 @@ _live_lock = threading.Lock()
 _interrupted = threading.Event()
 
 # Launch throttle: serializes fan-out launches >= _launch_interval apart. Two
-# callers, two reasons -- science paces the SIMBAD/Gaia catalog queries the per-frame
-# L0 pointing QC fires; masters desynchronizes the I/O-heavy stack read/assemble
+# callers, two reasons -- science paces the SIMBAD/Gaia catalog queries AstroQuery
+# fires per frame; masters desynchronizes the I/O-heavy stack read/assemble
 # phase so a lockstep wave doesn't saturate the disk. `_last_launch` is the monotonic
 # time of the last launch.
 _launch_lock = threading.Lock()

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -20,6 +20,7 @@ import sys
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.modules.astro_query import AstroQuery
 from kpfpipe.quality_control.checkpoints import CheckpointL0, CheckpointL1, CheckpointL2
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import kpf_filepath
@@ -82,6 +83,17 @@ def main():
         sys.exit(2)
 
     obs_id = args.obs_id or getattr(data, "obs_id", None) or "unknown"
+
+    # AstroQuery resolves target astrometry onto data.catalog_query, which the L0
+    # pointing-offset diagnostics consume; run it before the checkpoint. Only L0
+    # needs it, and AstroQuery requires a science (IMTYPE 'Object') frame.
+    if args.level == "L0":
+        try:
+            astro_config = ConfigHandler(args.config) if args.config else None
+            AstroQuery(data, astro_config).perform()
+        except Exception as exc:
+            print(f"Error: AstroQuery failed: {exc}", file=sys.stderr)
+            sys.exit(2)
 
     # ------------------------------------------------------------------ #
     # Run QC (via the Checkpoint stage, which folds in Diagnostics + QC and

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -84,9 +84,9 @@ def main():
 
     obs_id = args.obs_id or getattr(data, "obs_id", None) or "unknown"
 
-    # AstroQuery resolves target astrometry onto data.catalog_record, which the L0
-    # pointing-offset diagnostics consume; run it before the checkpoint. Only L0
-    # needs it, and AstroQuery requires a science (IMTYPE 'Object') frame.
+    # AstroQuery resolves target astrometry into data's CATALOG_RECORD extension,
+    # which the L0 pointing-offset diagnostics consume; run it before the checkpoint.
+    # Only L0 needs it, and AstroQuery requires a science (IMTYPE 'Object') frame.
     if args.level == "L0":
         try:
             astro_config = ConfigHandler(args.config) if args.config else None

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -85,9 +85,8 @@ def main():
     obs_id = args.obs_id or getattr(data, "obs_id", None) or "unknown"
 
     # AstroQuery resolves the CATALOG_RECORD rows the L0 pointing-offset diagnostics
-    # consume, so run it before the checkpoint. Only science frames (IMTYPE 'Object')
-    # have a target to resolve; skip calibration frames. A failure is non-fatal -- the
-    # frame stays inspectable, the offsets just come out empty.
+    # consume, so run it before the checkpoint. Calibration frames have no target to
+    # resolve; a failure is non-fatal -- the offsets just come out empty.
     if args.level == "L0":
         imtype = str(data.headers["PRIMARY"].get("IMTYPE", "")).strip().lower()
         if imtype == "object":

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -84,11 +84,10 @@ def main():
 
     obs_id = args.obs_id or getattr(data, "obs_id", None) or "unknown"
 
-    # AstroQuery resolves the gaia/simbad/wmko rows of CATALOG_RECORD that the L0
-    # pointing-offset diagnostics consume, so run it before the checkpoint. It runs
-    # only on L0 science frames (IMTYPE 'Object'); calibration frames have no target
-    # to resolve, so skip them rather than error. A resolution failure is non-fatal
-    # here -- the frame is still inspectable, the offsets just come out empty.
+    # AstroQuery resolves the CATALOG_RECORD rows the L0 pointing-offset diagnostics
+    # consume, so run it before the checkpoint. Only science frames (IMTYPE 'Object')
+    # have a target to resolve; skip calibration frames. A failure is non-fatal -- the
+    # frame stays inspectable, the offsets just come out empty.
     if args.level == "L0":
         imtype = str(data.headers["PRIMARY"].get("IMTYPE", "")).strip().lower()
         if imtype == "object":

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -84,9 +84,10 @@ def main():
 
     obs_id = args.obs_id or getattr(data, "obs_id", None) or "unknown"
 
-    # AstroQuery resolves target astrometry into data's CATALOG_RECORD extension,
-    # which the L0 pointing-offset diagnostics consume; run it before the checkpoint.
-    # Only L0 needs it, and AstroQuery requires a science (IMTYPE 'Object') frame.
+    # The native wmko row of CATALOG_RECORD (and TARGOFF) is populated at read;
+    # AstroQuery adds the gaia/simbad rows the L0 pointing-offset diagnostics also
+    # consume, so run it before the checkpoint. Only L0 needs it, and AstroQuery
+    # requires a science (IMTYPE 'Object') frame.
     if args.level == "L0":
         try:
             astro_config = ConfigHandler(args.config) if args.config else None

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -84,17 +84,21 @@ def main():
 
     obs_id = args.obs_id or getattr(data, "obs_id", None) or "unknown"
 
-    # The native wmko row of CATALOG_RECORD (and TARGOFF) is populated at read;
-    # AstroQuery adds the gaia/simbad rows the L0 pointing-offset diagnostics also
-    # consume, so run it before the checkpoint. Only L0 needs it, and AstroQuery
-    # requires a science (IMTYPE 'Object') frame.
+    # AstroQuery resolves the gaia/simbad/wmko rows of CATALOG_RECORD that the L0
+    # pointing-offset diagnostics consume, so run it before the checkpoint. It runs
+    # only on L0 science frames (IMTYPE 'Object'); calibration frames have no target
+    # to resolve, so skip them rather than error. A resolution failure is non-fatal
+    # here -- the frame is still inspectable, the offsets just come out empty.
     if args.level == "L0":
-        try:
-            astro_config = ConfigHandler(args.config) if args.config else None
-            AstroQuery(data, astro_config).perform()
-        except Exception as exc:
-            print(f"Error: AstroQuery failed: {exc}", file=sys.stderr)
-            sys.exit(2)
+        imtype = str(data.headers["PRIMARY"].get("IMTYPE", "")).strip().lower()
+        if imtype == "object":
+            try:
+                astro_config = ConfigHandler(args.config) if args.config else None
+                AstroQuery(data, astro_config).perform()
+            except Exception as exc:
+                print(f"Warning: AstroQuery failed: {exc}", file=sys.stderr)
+        else:
+            print(f"Skipping AstroQuery (IMTYPE={imtype!r}, not a science frame)")
 
     # ------------------------------------------------------------------ #
     # Run QC (via the Checkpoint stage, which folds in Diagnostics + QC and

--- a/scripts/quality_control/qc.py
+++ b/scripts/quality_control/qc.py
@@ -84,7 +84,7 @@ def main():
 
     obs_id = args.obs_id or getattr(data, "obs_id", None) or "unknown"
 
-    # AstroQuery resolves target astrometry onto data.catalog_query, which the L0
+    # AstroQuery resolves target astrometry onto data.catalog_record, which the L0
     # pointing-offset diagnostics consume; run it before the checkpoint. Only L0
     # needs it, and AstroQuery requires a science (IMTYPE 'Object') frame.
     if args.level == "L0":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,38 @@ def pytest_collection_modifyitems(config, items):
 # ---------------------------------------------------------------------------
 
 
+def _catalog_record_hdu():
+    """A CATALOG_RECORD BinTableHDU carrying the canonical 'kpf-drp' row (built via
+    AstroQuery's writer for schema fidelity). A science L0 reaches to_kpf1 only after
+    AstroQuery has populated this, so the fixture embeds it; without it to_kpf1 raises
+    on a science frame. Single-source (gaia) so the overlay logs no mixed-source
+    warning."""
+    from kpfpipe.data_models.level0 import KPF0
+    from kpfpipe.modules.astro_query import AstroQuery
+
+    l0 = KPF0()
+    l0.headers["PRIMARY"]["IMTYPE"] = "Object"
+    AstroQuery(l0)._write_catalog_record(
+        "kpf-drp",
+        {
+            "object": "Gaia_HD10700",
+            "radec_src": "gaia",
+            "plx_src": "gaia",
+            "rv_src": "gaia",
+            "ra": "01:44:04.0000",
+            "dec": "-15:56:14.900",
+            "pmra": -1.7,
+            "pmdec": 0.85,
+            "parallax": 273.8,
+            "rv": -16.6,
+            "frame": "icrs",
+            "epoch": 2016.0,
+            "equinox": 2000.0,
+        },
+    )
+    return fits.BinTableHDU(data=l0.data["CATALOG_RECORD"], name="CATALOG_RECORD")
+
+
 @pytest.fixture(scope="session")
 def synthetic_l0_file(tmp_path_factory):
     """Create a minimal synthetic L0 FITS file (session-scoped read-only source:
@@ -102,6 +134,7 @@ def synthetic_l0_file(tmp_path_factory):
             image_hdu("RED_AMP1", (32, 32), rng),
             image_hdu("CA_HK", (16, 16), rng),
             telemetry_hdu,
+            _catalog_record_hdu(),
         ]
     )
     hdul.writeto(fn, overwrite=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,13 +73,11 @@ def pytest_collection_modifyitems(config, items):
 
 
 def _catalog_record_hdu():
-    """A CATALOG_RECORD BinTableHDU with the canonical 'kpf-drp' row (built via
-    AstroQuery's writer for schema fidelity). A science L0's to_kpf1 needs this
-    populated, so the fixture embeds it; single-source (gaia) so the overlay logs
-    no mixed-source warning."""
-    # Deferred: this root conftest is imported at collection for every session, and
-    # astro_query pulls in astroquery/astropy (~2 s). Only the sessions that build
-    # this fixture should pay for it. No import cycle is involved.
+    """A CATALOG_RECORD BinTableHDU with the canonical 'kpf-drp' row, built via
+    AstroQuery's writer for schema fidelity. A science L0's to_kpf1 needs this
+    populated; single-source (gaia) so the overlay logs no mixed-source warning."""
+    # Deferred, not for a cycle: this root conftest is imported at collection for
+    # every session, and astro_query pulls in astroquery/astropy (~2 s).
     from kpfpipe.data_models.level0 import KPF0
     from kpfpipe.modules.astro_query import AstroQuery
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,11 +73,10 @@ def pytest_collection_modifyitems(config, items):
 
 
 def _catalog_record_hdu():
-    """A CATALOG_RECORD BinTableHDU carrying the canonical 'kpf-drp' row (built via
-    AstroQuery's writer for schema fidelity). A science L0 reaches to_kpf1 only after
-    AstroQuery has populated this, so the fixture embeds it; without it to_kpf1 raises
-    on a science frame. Single-source (gaia) so the overlay logs no mixed-source
-    warning."""
+    """A CATALOG_RECORD BinTableHDU with the canonical 'kpf-drp' row (built via
+    AstroQuery's writer for schema fidelity). A science L0's to_kpf1 needs this
+    populated, so the fixture embeds it; single-source (gaia) so the overlay logs
+    no mixed-source warning."""
     from kpfpipe.data_models.level0 import KPF0
     from kpfpipe.modules.astro_query import AstroQuery
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,9 @@ def _catalog_record_hdu():
     AstroQuery's writer for schema fidelity). A science L0's to_kpf1 needs this
     populated, so the fixture embeds it; single-source (gaia) so the overlay logs
     no mixed-source warning."""
+    # Deferred: this root conftest is imported at collection for every session, and
+    # astro_query pulls in astroquery/astropy (~2 s). Only the sessions that build
+    # this fixture should pay for it. No import cycle is involved.
     from kpfpipe.data_models.level0 import KPF0
     from kpfpipe.modules.astro_query import AstroQuery
 

--- a/tests/profiling/_profiling.py
+++ b/tests/profiling/_profiling.py
@@ -75,11 +75,11 @@ NETWORK_MARKERS = (
     "certifi",
 )
 
-# DiagL0 resolves each frame's pointing against Gaia DR3 and SIMBAD (astroquery)
-# -- network catalog round-trips as nondeterministic as the barycentric IERS
-# fetch, so they are likewise quarantined from the QC slice of the recipe summary
-# (reported separately, never in the denominator). Matched on the astroquery
-# package path; see _astrometry_cumtime.
+# AstroQuery (modules/astro_query.py) resolves each frame against Gaia DR3 and
+# SIMBAD (astroquery) as its own recipe step -- network catalog round-trips as
+# nondeterministic as the barycentric IERS fetch, so they are quarantined from the
+# AstroQuery stage slice of the recipe summary (reported separately, never in the
+# denominator). Matched on the astroquery package path; see _astrometry_cumtime.
 ASTROQUERY_MARKER = "/astroquery/"
 
 # The masters I/O-vs-compute split measures disk I/O at the data-model
@@ -197,10 +197,40 @@ def extract_l2(config):
     return SpectralExtraction(process_l1(config), config).perform()
 
 
+# Synthetic SCI2 (trace 3) catalog C*# cards seeded onto the L2 PRIMARY. The
+# profiling builders skip AstroQuery (a live Gaia/SIMBAD query), so the C*# cards
+# KPF0.to_kpf1 would overlay from CATALOG_RECORD stay blank; BarycentricCorrection
+# and CrossCorrelation read trace-3 astrometry off PRIMARY and would otherwise
+# raise. Fixed stand-in values -- profiling measures timing, not RV accuracy.
+_SYNTHETIC_CATALOG_CARDS = {
+    "CSRC3": "gaia",
+    "CRA3": "12:00:00.0000",  # ICRS RA, sexagesimal hourangle
+    "CDEC3": "+00:00:00.000",  # ICRS Dec, sexagesimal deg
+    "CPMR3": 0.0,  # proper motion RA*cosDec, arcsec/yr
+    "CPMD3": 0.0,  # proper motion Dec, arcsec/yr
+    "CPLX3": 10.0,  # parallax, mas (= 100 pc)
+    "CRV3": 0.0,  # systemic RV, km/s
+    "CEPCH3": 2016.0,  # epoch, Julian year
+}
+
+
+def _seed_catalog_cards(l2):
+    """Overlay the synthetic SCI2 C*# astrometry cards onto the L2 PRIMARY.
+
+    Stands in for AstroQuery's catalog overlay (which KPF0.to_kpf1 applies in the
+    real pipeline) so the barycentric/CCF/RV harnesses have the trace-3 cards they
+    read; see :data:`_SYNTHETIC_CATALOG_CARDS`.
+    """
+    for card, value in _SYNTHETIC_CATALOG_CARDS.items():
+        l2.headers["PRIMARY"][card] = value
+    return l2
+
+
 def wls_l2(config):
     from kpfpipe.modules.wavelength_calibration import WavelengthCalibration
 
-    return WavelengthCalibration(extract_l2(config), config).perform()
+    l2 = WavelengthCalibration(extract_l2(config), config).perform()
+    return _seed_catalog_cards(l2)
 
 
 def bary_l2(config):
@@ -401,7 +431,7 @@ def _network_own(rows):
     """Total own time of network calls (SSL/socket), for the separate report line.
 
     Network is a nondeterministic IERS download during barycentric correction plus
-    the DiagL0 Gaia/SIMBAD pointing lookups, so it is quarantined from the recipe's
+    AstroQuery's Gaia/SIMBAD catalog lookups, so it is quarantined from the recipe's
     High-level summary.
     """
     return sum(
@@ -412,14 +442,16 @@ def _network_own(rows):
 
 
 def _astrometry_cumtime(stats):
-    """Cumulative time of DiagL0's nondeterministic astrometry catalog queries.
+    """Cumulative time of AstroQuery's nondeterministic catalog queries.
 
-    DiagL0 resolves each frame's pointing against Gaia DR3 and SIMBAD (astroquery)
-    -- network round-trips as nondeterministic as the barycentric IERS fetch. Sum
-    the *outermost* astroquery frames (caller not itself astroquery) whose caller
-    is a ``diagnostics/`` method, so the full per-query time is counted once and
-    the identical Gaia query inside BarycentricCorrection -- already excluded with
-    that whole quarantined stage -- is not double-counted here.
+    AstroQuery (``modules/astro_query.py``) resolves each science frame against
+    Gaia DR3 and SIMBAD (astroquery) -- network round-trips as nondeterministic as
+    the barycentric IERS fetch. Sum the *outermost* astroquery frames (caller not
+    itself astroquery) whose caller is an AstroQuery method, so the full per-query
+    time is counted once while AstroQuery's own deterministic merge/sanitize/write
+    stays in the partition. DiagL0 no longer queries -- it reads the persisted
+    ``CATALOG_RECORD`` -- and BarycentricCorrection reads the PRIMARY ``C*#`` cards,
+    so neither issues a catalog query for this to double-count.
     """
     total = 0.0
     for func, (_cc, _nc, _tt, _ct, callers) in stats.stats.items():
@@ -429,10 +461,8 @@ def _astrometry_cumtime(stats):
             cfn = caller[0]
             if ASTROQUERY_MARKER in cfn:
                 continue  # nested astroquery frame; its time is in the outer one
-            if _is_kpf_module(cfn) and _module_label(cfn).startswith(
-                "quality_control/diagnostics/"
-            ):
-                total += cvals[3]  # per-caller cumtime; outermost DiagL0 query only
+            if _is_kpf_module(cfn) and _module_label(cfn) == "modules/astro_query.py":
+                total += cvals[3]  # per-caller cumtime; outermost AstroQuery query only
     return total
 
 
@@ -549,9 +579,7 @@ def _quality_control_breakdown(stats):
     of a single shared base ``run`` -- so each level's cost is the cumtime its
     check methods contribute there, keyed ``DiagL{n}`` / ``QCL{n}``. ``checkpoints``
     is the remainder (the thin base-``run`` dispatch/keyword-routing plus the
-    checkpoint validation methods). DiagL0's nondeterministic Gaia/SIMBAD pointing
-    lookups are carved out of its row (and the total), matching the recipe
-    summary, which reports them as a separate quarantined slice. Returns ``rows``
+    checkpoint validation methods). Returns ``rows``
     (``(label, seconds, fraction)``) and the QC ``total``; empty when no
     checkpoints ran (masters).
     """
@@ -584,13 +612,6 @@ def _quality_control_breakdown(stats):
             if label.startswith(subdir) and run_key in callers:
                 lvl = _qc_level_label(filename)
                 agg[lvl] = agg.get(lvl, 0.0) + callers[run_key][3]
-
-    # Quarantine DiagL0's Gaia/SIMBAD lookups from its row and the total, matching
-    # the recipe summary (which reports them separately as a nondeterministic slice).
-    astrometry = _astrometry_cumtime(stats)
-    if "DiagL0" in agg:
-        agg["DiagL0"] = max(agg["DiagL0"] - astrometry, 0.0)
-    total = max(total - astrometry, 0.0)
 
     # Everything not charged to a level's checks is the checkpoint wrapper (the
     # base-run dispatch + keyword routing + validation); max() guards float noise.
@@ -670,9 +691,9 @@ def _recipe_summary(stats, call, network_own):
     ``calibration_association`` (it lands in that stage, never double-counted).
 
     Barycentric correction is quarantined (nondeterministic IERS fetch): its
-    slice is reported separately and excluded from the denominator. The DiagL0
-    Gaia/SIMBAD pointing lookups are quarantined the same way -- carved out of the
-    QC slice, since they nest inside it rather than being a top-level stage.
+    slice is reported separately and excluded from the denominator. AstroQuery's
+    Gaia/SIMBAD catalog lookups are quarantined the same way -- carved out of the
+    AstroQuery stage slice, keeping that stage's deterministic merge/write compute.
     Returns the sorted ``rows`` (``(label, seconds, fraction, kind)``), the
     ``denominator`` (wall-clock minus those quarantined slices), ``bary_seconds``,
     ``astrometry_seconds``, and ``network_seconds``.
@@ -697,12 +718,12 @@ def _recipe_summary(stats, call, network_own):
         buckets[OVERHEAD_LABEL] = buckets.get(OVERHEAD_LABEL, 0.0) + main_own
         kinds[OVERHEAD_LABEL] = "overhead"
 
-    # Carve DiagL0's nondeterministic astrometry lookups out of the QC slice, the
-    # same quarantine the barycentric stage gets (reported separately below).
+    # Carve AstroQuery's nondeterministic catalog lookups out of its stage slice,
+    # the same quarantine the barycentric stage gets (reported separately below).
     astrometry_seconds = _astrometry_cumtime(stats)
-    if astrometry_seconds and QC_LABEL in buckets:
-        astrometry_seconds = min(astrometry_seconds, buckets[QC_LABEL])
-        buckets[QC_LABEL] -= astrometry_seconds
+    if astrometry_seconds and "astro_query" in buckets:
+        astrometry_seconds = min(astrometry_seconds, buckets["astro_query"])
+        buckets["astro_query"] -= astrometry_seconds
     else:
         astrometry_seconds = 0.0
 
@@ -948,7 +969,7 @@ def _render_recipe(title, summary, split=None, quicklook=None, quality=None):
     if has_bary:
         items.append("the barycentric-correction stage")
     if has_astro:
-        items.append("the DiagL0 astrometry lookups")
+        items.append("the AstroQuery catalog lookups")
     items.append("network time")
     if len(items) > 1:
         joined = ", ".join(items[:-1]) + ", and " + items[-1]
@@ -986,7 +1007,7 @@ def _render_recipe(title, summary, split=None, quicklook=None, quality=None):
         )
     if has_astro:
         excluded.append(
-            f"- **Astrometry lookups** (Gaia DR3 + SIMBAD, in DiagL0) — "
+            f"- **Astrometry lookups** (Gaia DR3 + SIMBAD, in AstroQuery) — "
             f"{summary['astrometry_seconds']:.3f} s cumulative (excluded; "
             "nondeterministic catalog network queries)."
         )
@@ -994,7 +1015,7 @@ def _render_recipe(title, summary, split=None, quicklook=None, quality=None):
         if not has_bary:
             whence = "not disk I/O"
         elif has_astro:
-            whence = "inside barycentric + the DiagL0 lookups"
+            whence = "inside barycentric + the AstroQuery lookups"
         else:
             whence = "mostly inside barycentric"
         excluded.append(
@@ -1056,9 +1077,7 @@ def _render_recipe(title, summary, split=None, quicklook=None, quality=None):
             f"({quality['total']:.3f} s total; % of that). The recipe runs all QC "
             "through `CheckpointL{n}.run()`, which folds in each level's "
             "diagnostics (`DiagL{n}`) then QC flags (`QCL{n}`); `checkpoints` is "
-            "the thin dispatch/keyword-routing plus header/flag validation. "
-            "DiagL0's nondeterministic Gaia/SIMBAD pointing lookups are excluded "
-            "here (reported with the quarantined slices above)."
+            "the thin dispatch/keyword-routing plus header/flag validation."
         )
         w("")
         w("| level | % | s |")

--- a/tests/profiling/_profiling.py
+++ b/tests/profiling/_profiling.py
@@ -198,10 +198,9 @@ def extract_l2(config):
 
 
 # Synthetic SCI2 (trace 3) catalog C*# cards seeded onto the L2 PRIMARY. The
-# profiling builders skip AstroQuery (a live Gaia/SIMBAD query), so the C*# cards
-# KPF0.to_kpf1 would overlay from CATALOG_RECORD stay blank; BarycentricCorrection
-# and CrossCorrelation read trace-3 astrometry off PRIMARY and would otherwise
-# raise. Fixed stand-in values -- profiling measures timing, not RV accuracy.
+# profiling builders skip AstroQuery (a live Gaia/SIMBAD query), so the cards
+# BarycentricCorrection and CrossCorrelation read would otherwise be blank. Fixed
+# stand-in values -- profiling measures timing, not RV accuracy.
 _SYNTHETIC_CATALOG_CARDS = {
     "CSRC3": "gaia",
     "CRA3": "12:00:00.0000",  # ICRS RA, sexagesimal hourangle
@@ -217,9 +216,8 @@ _SYNTHETIC_CATALOG_CARDS = {
 def _seed_catalog_cards(l2):
     """Overlay the synthetic SCI2 C*# astrometry cards onto the L2 PRIMARY.
 
-    Stands in for AstroQuery's catalog overlay (which KPF0.to_kpf1 applies in the
-    real pipeline) so the barycentric/CCF/RV harnesses have the trace-3 cards they
-    read; see :data:`_SYNTHETIC_CATALOG_CARDS`.
+    Stands in for the AstroQuery-fed overlay KPF0.to_kpf1 applies in the real
+    pipeline, so the barycentric/CCF/RV harnesses have the trace-3 cards they read.
     """
     for card, value in _SYNTHETIC_CATALOG_CARDS.items():
         l2.headers["PRIMARY"][card] = value
@@ -449,9 +447,7 @@ def _astrometry_cumtime(stats):
     the barycentric IERS fetch. Sum the *outermost* astroquery frames (caller not
     itself astroquery) whose caller is an AstroQuery method, so the full per-query
     time is counted once while AstroQuery's own deterministic merge/sanitize/write
-    stays in the partition. DiagL0 no longer queries -- it reads the persisted
-    ``CATALOG_RECORD`` -- and BarycentricCorrection reads the PRIMARY ``C*#`` cards,
-    so neither issues a catalog query for this to double-count.
+    stays in the partition.
     """
     total = 0.0
     for func, (_cc, _nc, _tt, _ct, callers) in stats.stats.items():
@@ -579,9 +575,8 @@ def _quality_control_breakdown(stats):
     of a single shared base ``run`` -- so each level's cost is the cumtime its
     check methods contribute there, keyed ``DiagL{n}`` / ``QCL{n}``. ``checkpoints``
     is the remainder (the thin base-``run`` dispatch/keyword-routing plus the
-    checkpoint validation methods). Returns ``rows``
-    (``(label, seconds, fraction)``) and the QC ``total``; empty when no
-    checkpoints ran (masters).
+    checkpoint validation methods). Returns ``rows`` (``(label, seconds, fraction)``)
+    and the QC ``total``; empty when no checkpoints ran (masters).
     """
     ck_key = _qc_sublayer_run_key(stats, "quality_control/checkpoints/")
     if ck_key is None:

--- a/tests/profiling/profile_barycentric_correction.py
+++ b/tests/profiling/profile_barycentric_correction.py
@@ -1,7 +1,7 @@
 """Profile ``BarycentricCorrection.perform`` (per-order barycentric correction).
 
-Note: the first run may include a one-time Gaia DR3 network lookup, which the
-report will surface as a (non-compute) cumulative-time entry.
+Note: the first run may trigger barycorrpy's one-time IERS / leap-second table
+download; the report will surface that network time as a (non-compute) entry.
 
 Run with ``make profile-barycentric_correction`` or
 ``python tests/profiling/profile_barycentric_correction.py``. Requires real frames in

--- a/tests/regression/_catalog.py
+++ b/tests/regression/_catalog.py
@@ -1,0 +1,52 @@
+"""Synthetic CATALOG_RECORD tables for the data-model tests.
+
+Built column by column rather than through ``AstroQuery._write_catalog_record``,
+so the data-model pass-through tests stay independent of the module that
+populates the extension (the AstroQuery-built variant lives in conftest, for the
+tests that need schema fidelity against the real writer).
+"""
+
+import numpy as np
+from astropy.table import Table
+
+SOURCES = ("gaia", "kpf-drp")
+
+_STR_CELLS = {
+    "object": "12345",
+    "radec_src": "gaia",
+    "plx_src": "gaia",
+    "rv_src": "gaia",
+    "ra": "01:44:04.0000",
+    "dec": "-15:56:14.900",
+    "frame": "icrs",
+    "color_name": "Gaia BP-RP",
+}
+_FLOAT_CELLS = {
+    "pmra": -1.7,
+    "pmdec": 0.85,
+    "parallax": 273.8,
+    "epoch": 2016.0,
+    "equinox": 2000.0,
+    "color": 1.2,
+}
+
+
+def catalog_record_table(rv=-16.6):
+    """A two-row CATALOG_RECORD table: a 'gaia' source row + the merged 'kpf-drp'.
+
+    Carries the full write schema, since KPF0.to_kpf1 reads every canonical column
+    when overlaying the row onto the C*# cards. ``rv=None`` leaves the radial
+    velocity (and the redshift derived from it) missing -- NaN, the sentinel
+    astropy's FITS reader hands back masked and ``KPFDataModel.from_fits``
+    normalizes.
+    """
+    table = Table()
+    table["source"] = np.array(SOURCES, dtype=str)
+    for column, value in _STR_CELLS.items():
+        table[column] = np.array([value] * 2, dtype=str)
+    for column, value in _FLOAT_CELLS.items():
+        table[column] = np.array([value] * 2, dtype=float)
+    missing = rv is None
+    table["rv"] = np.array([np.nan if missing else rv] * 2, dtype=float)
+    table["z"] = np.array([np.nan if missing else -5.5e-5] * 2, dtype=float)
+    return table

--- a/tests/regression/_catalog.py
+++ b/tests/regression/_catalog.py
@@ -1,9 +1,8 @@
 """Synthetic CATALOG_RECORD tables for the data-model tests.
 
-Built column by column rather than through ``AstroQuery._write_catalog_record``,
-so the data-model pass-through tests stay independent of the module that
-populates the extension (the AstroQuery-built variant lives in conftest, for the
-tests that need schema fidelity against the real writer).
+Built column by column rather than through ``AstroQuery._write_catalog_record``, so
+the pass-through tests stay independent of the module that populates the extension.
+The AstroQuery-built variant lives in conftest, for tests needing schema fidelity.
 """
 
 import numpy as np
@@ -35,10 +34,9 @@ def catalog_record_table(rv=-16.6):
     """A two-row CATALOG_RECORD table: a 'gaia' source row + the merged 'kpf-drp'.
 
     Carries the full write schema, since KPF0.to_kpf1 reads every canonical column
-    when overlaying the row onto the C*# cards. ``rv=None`` leaves the radial
-    velocity (and the redshift derived from it) missing -- NaN, the sentinel
-    astropy's FITS reader hands back masked and ``KPFDataModel.from_fits``
-    normalizes.
+    when overlaying the row onto the C*# cards. ``rv=None`` leaves rv (and the
+    redshift derived from it) NaN -- the sentinel astropy's FITS reader hands back
+    masked and ``KPFDataModel.from_fits`` normalizes.
     """
     table = Table()
     table["source"] = np.array(SOURCES, dtype=str)

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -1,11 +1,10 @@
 """Regression tests for the AstroQuery module.
 
-Covers ``merge_catalog_records`` -- the merge of the gaia/simbad/wmko records into
-the canonical ``kpf-drp`` row -- ``read_wmko_header`` (off synthetic L0 PRIMARY
-TARG*), and the external Gaia/SIMBAD query contract (``TestExternalQueries``). The
-network is never touched: ``Gaia.launch_job``/``Simbad`` are mocked with one-row
-result Tables, so query parsing, each fail-soft None+warning path, and the
-``_verify_units`` schema-drift guard are exercised offline.
+Covers ``merge_catalog_records`` (gaia/simbad/wmko -> the canonical ``kpf-drp``
+row), ``read_wmko_header`` off synthetic L0 PRIMARY TARG*, and the external
+query contract. The network is never touched: ``Gaia.launch_job``/``Simbad`` are
+mocked with one-row result Tables, so parsing, the fail-soft None+warning paths,
+and the ``_verify_units`` schema-drift guard all run offline.
 """
 
 import logging
@@ -37,9 +36,8 @@ def _dec_str(deg):
 
 
 def _record(obj, ra=180.0, **overrides):
-    """A complete canonical record at ``ra`` (finite PM/plx/rv) in the EPRV C*#
-    format: RA/Dec sexagesimal strings, PM arcsec/yr. Pass a field as None (via
-    overrides) to mark it missing."""
+    """A complete canonical record at ``ra`` in the EPRV C*# format: sexagesimal
+    RA/Dec, PM in arcsec/yr. Override a field with None to mark it missing."""
     rec = {
         "object": obj,
         "ra": _ra_str(ra),
@@ -58,16 +56,17 @@ def _record(obj, ra=180.0, **overrides):
     return rec
 
 
-def _merge(records, targradv=None):
-    """Merge the given {source: in-memory record} the way perform does: preset each
-    source's just-built record on a fresh AstroQuery, then merge. Returns the
-    canonical kpf-drp record dict (missing cells are None, as merge emits them).
-    ``targradv`` seeds L0 PRIMARY TARGRADV so the rv fallback can be exercised."""
+def _merge(records, targradv=None, priority=("gaia", "simbad", "wmko")):
+    """Merge {source: record} the way perform does: preset each source's record on
+    a fresh AstroQuery, then merge. Returns the canonical kpf-drp record dict
+    (missing cells None). ``targradv`` seeds TARGRADV for the rv fallback. The
+    default ``priority`` admits all three sources so these tests exercise the merge
+    itself; the shipped policy is pinned separately in TestAstrometryPriority."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["IMTYPE"] = "object"
     if targradv is not None:
         l0.headers["PRIMARY"]["TARGRADV"] = targradv
-    aq = AstroQuery(l0)
+    aq = AstroQuery(l0, {"astrometry_priority": priority})
     for source, record in records.items():
         setattr(aq, f"_{source}", record)
     return aq.merge_catalog_records()
@@ -107,7 +106,6 @@ class TestMergeCatalogRecords:
         assert row["rv_src"] == "gaia"
 
     def test_color_rides_with_astrometric_base(self):
-        # color/color_name ride with the astrometric base (Gaia), like the position.
         row = _merge(
             {
                 "gaia": _record("G", color=1.1, color_name="Gaia BP-RP"),
@@ -119,9 +117,8 @@ class TestMergeCatalogRecords:
         assert row["color_name"] == "Gaia BP-RP"
 
     def test_color_borrowed_from_lower_priority_when_base_lacks(self, caplog):
-        # Base (Gaia) has no color -> borrowed from the next catalog that has one
-        # (SIMBAD), flagged by a mixed-catalog WARNING. Unlike rv, a color index is
-        # independent of the astrometry, so a cross-source color is acceptable.
+        # Unlike rv, a color index is independent of the astrometry, so borrowing
+        # one from a lower-priority catalog is acceptable -- with a WARNING.
         with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
             row = _merge(
                 {
@@ -135,7 +132,6 @@ class TestMergeCatalogRecords:
         assert "astrometric base has no color" in caplog.text
 
     def test_color_missing_everywhere_left_blank(self):
-        # No source supplies a color -> merged color stays blank, no borrow.
         row = _merge(
             {
                 "gaia": _record("G", color=None, color_name=None),
@@ -146,8 +142,8 @@ class TestMergeCatalogRecords:
         assert row["color_name"] is None
 
     def test_rv_not_borrowed_from_lower_priority(self):
-        # Gaia is the base and lacks rv; SIMBAD's rv is not pulled in, and with no
-        # TARGRADV rv is left missing.
+        # Gaia is the base and lacks rv; SIMBAD's is not borrowed, and with no
+        # TARGRADV the rv stays missing.
         row = _merge(
             {
                 "gaia": _record("G", rv=None),
@@ -159,8 +155,8 @@ class TestMergeCatalogRecords:
         assert row["rv_src"] == ""
 
     def test_rv_missing_falls_back_to_targradv(self, caplog):
-        # Base (Gaia) lacks rv -> rv comes from the telescope TARGRADV on PRIMARY (km/s,
-        # no conversion), tagged rv_src='wmko', with a WARNING.
+        # Base lacks rv -> fall back to the telescope TARGRADV on PRIMARY
+        # ([km/s], no conversion), tagged rv_src='wmko'.
         with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
             row = _merge({"gaia": _record("G", rv=None)}, targradv=-4.5)
         assert row["radec_src"] == "gaia"
@@ -169,8 +165,8 @@ class TestMergeCatalogRecords:
         assert "falling back to the telescope TARGRADV" in caplog.text
 
     def test_missing_parallax_disqualifies_astrometric_base(self):
-        # parallax is part of the astrometric block, so Gaia lacking it is disqualified
-        # as the base; the whole position comes from SIMBAD (next complete source).
+        # parallax is part of the astrometric block, so Gaia lacking it is
+        # disqualified as the base and the whole position comes from SIMBAD.
         row = _merge(
             {
                 "gaia": _record("G", ra=10.0, parallax=None),
@@ -184,7 +180,6 @@ class TestMergeCatalogRecords:
         assert row["plx_src"] == "simbad"
 
     def test_demoted_source_warns_naming_missing_field(self, caplog):
-        # A demoted higher-priority source warns, naming the source and missing field.
         with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
             row = _merge(
                 {
@@ -196,8 +191,8 @@ class TestMergeCatalogRecords:
         assert "gaia astrometry incomplete (missing parallax)" in caplog.text
 
     def test_lone_source_missing_parallax_raises(self):
-        # parallax is part of the astrometric block, so a sole source lacking it cannot
-        # anchor the canonical position.
+        # parallax is part of the astrometric block, so a sole source lacking it
+        # cannot anchor the canonical position.
         with pytest.raises(ValueError, match="position"):
             _merge({"gaia": _record("G", parallax=None)})
 
@@ -208,7 +203,6 @@ class TestMergeCatalogRecords:
         assert row["rv_src"] == "wmko"  # rv rides with the sole source
 
     def test_no_source_raises(self):
-        # No source built a record -> nothing to correct -> raise.
         with pytest.raises(ValueError, match="position"):
             _merge({})
 
@@ -218,7 +212,7 @@ class TestMergeCatalogRecords:
             _merge({"gaia": _record("G", pmra=None)})
 
     def test_optional_rv_missing_everywhere_left_missing(self):
-        # Position present but no source supplies rv -> merged row builds, rv is None.
+        # rv is optional: the merged row still builds with the position intact.
         row = _merge(
             {
                 "gaia": _record("G", rv=None),
@@ -231,10 +225,52 @@ class TestMergeCatalogRecords:
         assert row["parallax"] == pytest.approx(50.0)  # parallax still filled
 
 
+class TestAstrometryPriority:
+    """Which sources may anchor the merged position.
+
+    The knob exists so a catalog outage cannot silently substitute lower-precision
+    telescope astrometry into the RV path: a source outside the priority still gets
+    its row (DiagL0 needs the wmko row for TARGOFF) but can never become the base.
+    """
+
+    def test_shipped_default_bars_wmko_from_anchoring(self):
+        # The default must not let a Gaia+SIMBAD outage fall through to TCS values.
+        aq = AstroQuery(_l0_for_query())
+        assert "wmko" not in aq.astrometry_priority
+
+    def test_source_outside_priority_cannot_anchor(self):
+        with pytest.raises(ValueError, match="astrometry_priority"):
+            _merge({"wmko": _record("W")}, priority=("gaia", "simbad"))
+
+    def test_priority_order_is_honored(self):
+        # Reversing the order moves the base, proving the list drives selection.
+        records = {"gaia": _record("G", ra=10.0), "simbad": _record("S", ra=20.0)}
+        assert _merge(records, priority=("gaia", "simbad"))["radec_src"] == "gaia"
+        assert _merge(records, priority=("simbad", "gaia"))["radec_src"] == "simbad"
+
+    def test_excluded_source_still_supplies_rv_and_color(self):
+        # Barring wmko from the position does not bar the TARGRADV rv fallback.
+        row = _merge(
+            {"gaia": _record("G", rv=None)},
+            targradv=-4.5,
+            priority=("gaia",),
+        )
+        assert row["radec_src"] == "gaia"
+        assert row["rv"] == pytest.approx(-4.5)
+        assert row["rv_src"] == "wmko"
+
+    @pytest.mark.parametrize("bad", [(), ("gaia", "nope"), ("tcs",)])
+    def test_invalid_priority_raises_at_construction(self, bad):
+        # Caught at construction: an unknown name would otherwise read as "that
+        # source had no record" and silently demote the position.
+        with pytest.raises(ValueError, match="astrometry_priority"):
+            AstroQuery(_l0_for_query(), {"astrometry_priority": bad})
+
+
 class TestSingleSourceProvenance:
     def test_source_row_provenance_defaults_to_source(self):
-        # A plain source row's provenance labels are all its own label (its values
-        # are its own).
+        # A source row holds only its own values, so all three provenance labels
+        # are its own label.
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "object"
         aq = AstroQuery(l0)
@@ -259,7 +295,6 @@ class TestRedshift:
         )
 
     def test_written_row_carries_redshift(self):
-        # A written row's z column is the redshift derived from its rv.
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "object"
         aq = AstroQuery(l0)
@@ -290,8 +325,8 @@ class TestColor:
 
 
 class TestReadWmkoHeader:
-    """read_wmko_header builds the native wmko record from L0 PRIMARY TARG* (moved
-    here from KPF0 read-time population); fail-soft on absent/malformed astrometry."""
+    """read_wmko_header builds the native wmko record from L0 PRIMARY TARG*,
+    fail-soft on absent or malformed astrometry."""
 
     _GOOD_TARG = {
         "TARGRA": "12:00:00.00",
@@ -315,9 +350,9 @@ class TestReadWmkoHeader:
         return l0
 
     def test_good_targ_builds_row(self):
-        # Well-formed FK5 TARG* -> a wmko record rotated to ICRS (so all sources
-        # share one frame), sanitized to the EPRV C*# format. The matching WMKOCR
-        # flag is a header, written later by _set_headers (see TestPerform).
+        # Well-formed FK5 TARG* -> a wmko record rotated to ICRS, so all sources
+        # share one frame. The WMKOCR flag is a header, written later by
+        # _set_headers (covered in TestPerform).
         l0 = self._l0_targ(**self._GOOD_TARG)
         aq = AstroQuery(l0)
         aq.read_wmko_header()  # builds the wmko row and writes it in one go
@@ -325,8 +360,8 @@ class TestReadWmkoHeader:
         wmko = table[table["source"] == "wmko"][0]
         assert wmko["object"] == "testtarget"
         assert wmko["frame"] == "icrs"  # native FK5 rotated to ICRS, not relabeled
-        # ICRS position sits within the ~tens-of-mas FK5->ICRS frame bias of the
-        # FK5 input, and is shifted from it (a real rotation, not a copy).
+        # Within the ~tens-of-mas FK5->ICRS frame bias of the input, but shifted
+        # from it -- a real rotation, not a copy.
         ra = Angle(wmko["ra"], unit=u.hourangle)
         dec = Angle(wmko["dec"], unit=u.deg)
         fk5_ra = Angle(self._GOOD_TARG["TARGRA"], unit=u.hourangle)
@@ -336,10 +371,8 @@ class TestReadWmkoHeader:
         assert wmko["ra"] != "12:00:00.0000"  # rotated, not copied
 
     def test_pmra_time_to_angle_conversion(self):
-        # TARGPMRA is DCS seconds-of-time/yr: read_wmko_header must convert it to
-        # on-sky arcsec/yr via x15 x cos(dec). TARGPMDC is already arcsec/yr and
-        # passes through. Uses a non-zero TARGPMRA so the factor is exercised (a
-        # zero would pass regardless).
+        # TARGPMRA is DCS seconds-of-time/yr: convert to on-sky arcsec/yr via
+        # x15 x cos(dec). TARGPMDC is already arcsec/yr and passes through.
         dec_deg = 40.0
         rec = AstroQuery(
             self._l0_targ(**{**self._GOOD_TARG, "TARGPMRA": 0.5, "TARGPMDC": 2.0})
@@ -377,10 +410,10 @@ class TestReadWmkoHeader:
         assert "could not build wmko CATALOG_RECORD" in caplog.text
 
     def test_nonnumeric_numeric_fields_laundered_to_none(self):
-        # A non-numeric TARG* numeric card must be laundered to None via _scalar;
-        # otherwise the stray value survives the merge's completeness gate as a
-        # valid-looking solution. (A stray string is the residual reachable case:
-        # astropy rejects NaN in headers, and a valueless card already reads as None.)
+        # A non-numeric TARG* numeric card must be laundered to None by _scalar,
+        # or the stray value passes the merge's completeness gate as a
+        # valid-looking solution. A string is the only reachable case: astropy
+        # rejects NaN in headers, and a valueless card already reads as None.
         rec = AstroQuery(
             self._l0_targ(**{**self._GOOD_TARG, "TARGPLAX": "UNKNOWN"})
         ).read_wmko_header()
@@ -399,25 +432,27 @@ class TestReadWmkoHeader:
         with pytest.raises(ValueError, match="TARGFRAM"):
             AstroQuery(self._l0_targ(**targ)).read_wmko_header()
 
-    def test_use_wmko_tcs_false_skips_build(self):
-        # use_wmko_tcs off -> read_wmko_header is not called; with catalogs off too,
-        # no position -> merge raises.
+    def test_wmko_row_built_even_when_barred_from_anchoring(self):
+        # The wmko row is unconditional -- TARGOFF needs it -- but with wmko outside
+        # astrometry_priority and both catalogs off, nothing may anchor, so merge
+        # raises rather than quietly falling back to telescope astrometry.
         aq = AstroQuery(
             self._l0_targ(**self._GOOD_TARG),
-            {"do_gaia_query": False, "do_simbad_query": False, "use_wmko_tcs": False},
+            {"do_gaia_query": False, "do_simbad_query": False},
         )
-        with pytest.raises(ValueError, match="position"):
+        with pytest.raises(ValueError, match="astrometry_priority"):
             aq.perform()
-        assert aq._wmko is None
+        assert aq._wmko is not None
+        table = aq.l0_obj.data["CATALOG_RECORD"]
+        assert "wmko" in [str(s) for s in table["source"]]
 
 
 # ---------------------------------------------------------------------------
 # External Gaia / SIMBAD queries -- mocked (no network)
 # ---------------------------------------------------------------------------
 
-# Default one-row result values, keyed to each catalog's canonical column schema.
-# pmra/pmdec are 500 / -250 mas/yr so the mas->arcsec/yr conversion (/1e3) is
-# visible (0.5 / -0.25); ra/dec 180/40 deg drive the sexagesimal formatting.
+# Default one-row result values, keyed to each catalog's column schema. pmra/pmdec
+# are 500 / -250 mas/yr so the mas -> arcsec/yr conversion is visible (0.5 / -0.25).
 _GAIA_VALUES = {
     "ra": 180.0,
     "dec": 40.0,
@@ -445,8 +480,8 @@ def _units_table(unit_map, value_map, unit_overrides=None):
     """One-row astropy Table with canonical column units.
 
     A plain Table (not QTable), so ``_verify_units`` sees ``column.unit`` while row
-    access yields plain floats for ``_scalar``. ``unit_overrides`` swaps a column's
-    unit to drive the schema-drift guard.
+    access yields plain floats for ``_scalar``. ``unit_overrides`` swaps a unit to
+    drive the schema-drift guard.
     """
     units = dict(unit_map)
     if unit_overrides:
@@ -503,8 +538,8 @@ class TestExternalQueries:
     # -- pure helpers ------------------------------------------------------
 
     def test_scalar_variants(self):
-        # astroquery hands back masked/NaN cells for unmeasured quantities; all the
-        # missing/unusable forms must coerce to a clean None, real values to float.
+        # astroquery hands back masked/NaN cells for unmeasured quantities; every
+        # unusable form must coerce to a clean None, real values to float.
         assert AstroQuery._scalar(None) is None
         assert AstroQuery._scalar(np.ma.masked) is None
         assert AstroQuery._scalar(float("nan")) is None
@@ -546,7 +581,7 @@ class TestExternalQueries:
         assert AstroQuery(_l0_for_query())._simbad_resolvable_name() is None
         assert AstroQuery(_l0_for_query(OBJECT=""))._simbad_resolvable_name() is None
 
-    def test_verify_units_missing_and_mismatch_raise(self):
+    def test_verify_units_missing_and_mismatch_raises(self):
         AstroQuery._verify_units(_gaia_table(), _GAIA_UNITS, "Gaia DR3")  # no raise
         dropped = _gaia_table()
         dropped.remove_column("parallax")
@@ -614,7 +649,7 @@ class TestExternalQueries:
 
     def test_query_gaia_lookup_failure_returns_none(self, caplog):
         # A dropped connection is transient, so the lookup is retried before it is
-        # given up on; sleep is patched so the backoff is not actually waited out.
+        # given up on; sleep is patched so the backoff is not waited out.
         aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with (
             _patch_gaia(ConnectionError("gaia down")) as launch_job,
@@ -731,11 +766,10 @@ def _adql_select_columns(query):
 class TestRequestMatchesParse:
     """Each query asks for exactly the columns its parser reads.
 
-    The mocked result tables above are built from _GAIA_UNITS/_SIMBAD_UNITS -- the
-    same schema the parser consumes -- so they answer whatever was asked and a
-    request that drifts from the parse (asking SIMBAD for the deprecated 'plx'
-    while reading 'plx_value') leaves every other test green. These pin the
-    request side against that schema.
+    The mocked tables are built from _GAIA_UNITS/_SIMBAD_UNITS -- the schema the
+    parser consumes -- so they answer whatever was asked, and a request that drifts
+    from the parse (asking SIMBAD for the deprecated 'plx' while reading
+    'plx_value') leaves every other test green. These pin the request side.
     """
 
     def test_gaia_select_list_matches_parsed_columns(self):
@@ -754,8 +788,8 @@ class TestRequestMatchesParse:
     def test_gaia_release_selects_table_and_designation(
         self, gaiaid, table, designation
     ):
-        # A source_id denotes different stars in different releases, so querying the
-        # table GAIAID names is what keeps the astrometry attached to the right star.
+        # A source_id denotes different stars in different releases, so querying
+        # the table GAIAID names is what keeps the astrometry on the right star.
         aq = AstroQuery(_l0_for_query(GAIAID=gaiaid))
         with _patch_gaia(_gaia_job(_gaia_table())) as launch_job:
             rec = aq.query_gaia()
@@ -774,19 +808,19 @@ class TestRequestMatchesParse:
         assert requested == set(_SIMBAD_UNITS) - {"ra", "dec"}
 
 
-def _release_aware_launch_job(present=(), unpublished=()):
+def _release_aware_launch_job(present=(), failing=()):
     """Gaia.launch_job stand-in keyed on the release its query names.
 
     A release probe (``SELECT source_id ...``) answers one row for a release in
-    ``present`` and none otherwise; a release in ``unpublished`` raises the way a
-    missing archive table would. The full record query returns the standard one-row
-    table, so the resolved release is visible in its FROM clause.
+    ``present`` and none otherwise; one in ``failing`` errors the way an archive
+    outage would. The full record query returns the standard one-row table, so the
+    resolved release shows up in its FROM clause.
     """
 
     def launch_job(query):
         release = re.search(r"FROM gaia(dr\d)\.gaia_source", query).group(1).upper()
-        if release in unpublished:
-            raise ValueError(f"table gaia{release.lower()}.gaia_source not found")
+        if release in failing:
+            raise ValueError(f"gaia{release.lower()}.gaia_source unreachable")
         if query.lstrip().startswith("SELECT source_id "):
             ids = [12345] if release in present else []
             return _gaia_job(Table({"source_id": ids}))
@@ -827,13 +861,14 @@ class TestBareGaiaIdResolution:
             self._query(present={"DR3"})
         assert "carries no data release" in caplog.text
 
-    def test_failed_probe_is_skipped_quietly(self, caplog):
-        # A probe that errors must not abort the search, nor add WARNING noise --
-        # the search moves on and the outcome is reported once.
+    def test_failed_probe_warns_and_falls_through(self, caplog):
+        # Every probed release is published, so a failed probe is a real fault: the
+        # fall-through can attach a different star's astrometry and must be auditable.
         with caplog.at_level(logging.WARNING):
-            rec = self._query(present={"DR2"}, unpublished={"DR3"})
+            rec = self._query(present={"DR2"}, failing={"DR3"})
         assert rec["object"] == "Gaia DR2 12345"
-        assert "could not probe" not in caplog.text
+        assert "could not probe Gaia DR3" in caplog.text
+        assert "may denote a different star" in caplog.text
 
     def test_no_matching_release_raises(self):
         # Fail loud: a bare id matching nothing must not fall back to a guess.
@@ -849,8 +884,8 @@ class TestBareGaiaIdResolution:
 def _perform(**config):
     """Run perform() on a science L0 with both catalogs mocked at distinct RAs.
 
-    Gaia answers at RA 10 deg, SIMBAD at RA 20 deg, so the merged row names which
-    query landed on which source attribute. Returns (AstroQuery, merged row).
+    Gaia answers at RA 10 deg, SIMBAD at 20 deg, so the merged row shows which query
+    landed on which source attribute. Returns (AstroQuery, CATALOG_RECORD table).
     """
     l0 = _l0_for_query(GAIAID="DR3 12345", OBJECT="tau Cet")
     aq = AstroQuery(l0, config or None)
@@ -873,10 +908,9 @@ def _kpf_drp_row(record):
 class TestPerform:
     """perform() wires each query onto its own source attribute, then merges.
 
-    TestMergeCatalogRecords presets the source attributes by hand, so it cannot see
-    perform's own wiring; these tests drive the entry point end to end so a query
-    routed to the wrong attribute -- which would silently invert the gaia > simbad
-    precedence and mislabel provenance -- fails here.
+    TestMergeCatalogRecords presets those attributes by hand and so cannot see the
+    wiring; these drive the entry point end to end, catching a query routed to the
+    wrong attribute -- which would invert the gaia > simbad precedence silently.
     """
 
     def test_each_query_lands_on_its_own_attribute(self):
@@ -887,8 +921,6 @@ class TestPerform:
         assert aq._simbad["ra"] == _ra_str(20.0)
 
     def test_merged_row_takes_gaia_over_simbad(self):
-        # Both catalogs resolve; the merge must land on the Gaia position and stamp
-        # the provenance to match.
         _, record = _perform()
         row = _kpf_drp_row(record)
         assert row["ra"] == _ra_str(10.0)
@@ -898,9 +930,8 @@ class TestPerform:
         assert row["object"] == "Gaia DR3 12345"
 
     def test_presence_flags_written_for_every_source(self):
-        # _set_headers is the module's sole header write: one flag per source, always
-        # all three, so an absent flag means AstroQuery never ran (what DiagL0 warns
-        # on). wmko is 0 here -- the L0 carries no TARG* pointing.
+        # Always all three flags, so an absent one means AstroQuery never ran
+        # (what DiagL0 warns on). wmko is 0 here: the L0 carries no TARG*.
         aq, _ = _perform()
         hdr = aq.l0_obj.headers["CATALOG_RECORD"]
         assert hdr["GAIACR"] == 1
@@ -913,8 +944,8 @@ class TestPerform:
         assert aq.l0_obj.headers["CATALOG_RECORD"]["SIMBADCR"] == 1
 
     def test_gaia_off_falls_through_to_simbad(self):
-        # The toggle gates the query, so the merge falls to the next source down --
-        # and the provenance follows it rather than staying stamped "gaia".
+        # The merge falls to the next source down, and the provenance follows it
+        # rather than staying stamped "gaia".
         aq, record = _perform(do_gaia_query=False)
         assert aq._gaia is None
         row = _kpf_drp_row(record)

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -1,9 +1,10 @@
 """Regression tests for the AstroQuery module.
 
-Focus: ``merge_catalog_records`` -- the merge of the gaia/simbad/wmko CATALOG_RECORD
-rows into the canonical ``kpf-drp`` row -- and ``read_wmko_header``. The external
-Gaia/SIMBAD queries are not exercised here (no network); rows are written directly via
-``AstroQuery._write_catalog_record`` and the merge is driven off them.
+Focus: ``merge_catalog_records`` -- the merge of the gaia/simbad/wmko records into
+the canonical ``kpf-drp`` row -- and ``read_wmko_header``. The external Gaia/SIMBAD
+queries are not exercised here (no network); merge is driven off in-memory source
+records preset on the instance (as perform's build steps leave them), and
+read_wmko_header off synthetic L0 PRIMARY TARG*.
 """
 
 import logging
@@ -49,65 +50,49 @@ def _record(obj, ra=180.0, **overrides):
     return rec
 
 
-def _make_l0(records, imtype="object"):
-    """A science KPF0 (IMTYPE) with the given {source: record} rows written directly
-    via AstroQuery's writer (no network)."""
+def _merge(records):
+    """Merge the given {source: in-memory record} the way perform does: preset each
+    source's just-built record on a fresh AstroQuery, then merge. Returns the
+    canonical kpf-drp record dict (missing cells are None, as merge emits them)."""
     l0 = KPF0()
-    l0.headers["PRIMARY"]["IMTYPE"] = imtype
+    l0.headers["PRIMARY"]["IMTYPE"] = "object"
     aq = AstroQuery(l0)
     for source, record in records.items():
-        aq._write_catalog_record(source, record)
-    return l0
-
-
-def _merged_row(l0):
-    table = l0.data["CATALOG_RECORD"]
-    return table[table["source"] == "kpf-drp"][0]
+        setattr(aq, f"_{source}", record)
+    return aq.merge_catalog_records()
 
 
 class TestMergeCatalogRecords:
     def test_all_gaia_complete(self):
-        l0 = _make_l0({"gaia": _record("G123")})
-        AstroQuery(l0).merge_catalog_records()
-
-        row = _merged_row(l0)
+        row = _merge({"gaia": _record("G123")})
         assert row["radec_src"] == "gaia"
         assert row["object"] == "G123"
         assert row["ra"] == _ra_str(180.0)
         assert row["parallax"] == pytest.approx(50.0)
         assert row["rv"] == pytest.approx(10.0)
-        # Four rows now: gaia + the merged kpf-drp, and no CATCR presence flag.
-        assert len(l0.data["CATALOG_RECORD"]) == 2
-        assert "CATCR" not in l0.headers["CATALOG_RECORD"]
 
     def test_position_follows_priority(self):
         # All three complete but at different RAs -> position from Gaia (highest).
-        l0 = _make_l0(
+        row = _merge(
             {
                 "gaia": _record("G", ra=10.0),
                 "simbad": _record("S", ra=20.0),
                 "wmko": _record("W", ra=30.0),
             }
         )
-        AstroQuery(l0).merge_catalog_records()
-
-        row = _merged_row(l0)
         assert row["radec_src"] == "gaia"
         assert row["ra"] == _ra_str(10.0)
 
     def test_rv_filled_from_lower_priority_logs_mix(self, caplog):
         # Gaia supplies position + parallax but lacks rv -> rv borrowed from SIMBAD.
-        l0 = _make_l0(
-            {
-                "gaia": _record("G", rv=None),
-                "simbad": _record("S", rv=99.0),
-                "wmko": _record("W"),
-            }
-        )
         with caplog.at_level(logging.DEBUG, logger="kpfpipe.modules.astro_query"):
-            AstroQuery(l0).merge_catalog_records()
-
-        row = _merged_row(l0)
+            row = _merge(
+                {
+                    "gaia": _record("G", rv=None),
+                    "simbad": _record("S", rv=99.0),
+                    "wmko": _record("W"),
+                }
+            )
         assert row["radec_src"] == "gaia"  # position still from Gaia
         assert row["rv"] == pytest.approx(99.0)  # rv from SIMBAD
         assert row["rv_src"] == "simbad"
@@ -117,74 +102,56 @@ class TestMergeCatalogRecords:
 
     def test_parallax_priority_over_wmko(self):
         # Gaia lacks parallax; SIMBAD (higher priority than WMKO) supplies it.
-        l0 = _make_l0(
+        row = _merge(
             {
                 "gaia": _record("G", parallax=None),
                 "simbad": _record("S", parallax=7.0),
                 "wmko": _record("W", parallax=8.0),
             }
         )
-        AstroQuery(l0).merge_catalog_records()
-        row = _merged_row(l0)
         assert row["parallax"] == pytest.approx(7.0)
         assert row["plx_src"] == "simbad"
 
     def test_wmko_only(self, caplog):
-        l0 = _make_l0({"wmko": _record("W")})
         with caplog.at_level(logging.DEBUG, logger="kpfpipe.modules.astro_query"):
-            AstroQuery(l0).merge_catalog_records()
-
-        row = _merged_row(l0)
+            row = _merge({"wmko": _record("W")})
         assert row["radec_src"] == "wmko"
         assert row["object"] == "W"
         assert "mixes sources" not in caplog.text  # single source, no mixing
 
-    def test_missing_position_raises(self):
-        # Only WMKO has a position, but it is excluded from the merge -> no position.
-        l0 = _make_l0({"wmko": _record("W")})
-        aq = AstroQuery(l0, {"use_wmko": False})
-        with pytest.raises(ValueError, match="canonical astrometry position"):
-            aq.merge_catalog_records()
+    def test_no_source_raises(self):
+        # No source built a record -> nothing to correct -> raise.
+        with pytest.raises(ValueError, match="position"):
+            _merge({})
 
     def test_incomplete_position_raises(self):
         # The only candidate lacks a coherent position block (pmra missing).
-        l0 = _make_l0({"gaia": _record("G", pmra=None)})
-        with pytest.raises(ValueError, match="canonical astrometry position"):
-            AstroQuery(l0).merge_catalog_records()
+        with pytest.raises(ValueError, match="position"):
+            _merge({"gaia": _record("G", pmra=None)})
 
-    def test_optional_rv_missing_everywhere_left_nan(self):
-        # Position present but no source supplies rv -> merged row builds, rv is NaN.
-        l0 = _make_l0(
+    def test_optional_rv_missing_everywhere_left_missing(self):
+        # Position present but no source supplies rv -> merged row builds, rv is None.
+        row = _merge(
             {
                 "gaia": _record("G", rv=None),
                 "simbad": _record("S", rv=None),
             }
         )
-        AstroQuery(l0).merge_catalog_records()
-
-        row = _merged_row(l0)
         assert row["radec_src"] == "gaia"
-        assert np.isnan(row["rv"])
+        assert row["rv"] is None
         assert row["rv_src"] == ""  # nothing supplied rv -> empty provenance
         assert row["parallax"] == pytest.approx(50.0)  # parallax still filled
-
-    def test_use_wmko_gates_merge_only(self):
-        # Gaia complete; WMKO present but excluded from the merge. Merge still
-        # succeeds off Gaia, and the wmko row itself is untouched.
-        l0 = _make_l0({"gaia": _record("G"), "wmko": _record("W")})
-        AstroQuery(l0, {"use_wmko": False}).merge_catalog_records()
-
-        assert _merged_row(l0)["radec_src"] == "gaia"
-        table = l0.data["CATALOG_RECORD"]
-        assert len(table[table["source"] == "wmko"]) == 1  # wmko row preserved
-        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
 
 
 class TestSingleSourceProvenance:
     def test_source_row_provenance_defaults_to_source(self):
         # A plain source row's provenance labels are all its own label (its values
         # are its own).
-        l0 = _make_l0({"gaia": _record("G"), "wmko": _record("W")})
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "object"
+        aq = AstroQuery(l0)
+        aq._write_catalog_record("gaia", _record("G"))
+        aq._write_catalog_record("wmko", _record("W"))
         table = l0.data["CATALOG_RECORD"]
         gaia = table[table["source"] == "gaia"][0]
         wmko = table[table["source"] == "wmko"][0]
@@ -223,7 +190,7 @@ class TestReadWmkoHeader:
         # share one frame), sanitized to the EPRV C*# format; writing sets WMKOCR=1.
         l0 = self._l0_targ(**self._GOOD_TARG)
         aq = AstroQuery(l0)
-        aq._write_catalog_record("wmko", aq.read_wmko_header())
+        aq.read_wmko_header()  # builds the wmko row and writes it in one go
         assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
         table = l0.data["CATALOG_RECORD"]
         wmko = table[table["source"] == "wmko"][0]
@@ -279,3 +246,15 @@ class TestReadWmkoHeader:
         targ = {k: v for k, v in self._GOOD_TARG.items() if k != "TARGFRAM"}
         with pytest.raises(ValueError, match="TARGFRAM"):
             AstroQuery(self._l0_targ(**targ)).read_wmko_header()
+
+    def test_use_wmko_tcs_false_skips_build(self):
+        # use_wmko_tcs gates the wmko build in perform, like do_gaia_query/
+        # do_simbad_query gate their queries: off -> read_wmko_header is not called,
+        # so no wmko record and (catalogs off too) no position -> merge raises.
+        aq = AstroQuery(
+            self._l0_targ(**self._GOOD_TARG),
+            {"do_gaia_query": False, "do_simbad_query": False, "use_wmko_tcs": False},
+        )
+        with pytest.raises(ValueError, match="position"):
+            aq.perform()
+        assert aq._wmko is None

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -49,6 +49,8 @@ def _record(obj, ra=180.0, **overrides):
         "frame": "icrs",
         "epoch": 2016.0,
         "equinox": 2000.0,
+        "color": 0.8,
+        "color_name": "Gaia BP-RP",
     }
     rec.update(overrides)
     return rec
@@ -102,6 +104,19 @@ class TestMergeCatalogRecords:
         assert row["radec_src"] == "gaia"
         assert row["rv"] == pytest.approx(11.0)
         assert row["rv_src"] == "gaia"
+
+    def test_color_rides_with_astrometric_base(self):
+        # color/color_name come from the astrometric base source, like the position:
+        # Gaia is the base, so its color wins over SIMBAD's.
+        row = _merge(
+            {
+                "gaia": _record("G", color=1.1, color_name="Gaia BP-RP"),
+                "simbad": _record("S", color=0.6, color_name="B-V"),
+            }
+        )
+        assert row["radec_src"] == "gaia"
+        assert row["color"] == pytest.approx(1.1)
+        assert row["color_name"] == "Gaia BP-RP"
 
     def test_rv_not_borrowed_from_lower_priority(self):
         # rv is no longer borrowed across catalogs: Gaia is the base and lacks rv;
@@ -238,6 +253,18 @@ class TestRedshift:
         assert np.isnan(row["z"])
 
 
+class TestColor:
+    """_color pairs a bluer-minus-redder magnitude difference with its label."""
+
+    def test_color_variants(self):
+        assert AstroQuery._color(9.5, 8.5, "Gaia BP-RP") == (
+            pytest.approx(1.0),
+            "Gaia BP-RP",
+        )
+        assert AstroQuery._color(None, 8.5, "B-V") == (None, None)
+        assert AstroQuery._color(9.5, None, "B-V") == (None, None)
+
+
 class TestReadWmkoHeader:
     """read_wmko_header builds the native wmko record from L0 PRIMARY TARG* (moved
     here from KPF0 read-time population); fail-soft on absent/malformed astrometry."""
@@ -298,6 +325,19 @@ class TestReadWmkoHeader:
         assert rec["pmra"] == pytest.approx(expected_pmra)
         assert expected_pmra != pytest.approx(0.5)  # factor actually applied
         assert rec["pmdec"] == pytest.approx(2.0)  # dec PM unchanged
+
+    def test_builds_g_minus_j_color(self):
+        # The G-J color comes straight off PRIMARY: GAIAMAG - 2MASSMAG.
+        rec = AstroQuery(
+            self._l0_targ(**{**self._GOOD_TARG, "GAIAMAG": 7.25, "2MASSMAG": 5.5})
+        ).read_wmko_header()
+        assert rec["color"] == pytest.approx(1.75)
+        assert rec["color_name"] == "G-J"
+
+    def test_absent_magnitude_leaves_color_none(self):
+        # A missing GAIAMAG/2MASSMAG -> no color (both fields None), not an error.
+        rec = AstroQuery(self._l0_targ(**self._GOOD_TARG)).read_wmko_header()
+        assert rec["color"] is None and rec["color_name"] is None
 
     def test_no_targ_returns_none_no_warning(self, caplog):
         # No TARGRA (e.g. a science frame with no pointing) -> None, silently.
@@ -365,6 +405,8 @@ _GAIA_VALUES = {
     "parallax": 100.0,
     "radial_velocity": 12.3,
     "ref_epoch": 2016.0,
+    "phot_bp_mean_mag": 9.5,
+    "phot_rp_mean_mag": 8.5,
 }
 _SIMBAD_VALUES = {
     "ra": 180.0,
@@ -373,6 +415,8 @@ _SIMBAD_VALUES = {
     "pmdec": -250.0,
     "plx_value": 100.0,
     "rvz_radvel": 12.3,
+    "B": 9.5,
+    "V": 8.5,
 }
 
 
@@ -500,6 +544,8 @@ class TestExternalQueries:
         assert rec["frame"] == "icrs"
         assert rec["equinox"] == pytest.approx(2000.0)
         assert rec["object"] == "12345"
+        assert rec["color"] == pytest.approx(1.0)  # G_BP - G_RP
+        assert rec["color_name"] == "Gaia BP-RP"
         # Row + presence flag written to CATALOG_RECORD.
         assert l0.headers["CATALOG_RECORD"]["GAIACR"] == 1
         assert "gaia" in [str(s) for s in l0.data["CATALOG_RECORD"]["source"]]
@@ -509,6 +555,25 @@ class TestExternalQueries:
         with _patch_gaia(_gaia_job(_gaia_table({"radial_velocity": float("nan")}))):
             rec = aq.query_gaia()
         assert rec["rv"] is None
+
+    def test_query_gaia_missing_photometry_leaves_color_none(self):
+        # A color needs both magnitudes; one unmeasured (masked/NaN) -> no color.
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        with _patch_gaia(_gaia_job(_gaia_table({"phot_rp_mean_mag": float("nan")}))):
+            rec = aq.query_gaia()
+        assert rec["color"] is None and rec["color_name"] is None
+
+    def test_record_without_color_writes_blank(self):
+        # A record that omits color/color_name writes NaN / "" for them, not an error.
+        record = _record("K")
+        record.pop("color")
+        record.pop("color_name")
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "object"
+        aq = AstroQuery(l0)
+        aq._write_catalog_record("kpf-drp", record)
+        row = l0.data["CATALOG_RECORD"][0]
+        assert np.isnan(row["color"]) and row["color_name"] == ""
 
     def test_query_gaia_no_gaiaid_returns_none(self, caplog):
         aq = AstroQuery(_l0_for_query())  # no GAIAID
@@ -559,7 +624,20 @@ class TestExternalQueries:
         assert rec["object"] == "HD 10700"  # bare-numeric OBJECT -> HD prefix
         assert rec["frame"] == "icrs"
         assert rec["epoch"] == pytest.approx(2000.0)
+        assert rec["color"] == pytest.approx(1.0)  # Johnson B - V
+        assert rec["color_name"] == "B-V"
         assert l0.headers["CATALOG_RECORD"]["SIMBADCR"] == 1
+
+    def test_query_simbad_missing_photometry_leaves_color_none(self):
+        # A color needs both magnitudes; one unmeasured -> no color.
+        l0 = _l0_for_query(OBJECT="10700")
+        aq = AstroQuery(l0)
+        with patch(
+            "kpfpipe.modules.astro_query.Simbad",
+            return_value=_simbad_instance(_simbad_table({"V": float("nan")})),
+        ):
+            rec = aq.query_simbad()
+        assert rec["color"] is None and rec["color_name"] is None
 
     def test_query_simbad_no_object_returns_none(self, caplog):
         aq = AstroQuery(_l0_for_query())

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -19,6 +19,7 @@ from astropy.table import Column, Table
 
 from kpfpipe.data_models import KPF0
 from kpfpipe.modules.astro_query import _GAIA_UNITS, _SIMBAD_UNITS, AstroQuery
+from kpfpipe.utils.astro import compute_redshift
 
 
 def _ra_str(deg):
@@ -206,6 +207,35 @@ class TestSingleSourceProvenance:
         for col in ("radec_src", "plx_src", "rv_src"):
             assert gaia[col] == "gaia"
             assert wmko[col] == "wmko"
+
+
+class TestRedshift:
+    """z (CZ#) is derived from rv at write time, stored on every CATALOG_RECORD row."""
+
+    def test_redshift_helper_variants(self):
+        assert AstroQuery._redshift(None) is None
+        assert AstroQuery._redshift(0.0) == pytest.approx(0.0)
+        assert AstroQuery._redshift(10.0) == pytest.approx(
+            compute_redshift(10.0 * u.km / u.s)
+        )
+
+    def test_written_row_carries_redshift(self):
+        # A written row's z column is the redshift derived from its rv.
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "object"
+        aq = AstroQuery(l0)
+        aq._write_catalog_record("gaia", _record("G", rv=11.0))
+        row = l0.data["CATALOG_RECORD"][0]
+        assert row["z"] == pytest.approx(compute_redshift(11.0 * u.km / u.s))
+
+    def test_missing_rv_leaves_redshift_nan(self):
+        # rv absent -> z is NaN (blank CZ# downstream), not an error.
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "object"
+        aq = AstroQuery(l0)
+        aq._write_catalog_record("gaia", _record("G", rv=None))
+        row = l0.data["CATALOG_RECORD"][0]
+        assert np.isnan(row["z"])
 
 
 class TestReadWmkoHeader:

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -35,8 +35,8 @@ def _dec_str(deg):
 
 
 def _record(obj, ra=180.0, **overrides):
-    """A complete canonical record at ``ra`` (zero PM, finite plx/rv), in the EPRV
-    C*# format: RA/Dec sexagesimal strings, PM arcsec/yr. Pass a field as None (via
+    """A complete canonical record at ``ra`` (finite PM/plx/rv) in the EPRV C*#
+    format: RA/Dec sexagesimal strings, PM arcsec/yr. Pass a field as None (via
     overrides) to mark it missing."""
     rec = {
         "object": obj,
@@ -93,8 +93,7 @@ class TestMergeCatalogRecords:
         assert row["ra"] == _ra_str(10.0)
 
     def test_rv_rides_with_astrometric_base(self):
-        # rv comes from the astrometric base source, not borrowed across catalogs:
-        # Gaia is the base and supplies rv, so SIMBAD's rv is ignored.
+        # rv comes from the astrometric base (Gaia), not borrowed from SIMBAD.
         row = _merge(
             {
                 "gaia": _record("G", rv=11.0),
@@ -106,8 +105,7 @@ class TestMergeCatalogRecords:
         assert row["rv_src"] == "gaia"
 
     def test_color_rides_with_astrometric_base(self):
-        # color/color_name come from the astrometric base source, like the position:
-        # Gaia is the base, so its color wins over SIMBAD's.
+        # color/color_name ride with the astrometric base (Gaia), like the position.
         row = _merge(
             {
                 "gaia": _record("G", color=1.1, color_name="Gaia BP-RP"),
@@ -119,8 +117,8 @@ class TestMergeCatalogRecords:
         assert row["color_name"] == "Gaia BP-RP"
 
     def test_rv_not_borrowed_from_lower_priority(self):
-        # rv is no longer borrowed across catalogs: Gaia is the base and lacks rv;
-        # SIMBAD's rv is NOT pulled in, and with no TARGRADV rv is left missing.
+        # Gaia is the base and lacks rv; SIMBAD's rv is not pulled in, and with no
+        # TARGRADV rv is left missing.
         row = _merge(
             {
                 "gaia": _record("G", rv=None),
@@ -142,9 +140,8 @@ class TestMergeCatalogRecords:
         assert "falling back to the telescope TARGRADV" in caplog.text
 
     def test_missing_parallax_disqualifies_astrometric_base(self):
-        # parallax is part of the astrometric block: Gaia lacking it is disqualified as
-        # the base entirely, so the whole position (and parallax) comes from SIMBAD,
-        # the highest-priority source that supplies a complete solution.
+        # parallax is part of the astrometric block, so Gaia lacking it is disqualified
+        # as the base; the whole position comes from SIMBAD (next complete source).
         row = _merge(
             {
                 "gaia": _record("G", ra=10.0, parallax=None),
@@ -158,9 +155,7 @@ class TestMergeCatalogRecords:
         assert row["plx_src"] == "simbad"
 
     def test_demoted_source_warns_naming_missing_field(self, caplog):
-        # A present-but-incomplete higher-priority source is demoted to a lower one;
-        # the fallback must be auditable, not silent -- warn naming the dropped
-        # source and the field(s) it lacks (contrast the rv fallback, which warns).
+        # A demoted higher-priority source warns, naming the source and missing field.
         with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
             row = _merge(
                 {
@@ -353,12 +348,10 @@ class TestReadWmkoHeader:
         assert "could not build wmko CATALOG_RECORD" in caplog.text
 
     def test_nonnumeric_numeric_fields_laundered_to_none(self):
-        # A non-numeric TARG* numeric card must be laundered to None via _scalar,
-        # matching the gaia/simbad paths -- otherwise the stray value survives the
-        # merge's is-not-None completeness gate as a valid-looking astrometric
-        # solution and corrupts the float CATALOG_RECORD. (A NaN cannot occur --
-        # astropy rejects NaN in FITS headers -- and a valueless card already reads
-        # back as None; a stray string is the residual reachable case.)
+        # A non-numeric TARG* numeric card must be laundered to None via _scalar;
+        # otherwise the stray value survives the merge's completeness gate as a
+        # valid-looking solution. (A stray string is the residual reachable case:
+        # astropy rejects NaN in headers, and a valueless card already reads as None.)
         rec = AstroQuery(
             self._l0_targ(**{**self._GOOD_TARG, "TARGPLAX": "UNKNOWN"})
         ).read_wmko_header()
@@ -378,9 +371,8 @@ class TestReadWmkoHeader:
             AstroQuery(self._l0_targ(**targ)).read_wmko_header()
 
     def test_use_wmko_tcs_false_skips_build(self):
-        # use_wmko_tcs gates the wmko build in perform, like do_gaia_query/
-        # do_simbad_query gate their queries: off -> read_wmko_header is not called,
-        # so no wmko record and (catalogs off too) no position -> merge raises.
+        # use_wmko_tcs off -> read_wmko_header is not called; with catalogs off too,
+        # no position -> merge raises.
         aq = AstroQuery(
             self._l0_targ(**self._GOOD_TARG),
             {"do_gaia_query": False, "do_simbad_query": False, "use_wmko_tcs": False},

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -20,6 +20,7 @@ from astropy.table import Column, Table
 from kpfpipe.data_models import KPF0
 from kpfpipe.modules.astro_query import _GAIA_UNITS, _SIMBAD_UNITS, AstroQuery
 from kpfpipe.utils.astro import compute_redshift
+from kpfpipe.utils.network import _RETRY_WAITS
 
 
 def _ra_str(deg):
@@ -601,12 +602,16 @@ class TestExternalQueries:
         assert "no usable GAIAID" in caplog.text
 
     def test_query_gaia_lookup_failure_returns_none(self, caplog):
+        # A dropped connection is transient, so the lookup is retried before it is
+        # given up on; sleep is patched so the backoff is not actually waited out.
         aq = AstroQuery(_l0_for_query(GAIAID="12345"))
         with (
-            _patch_gaia(ConnectionError("gaia down")),
+            _patch_gaia(ConnectionError("gaia down")) as launch_job,
+            patch("kpfpipe.utils.network.time.sleep"),
             caplog.at_level(logging.WARNING),
         ):
             assert aq.query_gaia() is None
+            assert launch_job.call_count == len(_RETRY_WAITS) + 1
         assert "Gaia query failed" in caplog.text
 
     def test_query_gaia_no_match_returns_none(self, caplog):
@@ -665,14 +670,17 @@ class TestExternalQueries:
         assert "no OBJECT name" in caplog.text
 
     def test_query_simbad_lookup_failure_returns_none(self, caplog):
+        # Retried like the Gaia failure above; see there for the sleep patch.
         aq = AstroQuery(_l0_for_query(OBJECT="tau Cet"))
         inst = MagicMock()
         inst.query_object.side_effect = ConnectionError("simbad down")
         with (
             patch("kpfpipe.modules.astro_query.Simbad", return_value=inst),
+            patch("kpfpipe.utils.network.time.sleep"),
             caplog.at_level(logging.WARNING),
         ):
             assert aq.query_simbad() is None
+            assert inst.query_object.call_count == len(_RETRY_WAITS) + 1
         assert "SIMBAD query failed" in caplog.text
 
     def test_query_simbad_no_match_returns_none(self, caplog):

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -50,12 +50,15 @@ def _record(obj, ra=180.0, **overrides):
     return rec
 
 
-def _merge(records):
+def _merge(records, targradv=None):
     """Merge the given {source: in-memory record} the way perform does: preset each
     source's just-built record on a fresh AstroQuery, then merge. Returns the
-    canonical kpf-drp record dict (missing cells are None, as merge emits them)."""
+    canonical kpf-drp record dict (missing cells are None, as merge emits them).
+    ``targradv`` seeds L0 PRIMARY TARGRADV so the rv fallback can be exercised."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["IMTYPE"] = "object"
+    if targradv is not None:
+        l0.headers["PRIMARY"]["TARGRADV"] = targradv
     aq = AstroQuery(l0)
     for source, record in records.items():
         setattr(aq, f"_{source}", record)
@@ -83,41 +86,69 @@ class TestMergeCatalogRecords:
         assert row["radec_src"] == "gaia"
         assert row["ra"] == _ra_str(10.0)
 
-    def test_rv_filled_from_lower_priority_logs_mix(self, caplog):
-        # Gaia supplies position + parallax but lacks rv -> rv borrowed from SIMBAD.
-        with caplog.at_level(logging.DEBUG, logger="kpfpipe.modules.astro_query"):
-            row = _merge(
-                {
-                    "gaia": _record("G", rv=None),
-                    "simbad": _record("S", rv=99.0),
-                    "wmko": _record("W"),
-                }
-            )
-        assert row["radec_src"] == "gaia"  # position still from Gaia
-        assert row["rv"] == pytest.approx(99.0)  # rv from SIMBAD
-        assert row["rv_src"] == "simbad"
-        assert row["parallax"] == pytest.approx(50.0)  # parallax stayed with Gaia
-        assert row["plx_src"] == "gaia"
-        assert "mixes sources" in caplog.text
-
-    def test_parallax_priority_over_wmko(self):
-        # Gaia lacks parallax; SIMBAD (higher priority than WMKO) supplies it.
+    def test_rv_rides_with_astrometric_base(self):
+        # rv comes from the astrometric base source, not borrowed across catalogs:
+        # Gaia is the base and supplies rv, so SIMBAD's rv is ignored.
         row = _merge(
             {
-                "gaia": _record("G", parallax=None),
-                "simbad": _record("S", parallax=7.0),
-                "wmko": _record("W", parallax=8.0),
+                "gaia": _record("G", rv=11.0),
+                "simbad": _record("S", rv=99.0),
             }
         )
+        assert row["radec_src"] == "gaia"
+        assert row["rv"] == pytest.approx(11.0)
+        assert row["rv_src"] == "gaia"
+
+    def test_rv_not_borrowed_from_lower_priority(self):
+        # rv is no longer borrowed across catalogs: Gaia is the base and lacks rv;
+        # SIMBAD's rv is NOT pulled in, and with no TARGRADV rv is left missing.
+        row = _merge(
+            {
+                "gaia": _record("G", rv=None),
+                "simbad": _record("S", rv=99.0),
+            }
+        )
+        assert row["radec_src"] == "gaia"
+        assert row["rv"] is None
+        assert row["rv_src"] == ""
+
+    def test_rv_missing_falls_back_to_targradv(self, caplog):
+        # Base (Gaia) lacks rv -> rv comes from the telescope TARGRADV on PRIMARY (km/s,
+        # no conversion), tagged rv_src='wmko', with a WARNING.
+        with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
+            row = _merge({"gaia": _record("G", rv=None)}, targradv=-4.5)
+        assert row["radec_src"] == "gaia"
+        assert row["rv"] == pytest.approx(-4.5)
+        assert row["rv_src"] == "wmko"
+        assert "falling back to the telescope TARGRADV" in caplog.text
+
+    def test_missing_parallax_disqualifies_astrometric_base(self):
+        # parallax is part of the astrometric block: Gaia lacking it is disqualified as
+        # the base entirely, so the whole position (and parallax) comes from SIMBAD,
+        # the highest-priority source that supplies a complete solution.
+        row = _merge(
+            {
+                "gaia": _record("G", ra=10.0, parallax=None),
+                "simbad": _record("S", ra=20.0, parallax=7.0),
+                "wmko": _record("W", ra=30.0, parallax=8.0),
+            }
+        )
+        assert row["radec_src"] == "simbad"
+        assert row["ra"] == _ra_str(20.0)  # position from SIMBAD, not Gaia
         assert row["parallax"] == pytest.approx(7.0)
         assert row["plx_src"] == "simbad"
 
-    def test_wmko_only(self, caplog):
-        with caplog.at_level(logging.DEBUG, logger="kpfpipe.modules.astro_query"):
-            row = _merge({"wmko": _record("W")})
+    def test_lone_source_missing_parallax_raises(self):
+        # parallax is part of the astrometric block, so a sole source lacking it cannot
+        # anchor the canonical position.
+        with pytest.raises(ValueError, match="position"):
+            _merge({"gaia": _record("G", parallax=None)})
+
+    def test_wmko_only(self):
+        row = _merge({"wmko": _record("W")})
         assert row["radec_src"] == "wmko"
         assert row["object"] == "W"
-        assert "mixes sources" not in caplog.text  # single source, no mixing
+        assert row["rv_src"] == "wmko"  # rv rides with the sole source
 
     def test_no_source_raises(self):
         # No source built a record -> nothing to correct -> raise.

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -116,6 +116,33 @@ class TestMergeCatalogRecords:
         assert row["color"] == pytest.approx(1.1)
         assert row["color_name"] == "Gaia BP-RP"
 
+    def test_color_borrowed_from_lower_priority_when_base_lacks(self, caplog):
+        # Base (Gaia) has no color -> borrowed from the next catalog that has one
+        # (SIMBAD), flagged by a mixed-catalog WARNING. Unlike rv, a color index is
+        # independent of the astrometry, so a cross-source color is acceptable.
+        with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
+            row = _merge(
+                {
+                    "gaia": _record("G", color=None, color_name=None),
+                    "simbad": _record("S", color=0.6, color_name="B-V"),
+                }
+            )
+        assert row["radec_src"] == "gaia"
+        assert row["color"] == pytest.approx(0.6)
+        assert row["color_name"] == "B-V"
+        assert "astrometric base has no color" in caplog.text
+
+    def test_color_missing_everywhere_left_blank(self):
+        # No source supplies a color -> merged color stays blank, no borrow.
+        row = _merge(
+            {
+                "gaia": _record("G", color=None, color_name=None),
+                "simbad": _record("S", color=None, color_name=None),
+            }
+        )
+        assert row["color"] is None
+        assert row["color_name"] is None
+
     def test_rv_not_borrowed_from_lower_priority(self):
         # Gaia is the base and lacks rv; SIMBAD's rv is not pulled in, and with no
         # TARGRADV rv is left missing.

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -1,21 +1,24 @@
 """Regression tests for the AstroQuery module.
 
-Focus: ``merge_catalog_records`` -- the merge of the gaia/simbad/wmko records into
-the canonical ``kpf-drp`` row -- and ``read_wmko_header``. The external Gaia/SIMBAD
-queries are not exercised here (no network); merge is driven off in-memory source
-records preset on the instance (as perform's build steps leave them), and
-read_wmko_header off synthetic L0 PRIMARY TARG*.
+Covers ``merge_catalog_records`` -- the merge of the gaia/simbad/wmko records into
+the canonical ``kpf-drp`` row -- ``read_wmko_header`` (off synthetic L0 PRIMARY
+TARG*), and the external Gaia/SIMBAD query contract (``TestExternalQueries``). The
+network is never touched: ``Gaia.launch_job``/``Simbad`` are mocked with one-row
+result Tables, so query parsing, each fail-soft None+warning path, and the
+``_verify_units`` schema-drift guard are exercised offline.
 """
 
 import logging
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
 from astropy import units as u
-from astropy.coordinates import Angle
+from astropy.coordinates import Angle, SkyCoord
+from astropy.table import Column, Table
 
 from kpfpipe.data_models import KPF0
-from kpfpipe.modules.astro_query import AstroQuery
+from kpfpipe.modules.astro_query import _GAIA_UNITS, _SIMBAD_UNITS, AstroQuery
 
 
 def _ra_str(deg):
@@ -289,3 +292,253 @@ class TestReadWmkoHeader:
         with pytest.raises(ValueError, match="position"):
             aq.perform()
         assert aq._wmko is None
+
+
+# ---------------------------------------------------------------------------
+# External Gaia / SIMBAD queries -- mocked (no network)
+# ---------------------------------------------------------------------------
+
+# Default one-row result values, keyed to each catalog's canonical column schema.
+# pmra/pmdec are 500 / -250 mas/yr so the mas->arcsec/yr conversion (/1e3) is
+# visible (0.5 / -0.25); ra/dec 180/40 deg drive the sexagesimal formatting.
+_GAIA_VALUES = {
+    "ra": 180.0,
+    "dec": 40.0,
+    "pmra": 500.0,
+    "pmdec": -250.0,
+    "parallax": 100.0,
+    "radial_velocity": 12.3,
+    "ref_epoch": 2016.0,
+}
+_SIMBAD_VALUES = {
+    "ra": 180.0,
+    "dec": 40.0,
+    "pmra": 500.0,
+    "pmdec": -250.0,
+    "plx_value": 100.0,
+    "rvz_radvel": 12.3,
+}
+
+
+def _units_table(unit_map, value_map, unit_overrides=None):
+    """One-row astropy Table with canonical column units.
+
+    A plain Table (not QTable), so ``_verify_units`` sees ``column.unit`` while row
+    access yields plain floats for ``_scalar``. ``unit_overrides`` swaps a column's
+    unit to drive the schema-drift guard.
+    """
+    units = dict(unit_map)
+    if unit_overrides:
+        units.update(unit_overrides)
+    table = Table()
+    for col, unit in units.items():
+        table[col] = Column([value_map[col]], unit=unit)
+    return table
+
+
+def _gaia_table(values=None, units=None):
+    vals = {**_GAIA_VALUES, **(values or {})}
+    return _units_table(_GAIA_UNITS, vals, units)
+
+
+def _simbad_table(values=None, units=None):
+    vals = {**_SIMBAD_VALUES, **(values or {})}
+    return _units_table(_SIMBAD_UNITS, vals, units)
+
+
+def _gaia_job(table):
+    """Stand-in for Gaia.launch_job(query): an object whose get_results() -> table."""
+    job = MagicMock()
+    job.get_results.return_value = table
+    return job
+
+
+def _simbad_instance(table):
+    """Stand-in for Simbad(): an instance whose query_object() -> table (or None)."""
+    inst = MagicMock()
+    inst.query_object.return_value = table
+    return inst
+
+
+def _l0_for_query(**primary):
+    """A fresh science L0 whose PRIMARY carries the given cards (e.g. GAIAID/OBJECT)."""
+    l0 = KPF0()
+    l0.headers["PRIMARY"]["IMTYPE"] = "object"
+    for key, value in primary.items():
+        l0.headers["PRIMARY"][key] = value
+    return l0
+
+
+def _patch_gaia(job_or_exc):
+    target = "kpfpipe.modules.astro_query.Gaia.launch_job"
+    if isinstance(job_or_exc, Exception):
+        return patch(target, side_effect=job_or_exc)
+    return patch(target, return_value=job_or_exc)
+
+
+class TestExternalQueries:
+    """Gaia/SIMBAD query parsing, fail-soft None+warning, and the unit guard."""
+
+    # -- pure helpers ------------------------------------------------------
+
+    def test_scalar_variants(self):
+        # astroquery hands back masked/NaN cells for unmeasured quantities; all the
+        # missing/unusable forms must coerce to a clean None, real values to float.
+        assert AstroQuery._scalar(None) is None
+        assert AstroQuery._scalar(np.ma.masked) is None
+        assert AstroQuery._scalar(float("nan")) is None
+        assert AstroQuery._scalar("not-a-number") is None
+        assert AstroQuery._scalar(3.5) == 3.5
+        assert AstroQuery._scalar("2.5") == 2.5
+
+    def test_gaia_source_id(self):
+        assert AstroQuery(_l0_for_query(GAIAID="Gaia DR3 12345"))._gaia_source_id() == (
+            "12345"
+        )
+        assert AstroQuery(_l0_for_query(GAIAID="12345"))._gaia_source_id() == "12345"
+        assert AstroQuery(_l0_for_query())._gaia_source_id() is None
+        assert (
+            AstroQuery(_l0_for_query(GAIAID="Gaia DR3 abc"))._gaia_source_id() is None
+        )
+        assert AstroQuery(_l0_for_query(GAIAID=""))._gaia_source_id() is None
+
+    def test_simbad_resolvable_name(self):
+        assert (
+            AstroQuery(_l0_for_query(OBJECT="10700"))._simbad_resolvable_name()
+            == "HD 10700"
+        )
+        assert (
+            AstroQuery(_l0_for_query(OBJECT="tau Cet"))._simbad_resolvable_name()
+            == "tau Cet"
+        )
+        assert AstroQuery(_l0_for_query())._simbad_resolvable_name() is None
+        assert AstroQuery(_l0_for_query(OBJECT=""))._simbad_resolvable_name() is None
+
+    def test_verify_units_missing_and_mismatch_raise(self):
+        AstroQuery._verify_units(_gaia_table(), _GAIA_UNITS, "Gaia DR3")  # no raise
+        dropped = _gaia_table()
+        dropped.remove_column("parallax")
+        with pytest.raises(ValueError, match="unexpected column units"):
+            AstroQuery._verify_units(dropped, _GAIA_UNITS, "Gaia DR3")
+        bad = _gaia_table(units={"parallax": u.arcsec})
+        with pytest.raises(ValueError, match="unexpected column units"):
+            AstroQuery._verify_units(bad, _GAIA_UNITS, "Gaia DR3")
+
+    # -- Gaia --------------------------------------------------------------
+
+    def test_query_gaia_parses_and_writes(self):
+        l0 = _l0_for_query(GAIAID="Gaia DR3 12345")
+        aq = AstroQuery(l0)
+        with _patch_gaia(_gaia_job(_gaia_table())):
+            rec = aq.query_gaia()
+        assert rec is not None
+        exp_ra, exp_dec = AstroQuery._sexagesimal_radec(
+            SkyCoord(180.0, 40.0, unit=u.deg, frame="icrs")
+        )
+        assert rec["ra"] == exp_ra and rec["dec"] == exp_dec
+        assert rec["pmra"] == pytest.approx(0.5)  # 500 mas/yr -> arcsec/yr
+        assert rec["pmdec"] == pytest.approx(-0.25)
+        assert rec["parallax"] == pytest.approx(100.0)
+        assert rec["rv"] == pytest.approx(12.3)
+        assert rec["epoch"] == pytest.approx(2016.0)
+        assert rec["frame"] == "icrs"
+        assert rec["equinox"] == pytest.approx(2000.0)
+        assert rec["object"] == "12345"
+        # Row + presence flag written to CATALOG_RECORD.
+        assert l0.headers["CATALOG_RECORD"]["GAIACR"] == 1
+        assert "gaia" in [str(s) for s in l0.data["CATALOG_RECORD"]["source"]]
+
+    def test_query_gaia_missing_rv_becomes_none(self):
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        with _patch_gaia(_gaia_job(_gaia_table({"radial_velocity": float("nan")}))):
+            rec = aq.query_gaia()
+        assert rec["rv"] is None
+
+    def test_query_gaia_no_gaiaid_returns_none(self, caplog):
+        aq = AstroQuery(_l0_for_query())  # no GAIAID
+        with caplog.at_level(logging.WARNING):
+            assert aq.query_gaia() is None
+        assert "no usable GAIAID" in caplog.text
+
+    def test_query_gaia_lookup_failure_returns_none(self, caplog):
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        with (
+            _patch_gaia(ConnectionError("gaia down")),
+            caplog.at_level(logging.WARNING),
+        ):
+            assert aq.query_gaia() is None
+        assert "Gaia query failed" in caplog.text
+
+    def test_query_gaia_no_match_returns_none(self, caplog):
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        with _patch_gaia(_gaia_job(Table())), caplog.at_level(logging.WARNING):
+            assert aq.query_gaia() is None
+        assert "no match" in caplog.text
+
+    def test_query_gaia_unit_mismatch_raises(self):
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        with _patch_gaia(_gaia_job(_gaia_table(units={"parallax": u.arcsec}))):
+            with pytest.raises(ValueError, match="unexpected column units"):
+                aq.query_gaia()
+
+    # -- SIMBAD ------------------------------------------------------------
+
+    def test_query_simbad_parses_and_writes(self):
+        l0 = _l0_for_query(OBJECT="10700")
+        aq = AstroQuery(l0)
+        with patch(
+            "kpfpipe.modules.astro_query.Simbad",
+            return_value=_simbad_instance(_simbad_table()),
+        ):
+            rec = aq.query_simbad()
+        assert rec is not None
+        exp_ra, exp_dec = AstroQuery._sexagesimal_radec(
+            SkyCoord(180.0, 40.0, unit=u.deg, frame="icrs")
+        )
+        assert rec["ra"] == exp_ra and rec["dec"] == exp_dec
+        assert rec["pmra"] == pytest.approx(0.5)
+        assert rec["pmdec"] == pytest.approx(-0.25)
+        assert rec["parallax"] == pytest.approx(100.0)
+        assert rec["rv"] == pytest.approx(12.3)
+        assert rec["object"] == "HD 10700"  # bare-numeric OBJECT -> HD prefix
+        assert rec["frame"] == "icrs"
+        assert rec["epoch"] == pytest.approx(2000.0)
+        assert l0.headers["CATALOG_RECORD"]["SIMBADCR"] == 1
+
+    def test_query_simbad_no_object_returns_none(self, caplog):
+        aq = AstroQuery(_l0_for_query())
+        with caplog.at_level(logging.WARNING):
+            assert aq.query_simbad() is None
+        assert "no OBJECT name" in caplog.text
+
+    def test_query_simbad_lookup_failure_returns_none(self, caplog):
+        aq = AstroQuery(_l0_for_query(OBJECT="tau Cet"))
+        inst = MagicMock()
+        inst.query_object.side_effect = ConnectionError("simbad down")
+        with (
+            patch("kpfpipe.modules.astro_query.Simbad", return_value=inst),
+            caplog.at_level(logging.WARNING),
+        ):
+            assert aq.query_simbad() is None
+        assert "SIMBAD query failed" in caplog.text
+
+    def test_query_simbad_no_match_returns_none(self, caplog):
+        aq = AstroQuery(_l0_for_query(OBJECT="NotARealStar"))
+        with (
+            patch(
+                "kpfpipe.modules.astro_query.Simbad",
+                return_value=_simbad_instance(None),
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            assert aq.query_simbad() is None
+        assert "no match" in caplog.text
+
+    def test_query_simbad_unit_mismatch_raises(self):
+        aq = AstroQuery(_l0_for_query(OBJECT="tau Cet"))
+        with patch(
+            "kpfpipe.modules.astro_query.Simbad",
+            return_value=_simbad_instance(_simbad_table(units={"plx_value": u.arcsec})),
+        ):
+            with pytest.raises(ValueError, match="unexpected column units"):
+                aq.query_simbad()

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -219,18 +219,25 @@ class TestReadWmkoHeader:
         return l0
 
     def test_good_targ_builds_row_and_flag(self):
-        # Well-formed FK5 TARG* -> a wmko record sanitized to the EPRV C*# format,
-        # carrying its true frame ('fk5', not relabeled ICRS); writing it sets WMKOCR=1.
+        # Well-formed FK5 TARG* -> a wmko record rotated to ICRS (so all sources
+        # share one frame), sanitized to the EPRV C*# format; writing sets WMKOCR=1.
         l0 = self._l0_targ(**self._GOOD_TARG)
         aq = AstroQuery(l0)
         aq._write_catalog_record("wmko", aq.read_wmko_header())
         assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
         table = l0.data["CATALOG_RECORD"]
         wmko = table[table["source"] == "wmko"][0]
-        assert wmko["ra"] == "12:00:00.0000"  # RA hour-angle sexagesimal
-        assert wmko["dec"] == "+40:00:00.000"
         assert wmko["object"] == "testtarget"
-        assert wmko["frame"] == "fk5"  # true frame, not relabeled ICRS
+        assert wmko["frame"] == "icrs"  # native FK5 rotated to ICRS, not relabeled
+        # ICRS position sits within the ~tens-of-mas FK5->ICRS frame bias of the
+        # FK5 input, and is shifted from it (a real rotation, not a copy).
+        ra = Angle(wmko["ra"], unit=u.hourangle)
+        dec = Angle(wmko["dec"], unit=u.deg)
+        fk5_ra = Angle(self._GOOD_TARG["TARGRA"], unit=u.hourangle)
+        fk5_dec = Angle(self._GOOD_TARG["TARGDEC"], unit=u.deg)
+        assert abs((ra - fk5_ra).arcsec) < 1.0
+        assert abs((dec - fk5_dec).arcsec) < 1.0
+        assert wmko["ra"] != "12:00:00.0000"  # rotated, not copied
 
     def test_pmra_time_to_angle_conversion(self):
         # TARGPMRA is DCS seconds-of-time/yr: read_wmko_header must convert it to

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -9,6 +9,7 @@ result Tables, so query parsing, each fail-soft None+warning path, and the
 """
 
 import logging
+import re
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -313,13 +314,13 @@ class TestReadWmkoHeader:
             p[key] = value
         return l0
 
-    def test_good_targ_builds_row_and_flag(self):
+    def test_good_targ_builds_row(self):
         # Well-formed FK5 TARG* -> a wmko record rotated to ICRS (so all sources
-        # share one frame), sanitized to the EPRV C*# format; writing sets WMKOCR=1.
+        # share one frame), sanitized to the EPRV C*# format. The matching WMKOCR
+        # flag is a header, written later by _set_headers (see TestPerform).
         l0 = self._l0_targ(**self._GOOD_TARG)
         aq = AstroQuery(l0)
         aq.read_wmko_header()  # builds the wmko row and writes it in one go
-        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
         table = l0.data["CATALOG_RECORD"]
         wmko = table[table["source"] == "wmko"][0]
         assert wmko["object"] == "testtarget"
@@ -566,8 +567,7 @@ class TestExternalQueries:
         assert rec["object"] == "12345"
         assert rec["color"] == pytest.approx(1.0)  # G_BP - G_RP
         assert rec["color_name"] == "Gaia BP-RP"
-        # Row + presence flag written to CATALOG_RECORD.
-        assert l0.headers["CATALOG_RECORD"]["GAIACR"] == 1
+        # Row written to CATALOG_RECORD; the GAIACR flag follows in _set_headers.
         assert "gaia" in [str(s) for s in l0.data["CATALOG_RECORD"]["source"]]
 
     def test_query_gaia_missing_rv_becomes_none(self):
@@ -650,7 +650,8 @@ class TestExternalQueries:
         assert rec["epoch"] == pytest.approx(2000.0)
         assert rec["color"] == pytest.approx(1.0)  # Johnson B - V
         assert rec["color_name"] == "B-V"
-        assert l0.headers["CATALOG_RECORD"]["SIMBADCR"] == 1
+        # Row written; the SIMBADCR flag follows in _set_headers.
+        assert "simbad" in [str(s) for s in l0.data["CATALOG_RECORD"]["source"]]
 
     def test_query_simbad_missing_photometry_leaves_color_none(self):
         # A color needs both magnitudes; one unmeasured -> no color.
@@ -703,3 +704,130 @@ class TestExternalQueries:
         ):
             with pytest.raises(ValueError, match="unexpected column units"):
                 aq.query_simbad()
+
+
+# ---------------------------------------------------------------------------
+# Request vs parse -- the fields asked for are the fields read back
+# ---------------------------------------------------------------------------
+
+
+def _adql_select_columns(query):
+    """The column names in an ADQL SELECT list, as a set."""
+    select = re.search(r"SELECT\s+(.*?)\s+FROM", query, re.DOTALL | re.IGNORECASE)
+    return {col.strip() for col in select.group(1).split(",")}
+
+
+class TestRequestMatchesParse:
+    """Each query asks for exactly the columns its parser reads.
+
+    The mocked result tables above are built from _GAIA_UNITS/_SIMBAD_UNITS -- the
+    same schema the parser consumes -- so they answer whatever was asked and a
+    request that drifts from the parse (asking SIMBAD for the deprecated 'plx'
+    while reading 'plx_value') leaves every other test green. These pin the
+    request side against that schema.
+    """
+
+    def test_gaia_select_list_matches_parsed_columns(self):
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        with _patch_gaia(_gaia_job(_gaia_table())) as launch_job:
+            aq.query_gaia()
+        assert _adql_select_columns(launch_job.call_args.args[0]) == set(_GAIA_UNITS)
+
+    def test_gaia_queries_the_dr3_source_table(self):
+        # _gaia_source_id strips the release prefix off GAIAID, so the table this
+        # query names is the only thing tying the source_id to DR3.
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        with _patch_gaia(_gaia_job(_gaia_table())) as launch_job:
+            aq.query_gaia()
+        assert "gaiadr3.gaia_source" in launch_job.call_args.args[0]
+
+    def test_simbad_votable_fields_match_parsed_columns(self):
+        # ra/dec arrive in SIMBAD's default basic set, so they are not requested.
+        aq = AstroQuery(_l0_for_query(OBJECT="tau Cet"))
+        inst = _simbad_instance(_simbad_table())
+        with patch("kpfpipe.modules.astro_query.Simbad", return_value=inst):
+            aq.query_simbad()
+        requested = set(inst.add_votable_fields.call_args.args)
+        assert requested == set(_SIMBAD_UNITS) - {"ra", "dec"}
+
+
+# ---------------------------------------------------------------------------
+# perform() -- the real entry point, with both catalogs mocked (no network)
+# ---------------------------------------------------------------------------
+
+
+def _perform(**config):
+    """Run perform() on a science L0 with both catalogs mocked at distinct RAs.
+
+    Gaia answers at RA 10 deg, SIMBAD at RA 20 deg, so the merged row names which
+    query landed on which source attribute. Returns (AstroQuery, merged row).
+    """
+    l0 = _l0_for_query(GAIAID="12345", OBJECT="tau Cet")
+    aq = AstroQuery(l0, config or None)
+    with (
+        _patch_gaia(_gaia_job(_gaia_table({"ra": 10.0}))),
+        patch(
+            "kpfpipe.modules.astro_query.Simbad",
+            return_value=_simbad_instance(_simbad_table({"ra": 20.0})),
+        ),
+    ):
+        aq.perform()
+    return aq, aq.l0_obj.data["CATALOG_RECORD"]
+
+
+def _kpf_drp_row(record):
+    """The canonical merged row of a CATALOG_RECORD table."""
+    return record[record["source"] == "kpf-drp"][0]
+
+
+class TestPerform:
+    """perform() wires each query onto its own source attribute, then merges.
+
+    TestMergeCatalogRecords presets the source attributes by hand, so it cannot see
+    perform's own wiring; these tests drive the entry point end to end so a query
+    routed to the wrong attribute -- which would silently invert the gaia > simbad
+    precedence and mislabel provenance -- fails here.
+    """
+
+    def test_each_query_lands_on_its_own_attribute(self):
+        aq, _ = _perform()
+        assert aq._gaia["object"] == "12345"  # from GAIAID, via query_gaia
+        assert aq._simbad["object"] == "tau Cet"  # from OBJECT, via query_simbad
+        assert aq._gaia["ra"] == _ra_str(10.0)
+        assert aq._simbad["ra"] == _ra_str(20.0)
+
+    def test_merged_row_takes_gaia_over_simbad(self):
+        # Both catalogs resolve; the merge must land on the Gaia position and stamp
+        # the provenance to match.
+        _, record = _perform()
+        row = _kpf_drp_row(record)
+        assert row["ra"] == _ra_str(10.0)
+        assert row["radec_src"] == "gaia"
+        assert row["plx_src"] == "gaia"
+        assert row["rv_src"] == "gaia"
+        assert row["object"] == "12345"
+
+    def test_presence_flags_written_for_every_source(self):
+        # _set_headers is the module's sole header write: one flag per source, always
+        # all three, so an absent flag means AstroQuery never ran (what DiagL0 warns
+        # on). wmko is 0 here -- the L0 carries no TARG* pointing.
+        aq, _ = _perform()
+        hdr = aq.l0_obj.headers["CATALOG_RECORD"]
+        assert hdr["GAIACR"] == 1
+        assert hdr["SIMBADCR"] == 1
+        assert hdr["WMKOCR"] == 0
+
+    def test_gated_off_source_flagged_zero(self):
+        aq, _ = _perform(do_gaia_query=False)
+        assert aq.l0_obj.headers["CATALOG_RECORD"]["GAIACR"] == 0
+        assert aq.l0_obj.headers["CATALOG_RECORD"]["SIMBADCR"] == 1
+
+    def test_gaia_off_falls_through_to_simbad(self):
+        # The toggle gates the query, so the merge falls to the next source down --
+        # and the provenance follows it rather than staying stamped "gaia".
+        aq, record = _perform(do_gaia_query=False)
+        assert aq._gaia is None
+        row = _kpf_drp_row(record)
+        assert row["ra"] == _ra_str(20.0)
+        assert row["radec_src"] == "simbad"
+        assert row["object"] == "tau Cet"

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -512,16 +512,27 @@ class TestExternalQueries:
         assert AstroQuery._scalar(3.5) == 3.5
         assert AstroQuery._scalar("2.5") == 2.5
 
-    def test_gaia_source_id(self):
-        assert AstroQuery(_l0_for_query(GAIAID="Gaia DR3 12345"))._gaia_source_id() == (
-            "12345"
-        )
-        assert AstroQuery(_l0_for_query(GAIAID="12345"))._gaia_source_id() == "12345"
-        assert AstroQuery(_l0_for_query())._gaia_source_id() is None
-        assert (
-            AstroQuery(_l0_for_query(GAIAID="Gaia DR3 abc"))._gaia_source_id() is None
-        )
-        assert AstroQuery(_l0_for_query(GAIAID=""))._gaia_source_id() is None
+    @pytest.mark.parametrize(
+        ("gaiaid", "expected"),
+        [
+            ("Gaia DR3 12345", ("DR3", "12345")),
+            ("DR3 12345", ("DR3", "12345")),  # the form real L0 frames carry
+            ("DR2 12345", ("DR2", "12345")),
+            ("dr2 12345", ("DR2", "12345")),
+            ("12345", (None, "12345")),  # bare id -> release resolved against Gaia
+            (None, None),
+            ("", None),
+            ("Gaia DR3 abc", None),
+            # Real Gaia releases we cannot query: DR1 lacks RV/photometry, EDR3 is
+            # superseded by DR3, DR4 has not published yet.
+            ("DR1 12345", None),
+            ("EDR3 12345", None),
+            ("DR4 12345", None),
+        ],
+    )
+    def test_gaia_source(self, gaiaid, expected):
+        primary = {} if gaiaid is None else {"GAIAID": gaiaid}
+        assert AstroQuery(_l0_for_query(**primary))._gaia_source() == expected
 
     def test_simbad_resolvable_name(self):
         assert (
@@ -564,21 +575,21 @@ class TestExternalQueries:
         assert rec["epoch"] == pytest.approx(2016.0)
         assert rec["frame"] == "icrs"
         assert rec["equinox"] == pytest.approx(2000.0)
-        assert rec["object"] == "12345"
+        assert rec["object"] == "Gaia DR3 12345"  # full designation -> EPRV CID#
         assert rec["color"] == pytest.approx(1.0)  # G_BP - G_RP
         assert rec["color_name"] == "Gaia BP-RP"
         # Row written to CATALOG_RECORD; the GAIACR flag follows in _set_headers.
         assert "gaia" in [str(s) for s in l0.data["CATALOG_RECORD"]["source"]]
 
     def test_query_gaia_missing_rv_becomes_none(self):
-        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with _patch_gaia(_gaia_job(_gaia_table({"radial_velocity": float("nan")}))):
             rec = aq.query_gaia()
         assert rec["rv"] is None
 
     def test_query_gaia_missing_photometry_leaves_color_none(self):
         # A color needs both magnitudes; one unmeasured (masked/NaN) -> no color.
-        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with _patch_gaia(_gaia_job(_gaia_table({"phot_rp_mean_mag": float("nan")}))):
             rec = aq.query_gaia()
         assert rec["color"] is None and rec["color_name"] is None
@@ -604,7 +615,7 @@ class TestExternalQueries:
     def test_query_gaia_lookup_failure_returns_none(self, caplog):
         # A dropped connection is transient, so the lookup is retried before it is
         # given up on; sleep is patched so the backoff is not actually waited out.
-        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with (
             _patch_gaia(ConnectionError("gaia down")) as launch_job,
             patch("kpfpipe.utils.network.time.sleep"),
@@ -615,13 +626,13 @@ class TestExternalQueries:
         assert "Gaia query failed" in caplog.text
 
     def test_query_gaia_no_match_returns_none(self, caplog):
-        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with _patch_gaia(_gaia_job(Table())), caplog.at_level(logging.WARNING):
             assert aq.query_gaia() is None
         assert "no match" in caplog.text
 
     def test_query_gaia_unit_mismatch_raises(self):
-        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with _patch_gaia(_gaia_job(_gaia_table(units={"parallax": u.arcsec}))):
             with pytest.raises(ValueError, match="unexpected column units"):
                 aq.query_gaia()
@@ -728,18 +739,30 @@ class TestRequestMatchesParse:
     """
 
     def test_gaia_select_list_matches_parsed_columns(self):
-        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+        aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with _patch_gaia(_gaia_job(_gaia_table())) as launch_job:
             aq.query_gaia()
         assert _adql_select_columns(launch_job.call_args.args[0]) == set(_GAIA_UNITS)
 
-    def test_gaia_queries_the_dr3_source_table(self):
-        # _gaia_source_id strips the release prefix off GAIAID, so the table this
-        # query names is the only thing tying the source_id to DR3.
-        aq = AstroQuery(_l0_for_query(GAIAID="12345"))
+    @pytest.mark.parametrize(
+        ("gaiaid", "table", "designation"),
+        [
+            ("DR3 12345", "gaiadr3.gaia_source", "Gaia DR3 12345"),
+            ("DR2 12345", "gaiadr2.gaia_source", "Gaia DR2 12345"),
+        ],
+    )
+    def test_gaia_release_selects_table_and_designation(
+        self, gaiaid, table, designation
+    ):
+        # A source_id denotes different stars in different releases, so querying the
+        # table GAIAID names is what keeps the astrometry attached to the right star.
+        aq = AstroQuery(_l0_for_query(GAIAID=gaiaid))
         with _patch_gaia(_gaia_job(_gaia_table())) as launch_job:
-            aq.query_gaia()
-        assert "gaiadr3.gaia_source" in launch_job.call_args.args[0]
+            rec = aq.query_gaia()
+        assert f"FROM {table}" in launch_job.call_args.args[0]
+        assert rec["object"] == designation
+        # A named release is taken at its word -- no probe queries.
+        assert launch_job.call_count == 1
 
     def test_simbad_votable_fields_match_parsed_columns(self):
         # ra/dec arrive in SIMBAD's default basic set, so they are not requested.
@@ -749,6 +772,73 @@ class TestRequestMatchesParse:
             aq.query_simbad()
         requested = set(inst.add_votable_fields.call_args.args)
         assert requested == set(_SIMBAD_UNITS) - {"ra", "dec"}
+
+
+def _release_aware_launch_job(present=(), unpublished=()):
+    """Gaia.launch_job stand-in keyed on the release its query names.
+
+    A release probe (``SELECT source_id ...``) answers one row for a release in
+    ``present`` and none otherwise; a release in ``unpublished`` raises the way a
+    missing archive table would. The full record query returns the standard one-row
+    table, so the resolved release is visible in its FROM clause.
+    """
+
+    def launch_job(query):
+        release = re.search(r"FROM gaia(dr\d)\.gaia_source", query).group(1).upper()
+        if release in unpublished:
+            raise ValueError(f"table gaia{release.lower()}.gaia_source not found")
+        if query.lstrip().startswith("SELECT source_id "):
+            ids = [12345] if release in present else []
+            return _gaia_job(Table({"source_id": ids}))
+        return _gaia_job(_gaia_table())
+
+    return launch_job
+
+
+class TestBareGaiaIdResolution:
+    """A GAIAID with no release prefix is verified against the archive, not assumed.
+
+    The same source_id denotes different stars in different releases, so guessing one
+    would silently attach another star's astrometry to the frame.
+    """
+
+    @staticmethod
+    def _query(**kwargs):
+        aq = AstroQuery(_l0_for_query(GAIAID="12345"))  # bare: no release prefix
+        with patch(
+            "kpfpipe.modules.astro_query.Gaia.launch_job",
+            side_effect=_release_aware_launch_job(**kwargs),
+        ):
+            return aq.query_gaia()
+
+    def test_newest_matching_release_wins(self, caplog):
+        # Present in both -> DR3, the most recent.
+        with caplog.at_level(logging.WARNING):
+            rec = self._query(present={"DR2", "DR3"})
+        assert rec["object"] == "Gaia DR3 12345"
+        assert "resolved bare GAIAID 12345 to Gaia DR3" in caplog.text
+
+    def test_older_release_used_when_newer_lacks_the_id(self):
+        rec = self._query(present={"DR2"})
+        assert rec["object"] == "Gaia DR2 12345"
+
+    def test_bare_id_always_warns(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            self._query(present={"DR3"})
+        assert "carries no data release" in caplog.text
+
+    def test_failed_probe_is_skipped_quietly(self, caplog):
+        # A probe that errors must not abort the search, nor add WARNING noise --
+        # the search moves on and the outcome is reported once.
+        with caplog.at_level(logging.WARNING):
+            rec = self._query(present={"DR2"}, unpublished={"DR3"})
+        assert rec["object"] == "Gaia DR2 12345"
+        assert "could not probe" not in caplog.text
+
+    def test_no_matching_release_raises(self):
+        # Fail loud: a bare id matching nothing must not fall back to a guess.
+        with pytest.raises(ValueError, match="no queryable Gaia release"):
+            self._query()
 
 
 # ---------------------------------------------------------------------------
@@ -762,7 +852,7 @@ def _perform(**config):
     Gaia answers at RA 10 deg, SIMBAD at RA 20 deg, so the merged row names which
     query landed on which source attribute. Returns (AstroQuery, merged row).
     """
-    l0 = _l0_for_query(GAIAID="12345", OBJECT="tau Cet")
+    l0 = _l0_for_query(GAIAID="DR3 12345", OBJECT="tau Cet")
     aq = AstroQuery(l0, config or None)
     with (
         _patch_gaia(_gaia_job(_gaia_table({"ra": 10.0}))),
@@ -791,7 +881,7 @@ class TestPerform:
 
     def test_each_query_lands_on_its_own_attribute(self):
         aq, _ = _perform()
-        assert aq._gaia["object"] == "12345"  # from GAIAID, via query_gaia
+        assert aq._gaia["object"] == "Gaia DR3 12345"  # from GAIAID, via query_gaia
         assert aq._simbad["object"] == "tau Cet"  # from OBJECT, via query_simbad
         assert aq._gaia["ra"] == _ra_str(10.0)
         assert aq._simbad["ra"] == _ra_str(20.0)
@@ -805,7 +895,7 @@ class TestPerform:
         assert row["radec_src"] == "gaia"
         assert row["plx_src"] == "gaia"
         assert row["rv_src"] == "gaia"
-        assert row["object"] == "12345"
+        assert row["object"] == "Gaia DR3 12345"
 
     def test_presence_flags_written_for_every_source(self):
         # _set_headers is the module's sole header write: one flag per source, always

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -268,6 +268,18 @@ class TestReadWmkoHeader:
             assert AstroQuery(l0).read_wmko_header() is None
         assert "could not build wmko CATALOG_RECORD" in caplog.text
 
+    def test_nonnumeric_numeric_fields_laundered_to_none(self):
+        # A non-numeric TARG* numeric card must be laundered to None via _scalar,
+        # matching the gaia/simbad paths -- otherwise the stray value survives the
+        # merge's is-not-None completeness gate as a valid-looking astrometric
+        # solution and corrupts the float CATALOG_RECORD. (A NaN cannot occur --
+        # astropy rejects NaN in FITS headers -- and a valueless card already reads
+        # back as None; a stray string is the residual reachable case.)
+        rec = AstroQuery(
+            self._l0_targ(**{**self._GOOD_TARG, "TARGPLAX": "UNKNOWN"})
+        ).read_wmko_header()
+        assert rec["parallax"] is None
+
     def test_non_fk5_frame_raises(self):
         # KPF pointing is always FK5; any other TARGFRAM (e.g. galactic) raises
         # rather than being coerced onto a frame it does not have.

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -141,6 +141,20 @@ class TestMergeCatalogRecords:
         assert row["parallax"] == pytest.approx(7.0)
         assert row["plx_src"] == "simbad"
 
+    def test_demoted_source_warns_naming_missing_field(self, caplog):
+        # A present-but-incomplete higher-priority source is demoted to a lower one;
+        # the fallback must be auditable, not silent -- warn naming the dropped
+        # source and the field(s) it lacks (contrast the rv fallback, which warns).
+        with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
+            row = _merge(
+                {
+                    "gaia": _record("G", parallax=None),
+                    "simbad": _record("S"),
+                }
+            )
+        assert row["radec_src"] == "simbad"
+        assert "gaia astrometry incomplete (missing parallax)" in caplog.text
+
     def test_lone_source_missing_parallax_raises(self):
         # parallax is part of the astrometric block, so a sole source lacking it cannot
         # anchor the canonical position.

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -10,18 +10,33 @@ import logging
 
 import numpy as np
 import pytest
+from astropy import units as u
+from astropy.coordinates import Angle
 
 from kpfpipe.data_models import KPF0
 from kpfpipe.modules.astro_query import AstroQuery
 
 
-def _record(source_id, ra=180.0, **overrides):
-    """A complete canonical record at ``ra`` (zero PM, finite plx/rv). Pass a field
-    as None (via overrides) to mark it missing."""
+def _ra_str(deg):
+    """RA in deg -> the EPRV C*# sexagesimal hour-angle string the schema stores."""
+    return Angle(deg, u.deg).to_string(unit=u.hourangle, sep=":", pad=True, precision=4)
+
+
+def _dec_str(deg):
+    """Dec in deg -> the EPRV C*# sexagesimal string the schema stores."""
+    return Angle(deg, u.deg).to_string(
+        unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
+    )
+
+
+def _record(obj, ra=180.0, **overrides):
+    """A complete canonical record at ``ra`` (zero PM, finite plx/rv), in the EPRV
+    C*# format: RA/Dec sexagesimal strings, PM arcsec/yr. Pass a field as None (via
+    overrides) to mark it missing."""
     rec = {
-        "source_id": source_id,
-        "ra": ra,
-        "dec": 40.0,
+        "object": obj,
+        "ra": _ra_str(ra),
+        "dec": _dec_str(40.0),
         "pmra": 1.0,
         "pmdec": 2.0,
         "parallax": 50.0,
@@ -54,9 +69,9 @@ class TestMergeCatalogRecords:
         AstroQuery(l0).merge_catalog_records()
 
         row = _merged_row(l0)
-        assert row["astr_src"] == "gaia"
-        assert row["source_id"] == "G123"
-        assert row["ra"] == pytest.approx(180.0)
+        assert row["radec_src"] == "gaia"
+        assert row["object"] == "G123"
+        assert row["ra"] == _ra_str(180.0)
         assert row["parallax"] == pytest.approx(50.0)
         assert row["rv"] == pytest.approx(10.0)
         # Four rows now: gaia + the merged kpf-drp, and no CATCR presence flag.
@@ -75,8 +90,8 @@ class TestMergeCatalogRecords:
         AstroQuery(l0).merge_catalog_records()
 
         row = _merged_row(l0)
-        assert row["astr_src"] == "gaia"
-        assert row["ra"] == pytest.approx(10.0)
+        assert row["radec_src"] == "gaia"
+        assert row["ra"] == _ra_str(10.0)
 
     def test_rv_filled_from_lower_priority_logs_mix(self, caplog):
         # Gaia supplies position + parallax but lacks rv -> rv borrowed from SIMBAD.
@@ -91,9 +106,11 @@ class TestMergeCatalogRecords:
             AstroQuery(l0).merge_catalog_records()
 
         row = _merged_row(l0)
-        assert row["astr_src"] == "gaia"  # position still from Gaia
+        assert row["radec_src"] == "gaia"  # position still from Gaia
         assert row["rv"] == pytest.approx(99.0)  # rv from SIMBAD
+        assert row["rv_src"] == "simbad"
         assert row["parallax"] == pytest.approx(50.0)  # parallax stayed with Gaia
+        assert row["plx_src"] == "gaia"
         assert "mixes sources" in caplog.text
 
     def test_parallax_priority_over_wmko(self):
@@ -106,7 +123,9 @@ class TestMergeCatalogRecords:
             }
         )
         AstroQuery(l0).merge_catalog_records()
-        assert _merged_row(l0)["parallax"] == pytest.approx(7.0)
+        row = _merged_row(l0)
+        assert row["parallax"] == pytest.approx(7.0)
+        assert row["plx_src"] == "simbad"
 
     def test_wmko_only(self, caplog):
         l0 = _make_l0({"wmko": _record("W")})
@@ -114,8 +133,8 @@ class TestMergeCatalogRecords:
             AstroQuery(l0).merge_catalog_records()
 
         row = _merged_row(l0)
-        assert row["astr_src"] == "wmko"
-        assert row["source_id"] == "W"
+        assert row["radec_src"] == "wmko"
+        assert row["object"] == "W"
         assert "mixes sources" not in caplog.text  # single source, no mixing
 
     def test_missing_position_raises(self):
@@ -142,8 +161,9 @@ class TestMergeCatalogRecords:
         AstroQuery(l0).merge_catalog_records()
 
         row = _merged_row(l0)
-        assert row["astr_src"] == "gaia"
+        assert row["radec_src"] == "gaia"
         assert np.isnan(row["rv"])
+        assert row["rv_src"] == ""  # nothing supplied rv -> empty provenance
         assert row["parallax"] == pytest.approx(50.0)  # parallax still filled
 
     def test_use_wmko_gates_merge_only(self):
@@ -152,16 +172,20 @@ class TestMergeCatalogRecords:
         l0 = _make_l0({"gaia": _record("G"), "wmko": _record("W")})
         AstroQuery(l0, {"use_wmko": False}).merge_catalog_records()
 
-        assert _merged_row(l0)["astr_src"] == "gaia"
+        assert _merged_row(l0)["radec_src"] == "gaia"
         table = l0.data["CATALOG_RECORD"]
         assert len(table[table["source"] == "wmko"]) == 1  # wmko row preserved
         assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
 
 
-class TestSingleSourceAstrSrc:
-    def test_source_row_astr_src_defaults_to_source(self):
-        # A plain source row's astr_src is its own label (its position is its own).
+class TestSingleSourceProvenance:
+    def test_source_row_provenance_defaults_to_source(self):
+        # A plain source row's provenance labels are all its own label (its values
+        # are its own).
         l0 = _make_l0({"gaia": _record("G"), "wmko": _record("W")})
         table = l0.data["CATALOG_RECORD"]
-        assert table[table["source"] == "gaia"][0]["astr_src"] == "gaia"
-        assert table[table["source"] == "wmko"][0]["astr_src"] == "wmko"
+        gaia = table[table["source"] == "gaia"][0]
+        wmko = table[table["source"] == "wmko"][0]
+        for col in ("radec_src", "plx_src", "rv_src"):
+            assert gaia[col] == "gaia"
+            assert wmko[col] == "wmko"

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -1,9 +1,9 @@
 """Regression tests for the AstroQuery module.
 
 Focus: ``merge_catalog_records`` -- the merge of the gaia/simbad/wmko CATALOG_RECORD
-rows into the canonical ``kpf-drp`` row. The external Gaia/SIMBAD queries are not
-exercised here (no network); rows are written directly via ``KPF0.set_catalog_record``
-and the merge is driven off them.
+rows into the canonical ``kpf-drp`` row -- and ``read_wmko_header``. The external
+Gaia/SIMBAD queries are not exercised here (no network); rows are written directly via
+``AstroQuery._write_catalog_record`` and the merge is driven off them.
 """
 
 import logging
@@ -50,11 +50,13 @@ def _record(obj, ra=180.0, **overrides):
 
 
 def _make_l0(records, imtype="object"):
-    """A science KPF0 (IMTYPE) with the given {source: record} rows written."""
+    """A science KPF0 (IMTYPE) with the given {source: record} rows written directly
+    via AstroQuery's writer (no network)."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["IMTYPE"] = imtype
+    aq = AstroQuery(l0)
     for source, record in records.items():
-        l0.set_catalog_record(source, record)
+        aq._write_catalog_record(source, record)
     return l0
 
 
@@ -189,3 +191,70 @@ class TestSingleSourceProvenance:
         for col in ("radec_src", "plx_src", "rv_src"):
             assert gaia[col] == "gaia"
             assert wmko[col] == "wmko"
+
+
+class TestReadWmkoHeader:
+    """read_wmko_header builds the native wmko record from L0 PRIMARY TARG* (moved
+    here from KPF0 read-time population); fail-soft on absent/malformed astrometry."""
+
+    _GOOD_TARG = {
+        "TARGRA": "12:00:00.00",
+        "TARGDEC": "+40:00:00.0",
+        "TARGFRAM": "FK5",
+        "TARGEQUI": 2000.0,
+        "TARGPMRA": 0.0,
+        "TARGPMDC": 0.0,
+        "TARGPLAX": 100.0,
+        "TARGEPOC": 2000.0,
+    }
+
+    @staticmethod
+    def _l0_targ(**targ):
+        l0 = KPF0()
+        p = l0.headers["PRIMARY"]
+        p["IMTYPE"] = "object"
+        p["OBJECT"] = "testtarget"
+        for key, value in targ.items():
+            p[key] = value
+        return l0
+
+    def test_good_targ_builds_row_and_flag(self):
+        # Well-formed TARG* -> a wmko record sanitized to the EPRV C*# format;
+        # writing it sets WMKOCR=1.
+        l0 = self._l0_targ(**self._GOOD_TARG)
+        aq = AstroQuery(l0)
+        aq._write_catalog_record("wmko", aq.read_wmko_header())
+        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
+        table = l0.data["CATALOG_RECORD"]
+        wmko = table[table["source"] == "wmko"][0]
+        assert wmko["ra"] == "12:00:00.0000"  # RA hour-angle sexagesimal
+        assert wmko["dec"] == "+40:00:00.000"
+        assert wmko["object"] == "testtarget"
+
+    def test_pmra_time_to_angle_conversion(self):
+        # TARGPMRA is DCS seconds-of-time/yr: read_wmko_header must convert it to
+        # on-sky arcsec/yr via x15 x cos(dec). TARGPMDC is already arcsec/yr and
+        # passes through. Uses a non-zero TARGPMRA so the factor is exercised (a
+        # zero would pass regardless).
+        dec_deg = 40.0
+        rec = AstroQuery(
+            self._l0_targ(**{**self._GOOD_TARG, "TARGPMRA": 0.5, "TARGPMDC": 2.0})
+        ).read_wmko_header()
+
+        expected_pmra = 0.5 * 15.0 * np.cos(np.deg2rad(dec_deg))
+        assert rec["pmra"] == pytest.approx(expected_pmra)
+        assert expected_pmra != pytest.approx(0.5)  # factor actually applied
+        assert rec["pmdec"] == pytest.approx(2.0)  # dec PM unchanged
+
+    def test_no_targ_returns_none_no_warning(self, caplog):
+        # No TARGRA (e.g. a science frame with no pointing) -> None, silently.
+        with caplog.at_level(logging.WARNING):
+            assert AstroQuery(self._l0_targ()).read_wmko_header() is None
+        assert "CATALOG_RECORD" not in caplog.text
+
+    def test_malformed_targ_warns_returns_none(self, caplog):
+        # Unparseable TARG* astrometry -> warns and returns None (never raises).
+        l0 = self._l0_targ(**{**self._GOOD_TARG, "TARGDEC": "not-a-coordinate"})
+        with caplog.at_level(logging.WARNING):
+            assert AstroQuery(l0).read_wmko_header() is None
+        assert "could not build wmko CATALOG_RECORD" in caplog.text

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -1,0 +1,167 @@
+"""Regression tests for the AstroQuery module.
+
+Focus: ``merge_catalog_records`` -- the merge of the gaia/simbad/wmko CATALOG_RECORD
+rows into the canonical ``kpf-drp`` row. The external Gaia/SIMBAD queries are not
+exercised here (no network); rows are written directly via ``KPF0.set_catalog_record``
+and the merge is driven off them.
+"""
+
+import logging
+
+import numpy as np
+import pytest
+
+from kpfpipe.data_models import KPF0
+from kpfpipe.modules.astro_query import AstroQuery
+
+
+def _record(source_id, ra=180.0, **overrides):
+    """A complete canonical record at ``ra`` (zero PM, finite plx/rv). Pass a field
+    as None (via overrides) to mark it missing."""
+    rec = {
+        "source_id": source_id,
+        "ra": ra,
+        "dec": 40.0,
+        "pmra": 1.0,
+        "pmdec": 2.0,
+        "parallax": 50.0,
+        "rv": 10.0,
+        "frame": "icrs",
+        "epoch": 2016.0,
+        "equinox": 2000.0,
+    }
+    rec.update(overrides)
+    return rec
+
+
+def _make_l0(records, imtype="object"):
+    """A science KPF0 (IMTYPE) with the given {source: record} rows written."""
+    l0 = KPF0()
+    l0.headers["PRIMARY"]["IMTYPE"] = imtype
+    for source, record in records.items():
+        l0.set_catalog_record(source, record)
+    return l0
+
+
+def _merged_row(l0):
+    table = l0.data["CATALOG_RECORD"]
+    return table[table["source"] == "kpf-drp"][0]
+
+
+class TestMergeCatalogRecords:
+    def test_all_gaia_complete(self):
+        l0 = _make_l0({"gaia": _record("G123")})
+        AstroQuery(l0).merge_catalog_records()
+
+        row = _merged_row(l0)
+        assert row["astr_src"] == "gaia"
+        assert row["source_id"] == "G123"
+        assert row["ra"] == pytest.approx(180.0)
+        assert row["parallax"] == pytest.approx(50.0)
+        assert row["rv"] == pytest.approx(10.0)
+        # Four rows now: gaia + the merged kpf-drp, and no CATCR presence flag.
+        assert len(l0.data["CATALOG_RECORD"]) == 2
+        assert "CATCR" not in l0.headers["CATALOG_RECORD"]
+
+    def test_position_follows_priority(self):
+        # All three complete but at different RAs -> position from Gaia (highest).
+        l0 = _make_l0(
+            {
+                "gaia": _record("G", ra=10.0),
+                "simbad": _record("S", ra=20.0),
+                "wmko": _record("W", ra=30.0),
+            }
+        )
+        AstroQuery(l0).merge_catalog_records()
+
+        row = _merged_row(l0)
+        assert row["astr_src"] == "gaia"
+        assert row["ra"] == pytest.approx(10.0)
+
+    def test_rv_filled_from_lower_priority_logs_mix(self, caplog):
+        # Gaia supplies position + parallax but lacks rv -> rv borrowed from SIMBAD.
+        l0 = _make_l0(
+            {
+                "gaia": _record("G", rv=None),
+                "simbad": _record("S", rv=99.0),
+                "wmko": _record("W"),
+            }
+        )
+        with caplog.at_level(logging.DEBUG, logger="kpfpipe.modules.astro_query"):
+            AstroQuery(l0).merge_catalog_records()
+
+        row = _merged_row(l0)
+        assert row["astr_src"] == "gaia"  # position still from Gaia
+        assert row["rv"] == pytest.approx(99.0)  # rv from SIMBAD
+        assert row["parallax"] == pytest.approx(50.0)  # parallax stayed with Gaia
+        assert "mixes sources" in caplog.text
+
+    def test_parallax_priority_over_wmko(self):
+        # Gaia lacks parallax; SIMBAD (higher priority than WMKO) supplies it.
+        l0 = _make_l0(
+            {
+                "gaia": _record("G", parallax=None),
+                "simbad": _record("S", parallax=7.0),
+                "wmko": _record("W", parallax=8.0),
+            }
+        )
+        AstroQuery(l0).merge_catalog_records()
+        assert _merged_row(l0)["parallax"] == pytest.approx(7.0)
+
+    def test_wmko_only(self, caplog):
+        l0 = _make_l0({"wmko": _record("W")})
+        with caplog.at_level(logging.DEBUG, logger="kpfpipe.modules.astro_query"):
+            AstroQuery(l0).merge_catalog_records()
+
+        row = _merged_row(l0)
+        assert row["astr_src"] == "wmko"
+        assert row["source_id"] == "W"
+        assert "mixes sources" not in caplog.text  # single source, no mixing
+
+    def test_missing_position_raises(self):
+        # Only WMKO has a position, but it is excluded from the merge -> no position.
+        l0 = _make_l0({"wmko": _record("W")})
+        aq = AstroQuery(l0, {"use_wmko": False})
+        with pytest.raises(ValueError, match="canonical astrometry position"):
+            aq.merge_catalog_records()
+
+    def test_incomplete_position_raises(self):
+        # The only candidate lacks a coherent position block (pmra missing).
+        l0 = _make_l0({"gaia": _record("G", pmra=None)})
+        with pytest.raises(ValueError, match="canonical astrometry position"):
+            AstroQuery(l0).merge_catalog_records()
+
+    def test_optional_rv_missing_everywhere_left_nan(self):
+        # Position present but no source supplies rv -> merged row builds, rv is NaN.
+        l0 = _make_l0(
+            {
+                "gaia": _record("G", rv=None),
+                "simbad": _record("S", rv=None),
+            }
+        )
+        AstroQuery(l0).merge_catalog_records()
+
+        row = _merged_row(l0)
+        assert row["astr_src"] == "gaia"
+        assert np.isnan(row["rv"])
+        assert row["parallax"] == pytest.approx(50.0)  # parallax still filled
+
+    def test_use_wmko_gates_merge_only(self):
+        # Gaia complete; WMKO present but excluded from the merge. Merge still
+        # succeeds off Gaia, and the wmko row itself is untouched.
+        l0 = _make_l0({"gaia": _record("G"), "wmko": _record("W")})
+        AstroQuery(l0, {"use_wmko": False}).merge_catalog_records()
+
+        assert _merged_row(l0)["astr_src"] == "gaia"
+        table = l0.data["CATALOG_RECORD"]
+        assert len(table[table["source"] == "wmko"]) == 1  # wmko row preserved
+        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
+
+
+class TestSingleSourceAstrSrc:
+    def test_source_row_astr_src_defaults_to_source(self):
+        # A plain source row's astr_src is its own label (its position is its own).
+        l0 = _make_l0({"gaia": _record("G"), "wmko": _record("W")})
+        table = l0.data["CATALOG_RECORD"]
+        assert table[table["source"] == "gaia"][0]["astr_src"] == "gaia"
+        assert table[table["source"] == "wmko"][0]["astr_src"] == "wmko"

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -219,8 +219,8 @@ class TestReadWmkoHeader:
         return l0
 
     def test_good_targ_builds_row_and_flag(self):
-        # Well-formed TARG* -> a wmko record sanitized to the EPRV C*# format;
-        # writing it sets WMKOCR=1.
+        # Well-formed FK5 TARG* -> a wmko record sanitized to the EPRV C*# format,
+        # carrying its true frame ('fk5', not relabeled ICRS); writing it sets WMKOCR=1.
         l0 = self._l0_targ(**self._GOOD_TARG)
         aq = AstroQuery(l0)
         aq._write_catalog_record("wmko", aq.read_wmko_header())
@@ -230,6 +230,7 @@ class TestReadWmkoHeader:
         assert wmko["ra"] == "12:00:00.0000"  # RA hour-angle sexagesimal
         assert wmko["dec"] == "+40:00:00.000"
         assert wmko["object"] == "testtarget"
+        assert wmko["frame"] == "fk5"  # true frame, not relabeled ICRS
 
     def test_pmra_time_to_angle_conversion(self):
         # TARGPMRA is DCS seconds-of-time/yr: read_wmko_header must convert it to
@@ -258,3 +259,16 @@ class TestReadWmkoHeader:
         with caplog.at_level(logging.WARNING):
             assert AstroQuery(l0).read_wmko_header() is None
         assert "could not build wmko CATALOG_RECORD" in caplog.text
+
+    def test_non_fk5_frame_raises(self):
+        # KPF pointing is always FK5; any other TARGFRAM (e.g. galactic) raises
+        # rather than being coerced onto a frame it does not have.
+        l0 = self._l0_targ(**{**self._GOOD_TARG, "TARGFRAM": "galactic"})
+        with pytest.raises(ValueError, match="TARGFRAM"):
+            AstroQuery(l0).read_wmko_header()
+
+    def test_absent_frame_raises(self):
+        # An absent TARGFRAM cannot be verified as FK5 -> raise (never guess a frame).
+        targ = {k: v for k, v in self._GOOD_TARG.items() if k != "TARGFRAM"}
+        with pytest.raises(ValueError, match="TARGFRAM"):
+            AstroQuery(self._l0_targ(**targ)).read_wmko_header()

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -7,8 +7,10 @@ SCI2 catalog cards on PRIMARY. barycorrpy calls are stubbed via monkeypatching.
 
 import logging
 
+import astropy.units as u
 import numpy as np
 import pytest
+from astropy.coordinates import Distance, SkyCoord
 from astropy.table import Table
 from astropy.time import Time
 
@@ -963,6 +965,140 @@ class TestPerform:
         # No monkeypatch on _fix_expmeter_outliers -- real filter runs.
         kpf2 = BarycentricCorrection(synthetic_kpf2).perform(fix_expmeter_outliers=True)
         assert np.all(np.isfinite(np.asarray(kpf2.data["BJD_TDB"])))
+
+
+# ---------------------------------------------------------------------------
+# perform(skycoord=...) -- interactive astrometry override
+# ---------------------------------------------------------------------------
+
+
+def _user_skycoord(ra_deg=90.0):
+    """A fully-specified SkyCoord, as an interactive caller would build one."""
+    return SkyCoord(
+        ra=ra_deg * u.deg,
+        dec=30.0 * u.deg,
+        pm_ra_cosdec=100.0 * u.mas / u.yr,
+        pm_dec=-50.0 * u.mas / u.yr,
+        distance=Distance(parallax=25.0 * u.mas),
+        obstime=Time(2020.0, format="jyear"),
+        frame="icrs",
+    )
+
+
+class TestSkycoordOverride:
+    """A user-supplied SkyCoord bypasses the PRIMARY C*# cards, so an L2 in hand can
+    be re-corrected with different astrometry without re-reducing from L0."""
+
+    @staticmethod
+    def _capture(monkeypatch):
+        captured = {}
+
+        def mock_compute(astrometry, obs_times, location, rv_mps=0.0):
+            captured.update(astrometry)
+            n = len(np.atleast_1d(obs_times.jd))
+            return np.zeros(n), np.atleast_1d(obs_times.jd)
+
+        monkeypatch.setattr(
+            BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
+        )
+        monkeypatch.setattr(
+            BarycentricCorrection,
+            "_fix_expmeter_outliers",
+            staticmethod(lambda f, kernel_size=5: f.copy()),
+        )
+        return captured
+
+    def test_converts_skycoord_to_barycorrpy_units(self, synthetic_kpf2, monkeypatch):
+        captured = self._capture(monkeypatch)
+        BarycentricCorrection(synthetic_kpf2).perform(skycoord=_user_skycoord())
+
+        assert captured["ra"] == pytest.approx(90.0)
+        assert captured["dec"] == pytest.approx(30.0)
+        assert captured["pmra"] == pytest.approx(100.0)
+        assert captured["pmdec"] == pytest.approx(-50.0)
+        assert captured["px"] == pytest.approx(25.0)
+        assert captured["epoch"] == pytest.approx(Time(2020.0, format="jyear").jd)
+
+    def test_overrides_the_header_cards(self, synthetic_kpf2, monkeypatch):
+        """The fixture's CRA3 is 12h (180 deg); the override must win."""
+        captured = self._capture(monkeypatch)
+        BarycentricCorrection(synthetic_kpf2).perform(skycoord=_user_skycoord())
+        assert captured["ra"] == pytest.approx(90.0)
+
+    def test_works_without_catalog_cards(self, synthetic_kpf2, monkeypatch):
+        """The whole point of the escape hatch: an L2 whose C*# cards are absent
+        (AstroQuery never ran) can still be corrected interactively."""
+        for card in ("CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3"):
+            del synthetic_kpf2.headers["PRIMARY"][card]
+        captured = self._capture(monkeypatch)
+
+        kpf2 = BarycentricCorrection(synthetic_kpf2).perform(skycoord=_user_skycoord())
+
+        assert captured["ra"] == pytest.approx(90.0)
+        assert len(kpf2.data["BJD_TDB"]) == NORDER
+
+    def test_header_cards_not_modified(self, synthetic_kpf2, monkeypatch):
+        self._capture(monkeypatch)
+        BarycentricCorrection(synthetic_kpf2).perform(skycoord=_user_skycoord())
+        assert synthetic_kpf2.headers["PRIMARY"]["CRA3"] == "12:00:00.0000"
+
+    def test_records_user_provenance(self, synthetic_kpf2, monkeypatch):
+        self._capture(monkeypatch)
+        bc = BarycentricCorrection(synthetic_kpf2)
+        bc.perform(skycoord=_user_skycoord())
+        assert bc._astrometry_source == "user SkyCoord"
+
+    def test_override_is_not_cached(self, synthetic_kpf2, monkeypatch):
+        """The override must not poison _astrometry, or a later header-path call
+        would silently reuse the user's values."""
+        captured = self._capture(monkeypatch)
+        bc = BarycentricCorrection(synthetic_kpf2)
+        bc.perform(skycoord=_user_skycoord())
+        assert bc._astrometry is None
+
+        bc.perform()  # no override -> back to the header
+        assert captured["ra"] == pytest.approx(180.0)
+
+    def test_default_reads_the_header(self, synthetic_kpf2, monkeypatch):
+        captured = self._capture(monkeypatch)
+        BarycentricCorrection(synthetic_kpf2).perform()
+        assert captured["ra"] == pytest.approx(180.0)
+
+    @pytest.mark.parametrize(
+        "kwargs, error, match",
+        [
+            # No proper motion -> the frame carries no velocity data.
+            (
+                {"distance": Distance(parallax=25.0 * u.mas)},
+                TypeError,
+                "no associated differentials",
+            ),
+            # No distance -> .distance is a dimensionless 1.0, not convertible to pc.
+            (
+                {
+                    "pm_ra_cosdec": 100.0 * u.mas / u.yr,
+                    "pm_dec": -50.0 * u.mas / u.yr,
+                },
+                u.UnitConversionError,
+                "not convertible",
+            ),
+        ],
+    )
+    def test_incomplete_skycoord_raises(
+        self, synthetic_kpf2, monkeypatch, kwargs, error, match
+    ):
+        """Deliberately unvalidated: astropy raises on its own for a SkyCoord built
+        without the components the correction needs."""
+        self._capture(monkeypatch)
+        incomplete = SkyCoord(
+            ra=90.0 * u.deg,
+            dec=30.0 * u.deg,
+            obstime=Time(2020.0, format="jyear"),
+            frame="icrs",
+            **kwargs,
+        )
+        with pytest.raises(error, match=match):
+            BarycentricCorrection(synthetic_kpf2).perform(skycoord=incomplete)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -41,9 +41,8 @@ _T0 = "2024-01-01T"
 _WAVE_COLS = ["5000", "5100", "5200", "5300"]  # 100Å spacing → dispersion = 100Å
 _FLUX_VALUE = 100.0  # uniform ADU per reading
 
-# SCI2 catalog cards, as KPF0.to_kpf1 writes them from AstroQuery's canonical record:
-# ICRS, RA/Dec sexagesimal (RA hourangle, Dec deg), PM arcsec/yr, parallax mas, rv
-# km/s, epoch Julian years. RA 180 deg / Dec 0 / 100 pc.
+# SCI2 catalog cards as KPF0.to_kpf1 writes them: ICRS, RA/Dec sexagesimal (hourangle
+# / deg), PM arcsec/yr, parallax mas, epoch Julian years. RA 180 deg, Dec 0, 100 pc.
 _CATALOG_CARDS = {
     "CSRC3": "gaia",
     "CID3": "1234567890123456789",
@@ -81,8 +80,7 @@ def synthetic_kpf2():
     kpf2.headers["INSTRUMENT_HEADER"]["DATE-BEG"] = f"{_T0}00:00:00.000"
     kpf2.headers["INSTRUMENT_HEADER"]["DATE-END"] = f"{_T0}00:05:00.000"
 
-    # Target astrometry reaches L2 on the EPRV PRIMARY C*# cards (AstroQuery ->
-    # KPF0.to_kpf1 -> KPF1.to_kpf2); BarycentricCorrection issues no query.
+    # Target astrometry reaches L2 on the PRIMARY C*# cards; the module never queries.
     for key, value in _CATALOG_CARDS.items():
         kpf2.headers["PRIMARY"][key] = value
 
@@ -690,8 +688,7 @@ class TestFluxWeightedMidpointFormat:
 
 
 class TestGetAstrometry:
-    """Convert the C*# cards into barycorrpy's argument set and sanitize the
-    parallax."""
+    """Convert the C*# cards to barycorrpy's arguments and sanitize the parallax."""
 
     def test_converts_cards_to_barycorrpy_units(self, synthetic_kpf2):
         primary = synthetic_kpf2.headers["PRIMARY"]
@@ -724,8 +721,8 @@ class TestGetAstrometry:
     # an absent card (covered below) or a blank one, never as NaN.
     @pytest.mark.parametrize("parallax", [-0.4, 0.0, ""])
     def test_unusable_parallax_becomes_zero(self, caplog, synthetic_kpf2, parallax):
-        """A negative or zero catalog parallax (routine for faint Gaia sources)
-        degrades to px=0, not a negative distance."""
+        """A nonpositive parallax (routine for faint Gaia sources) degrades to px=0,
+        not a negative distance."""
         synthetic_kpf2.headers["PRIMARY"]["CPLX3"] = parallax
         bc = BarycentricCorrection(synthetic_kpf2)
         with caplog.at_level(logging.WARNING):
@@ -734,8 +731,7 @@ class TestGetAstrometry:
         assert "CPLX3" in caplog.text
 
     def test_missing_parallax_becomes_zero(self, caplog, synthetic_kpf2):
-        """CPLX# is Required=No in the EPRV standard and is skipped from PRIMARY
-        when the catalog measured none."""
+        """CPLX# is Required=No, so it is absent when the catalog measured none."""
         del synthetic_kpf2.headers["PRIMARY"]["CPLX3"]
         bc = BarycentricCorrection(synthetic_kpf2)
         with caplog.at_level(logging.WARNING):
@@ -745,7 +741,7 @@ class TestGetAstrometry:
 
     @pytest.mark.parametrize("card", ["CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3"])
     def test_missing_position_card_raises(self, synthetic_kpf2, card):
-        """The position block is all-or-nothing: AstroQuery's merge refuses to emit a
+        """The position block is all-or-nothing: AstroQuery's merge never emits a
         canonical row without it, so a gap means the pipeline is misordered."""
         del synthetic_kpf2.headers["PRIMARY"][card]
         bc = BarycentricCorrection(synthetic_kpf2)
@@ -986,7 +982,7 @@ def _user_skycoord(ra_deg=90.0):
 
 class TestSkycoordOverride:
     """A user-supplied SkyCoord bypasses the PRIMARY C*# cards, so an L2 in hand can
-    be re-corrected with different astrometry without re-reducing from L0."""
+    be re-corrected without re-reducing from L0."""
 
     @staticmethod
     def _capture(monkeypatch):
@@ -1025,8 +1021,8 @@ class TestSkycoordOverride:
         assert captured["ra"] == pytest.approx(90.0)
 
     def test_works_without_catalog_cards(self, synthetic_kpf2, monkeypatch):
-        """The whole point of the escape hatch: an L2 whose C*# cards are absent
-        (AstroQuery never ran) can still be corrected interactively."""
+        """An L2 whose C*# cards are absent (AstroQuery never ran) is still
+        correctable -- the point of the escape hatch."""
         for card in ("CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3"):
             del synthetic_kpf2.headers["PRIMARY"][card]
         captured = self._capture(monkeypatch)
@@ -1048,8 +1044,8 @@ class TestSkycoordOverride:
         assert bc._astrometry_source == "user SkyCoord"
 
     def test_override_is_not_cached(self, synthetic_kpf2, monkeypatch):
-        """The override must not poison _astrometry, or a later header-path call
-        would silently reuse the user's values."""
+        """The override must not poison the cache, or a later header-path call would
+        silently reuse the user's values."""
         captured = self._capture(monkeypatch)
         bc = BarycentricCorrection(synthetic_kpf2)
         bc.perform(skycoord=_user_skycoord())
@@ -1086,8 +1082,8 @@ class TestSkycoordOverride:
     def test_incomplete_skycoord_raises(
         self, synthetic_kpf2, monkeypatch, kwargs, error, match
     ):
-        """Deliberately unvalidated: astropy raises on its own for a SkyCoord built
-        without the components the correction needs."""
+        """Deliberately unvalidated: astropy raises on its own for a SkyCoord missing
+        components the correction needs."""
         self._capture(monkeypatch)
         incomplete = SkyCoord(
             ra=90.0 * u.deg,

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -43,8 +43,7 @@ _FLUX_VALUE = 100.0  # uniform ADU per reading
 
 # SCI2 catalog cards, as KPF0.to_kpf1 writes them from AstroQuery's canonical record:
 # ICRS, RA/Dec sexagesimal (RA hourangle, Dec deg), PM arcsec/yr, parallax mas, rv
-# km/s, epoch Julian years. RA 180 deg / Dec 0 / 100 pc, matching the astrometry the
-# stubbed Gaia query used to supply.
+# km/s, epoch Julian years. RA 180 deg / Dec 0 / 100 pc.
 _CATALOG_CARDS = {
     "CSRC3": "gaia",
     "CID3": "1234567890123456789",
@@ -691,9 +690,8 @@ class TestFluxWeightedMidpointFormat:
 
 
 class TestGetAstrometry:
-    """The C*# cards are AstroQuery's canonical record; this is the unit
-    conversion into barycorrpy's argument set, plus the parallax sanitation the
-    faithful-catalog-record contract pushes downstream."""
+    """Convert the C*# cards into barycorrpy's argument set and sanitize the
+    parallax."""
 
     def test_converts_cards_to_barycorrpy_units(self, synthetic_kpf2):
         primary = synthetic_kpf2.headers["PRIMARY"]
@@ -726,9 +724,8 @@ class TestGetAstrometry:
     # an absent card (covered below) or a blank one, never as NaN.
     @pytest.mark.parametrize("parallax", [-0.4, 0.0, ""])
     def test_unusable_parallax_becomes_zero(self, caplog, synthetic_kpf2, parallax):
-        """AstroQuery persists catalog values faithfully -- a negative Gaia parallax
-        is routine -- so BarycentricCorrection degrades to px=0 rather than
-        computing a negative distance."""
+        """A negative or zero catalog parallax (routine for faint Gaia sources)
+        degrades to px=0, not a negative distance."""
         synthetic_kpf2.headers["PRIMARY"]["CPLX3"] = parallax
         bc = BarycentricCorrection(synthetic_kpf2)
         with caplog.at_level(logging.WARNING):
@@ -909,8 +906,8 @@ class TestPerform:
         BarycentricCorrection(synthetic_kpf2).perform()
         assert captured["rv_mps"] == pytest.approx(81870.0)
 
-    def test_missing_crv_defaults_to_zero(self, bc_monkeypatched, monkeypatch):
-        """No CRV3 on PRIMARY (no catalog rv, no TARGRADV) → rv_mps=0."""
+    def test_missing_crv_defaults_to_zero(self, caplog, bc_monkeypatched, monkeypatch):
+        """No CRV3 on PRIMARY (no catalog rv, no TARGRADV) → rv_mps=0, warns."""
         # synthetic_kpf2 fixture does not set CRV3
         captured = {}
 
@@ -922,8 +919,10 @@ class TestPerform:
         monkeypatch.setattr(
             BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
         )
-        bc_monkeypatched.perform()
+        with caplog.at_level(logging.WARNING):
+            bc_monkeypatched.perform()
         assert captured["rv_mps"] == 0.0
+        assert "CRV3" in caplog.text
 
     def test_state_populated(self, bc_monkeypatched):
         for attr in ("_ccd_bjd", "_ccd_kms", "_ccd_z"):

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -319,7 +319,7 @@ class TestFluxWeightedMidpointExpmeter:
             output="expmeter",
             interpolate=False,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
         _, t_mid, _ = bc._get_timestamps()
         np.testing.assert_allclose(np.mean(t_fwm.jd), np.mean(t_mid.jd), atol=1e-6)
@@ -330,7 +330,7 @@ class TestFluxWeightedMidpointExpmeter:
             output="expmeter",
             interpolate=False,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
         assert w.shape == (len(_WAVE_COLS),)
         assert len(t_fwm) == len(_WAVE_COLS)
@@ -355,7 +355,7 @@ class TestFluxWeightedMidpointExpmeter:
             output="expmeter",
             interpolate=False,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
 
         # Compare midpoints as seconds from the first reading: JD magnitudes
@@ -402,7 +402,7 @@ class TestFluxWeightedMidpointExpmeter:
                 output="expmeter",
                 interpolate=False,
                 extrapolate=False,
-                fix_expmeter_outliers=False,
+                fix_outliers=False,
             )
 
     def test_interpolate_shifts_midpoint_with_front_weighted_flux(self, synthetic_kpf2):
@@ -429,13 +429,13 @@ class TestFluxWeightedMidpointExpmeter:
             output="expmeter",
             interpolate=False,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
         _, t_yes = bc.compute_flux_weighted_midpoint_times(
             output="expmeter",
             interpolate=True,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
         # Shift should be sub-minute → tens of microdays, easily > 1e-9 days
         assert np.mean(t_yes.jd) > np.mean(t_no.jd) + 1e-7
@@ -475,13 +475,13 @@ class TestFluxWeightedMidpointExpmeter:
             output="expmeter",
             interpolate=False,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
         _, t_yes = bc.compute_flux_weighted_midpoint_times(
             output="expmeter",
             interpolate=False,
             extrapolate=True,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
         # Bright first reading + 2-minute leading shutter gap → big leading
         # extrapolation pulls FWM clearly earlier than the no-extrap case.
@@ -489,7 +489,7 @@ class TestFluxWeightedMidpointExpmeter:
 
 
 class TestFluxWeightedMidpointOrders:
-    _KWARGS = dict(interpolate=False, extrapolate=False, fix_expmeter_outliers=False)
+    _KWARGS = dict(interpolate=False, extrapolate=False, fix_outliers=False)
 
     def test_output_shape(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
@@ -544,7 +544,7 @@ class TestFluxWeightedMidpointOrders:
 
 
 class TestFluxWeightedMidpointCcds:
-    _KWARGS = dict(interpolate=False, extrapolate=False, fix_expmeter_outliers=False)
+    _KWARGS = dict(interpolate=False, extrapolate=False, fix_outliers=False)
 
     def test_output_shape(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)
@@ -678,7 +678,7 @@ class TestFluxWeightedMidpointFormat:
         w, t = bc.compute_flux_weighted_midpoint_times(
             interpolate=False,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )
         assert w.shape == (NORDER,)
 
@@ -1002,7 +1002,7 @@ class TestMissingHeader:
                 output="expmeter",
                 interpolate=False,
                 extrapolate=True,
-                fix_expmeter_outliers=False,
+                fix_outliers=False,
             )
 
     def test_missing_date_beg_ok_without_extrapolate(self, synthetic_kpf2):
@@ -1014,5 +1014,5 @@ class TestMissingHeader:
             output="expmeter",
             interpolate=False,
             extrapolate=False,
-            fix_expmeter_outliers=False,
+            fix_outliers=False,
         )

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -1,16 +1,14 @@
 """Tests for the BarycentricCorrection module (KPF2 -> KPF2).
 
 Static-method unit tests require no fixtures. Integration tests use a
-synthetic KPF2 with a small EXPMETER_SCI table and populated SCI2_WAVE.
-Gaia and barycorrpy calls are stubbed via monkeypatching.
+synthetic KPF2 with a small EXPMETER_SCI table, populated SCI2_WAVE, and the
+SCI2 catalog cards on PRIMARY. barycorrpy calls are stubbed via monkeypatching.
 """
 
 import logging
 
-import astropy.units as u
 import numpy as np
 import pytest
-from astropy.coordinates import Distance, SkyCoord
 from astropy.table import Table
 from astropy.time import Time
 
@@ -41,6 +39,22 @@ _T0 = "2024-01-01T"
 _WAVE_COLS = ["5000", "5100", "5200", "5300"]  # 100Å spacing → dispersion = 100Å
 _FLUX_VALUE = 100.0  # uniform ADU per reading
 
+# SCI2 catalog cards, as KPF0.to_kpf1 writes them from AstroQuery's canonical record:
+# ICRS, RA/Dec sexagesimal (RA hourangle, Dec deg), PM arcsec/yr, parallax mas, rv
+# km/s, epoch Julian years. RA 180 deg / Dec 0 / 100 pc, matching the astrometry the
+# stubbed Gaia query used to supply.
+_CATALOG_CARDS = {
+    "CSRC3": "gaia",
+    "CID3": "1234567890123456789",
+    "CRA3": "12:00:00.0000",
+    "CDEC3": "+00:00:00.000",
+    "CPMR3": 0.0,
+    "CPMD3": 0.0,
+    "CPLX3": 10.0,
+    "CEPCH3": 2016.0,
+    "CEQNX3": 2000.0,
+}
+
 
 def _make_expmeter_table():
     begs = [f"{_T0}00:00:00.000", f"{_T0}00:02:00.000", f"{_T0}00:04:00.000"]
@@ -65,7 +79,11 @@ def synthetic_kpf2():
     # KPF-native keywords live in INSTRUMENT_HEADER on L2 (preserved L1 PRIMARY).
     kpf2.headers["INSTRUMENT_HEADER"]["DATE-BEG"] = f"{_T0}00:00:00.000"
     kpf2.headers["INSTRUMENT_HEADER"]["DATE-END"] = f"{_T0}00:05:00.000"
-    kpf2.headers["INSTRUMENT_HEADER"]["GAIAID"] = "DR3 1234567890123456789"
+
+    # Target astrometry reaches L2 on the EPRV PRIMARY C*# cards (AstroQuery ->
+    # KPF0.to_kpf1 -> KPF1.to_kpf2); BarycentricCorrection issues no query.
+    for key, value in _CATALOG_CARDS.items():
+        kpf2.headers["PRIMARY"][key] = value
 
     kpf2.set_data("EXPMETER_SCI", _make_expmeter_table())
 
@@ -77,19 +95,6 @@ def synthetic_kpf2():
             )
 
     return kpf2
-
-
-def _fake_skycoord():
-    """Deterministic ICRS SkyCoord with realistic proper motion / parallax."""
-    return SkyCoord(
-        ra=180.0 * u.deg,
-        dec=0.0 * u.deg,
-        pm_ra_cosdec=0.0 * u.mas / u.yr,
-        pm_dec=0.0 * u.mas / u.yr,
-        distance=100.0 * u.pc,
-        obstime=Time(2016.0, format="jyear"),
-        frame="icrs",
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -280,18 +285,17 @@ class TestComputeBarycorrReference:
 
     def test_matches_barycorrpy_reference(self):
         # Fixed Tau Ceti-like astrometry at a fixed UTC epoch, observed from Keck.
-        skycoord = SkyCoord(
-            ra=26.0213 * u.deg,
-            dec=-15.9395 * u.deg,
-            pm_ra_cosdec=-1721.05 * u.mas / u.yr,
-            pm_dec=854.16 * u.mas / u.yr,
-            distance=Distance(parallax=273.96 * u.mas),
-            obstime=Time("J2000.0"),
-            frame="icrs",
-        )
+        astrometry = {
+            "ra": 26.0213,
+            "dec": -15.9395,
+            "pmra": -1721.05,
+            "pmdec": 854.16,
+            "px": 273.96,
+            "epoch": Time("J2000.0").jd,
+        }
         t = Time("2024-06-15T09:00:00.000", scale="utc")
         bc_vel, bjd_tdb = BarycentricCorrection._compute_barycorr(
-            skycoord, t, BarycentricCorrection.KECK_LOCATION
+            astrometry, t, BarycentricCorrection.KECK_LOCATION
         )
         # Physical sanity: BERV within Earth's orbital +/-30 km/s; BJD_TDB within
         # a few minutes of JD_UTC (clock + Romer light-travel delay).
@@ -680,114 +684,84 @@ class TestFluxWeightedMidpointFormat:
 
 
 # ---------------------------------------------------------------------------
-# _gaia_astrometry input validation
+# _get_astrometry -- read the PRIMARY C*# cards, convert, sanitize
 # ---------------------------------------------------------------------------
 
 
-class TestQueryGaiaValidation:
-    """Reject non-numeric source IDs before they hit the ADQL query string."""
+class TestGetAstrometry:
+    """The C*# cards are AstroQuery's canonical record; this is the unit
+    conversion into barycorrpy's argument set, plus the parallax sanitation the
+    faithful-catalog-record contract pushes downstream."""
 
-    @pytest.mark.parametrize(
-        "bad_id",
-        [
-            "foo",  # not a number at all
-            "12345 OR 1=1",  # injection attempt
-            "12345; DROP TABLE",
-            "",
-            "12.34",  # decimal
-            "-12345",  # negative
-        ],
-    )
-    def test_non_numeric_raises(self, synthetic_kpf2, bad_id):
-        synthetic_kpf2.headers["INSTRUMENT_HEADER"]["GAIAID"] = bad_id
+    def test_converts_cards_to_barycorrpy_units(self, synthetic_kpf2):
+        primary = synthetic_kpf2.headers["PRIMARY"]
+        primary["CPMR3"] = 0.5  # arcsec/yr
+        primary["CPMD3"] = -0.3  # arcsec/yr
+
+        astrometry = BarycentricCorrection(synthetic_kpf2)._get_astrometry()
+
+        # RA sexagesimal hourangle / Dec sexagesimal deg -> deg
+        assert astrometry["ra"] == pytest.approx(180.0)
+        assert astrometry["dec"] == pytest.approx(0.0)
+        # arcsec/yr -> mas/yr
+        assert astrometry["pmra"] == pytest.approx(500.0)
+        assert astrometry["pmdec"] == pytest.approx(-300.0)
+        # parallax stays mas; epoch Julian years -> JD
+        assert astrometry["px"] == pytest.approx(10.0)
+        assert astrometry["epoch"] == pytest.approx(Time(2016.0, format="jyear").jd)
+
+    def test_records_provenance_from_csrc(self, synthetic_kpf2):
+        synthetic_kpf2.headers["PRIMARY"]["CSRC3"] = "simbad"
         bc = BarycentricCorrection(synthetic_kpf2)
-        with pytest.raises(ValueError, match="all digits"):
-            bc._gaia_astrometry()
+        bc._get_astrometry()
+        assert bc._astrometry_source == "simbad"
 
+    def test_result_is_cached(self, synthetic_kpf2):
+        bc = BarycentricCorrection(synthetic_kpf2)
+        assert bc._get_astrometry() is bc._get_astrometry()
 
-# ---------------------------------------------------------------------------
-# _get_skycoord -- Gaia first, WMKO header fallback, else raise
-# ---------------------------------------------------------------------------
-
-
-class TestAstrometryResolution:
-    @staticmethod
-    def _add_wmko_keys(kpf2):
-        inst = kpf2.headers["INSTRUMENT_HEADER"]
-        inst["TARGRA"] = "10:59:27.50"
-        inst["TARGDEC"] = "+40:25:50.0"
-        inst["TARGEPOC"] = 2000.0
-        inst["TARGFRAM"] = "FK5"
-        inst["TARGPLAX"] = 72.0  # mas
-        inst["TARGPMRA"] = 0.0  # time-s/yr
-        inst["TARGPMDC"] = 0.0  # arcsec/yr
-
-    def test_gaia_used_when_enabled(self, synthetic_kpf2, monkeypatch):
-        sentinel = _fake_skycoord()
-        monkeypatch.setattr(
-            BarycentricCorrection, "_gaia_astrometry", lambda self: sentinel
-        )
-        # defaults: use_gaia_astrometry=True, use_wmko_fallback=False
-        assert BarycentricCorrection(synthetic_kpf2)._get_skycoord() is sentinel
-
-    def test_falls_back_to_wmko_on_gaia_error(
-        self, caplog, synthetic_kpf2, monkeypatch
-    ):
-        self._add_wmko_keys(synthetic_kpf2)
-
-        def boom(self):
-            raise ConnectionError("gaia server down")
-
-        monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", boom)
-
-        bc = BarycentricCorrection(synthetic_kpf2, config={"use_wmko_fallback": True})
+    # NaN is not representable in a FITS header, so an unmeasured parallax arrives as
+    # an absent card (covered below) or a blank one, never as NaN.
+    @pytest.mark.parametrize("parallax", [-0.4, 0.0, ""])
+    def test_unusable_parallax_becomes_zero(self, caplog, synthetic_kpf2, parallax):
+        """AstroQuery persists catalog values faithfully -- a negative Gaia parallax
+        is routine -- so BarycentricCorrection degrades to px=0 rather than
+        computing a negative distance."""
+        synthetic_kpf2.headers["PRIMARY"]["CPLX3"] = parallax
+        bc = BarycentricCorrection(synthetic_kpf2)
         with caplog.at_level(logging.WARNING):
-            sc = bc._get_skycoord()
-        assert "ConnectionError" in caplog.text
-        assert sc.icrs.distance.to(u.pc).value == pytest.approx(1e3 / 72.0)
+            astrometry = bc._get_astrometry()
+        assert astrometry["px"] == 0.0
+        assert "CPLX3" in caplog.text
 
-    def test_wmko_only_when_gaia_disabled(self, synthetic_kpf2, monkeypatch):
-        self._add_wmko_keys(synthetic_kpf2)
+    def test_missing_parallax_becomes_zero(self, caplog, synthetic_kpf2):
+        """CPLX# is Required=No in the EPRV standard and is skipped from PRIMARY
+        when the catalog measured none."""
+        del synthetic_kpf2.headers["PRIMARY"]["CPLX3"]
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with caplog.at_level(logging.WARNING):
+            astrometry = bc._get_astrometry()
+        assert astrometry["px"] == 0.0
+        assert "CPLX3" in caplog.text
 
-        def fail(self):
-            raise AssertionError("Gaia should not be queried when disabled")
+    @pytest.mark.parametrize("card", ["CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3"])
+    def test_missing_position_card_raises(self, synthetic_kpf2, card):
+        """The position block is all-or-nothing: AstroQuery's merge refuses to emit a
+        canonical row without it, so a gap means the pipeline is misordered."""
+        del synthetic_kpf2.headers["PRIMARY"][card]
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(ValueError, match=card):
+            bc._get_astrometry()
 
-        monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", fail)
-
-        bc = BarycentricCorrection(
-            synthetic_kpf2,
-            config={"use_gaia_astrometry": False, "use_wmko_fallback": True},
-        )
-        sc = bc._get_skycoord()
-        assert sc.ra.deg == pytest.approx(164.8645833)
-
-    def test_raises_and_surfaces_gaia_error_when_both_unavailable(
-        self, synthetic_kpf2, monkeypatch
-    ):
-        def boom(self):
-            raise ValueError("Gaia source_id must be all digits; got 'foo'")
-
-        monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", boom)
-
-        bc = BarycentricCorrection(synthetic_kpf2)  # wmko fallback off by default
-        with pytest.raises(ValueError, match="all digits"):
-            bc._get_skycoord()
-
-    def test_wmko_proper_motion_and_parallax_units(self, synthetic_kpf2):
-        self._add_wmko_keys(synthetic_kpf2)
-        inst = synthetic_kpf2.headers["INSTRUMENT_HEADER"]
-        inst["TARGPMRA"] = 0.01  # time-s/yr
-        inst["TARGPMDC"] = -0.5  # arcsec/yr
-
-        sc = BarycentricCorrection(synthetic_kpf2)._wmko_astrometry()
-        expected_pmra = 0.01 * 15.0 * np.cos(sc.dec.rad) * 1e3  # -> mas/yr (cosdec)
-        assert sc.pm_ra_cosdec.to(u.mas / u.yr).value == pytest.approx(expected_pmra)
-        assert sc.pm_dec.to(u.mas / u.yr).value == pytest.approx(-500.0)
-        assert sc.distance.to(u.pc).value == pytest.approx(1e3 / 72.0)
+    def test_blank_position_card_raises(self, synthetic_kpf2):
+        synthetic_kpf2.headers["PRIMARY"]["CRA3"] = ""
+        bc = BarycentricCorrection(synthetic_kpf2)
+        with pytest.raises(ValueError, match="run AstroQuery"):
+            bc._get_astrometry()
 
 
 # ---------------------------------------------------------------------------
-# perform() -- Gaia and barycorrpy stubbed
+# perform() -- barycorrpy stubbed
 # ---------------------------------------------------------------------------
 
 
@@ -796,12 +770,9 @@ class TestPerform:
 
     @pytest.fixture
     def bc_monkeypatched(self, synthetic_kpf2, monkeypatch):
-        """BarycentricCorrection with Gaia + barycorrpy stubbed."""
+        """BarycentricCorrection with barycorrpy stubbed."""
 
-        def mock_query(self):
-            return _fake_skycoord()
-
-        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
+        def mock_compute(astrometry, obs_times, location, rv_mps=0.0):
             n = len(np.atleast_1d(obs_times.jd))
             bc_vel = np.full(n, TestPerform.DELTA_RV_MPS, dtype=float)
             # BJD = JD + 500s (light-travel approx); same for every order in this stub
@@ -811,7 +782,6 @@ class TestPerform:
         def passthrough(f, kernel_size=5):
             return f.copy()
 
-        monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", mock_query)
         monkeypatch.setattr(
             BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
         )
@@ -912,17 +882,14 @@ class TestPerform:
         modules = bc_monkeypatched.l2_obj.receipt["FUNCTION"].values
         assert "barycentric_correction" in modules
 
-    def test_targradv_converted_km_to_m_and_passed_through(
+    def test_crv_converted_km_to_m_and_passed_through(
         self, synthetic_kpf2, monkeypatch
     ):
-        """TARGRADV (km/s) should arrive at _compute_barycorr as m/s."""
-        synthetic_kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = 81.87  # km/s
+        """CRV3 (km/s) should arrive at _compute_barycorr as m/s."""
+        synthetic_kpf2.headers["PRIMARY"]["CRV3"] = 81.87  # km/s
         captured = {}
 
-        def mock_query(self):
-            return _fake_skycoord()
-
-        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
+        def mock_compute(astrometry, obs_times, location, rv_mps=0.0):
             captured["rv_mps"] = rv_mps
             n = len(np.atleast_1d(obs_times.jd))
             return np.zeros(n), np.atleast_1d(obs_times.jd)
@@ -930,7 +897,6 @@ class TestPerform:
         def passthrough(f, kernel_size=5):
             return f.copy()
 
-        monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", mock_query)
         monkeypatch.setattr(
             BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
         )
@@ -941,12 +907,12 @@ class TestPerform:
         BarycentricCorrection(synthetic_kpf2).perform()
         assert captured["rv_mps"] == pytest.approx(81870.0)
 
-    def test_missing_targradv_defaults_to_zero(self, bc_monkeypatched, monkeypatch):
-        """No TARGRADV in INSTRUMENT_HEADER → rv_mps=0 passed through."""
-        # synthetic_kpf2 fixture does not set TARGRADV
+    def test_missing_crv_defaults_to_zero(self, bc_monkeypatched, monkeypatch):
+        """No CRV3 on PRIMARY (no catalog rv, no TARGRADV) → rv_mps=0."""
+        # synthetic_kpf2 fixture does not set CRV3
         captured = {}
 
-        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
+        def mock_compute(astrometry, obs_times, location, rv_mps=0.0):
             captured["rv_mps"] = rv_mps
             n = len(np.atleast_1d(obs_times.jd))
             return np.full(n, TestPerform.DELTA_RV_MPS), np.atleast_1d(obs_times.jd)
@@ -961,49 +927,11 @@ class TestPerform:
         for attr in ("_ccd_bjd", "_ccd_kms", "_ccd_z"):
             assert getattr(bc_monkeypatched, attr) is None
         kpf2 = bc_monkeypatched.perform()
-        assert bc_monkeypatched._astrometry_source == "Gaia DR3"
+        assert bc_monkeypatched._astrometry_source == "gaia"
         for key in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
             assert len(kpf2.data[key]) == NORDER
         for attr in ("_ccd_bjd", "_ccd_kms", "_ccd_z"):
             assert len(getattr(bc_monkeypatched, attr)) == 2
-
-    def test_records_gaia_provenance(self, bc_monkeypatched):
-        kpf2 = bc_monkeypatched.perform()
-        astrsrc = kpf2.headers["RECEIPT"].get("ASTRSRC")
-        assert astrsrc == "Gaia DR3"
-
-    def test_perform_falls_back_and_records_wmko_provenance(
-        self, caplog, synthetic_kpf2, monkeypatch
-    ):
-        TestAstrometryResolution._add_wmko_keys(synthetic_kpf2)
-
-        def boom(self):
-            raise ConnectionError("gaia down")
-
-        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
-            n = len(np.atleast_1d(obs_times.jd))
-            return np.zeros(n), np.atleast_1d(obs_times.jd)
-
-        monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", boom)
-        monkeypatch.setattr(
-            BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
-        )
-        monkeypatch.setattr(
-            BarycentricCorrection,
-            "_fix_expmeter_outliers",
-            staticmethod(lambda f, kernel_size=5: f.copy()),
-        )
-
-        bc = BarycentricCorrection(synthetic_kpf2)  # defaults: gaia on, wmko off
-        with caplog.at_level(logging.WARNING):
-            kpf2 = bc.perform(
-                use_wmko_fallback=True
-            )  # override the toggle for this call
-        assert "ConnectionError" in caplog.text
-
-        astrsrc = kpf2.headers["RECEIPT"].get("ASTRSRC")
-        assert astrsrc == "WMKO header"
-        assert bc._astrometry_source == "WMKO header"
 
     def test_real_outlier_filter_runs_end_to_end(self, synthetic_kpf2, monkeypatch):
         """Exercise fix_expmeter_outliers=True through perform() with a
@@ -1024,14 +952,10 @@ class TestPerform:
             "2024-01-01T01:00:00.000"
         )
 
-        def mock_query(self):
-            return _fake_skycoord()
-
-        def mock_compute(skycoord, obs_times, location, rv_mps=0.0):
+        def mock_compute(astrometry, obs_times, location, rv_mps=0.0):
             n = len(np.atleast_1d(obs_times.jd))
             return np.full(n, 1000.0), np.atleast_1d(obs_times.jd)
 
-        monkeypatch.setattr(BarycentricCorrection, "_gaia_astrometry", mock_query)
         monkeypatch.setattr(
             BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
         )
@@ -1053,11 +977,11 @@ class TestConstructor:
 
 
 class TestMissingHeader:
-    """perform() should fail loudly when required INSTRUMENT_HEADER keys are absent."""
+    """perform() should fail loudly when required header keys are absent."""
 
-    def test_missing_gaiaid_raises(self, synthetic_kpf2, monkeypatch):
+    def test_missing_catalog_cards_raises(self, synthetic_kpf2, monkeypatch):
         # Stub _fix_expmeter_outliers so we don't hit the griddata degeneracy
-        # before reaching the GAIAID lookup.
+        # before reaching the catalog-card lookup.
         def passthrough(f, kernel_size=5):
             return f.copy()
 
@@ -1065,11 +989,9 @@ class TestMissingHeader:
             BarycentricCorrection, "_fix_expmeter_outliers", staticmethod(passthrough)
         )
 
-        del synthetic_kpf2.headers["INSTRUMENT_HEADER"]["GAIAID"]
+        del synthetic_kpf2.headers["PRIMARY"]["CRA3"]
         bc = BarycentricCorrection(synthetic_kpf2)
-        # With the WMKO fallback disabled (default), the Gaia-side KeyError is
-        # surfaced inside the "no target astrometry" error.
-        with pytest.raises(ValueError, match="GAIAID"):
+        with pytest.raises(ValueError, match="CRA3"):
             bc.perform()
 
     def test_missing_date_beg_raises_when_extrapolating(self, synthetic_kpf2):

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -167,7 +167,7 @@ def header_kpf2():
     """KPF2 with only the header keywords the build/dispatch helpers need."""
     kpf2 = KPF2()
     kpf2.headers["INSTRUMENT_HEADER"]["TARGTEFF"] = 5772.0
-    kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = 0.0
+    kpf2.headers["PRIMARY"]["CRV3"] = 0.0
     kpf2.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = "Target"
     kpf2.headers["INSTRUMENT_HEADER"]["SKY-OBJ"] = "Sky"
     kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = "None"
@@ -218,7 +218,7 @@ class TestDispatch:
             CrossCorrelation(header_kpf2)._resolve_illumination_source("GREEN", "CAL")
 
     def test_settings_target(self, header_kpf2):
-        header_kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = 11.1  # SCI-OBJ='Target'
+        header_kpf2.headers["PRIMARY"]["CRV3"] = 11.1  # SCI-OBJ='Target'
         s = CrossCorrelation(header_kpf2)._resolve_illumination_source("GREEN", "SCI2")
         assert s == {
             "object": "target",
@@ -293,10 +293,17 @@ class TestStellarMaskName:
         with pytest.raises(ValueError, match="TARGTEFF"):
             CrossCorrelation(header_kpf2)._resolve_stellar_mask()
 
-    def test_missing_targradv_raises(self, header_kpf2):
-        del header_kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"]
-        with pytest.raises(ValueError, match="TARGRADV"):
+    def test_missing_crv_raises(self, header_kpf2):
+        """No default to 0: a grid centered on the wrong velocity misses the star."""
+        del header_kpf2.headers["PRIMARY"]["CRV3"]
+        with pytest.raises(ValueError, match="CRV3"):
             CrossCorrelation(header_kpf2)._get_systemic_rv()
+
+    def test_ignores_instrument_header_targradv(self, header_kpf2):
+        """The canonical catalog rv wins; the raw DCS value is no longer consulted."""
+        header_kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = -42.0
+        header_kpf2.headers["PRIMARY"]["CRV3"] = 7.5
+        assert CrossCorrelation(header_kpf2)._get_systemic_rv() == pytest.approx(7.5)
 
 
 class TestBuildLineMask:
@@ -329,9 +336,7 @@ class TestBuildLineMask:
 
 class TestBuildVelocityGrid:
     def test_centered_on_systemic_rv(self, header_kpf2):
-        header_kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = (
-            10.0  # SCI2 grid center = TARGRADV
-        )
+        header_kpf2.headers["PRIMARY"]["CRV3"] = 10.0  # SCI2 grid center = CRV3
         grid = CrossCorrelation(header_kpf2)._build_velocity_grid("GREEN", "SCI2")
         assert grid.mean() == pytest.approx(10.0)
 
@@ -365,7 +370,7 @@ def _build_cc_kpf2():
     shifted by _V_INJECT) for every orderlet and zero barycentric correction."""
     kpf2 = KPF2()
     kpf2.headers["INSTRUMENT_HEADER"]["TARGTEFF"] = 5772.0
-    kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = 0.0
+    kpf2.headers["PRIMARY"]["CRV3"] = 0.0
     # Illumination sources: SCI on a star, SKY on sky, CAL dark (skipped).
     kpf2.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = "Target"
     kpf2.headers["INSTRUMENT_HEADER"]["SKY-OBJ"] = "Sky"

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -218,3 +218,60 @@ class TestKPF0Provenance:
         fits.HDUList([primary]).writeto(fn, overwrite=True)
         with pytest.raises(ValueError, match="OFNAME absent"):
             KPF0.from_fits(fn)
+
+
+class TestKPF0CatalogRecord:
+    """The native wmko row of CATALOG_RECORD is populated at read from TARG*
+    (config/L0-headers.csv PopulatedBy = KPF0.from_fits) -- best-effort and never
+    fatal, so a malformed file still loads."""
+
+    _GOOD_TARG = {
+        "TARGRA": "12:00:00.00",
+        "TARGDEC": "+40:00:00.0",
+        "TARGFRAM": "FK5",
+        "TARGEQUI": 2000.0,
+        "TARGPMRA": 0.0,
+        "TARGPMDC": 0.0,
+        "TARGPLAX": 100.0,
+        "TARGEPOC": 2000.0,
+    }
+
+    def _l0_with_targ(self, tmp_path, **targ):
+        fn = str(tmp_path / "KP.20240405.00001.00.fits")
+        primary = fits.PrimaryHDU()
+        primary.header["INSTRUME"] = "KPF"
+        primary.header["DATE-OBS"] = "2024-04-05T00:00:01"
+        primary.header["OFNAME"] = "KP.20240405.00001.00.fits"
+        primary.header["OBJECT"] = "testtarget"
+        for key, value in targ.items():
+            primary.header[key] = value
+        fits.HDUList([primary]).writeto(fn, overwrite=True)
+        return fn
+
+    def test_wmko_row_populated_from_targ(self, tmp_path):
+        """Well-formed TARG* -> WMKOCR=1 and a converted wmko row (h->deg, etc.)."""
+        l0 = KPF0.from_fits(self._l0_with_targ(tmp_path, **self._GOOD_TARG))
+        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
+        table = l0.data["CATALOG_RECORD"]
+        wmko = table[table["source"] == "wmko"][0]
+        assert wmko["ra"] == pytest.approx(180.0)  # 12h -> 180 deg
+        assert wmko["dec"] == pytest.approx(40.0)
+        assert wmko["source_id"] == "testtarget"
+
+    def test_no_target_sets_flag_zero_silently(self, tmp_path, caplog):
+        """A frame with no TARGRA (calibration) -> WMKOCR=0, no row, no warning."""
+        with caplog.at_level(logging.WARNING):
+            l0 = KPF0.from_fits(self._l0_with_targ(tmp_path))
+        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 0
+        assert len(l0.data["CATALOG_RECORD"]) == 0
+        assert "CATALOG_RECORD" not in caplog.text
+
+    def test_malformed_targ_warns_and_loads(self, tmp_path, caplog):
+        """Unparseable TARG* astrometry warns, sets WMKOCR=0 (no row), and the file
+        still loads (no raise)."""
+        targ = {**self._GOOD_TARG, "TARGDEC": "not-a-coordinate"}
+        with caplog.at_level(logging.WARNING):
+            l0 = KPF0.from_fits(self._l0_with_targ(tmp_path, **targ))
+        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 0
+        assert len(l0.data["CATALOG_RECORD"]) == 0
+        assert "could not build wmko CATALOG_RECORD" in caplog.text

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -221,58 +221,24 @@ class TestKPF0Provenance:
 
 
 class TestKPF0CatalogRecord:
-    """The native wmko row of CATALOG_RECORD is populated at read from TARG*
-    (config/L0-headers.csv PopulatedBy = KPF0.from_fits) -- best-effort and never
-    fatal, so a malformed file still loads."""
+    """KPF0.read() creates the CATALOG_RECORD extension but no longer populates it --
+    AstroQuery is its sole populator (the native wmko row moved to
+    AstroQuery.read_wmko_header; see test_astro_query.py)."""
 
-    _GOOD_TARG = {
-        "TARGRA": "12:00:00.00",
-        "TARGDEC": "+40:00:00.0",
-        "TARGFRAM": "FK5",
-        "TARGEQUI": 2000.0,
-        "TARGPMRA": 0.0,
-        "TARGPMDC": 0.0,
-        "TARGPLAX": 100.0,
-        "TARGEPOC": 2000.0,
-    }
-
-    def _l0_with_targ(self, tmp_path, **targ):
+    def test_read_leaves_catalog_record_empty(self, tmp_path):
+        """A raw L0 read (even with TARG* present) leaves CATALOG_RECORD empty and
+        unflagged until AstroQuery runs."""
         fn = str(tmp_path / "KP.20240405.00001.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
-        primary.header["DATE-OBS"] = "2024-04-05T00:00:01"
         primary.header["OFNAME"] = "KP.20240405.00001.00.fits"
         primary.header["OBJECT"] = "testtarget"
-        for key, value in targ.items():
-            primary.header[key] = value
+        primary.header["IMTYPE"] = "Object"
+        primary.header["TARGRA"] = "12:00:00.00"
+        primary.header["TARGDEC"] = "+40:00:00.0"
         fits.HDUList([primary]).writeto(fn, overwrite=True)
-        return fn
 
-    def test_wmko_row_populated_from_targ(self, tmp_path):
-        """Well-formed TARG* -> WMKOCR=1 and a wmko row sanitized to the EPRV C*#
-        format (RA/Dec sexagesimal strings, PM arcsec/yr)."""
-        l0 = KPF0.from_fits(self._l0_with_targ(tmp_path, **self._GOOD_TARG))
-        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
-        table = l0.data["CATALOG_RECORD"]
-        wmko = table[table["source"] == "wmko"][0]
-        assert wmko["ra"] == "12:00:00.0000"  # RA hour-angle sexagesimal
-        assert wmko["dec"] == "+40:00:00.000"
-        assert wmko["object"] == "testtarget"
-
-    def test_no_target_sets_flag_zero_silently(self, tmp_path, caplog):
-        """A frame with no TARGRA (calibration) -> WMKOCR=0, no row, no warning."""
-        with caplog.at_level(logging.WARNING):
-            l0 = KPF0.from_fits(self._l0_with_targ(tmp_path))
-        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 0
+        l0 = KPF0.from_fits(fn)
+        assert "CATALOG_RECORD" in l0.extensions
         assert len(l0.data["CATALOG_RECORD"]) == 0
-        assert "CATALOG_RECORD" not in caplog.text
-
-    def test_malformed_targ_warns_and_loads(self, tmp_path, caplog):
-        """Unparseable TARG* astrometry warns, sets WMKOCR=0 (no row), and the file
-        still loads (no raise)."""
-        targ = {**self._GOOD_TARG, "TARGDEC": "not-a-coordinate"}
-        with caplog.at_level(logging.WARNING):
-            l0 = KPF0.from_fits(self._l0_with_targ(tmp_path, **targ))
-        assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 0
-        assert len(l0.data["CATALOG_RECORD"]) == 0
-        assert "could not build wmko CATALOG_RECORD" in caplog.text
+        assert "WMKOCR" not in l0.headers["CATALOG_RECORD"]

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -223,13 +223,11 @@ class TestKPF0Provenance:
 
 
 class TestKPF0CatalogRecord:
-    """KPF0.read() creates the CATALOG_RECORD extension but no longer populates it --
-    AstroQuery is its sole populator (the native wmko row moved to
-    AstroQuery.read_wmko_header; see test_astro_query.py)."""
+    """KPF0.read() creates the CATALOG_RECORD extension but never populates it --
+    AstroQuery is its sole writer."""
 
     def test_read_leaves_catalog_record_empty(self, tmp_path):
-        """A raw L0 read (even with TARG* present) leaves CATALOG_RECORD empty and
-        unflagged until AstroQuery runs."""
+        """A raw L0 read, even with TARG* present, leaves it empty and unflagged."""
         fn = str(tmp_path / "KP.20240405.00001.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
@@ -250,9 +248,8 @@ class TestCatalogRecordMissingValues:
     """A missing CATALOG_RECORD value survives a FITS round-trip as NaN.
 
     Astropy's FITS reader returns a NaN float cell masked, and a masked cell is not
-    NaN (``np.isnan`` on one is falsy), so a missing-value check would read it as
-    present. ``KPFDataModel.from_fits`` fills those cells back to NaN for every
-    level; L0 is the vehicle here since it is where AstroQuery writes the table.
+    NaN, so a missing-value check would read it as present; ``KPFDataModel.from_fits``
+    fills those cells back. L0 is the vehicle -- it is where AstroQuery writes.
     """
 
     @staticmethod
@@ -277,9 +274,8 @@ class TestCatalogRecordMissingValues:
 
     def test_missing_value_leaves_catalog_card_blank(self, tmp_path):
         """The regression this normalization exists for: a masked cell defeats the
-        'skip missing' branch in KPF0._catalog_primary_cards, so the C*# card would
-        be written as the string 'nan' -- and the L1 write would then raise, since
-        FITS headers reject NaN."""
+        'skip missing' branch in KPF0._catalog_primary_cards, so the C*# card is
+        written as 'nan' and the L1 write then raises."""
         l0 = self._l0_written_and_read(tmp_path, rv=None)
         l1 = l0.to_kpf1()
         assert not l1.headers["PRIMARY"].get("CRV2")

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -15,6 +15,8 @@ from astropy.table import Table
 
 from kpfpipe.data_models.level0 import KPF0
 
+from ._catalog import catalog_record_table
+
 # synthetic_l0_file and synthetic_l0_minimal fixtures live in tests/conftest.py
 
 
@@ -242,3 +244,44 @@ class TestKPF0CatalogRecord:
         assert "CATALOG_RECORD" in l0.extensions
         assert len(l0.data["CATALOG_RECORD"]) == 0
         assert "WMKOCR" not in l0.headers["CATALOG_RECORD"]
+
+
+class TestCatalogRecordMissingValues:
+    """A missing CATALOG_RECORD value survives a FITS round-trip as NaN.
+
+    Astropy's FITS reader returns a NaN float cell masked, and a masked cell is not
+    NaN (``np.isnan`` on one is falsy), so a missing-value check would read it as
+    present. ``KPFDataModel.from_fits`` fills those cells back to NaN for every
+    level; L0 is the vehicle here since it is where AstroQuery writes the table.
+    """
+
+    @staticmethod
+    def _l0_written_and_read(tmp_path, rv):
+        fn = str(tmp_path / "KP.20240405.00002.00.fits")
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["INSTRUME"] = "KPF"
+        l0.headers["PRIMARY"]["OFNAME"] = "KP.20240405.00002.00.fits"
+        l0.headers["PRIMARY"]["IMTYPE"] = "Object"
+        l0.set_data("CATALOG_RECORD", catalog_record_table(rv=rv))
+        l0.to_fits(fn)
+        return KPF0.from_fits(fn)
+
+    def test_missing_value_reads_back_as_nan_not_masked(self, tmp_path):
+        row = self._l0_written_and_read(tmp_path, rv=None).data["CATALOG_RECORD"][0]
+        assert row["rv"] is not np.ma.masked
+        assert np.isnan(row["rv"])
+
+    def test_present_value_reads_back_unchanged(self, tmp_path):
+        row = self._l0_written_and_read(tmp_path, rv=-16.6).data["CATALOG_RECORD"][0]
+        assert row["rv"] == pytest.approx(-16.6)
+
+    def test_missing_value_leaves_catalog_card_blank(self, tmp_path):
+        """The regression this normalization exists for: a masked cell defeats the
+        'skip missing' branch in KPF0._catalog_primary_cards, so the C*# card would
+        be written as the string 'nan' -- and the L1 write would then raise, since
+        FITS headers reject NaN."""
+        l0 = self._l0_written_and_read(tmp_path, rv=None)
+        l1 = l0.to_kpf1()
+        assert not l1.headers["PRIMARY"].get("CRV2")
+        assert l1.headers["PRIMARY"]["CRA2"] == "01:44:04.0000"
+        l1.to_fits(str(tmp_path / "kpf_L1_20240405T000000.fits"))

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -249,14 +249,15 @@ class TestKPF0CatalogRecord:
         return fn
 
     def test_wmko_row_populated_from_targ(self, tmp_path):
-        """Well-formed TARG* -> WMKOCR=1 and a converted wmko row (h->deg, etc.)."""
+        """Well-formed TARG* -> WMKOCR=1 and a wmko row sanitized to the EPRV C*#
+        format (RA/Dec sexagesimal strings, PM arcsec/yr)."""
         l0 = KPF0.from_fits(self._l0_with_targ(tmp_path, **self._GOOD_TARG))
         assert l0.headers["CATALOG_RECORD"]["WMKOCR"] == 1
         table = l0.data["CATALOG_RECORD"]
         wmko = table[table["source"] == "wmko"][0]
-        assert wmko["ra"] == pytest.approx(180.0)  # 12h -> 180 deg
-        assert wmko["dec"] == pytest.approx(40.0)
-        assert wmko["source_id"] == "testtarget"
+        assert wmko["ra"] == "12:00:00.0000"  # RA hour-angle sexagesimal
+        assert wmko["dec"] == "+40:00:00.000"
+        assert wmko["object"] == "testtarget"
 
     def test_no_target_sets_flag_zero_silently(self, tmp_path, caplog):
         """A frame with no TARGRA (calibration) -> WMKOCR=0, no row, no warning."""

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -36,12 +36,13 @@ class TestKPF0:
         assert l0.level == 0
         assert l0.obs_id == "KP.20240113.00001.00"
         assert "PRIMARY" in l0.extensions
-        # Real KPF0 objects always carry QUALITY_CONTROL and RECEIPT extensions
-        # (RECEIPT is the registry home of the DRP-RUN provenance cards, stamped
-        # at read).
+        # Real KPF0 objects always carry QUALITY_CONTROL, RECEIPT, and CATALOG_RECORD
+        # extensions (RECEIPT is the registry home of the DRP-RUN provenance cards,
+        # stamped at read; CATALOG_RECORD holds AstroQuery's astrometry).
         assert "QUALITY_CONTROL" in l0.extensions
         assert "RECEIPT" in l0.extensions
-        assert len(l0.extensions) == 3
+        assert "CATALOG_RECORD" in l0.extensions
+        assert len(l0.extensions) == 4
 
     def test_round_trip(self, synthetic_l0_file, tmp_path):
         l0 = KPF0.from_fits(synthetic_l0_file)

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -18,6 +18,7 @@ from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.data_models.masters.base import KPFMasterModel
+from kpfpipe.modules.astro_query import AstroQuery
 
 # synthetic_l0_file, synthetic_l0_minimal, synthetic_l1_file fixtures live in
 # tests/conftest.py
@@ -316,7 +317,7 @@ class TestToKpf1:
         # network); to_kpf1 overlays it onto the SCI-fiber C*# cards.
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
-        l0.set_catalog_record("kpf-drp", record)
+        AstroQuery(l0)._write_catalog_record("kpf-drp", record)
         return l0
 
     def test_catalog_overlay_populates_sci_cards(self):
@@ -343,9 +344,21 @@ class TestToKpf1:
         assert not p.get("CRV2")
         assert p["CRA2"] == "12:00:00.0000"
 
-    def test_no_catalog_record_leaves_sci_cards_blank(self, synthetic_l0_file):
-        # No AstroQuery / no 'kpf-drp' row -> SCI C*# cards blank, never raw TARG*.
-        p = KPF0.from_fits(synthetic_l0_file).to_kpf1().headers["PRIMARY"]
+    def test_science_frame_without_catalog_raises(self):
+        # A science frame (IMTYPE Object) whose CATALOG_RECORD is empty means
+        # AstroQuery never ran -> to_kpf1 fails loudly rather than emitting blank
+        # (or raw TARG*) SCI cards.
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "Object"
+        with pytest.raises(ValueError, match="CATALOG_RECORD is empty"):
+            l0.to_kpf1()
+
+    def test_calibration_frame_without_catalog_leaves_sci_cards_blank(self):
+        # A calibration frame carries no target astrometry, so an empty
+        # CATALOG_RECORD is expected: to_kpf1 succeeds with blank SCI C*# cards.
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "Bias"
+        p = l0.to_kpf1().headers["PRIMARY"]
         for kw in ("CRA2", "CID2", "CSRC2", "CPMR2"):
             assert not p.get(kw)
 

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -9,6 +9,7 @@ import importlib.metadata
 import logging
 import re
 
+import astropy.units as u
 import numpy as np
 import pandas as pd
 import pytest
@@ -19,6 +20,7 @@ from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.data_models.masters.base import KPFMasterModel
 from kpfpipe.modules.astro_query import AstroQuery
+from kpfpipe.utils.astro import compute_redshift
 
 # synthetic_l0_file, synthetic_l0_minimal, synthetic_l1_file fixtures live in
 # tests/conftest.py
@@ -332,6 +334,7 @@ class TestToKpf1:
             assert p[f"CPMD{i}"] == -0.3
             assert p[f"CPLX{i}"] == 50.0
             assert p[f"CRV{i}"] == 10.0
+            assert p[f"CZ{i}"] == pytest.approx(compute_redshift(10.0 * u.km / u.s))
             assert p[f"CEPCH{i}"] == 2016.0
             assert p[f"CEQNX{i}"] == 2000.0
 
@@ -342,6 +345,7 @@ class TestToKpf1:
         p = self._l0_with_catalog(record).to_kpf1().headers["PRIMARY"]
         assert not p.get("CPLX2")
         assert not p.get("CRV2")
+        assert not p.get("CZ2")  # z derives from rv, so it is blank when rv is absent
         assert p["CRA2"] == "12:00:00.0000"
 
     def test_science_frame_without_catalog_warns_and_leaves_blank(self, caplog):

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -344,14 +344,18 @@ class TestToKpf1:
         assert not p.get("CRV2")
         assert p["CRA2"] == "12:00:00.0000"
 
-    def test_science_frame_without_catalog_raises(self):
+    def test_science_frame_without_catalog_warns_and_leaves_blank(self, caplog):
         # A science frame (IMTYPE Object) whose CATALOG_RECORD is empty means
-        # AstroQuery never ran -> to_kpf1 fails loudly rather than emitting blank
-        # (or raw TARG*) SCI cards.
+        # AstroQuery never ran. to_kpf1 succeeds with blank SCI C*# cards but warns
+        # that BarycentricCorrection and CrossCorrelation will fail downstream.
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
-        with pytest.raises(ValueError, match="CATALOG_RECORD is empty"):
-            l0.to_kpf1()
+        with caplog.at_level(logging.WARNING):
+            p = l0.to_kpf1().headers["PRIMARY"]
+        assert "CATALOG_RECORD is empty" in caplog.text
+        assert "will fail downstream" in caplog.text
+        for kw in ("CRA2", "CID2", "CSRC2", "CPMR2"):
+            assert not p.get(kw)
 
     def test_calibration_frame_without_catalog_leaves_sci_cards_blank(self):
         # A calibration frame carries no target astrometry, so an empty

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -271,9 +271,8 @@ class TestHeaderMapFiberRealignment:
         assert self._source("EXSNR5")[0] == "SNRSC852"
 
     def test_sci_catalog_source_cells_blanked(self):
-        # The SCI-fiber (2,3,4) catalog C*# cards are populated by the CATALOG_RECORD
-        # overlay in to_kpf1, so their raw TARG*/GAIAID header_map source cells are
-        # blanked (INSTRUMENT and DEFAULT both NaN). SKY(1)/CAL(5) defaults are intact.
+        # The SCI-fiber (2,3,4) catalog C*# cards come from to_kpf1's CATALOG_RECORD
+        # overlay, so their raw header_map source cells are blanked; SKY(1)/CAL(5) not.
         hm = KPF1.keyword_registry.header_map
         for base in ("CID", "CSRC", "CRA", "CDEC", "CPMR", "CRV", "CZ", "CLSRC"):
             for i in (2, 3, 4):
@@ -319,8 +318,7 @@ class TestToKpf1:
 
     @staticmethod
     def _l0_with_catalog(record):
-        # A science KPF0 carrying a canonical 'kpf-drp' CATALOG_RECORD row (no
-        # network); to_kpf1 overlays it onto the SCI-fiber C*# cards.
+        # A science KPF0 carrying a canonical 'kpf-drp' CATALOG_RECORD row, no network.
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
         AstroQuery(l0)._write_catalog_record("kpf-drp", record)
@@ -363,9 +361,8 @@ class TestToKpf1:
         assert p["CRA2"] == "12:00:00.0000"
 
     def test_science_frame_without_catalog_warns_and_leaves_blank(self, caplog):
-        # A science frame (IMTYPE Object) whose CATALOG_RECORD is empty means
-        # AstroQuery never ran. to_kpf1 succeeds with blank SCI C*# cards but warns
-        # that BarycentricCorrection and CrossCorrelation will fail downstream.
+        # An empty CATALOG_RECORD on a science frame means AstroQuery never ran:
+        # to_kpf1 succeeds with blank SCI C*# cards but warns about the downstream fail.
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
         with caplog.at_level(logging.WARNING):
@@ -536,18 +533,16 @@ class TestCatalogRecordPassthrough:
         return l0
 
     def test_rows_and_flags_reach_l1(self):
-        """Beyond the C*# overlay, the rows themselves ride forward: L1 keeps the
-        whole table (every source row, not just the merged one) and the presence
-        flags, so the resolved astrometry stays auditable downstream."""
+        """Beyond the C*# overlay, L1 keeps the whole table (every source row, not
+        just the merged one) and the flags, so the astrometry stays auditable."""
         l1 = self._l0_with_catalog().to_kpf1()
         assert [str(s) for s in l1.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
         assert l1.headers["CATALOG_RECORD"]["GAIACR"] == 1
 
     def test_catalog_record_roundtrip(self, tmp_path):
         """CATALOG_RECORD is registered in L1-extensions.csv, so an L1 carrying it
-        reads back (an unlisted extension raises 'Non-standard extension'). The
-        missing rv must read back NaN, not masked -- KPFDataModel.from_fits
-        normalizes at every level, not just L0."""
+        reads back (an unlisted extension raises 'Non-standard extension'), and the
+        missing rv reads back NaN, not masked."""
         fn = str(tmp_path / "kpf_L1_20240405T000000.fits")
         self._l0_with_catalog(rv=None).to_kpf1().to_fits(fn)
         back = KPF1.from_fits(fn)

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -10,6 +10,7 @@ import logging
 import re
 
 import numpy as np
+import pandas as pd
 import pytest
 from astropy.io import fits
 
@@ -264,6 +265,19 @@ class TestHeaderMapFiberRealignment:
         assert self._source("EXSNR1")[0] == "SNRSC452"
         assert self._source("EXSNR5")[0] == "SNRSC852"
 
+    def test_sci_catalog_source_cells_blanked(self):
+        # The SCI-fiber (2,3,4) catalog C*# cards are populated by the CATALOG_RECORD
+        # overlay in to_kpf1, so their raw TARG*/GAIAID header_map source cells are
+        # blanked (INSTRUMENT and DEFAULT both NaN). SKY(1)/CAL(5) defaults are intact.
+        hm = KPF1.keyword_registry.header_map
+        for base in ("CID", "CSRC", "CRA", "CDEC", "CPMR", "CRV", "CZ", "CLSRC"):
+            for i in (2, 3, 4):
+                r = hm[hm["STANDARD"].astype(str).str.strip() == f"{base}{i}"].iloc[0]
+                assert pd.isna(r["INSTRUMENT"]) and pd.isna(r["DEFAULT"])
+        assert self._source("CSRC1")[1] == "sky"  # SKY default intact
+        assert self._source("CRV5")[1] == "0"  # CAL default intact
+        assert self._source("CLSRC5")[0] == "CAL-OBJ"  # CAL native card intact
+
 
 class TestToKpf1:
     def test_to_kpf1_creates_kpf1(self, synthetic_l0_file):
@@ -278,6 +292,75 @@ class TestToKpf1:
         assert l1.headers["PRIMARY"]["INSTRUME"] == "KPF"
         assert l1.headers["PRIMARY"]["DATE-OBS"] == "2024-01-13T10:26:56"
         assert l1.headers["PRIMARY"]["OBJECT"] == "HD_10700"
+
+    # Canonical CATALOG_RECORD row (EPRV C*# format) overlaid onto the SCI cards.
+    _KPF_DRP = {
+        "object": "Gaia123",
+        "radec_src": "gaia",
+        "plx_src": "gaia",
+        "rv_src": "gaia",
+        "ra": "12:00:00.0000",
+        "dec": "+40:00:00.000",
+        "pmra": 0.5,
+        "pmdec": -0.3,
+        "parallax": 50.0,
+        "rv": 10.0,
+        "frame": "icrs",
+        "epoch": 2016.0,
+        "equinox": 2000.0,
+    }
+
+    @staticmethod
+    def _l0_with_catalog(record):
+        # A science KPF0 carrying a canonical 'kpf-drp' CATALOG_RECORD row (no
+        # network); to_kpf1 overlays it onto the SCI-fiber C*# cards.
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "Object"
+        l0.set_catalog_record("kpf-drp", record)
+        return l0
+
+    def test_catalog_overlay_populates_sci_cards(self):
+        # Direct copy of the canonical row onto every SCI fiber (2,3,4), no conversion.
+        p = self._l0_with_catalog(dict(self._KPF_DRP)).to_kpf1().headers["PRIMARY"]
+        for i in (2, 3, 4):
+            assert p[f"CID{i}"] == "Gaia123"
+            assert p[f"CSRC{i}"] == "gaia"
+            assert p[f"CRA{i}"] == "12:00:00.0000"
+            assert p[f"CDEC{i}"] == "+40:00:00.000"
+            assert p[f"CPMR{i}"] == 0.5
+            assert p[f"CPMD{i}"] == -0.3
+            assert p[f"CPLX{i}"] == 50.0
+            assert p[f"CRV{i}"] == 10.0
+            assert p[f"CEPCH{i}"] == 2016.0
+            assert p[f"CEQNX{i}"] == 2000.0
+
+    def test_catalog_overlay_skips_missing_optional(self):
+        # parallax/rv absent from the canonical row -> those cards stay blank; the
+        # coherent position block is still written.
+        record = {**self._KPF_DRP, "parallax": None, "rv": None}
+        p = self._l0_with_catalog(record).to_kpf1().headers["PRIMARY"]
+        assert not p.get("CPLX2")
+        assert not p.get("CRV2")
+        assert p["CRA2"] == "12:00:00.0000"
+
+    def test_no_catalog_record_leaves_sci_cards_blank(self, synthetic_l0_file):
+        # No AstroQuery / no 'kpf-drp' row -> SCI C*# cards blank, never raw TARG*.
+        p = KPF0.from_fits(synthetic_l0_file).to_kpf1().headers["PRIMARY"]
+        for kw in ("CRA2", "CID2", "CSRC2", "CPMR2"):
+            assert not p.get(kw)
+
+    def test_catalog_overlay_warns_on_mixed_sources(self, caplog):
+        # rv from a different catalog than the position -> WARNING at PRIMARY commit.
+        record = {**self._KPF_DRP, "rv_src": "simbad"}
+        with caplog.at_level(logging.WARNING):
+            self._l0_with_catalog(record).to_kpf1()
+        assert "mixed sources" in caplog.text
+
+    def test_catalog_overlay_single_source_no_warning(self, caplog):
+        # All provenance labels agree (gaia) -> no mixed-source warning.
+        with caplog.at_level(logging.WARNING):
+            self._l0_with_catalog(dict(self._KPF_DRP)).to_kpf1()
+        assert "mixed sources" not in caplog.text
 
     def test_to_kpf1_converts_native_to_eprv(self, synthetic_l0_file):
         """to_kpf1 renames WMKO natives to their EPRV PRIMARY counterparts."""

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -22,6 +22,8 @@ from kpfpipe.data_models.masters.base import KPFMasterModel
 from kpfpipe.modules.astro_query import AstroQuery
 from kpfpipe.utils.astro import compute_redshift
 
+from ._catalog import SOURCES, catalog_record_table
+
 # synthetic_l0_file, synthetic_l0_minimal, synthetic_l1_file fixtures live in
 # tests/conftest.py
 
@@ -516,6 +518,43 @@ class TestToKpf1:
         assert "GREEN_AMP1" not in l1.extensions
         assert "GREEN_AMP2" not in l1.extensions
         assert "RED_AMP1" not in l1.extensions
+
+
+class TestCatalogRecordPassthrough:
+    """AstroQuery's CATALOG_RECORD rows + presence flags ride L0 -> L1 unchanged.
+
+    (The L1 -> L2 and L2 -> L4 hops have the same class in
+    test_data_models_l{2,4}.py.)
+    """
+
+    @staticmethod
+    def _l0_with_catalog(rv=-16.6):
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["IMTYPE"] = "Object"
+        l0.set_data("CATALOG_RECORD", catalog_record_table(rv=rv))
+        l0.set_keyword("GAIACR", 1)
+        return l0
+
+    def test_rows_and_flags_reach_l1(self):
+        """Beyond the C*# overlay, the rows themselves ride forward: L1 keeps the
+        whole table (every source row, not just the merged one) and the presence
+        flags, so the resolved astrometry stays auditable downstream."""
+        l1 = self._l0_with_catalog().to_kpf1()
+        assert [str(s) for s in l1.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
+        assert l1.headers["CATALOG_RECORD"]["GAIACR"] == 1
+
+    def test_catalog_record_roundtrip(self, tmp_path):
+        """CATALOG_RECORD is registered in L1-extensions.csv, so an L1 carrying it
+        reads back (an unlisted extension raises 'Non-standard extension'). The
+        missing rv must read back NaN, not masked -- KPFDataModel.from_fits
+        normalizes at every level, not just L0."""
+        fn = str(tmp_path / "kpf_L1_20240405T000000.fits")
+        self._l0_with_catalog(rv=None).to_kpf1().to_fits(fn)
+        back = KPF1.from_fits(fn)
+        assert [str(s) for s in back.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
+        assert back.headers["CATALOG_RECORD"]["GAIACR"] == 1
+        rv = back.data["CATALOG_RECORD"][0]["rv"]
+        assert rv is not np.ma.masked and np.isnan(rv)
 
 
 class TestDrpStatus:

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -311,6 +311,8 @@ class TestToKpf1:
         "frame": "icrs",
         "epoch": 2016.0,
         "equinox": 2000.0,
+        "color": 1.23,
+        "color_name": "Gaia BP-RP",
     }
 
     @staticmethod
@@ -337,15 +339,25 @@ class TestToKpf1:
             assert p[f"CZ{i}"] == pytest.approx(compute_redshift(10.0 * u.km / u.s))
             assert p[f"CEPCH{i}"] == 2016.0
             assert p[f"CEQNX{i}"] == 2000.0
+            assert p[f"CCLR{i}"] == 1.23
+            assert p[f"CCLRN{i}"] == "Gaia BP-RP"
 
     def test_catalog_overlay_skips_missing_optional(self):
         # parallax/rv absent from the canonical row -> those cards stay blank; the
         # coherent position block is still written.
-        record = {**self._KPF_DRP, "parallax": None, "rv": None}
+        record = {
+            **self._KPF_DRP,
+            "parallax": None,
+            "rv": None,
+            "color": None,
+            "color_name": None,
+        }
         p = self._l0_with_catalog(record).to_kpf1().headers["PRIMARY"]
         assert not p.get("CPLX2")
         assert not p.get("CRV2")
         assert not p.get("CZ2")  # z derives from rv, so it is blank when rv is absent
+        assert not p.get("CCLR2")
+        assert not p.get("CCLRN2")
         assert p["CRA2"] == "12:00:00.0000"
 
     def test_science_frame_without_catalog_warns_and_leaves_blank(self, caplog):

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -24,6 +24,7 @@ from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.masters import KPFMasterL2
 from kpfpipe.data_models.masters.base import KPFMasterModel
 
+from ._catalog import SOURCES, catalog_record_table
 from ._dtype_policy import FLUX, WAVE, assert_dtype, assert_roundtrip_dtype
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
@@ -106,6 +107,54 @@ class TestKPF2QualityControlRoundTrip:
             back = KPF2.from_fits(fn)
         assert back.obs_id == "KP.20240101.00000.00"
         assert back.generate_standard_filename() == "kpf_SL2_20240101T000000.fits"
+
+
+class TestCatalogRecordPassthrough:
+    """CATALOG_RECORD rides L1 -> L2 and survives KPF2's RV2 read path.
+
+    Same mechanism as QUALITY_CONTROL above: register_rvdata_extension teaches
+    rvdata's definition-driven L2 reader about the KPF-only extension. (The L0 ->
+    L1 and L2 -> L4 hops have the same class in test_data_models_l{1,4}.py.)
+    """
+
+    @staticmethod
+    def _l1_with_catalog(rv=-16.6):
+        # KPF1 creates CATALOG_RECORD only on the L0 pass-through or a read (it is
+        # Required=False in L1-extensions.csv), so a bare L1 makes it explicitly.
+        l1 = KPF1()
+        l1.create_extension("CATALOG_RECORD", "BinTableHDU")
+        l1.set_data("CATALOG_RECORD", catalog_record_table(rv=rv))
+        l1.headers["CATALOG_RECORD"]["GAIACR"] = (1, "Catalog record present")
+        return l1
+
+    def test_rows_and_flags_reach_l2(self):
+        l2 = self._l1_with_catalog().to_kpf2()
+        assert [str(s) for s in l2.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
+        assert l2.headers["CATALOG_RECORD"]["GAIACR"] == 1
+
+    def test_catalog_record_roundtrip(self, tmp_path):
+        """The missing rv reads back NaN, not masked. L2 reads through rvdata's
+        RV2._read, so only the KPFDataModel.from_fits chokepoint can normalize it."""
+        l2 = self._l1_with_catalog(rv=None).to_kpf2()
+        fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            l2.to_fits(fn)
+            back = KPF2.from_fits(fn)
+        assert [str(s) for s in back.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
+        assert back.headers["CATALOG_RECORD"]["GAIACR"] == 1
+        rv = back.data["CATALOG_RECORD"][0]["rv"]
+        assert rv is not np.ma.masked and np.isnan(rv)
+
+    def test_empty_catalog_record_roundtrips(self, tmp_path):
+        """An L2 that never saw AstroQuery (empty table) still writes and reads."""
+        fn = str(tmp_path / "kpf_SL2_20240101T000001.fits")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            KPF2().to_fits(fn)
+            back = KPF2.from_fits(fn)
+        assert "CATALOG_RECORD" in back.extensions
+        assert len(back.data["CATALOG_RECORD"]) == 0
 
 
 class TestToKPF2:

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -113,8 +113,7 @@ class TestCatalogRecordPassthrough:
     """CATALOG_RECORD rides L1 -> L2 and survives KPF2's RV2 read path.
 
     Same mechanism as QUALITY_CONTROL above: register_rvdata_extension teaches
-    rvdata's definition-driven L2 reader about the KPF-only extension. (The L0 ->
-    L1 and L2 -> L4 hops have the same class in test_data_models_l{1,4}.py.)
+    rvdata's definition-driven L2 reader about the KPF-only extension.
     """
 
     @staticmethod
@@ -133,8 +132,8 @@ class TestCatalogRecordPassthrough:
         assert l2.headers["CATALOG_RECORD"]["GAIACR"] == 1
 
     def test_catalog_record_roundtrip(self, tmp_path):
-        """The missing rv reads back NaN, not masked. L2 reads through rvdata's
-        RV2._read, so only the KPFDataModel.from_fits chokepoint can normalize it."""
+        """The missing rv reads back NaN, not masked -- L2 reads through rvdata's
+        RV2._read, so only the from_fits chokepoint can normalize it."""
         l2 = self._l1_with_catalog(rv=None).to_kpf2()
         fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
         with warnings.catch_warnings():

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -15,6 +15,8 @@ from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.data_models.masters import KPFMasterL4
 
+from ._catalog import SOURCES, catalog_record_table
+
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
 NORDER_RED = DETECTOR["norder"]["RED"]
 NORDER = NORDER_GREEN + NORDER_RED
@@ -90,6 +92,40 @@ class TestToKPF4:
         back = KPF4.from_fits(str(path))
         assert "QUALITY_CONTROL" in back.extensions
         assert back.headers["QUALITY_CONTROL"].get("NANSCI1") == 7
+
+
+class TestCatalogRecordPassthrough:
+    """CATALOG_RECORD rides L2 -> L4 and survives KPF4's RV4 read path.
+
+    (The L0 -> L1 and L1 -> L2 hops have the same class in
+    test_data_models_l{1,2}.py.)
+    """
+
+    @staticmethod
+    def _l2_with_catalog():
+        kpf2 = KPF2()
+        kpf2.set_data("CATALOG_RECORD", catalog_record_table())
+        kpf2.headers["CATALOG_RECORD"]["GAIACR"] = (1, "Catalog record present")
+        return kpf2
+
+    def test_kpf4_has_catalog_record_extension(self):
+        # Like QUALITY_CONTROL: RV4 does not create it, so KPF4 must, giving
+        # to_kpf4's pass-through a destination.
+        assert "CATALOG_RECORD" in KPF4().extensions
+
+    def test_rows_and_flags_reach_l4(self):
+        """The catalog rows (not just the flags) are copied onto L4, so the resolved
+        astrometry stays with the RV product it fed."""
+        kpf4 = self._l2_with_catalog().to_kpf4()
+        assert [str(s) for s in kpf4.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
+        assert kpf4.headers["CATALOG_RECORD"]["GAIACR"] == 1
+
+    def test_catalog_record_roundtrip(self, tmp_path):
+        path = tmp_path / "rt_l4_catalog.fits"
+        self._l2_with_catalog().to_kpf4().to_fits(str(path))
+        back = KPF4.from_fits(str(path))
+        assert [str(s) for s in back.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
+        assert back.headers["CATALOG_RECORD"]["GAIACR"] == 1
 
 
 class TestKPF4:

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -95,11 +95,7 @@ class TestToKPF4:
 
 
 class TestCatalogRecordPassthrough:
-    """CATALOG_RECORD rides L2 -> L4 and survives KPF4's RV4 read path.
-
-    (The L0 -> L1 and L1 -> L2 hops have the same class in
-    test_data_models_l{1,2}.py.)
-    """
+    """CATALOG_RECORD rides L2 -> L4 and survives KPF4's RV4 read path."""
 
     @staticmethod
     def _l2_with_catalog():
@@ -114,8 +110,8 @@ class TestCatalogRecordPassthrough:
         assert "CATALOG_RECORD" in KPF4().extensions
 
     def test_rows_and_flags_reach_l4(self):
-        """The catalog rows (not just the flags) are copied onto L4, so the resolved
-        astrometry stays with the RV product it fed."""
+        """The rows, not just the flags, are copied onto L4, so the astrometry stays
+        with the RV product it fed."""
         kpf4 = self._l2_with_catalog().to_kpf4()
         assert [str(s) for s in kpf4.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
         assert kpf4.headers["CATALOG_RECORD"]["GAIACR"] == 1

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -13,6 +13,7 @@ from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.level4 import KPF4
+from kpfpipe.modules.astro_query import AstroQuery
 from kpfpipe.quality_control.diagnostics import (
     DiagL0,
     DiagL1,
@@ -178,14 +179,17 @@ def _record_at(coord, **overrides):
 
 def _set_catalog_record(l0, records):
     """Write l0's CATALOG_RECORD extension + presence flags from a
-    {source: record-dict-or-None} mapping, via KPF0.set_catalog_record."""
+    {source: record-dict-or-None} mapping, via AstroQuery's writer."""
+    aq = AstroQuery(l0)
     for source, record in records.items():
-        l0.set_catalog_record(source, record)
+        aq._write_catalog_record(source, record)
 
 
 def _make_l0_pointing():
-    """A KPF0 with just an L0 PRIMARY pointing (RA/DEC/MJD-OBS), no catalog yet."""
+    """A KPF0 with just an L0 PRIMARY pointing (RA/DEC/MJD-OBS), no catalog yet.
+    IMTYPE 'Object' so AstroQuery (the CATALOG_RECORD writer) accepts it."""
     l0 = KPF0()
+    l0.headers["PRIMARY"]["IMTYPE"] = "Object"
     l0.headers["PRIMARY"]["RA"] = _PT_RA
     l0.headers["PRIMARY"]["DEC"] = _PT_DEC
     l0.headers["PRIMARY"]["MJD-OBS"] = 60540.6

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -263,7 +263,9 @@ class TestDiagL0Contingency:
         assert "no gaia astrometry in CATALOG_RECORD" in caplog.text
 
     def test_incomplete_record_emits_empty(self, caplog):
-        # A record present (flag 1) but missing a field the offset needs (parallax).
+        # A record present (flag 1) but missing a required field (epoch, the
+        # propagation baseline) -> unusable, offset empty. PM/parallax are not
+        # required (they fall back to zero); see the fall-back tests below.
         l0 = _make_l0_pointing()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
         _set_catalog_record(
@@ -271,7 +273,7 @@ class TestDiagL0Contingency:
             {
                 "gaia": _record_at(pt),
                 "simbad": _record_at(pt),
-                "wmko": _record_at(pt, parallax=None),
+                "wmko": _record_at(pt, epoch=None),
             },
         )
         with caplog.at_level(logging.WARNING):
@@ -279,11 +281,11 @@ class TestDiagL0Contingency:
         assert results["TARGOFF"][0] is None
         assert "incomplete wmko record in CATALOG_RECORD" in caplog.text
 
-    @pytest.mark.parametrize("bad_plx", [0.0, -5.0])
-    def test_nonpositive_parallax_emits_empty(self, bad_plx, caplog):
-        # Gaia DR3 reports parallax <= 0 for faint sources; a distance can't be
-        # formed from it, so the source is unusable and the offset comes out empty
-        # rather than raising (ZeroDivisionError / negative distance).
+    @pytest.mark.parametrize("bad_plx", [None, 0.0, -5.0])
+    def test_missing_or_nonpositive_parallax_falls_back(self, bad_plx, caplog):
+        # Gaia DR3 reports parallax <= 0 (or none) for faint sources; the offset
+        # falls back to parallax=0 (no distance) rather than emitting empty, so a
+        # frame with a Gaia position but no parallax still gets a finite offset.
         l0 = _make_l0_pointing()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
         _set_catalog_record(
@@ -294,11 +296,35 @@ class TestDiagL0Contingency:
                 "wmko": _record_at(pt),
             },
         )
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             results = DiagL0(l0).run()
-        assert results["GAIAOFF"][0] is None
-        assert results["OBJOFF"][0] < 0.1
-        assert "incomplete gaia record in CATALOG_RECORD" in caplog.text
+        assert results["GAIAOFF"][0] < 0.1  # at the pointing -> ~0, not empty
+        assert "using PM=0, parallax=0" in caplog.text
+        # The fall-back is offset-local: CATALOG_RECORD keeps the original value.
+        tbl = l0.data["CATALOG_RECORD"]
+        stored = float(tbl[tbl["source"] == "gaia"]["parallax"][0])
+        if bad_plx is None:
+            assert np.isnan(stored)
+        else:
+            assert stored == pytest.approx(bad_plx)
+
+    def test_missing_pm_falls_back(self, caplog):
+        # A record with position + epoch but no proper motion still yields a finite
+        # offset (PM falls back to zero), not an empty one.
+        l0 = _make_l0_pointing()
+        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+        _set_catalog_record(
+            l0,
+            {
+                "gaia": _record_at(pt, pmra=None, pmdec=None),
+                "simbad": _record_at(pt),
+                "wmko": _record_at(pt),
+            },
+        )
+        with caplog.at_level(logging.DEBUG):
+            results = DiagL0(l0).run()
+        assert results["GAIAOFF"][0] < 0.1
+        assert "using PM=0, parallax=0" in caplog.text
 
     def test_malformed_astrometry_emits_empty(self, caplog):
         # A record that passes the completeness check but is malformed (unparseable

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -13,6 +13,7 @@ from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level4 import KPF4
+from kpfpipe.modules.astro_query import AstroQuery
 from kpfpipe.quality_control.diagnostics import (
     DiagL0,
     DiagL1,
@@ -148,14 +149,14 @@ class TestEmptyLevels:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 -- pointing offsets from catalog_record (GAIAOFF, TARGOFF, OBJOFF)
+# DiagL0 -- pointing offsets from CATALOG_RECORD (GAIAOFF, TARGOFF, OBJOFF)
 # ---------------------------------------------------------------------------
 
 _PT_RA, _PT_DEC = "01:44:01.30", "-15:55:54.0"
 
 
 def _record_at(coord, **overrides):
-    """A canonical catalog_record record placed at ``coord`` (zero PM, finite plx)."""
+    """A canonical catalog record placed at ``coord`` (zero PM, finite plx)."""
     rec = {
         "source_id": "test",
         "ra": coord.ra.deg,
@@ -172,15 +173,32 @@ def _record_at(coord, **overrides):
     return rec
 
 
-def _make_l0_with_catalog():
-    """A KPF0 with L0 PRIMARY pointing and a fully-populated catalog_record whose
-    gaia/simbad/wmko records all sit at the pointing (all three offsets ~ 0)."""
+def _set_catalog_record(l0, records):
+    """Write l0's CATALOG_RECORD extension + presence flags from a
+    {source: record-dict-or-None} mapping, via AstroQuery's own output path."""
+    l0.headers["PRIMARY"]["IMTYPE"] = "Object"
+    aq = AstroQuery(l0)
+    aq._wmko = records.get("wmko")
+    aq._gaia = records.get("gaia")
+    aq._simbad = records.get("simbad")
+    aq._attach_catalog_record(l0)
+
+
+def _make_l0_pointing():
+    """A KPF0 with just an L0 PRIMARY pointing (RA/DEC/MJD-OBS), no catalog yet."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["RA"] = _PT_RA
     l0.headers["PRIMARY"]["DEC"] = _PT_DEC
     l0.headers["PRIMARY"]["MJD-OBS"] = 60540.6
+    return l0
+
+
+def _make_l0_with_catalog():
+    """A KPF0 with L0 PRIMARY pointing and a fully-populated CATALOG_RECORD whose
+    gaia/simbad/wmko records all sit at the pointing (all three offsets ~ 0)."""
+    l0 = _make_l0_pointing()
     pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-    l0.catalog_record = {src: _record_at(pt) for src in ("gaia", "simbad", "wmko")}
+    _set_catalog_record(l0, {src: _record_at(pt) for src in ("gaia", "simbad", "wmko")})
     return l0
 
 
@@ -196,10 +214,15 @@ class TestDiagL0Offsets:
     def test_offset_reflects_catalog_separation(self):
         # Move the Gaia record 10" north of the pointing -> GAIAOFF ~ 10", while
         # the still-at-pointing wmko record keeps TARGOFF ~ 0.
-        l0 = _make_l0_with_catalog()
+        l0 = _make_l0_pointing()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-        l0.catalog_record["gaia"] = _record_at(
-            pt.directional_offset_by(0 * u.deg, 10 * u.arcsec)
+        _set_catalog_record(
+            l0,
+            {
+                "gaia": _record_at(pt.directional_offset_by(0 * u.deg, 10 * u.arcsec)),
+                "simbad": _record_at(pt),
+                "wmko": _record_at(pt),
+            },
         )
         results = DiagL0(l0).run()
         assert results["GAIAOFF"][0] == pytest.approx(10.0, abs=0.1)
@@ -212,39 +235,46 @@ class TestDiagL0Contingency:
     _KEYS = ("GAIAOFF", "TARGOFF", "OBJOFF")
 
     def test_no_catalog_record_all_empty(self, caplog):
-        # AstroQuery not run: no catalog_record attribute at all.
-        l0 = KPF0()
-        l0.headers["PRIMARY"]["RA"] = _PT_RA
-        l0.headers["PRIMARY"]["DEC"] = _PT_DEC
-        l0.headers["PRIMARY"]["MJD-OBS"] = 60540.6
+        # AstroQuery not run: CATALOG_RECORD auto-created but no presence flags.
+        l0 = _make_l0_pointing()
         with caplog.at_level(logging.WARNING):
             DiagL0(l0).run()
         qc = l0.headers["QUALITY_CONTROL"]
         # All three present (registered) but valueless (read back as None).
         for key in self._KEYS:
             assert key in qc and qc[key] is None
-        assert caplog.text.count("no catalog_record on L0") == 3
+        assert caplog.text.count("no CATALOG_RECORD flags on L0") == 3
 
     def test_source_none_emits_empty_for_that_source(self, caplog):
-        # Gaia lookup disabled/failed -> GAIAOFF empty; wmko/simbad still compute.
-        l0 = _make_l0_with_catalog()
-        l0.catalog_record["gaia"] = None
+        # Gaia lookup disabled/failed -> GAIACR=0 -> GAIAOFF empty; others compute.
+        l0 = _make_l0_pointing()
+        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+        _set_catalog_record(
+            l0, {"gaia": None, "simbad": _record_at(pt), "wmko": _record_at(pt)}
+        )
         with caplog.at_level(logging.WARNING):
             results = DiagL0(l0).run()
         assert results["GAIAOFF"][0] is None
         assert results["TARGOFF"][0] < 0.1
         assert results["OBJOFF"][0] < 0.1
-        assert "no gaia astrometry in catalog_record" in caplog.text
+        assert "no gaia astrometry in CATALOG_RECORD" in caplog.text
 
     def test_incomplete_record_emits_empty(self, caplog):
-        # A record present but missing a field the offset needs (e.g. parallax).
-        l0 = _make_l0_with_catalog()
+        # A record present (flag 1) but missing a field the offset needs (parallax).
+        l0 = _make_l0_pointing()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-        l0.catalog_record["wmko"] = _record_at(pt, parallax=None)
+        _set_catalog_record(
+            l0,
+            {
+                "gaia": _record_at(pt),
+                "simbad": _record_at(pt),
+                "wmko": _record_at(pt, parallax=None),
+            },
+        )
         with caplog.at_level(logging.WARNING):
             results = DiagL0(l0).run()
         assert results["TARGOFF"][0] is None
-        assert "incomplete wmko record" in caplog.text
+        assert "incomplete wmko record in CATALOG_RECORD" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -279,6 +279,45 @@ class TestDiagL0Contingency:
         assert results["TARGOFF"][0] is None
         assert "incomplete wmko record in CATALOG_RECORD" in caplog.text
 
+    @pytest.mark.parametrize("bad_plx", [0.0, -5.0])
+    def test_nonpositive_parallax_emits_empty(self, bad_plx, caplog):
+        # Gaia DR3 reports parallax <= 0 for faint sources; a distance can't be
+        # formed from it, so the source is unusable and the offset comes out empty
+        # rather than raising (ZeroDivisionError / negative distance).
+        l0 = _make_l0_pointing()
+        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+        _set_catalog_record(
+            l0,
+            {
+                "gaia": _record_at(pt, parallax=bad_plx),
+                "simbad": _record_at(pt),
+                "wmko": _record_at(pt),
+            },
+        )
+        with caplog.at_level(logging.WARNING):
+            results = DiagL0(l0).run()
+        assert results["GAIAOFF"][0] is None
+        assert results["OBJOFF"][0] < 0.1
+        assert "incomplete gaia record in CATALOG_RECORD" in caplog.text
+
+    def test_malformed_astrometry_emits_empty(self, caplog):
+        # A record that passes the completeness check but is malformed (unparseable
+        # RA) is caught by _offset's backstop -> empty offset, not a raised frame.
+        l0 = _make_l0_pointing()
+        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+        _set_catalog_record(
+            l0,
+            {
+                "gaia": _record_at(pt),
+                "simbad": _record_at(pt),
+                "wmko": _record_at(pt, ra="garbage"),
+            },
+        )
+        with caplog.at_level(logging.WARNING):
+            results = DiagL0(l0).run()  # must not raise
+        assert results["TARGOFF"][0] is None
+        assert "could not compute wmko pointing offset" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # DiagL1 -- master calibration ages

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -156,11 +156,14 @@ _PT_RA, _PT_DEC = "01:44:01.30", "-15:55:54.0"
 
 
 def _record_at(coord, **overrides):
-    """A canonical catalog record placed at ``coord`` (zero PM, finite plx)."""
+    """A canonical catalog record placed at ``coord`` (zero PM, finite plx), in the
+    EPRV C*# format: RA/Dec sexagesimal strings, PM arcsec/yr."""
     rec = {
-        "source_id": "test",
-        "ra": coord.ra.deg,
-        "dec": coord.dec.deg,
+        "object": "test",
+        "ra": coord.ra.to_string(unit=u.hourangle, sep=":", pad=True, precision=4),
+        "dec": coord.dec.to_string(
+            unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
+        ),
         "pmra": 0.0,
         "pmdec": 0.0,
         "parallax": 100.0,

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -206,6 +206,47 @@ class TestDiagL0Offsets:
         assert results["TARGOFF"][0] < 0.1
 
 
+class TestDiagL0Contingency:
+    """Unavailable astrometry -> present-but-empty offset + WARNING, no crash."""
+
+    _KEYS = ("GAIAOFF", "TARGOFF", "OBJOFF")
+
+    def test_no_catalog_query_all_empty(self, caplog):
+        # AstroQuery not run: no catalog_query attribute at all.
+        l0 = KPF0()
+        l0.headers["PRIMARY"]["RA"] = _PT_RA
+        l0.headers["PRIMARY"]["DEC"] = _PT_DEC
+        l0.headers["PRIMARY"]["MJD-OBS"] = 60540.6
+        with caplog.at_level(logging.WARNING):
+            DiagL0(l0).run()
+        qc = l0.headers["QUALITY_CONTROL"]
+        # All three present (registered) but valueless (read back as None).
+        for key in self._KEYS:
+            assert key in qc and qc[key] is None
+        assert caplog.text.count("no catalog_query on L0") == 3
+
+    def test_source_none_emits_empty_for_that_source(self, caplog):
+        # Gaia lookup disabled/failed -> GAIAOFF empty; wmko/simbad still compute.
+        l0 = _make_l0_with_catalog()
+        l0.catalog_query["gaia"] = None
+        with caplog.at_level(logging.WARNING):
+            results = DiagL0(l0).run()
+        assert results["GAIAOFF"][0] is None
+        assert results["TARGOFF"][0] < 0.1
+        assert results["OBJOFF"][0] < 0.1
+        assert "no gaia astrometry in catalog_query" in caplog.text
+
+    def test_incomplete_record_emits_empty(self, caplog):
+        # A record present but missing a field the offset needs (e.g. parallax).
+        l0 = _make_l0_with_catalog()
+        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+        l0.catalog_query["wmko"] = _record_at(pt, parallax=None)
+        with caplog.at_level(logging.WARNING):
+            results = DiagL0(l0).run()
+        assert results["TARGOFF"][0] is None
+        assert "incomplete wmko record" in caplog.text
+
+
 # ---------------------------------------------------------------------------
 # DiagL1 -- master calibration ages
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -148,14 +148,14 @@ class TestEmptyLevels:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 -- pointing offsets from catalog_query (GAIAOFF, TARGOFF, OBJOFF)
+# DiagL0 -- pointing offsets from catalog_record (GAIAOFF, TARGOFF, OBJOFF)
 # ---------------------------------------------------------------------------
 
 _PT_RA, _PT_DEC = "01:44:01.30", "-15:55:54.0"
 
 
 def _record_at(coord, **overrides):
-    """A canonical catalog_query record placed at ``coord`` (zero PM, finite plx)."""
+    """A canonical catalog_record record placed at ``coord`` (zero PM, finite plx)."""
     rec = {
         "source_id": "test",
         "ra": coord.ra.deg,
@@ -173,14 +173,14 @@ def _record_at(coord, **overrides):
 
 
 def _make_l0_with_catalog():
-    """A KPF0 with L0 PRIMARY pointing and a fully-populated catalog_query whose
+    """A KPF0 with L0 PRIMARY pointing and a fully-populated catalog_record whose
     gaia/simbad/wmko records all sit at the pointing (all three offsets ~ 0)."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["RA"] = _PT_RA
     l0.headers["PRIMARY"]["DEC"] = _PT_DEC
     l0.headers["PRIMARY"]["MJD-OBS"] = 60540.6
     pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-    l0.catalog_query = {src: _record_at(pt) for src in ("gaia", "simbad", "wmko")}
+    l0.catalog_record = {src: _record_at(pt) for src in ("gaia", "simbad", "wmko")}
     return l0
 
 
@@ -198,7 +198,7 @@ class TestDiagL0Offsets:
         # the still-at-pointing wmko record keeps TARGOFF ~ 0.
         l0 = _make_l0_with_catalog()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-        l0.catalog_query["gaia"] = _record_at(
+        l0.catalog_record["gaia"] = _record_at(
             pt.directional_offset_by(0 * u.deg, 10 * u.arcsec)
         )
         results = DiagL0(l0).run()
@@ -211,8 +211,8 @@ class TestDiagL0Contingency:
 
     _KEYS = ("GAIAOFF", "TARGOFF", "OBJOFF")
 
-    def test_no_catalog_query_all_empty(self, caplog):
-        # AstroQuery not run: no catalog_query attribute at all.
+    def test_no_catalog_record_all_empty(self, caplog):
+        # AstroQuery not run: no catalog_record attribute at all.
         l0 = KPF0()
         l0.headers["PRIMARY"]["RA"] = _PT_RA
         l0.headers["PRIMARY"]["DEC"] = _PT_DEC
@@ -223,24 +223,24 @@ class TestDiagL0Contingency:
         # All three present (registered) but valueless (read back as None).
         for key in self._KEYS:
             assert key in qc and qc[key] is None
-        assert caplog.text.count("no catalog_query on L0") == 3
+        assert caplog.text.count("no catalog_record on L0") == 3
 
     def test_source_none_emits_empty_for_that_source(self, caplog):
         # Gaia lookup disabled/failed -> GAIAOFF empty; wmko/simbad still compute.
         l0 = _make_l0_with_catalog()
-        l0.catalog_query["gaia"] = None
+        l0.catalog_record["gaia"] = None
         with caplog.at_level(logging.WARNING):
             results = DiagL0(l0).run()
         assert results["GAIAOFF"][0] is None
         assert results["TARGOFF"][0] < 0.1
         assert results["OBJOFF"][0] < 0.1
-        assert "no gaia astrometry in catalog_query" in caplog.text
+        assert "no gaia astrometry in catalog_record" in caplog.text
 
     def test_incomplete_record_emits_empty(self, caplog):
         # A record present but missing a field the offset needs (e.g. parallax).
         l0 = _make_l0_with_catalog()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-        l0.catalog_query["wmko"] = _record_at(pt, parallax=None)
+        l0.catalog_record["wmko"] = _record_at(pt, parallax=None)
         with caplog.at_level(logging.WARNING):
             results = DiagL0(l0).run()
         assert results["TARGOFF"][0] is None

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -160,8 +160,8 @@ _CATALOG_SOURCES = ("wmko", "gaia", "simbad")
 
 
 def _record_at(coord, **overrides):
-    """A canonical catalog record placed at ``coord`` (zero PM, finite plx), in the
-    EPRV C*# format: RA/Dec sexagesimal strings, PM arcsec/yr."""
+    """A catalog record at ``coord`` (zero PM, finite plx) in EPRV C*# format:
+    RA/Dec sexagesimal strings, PM arcsec/yr."""
     rec = {
         "object": "test",
         "ra": coord.ra.to_string(unit=u.hourangle, sep=":", pad=True, precision=4),
@@ -181,10 +181,9 @@ def _record_at(coord, **overrides):
 
 
 def _set_catalog_record(l0, records):
-    """Write l0's CATALOG_RECORD extension + presence flags from a
-    {source: record-dict-or-None} mapping, the way perform does: the rows through
-    AstroQuery's writer, then every flag in one _set_headers pass. A source left out
-    of the mapping gets flag 0, exactly as a gated-off one does in production."""
+    """Write l0's CATALOG_RECORD rows + presence flags from a
+    {source: record-dict-or-None} mapping, the way perform does. A source left out of
+    the mapping gets flag 0, exactly as a gated-off one does in production."""
     aq = AstroQuery(l0)
     for source, record in records.items():
         aq._write_catalog_record(source, record)
@@ -195,7 +194,7 @@ def _set_catalog_record(l0, records):
 
 def _make_l0_pointing():
     """A KPF0 with just an L0 PRIMARY pointing (RA/DEC/MJD-OBS), no catalog yet.
-    IMTYPE 'Object' so AstroQuery (the CATALOG_RECORD writer) accepts it."""
+    IMTYPE 'Object' so AstroQuery accepts it."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["IMTYPE"] = "Object"
     l0.headers["PRIMARY"]["RA"] = _PT_RA
@@ -271,9 +270,8 @@ class TestDiagL0Contingency:
         assert "no gaia astrometry in CATALOG_RECORD" in caplog.text
 
     def test_incomplete_record_emits_empty(self, caplog):
-        # A record present (flag 1) but missing a required field (epoch, the
-        # propagation baseline) -> unusable, offset empty. PM/parallax are not
-        # required (they fall back to zero); see the fall-back tests below.
+        # A record present (flag 1) but missing epoch, the propagation baseline ->
+        # unusable, offset empty. PM/parallax instead fall back to zero (below).
         l0 = _make_l0_pointing()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
         _set_catalog_record(
@@ -291,9 +289,8 @@ class TestDiagL0Contingency:
 
     @pytest.mark.parametrize("bad_plx", [None, 0.0, -5.0])
     def test_missing_or_nonpositive_parallax_falls_back(self, bad_plx, caplog):
-        # Gaia DR3 reports parallax <= 0 (or none) for faint sources; the offset
-        # falls back to parallax=0 (no distance) rather than emitting empty, so a
-        # frame with a Gaia position but no parallax still gets a finite offset.
+        # Gaia DR3 reports parallax <= 0 (or none) for faint sources; the offset falls
+        # back to parallax=0 rather than emitting empty, so it stays finite.
         l0 = _make_l0_pointing()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
         _set_catalog_record(

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -13,7 +13,6 @@ from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level4 import KPF4
-from kpfpipe.modules.astro_query import AstroQuery
 from kpfpipe.quality_control.diagnostics import (
     DiagL0,
     DiagL1,
@@ -175,13 +174,9 @@ def _record_at(coord, **overrides):
 
 def _set_catalog_record(l0, records):
     """Write l0's CATALOG_RECORD extension + presence flags from a
-    {source: record-dict-or-None} mapping, via AstroQuery's own output path."""
-    l0.headers["PRIMARY"]["IMTYPE"] = "Object"
-    aq = AstroQuery(l0)
-    aq._wmko = records.get("wmko")
-    aq._gaia = records.get("gaia")
-    aq._simbad = records.get("simbad")
-    aq._attach_catalog_record(l0)
+    {source: record-dict-or-None} mapping, via KPF0.set_catalog_record."""
+    for source, record in records.items():
+        l0.set_catalog_record(source, record)
 
 
 def _make_l0_pointing():

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -155,6 +155,9 @@ class TestEmptyLevels:
 
 _PT_RA, _PT_DEC = "01:44:01.30", "-15:55:54.0"
 
+# The flag-carrying sources; 'kpf-drp' is the merged row and has no flag.
+_CATALOG_SOURCES = ("wmko", "gaia", "simbad")
+
 
 def _record_at(coord, **overrides):
     """A canonical catalog record placed at ``coord`` (zero PM, finite plx), in the
@@ -179,10 +182,15 @@ def _record_at(coord, **overrides):
 
 def _set_catalog_record(l0, records):
     """Write l0's CATALOG_RECORD extension + presence flags from a
-    {source: record-dict-or-None} mapping, via AstroQuery's writer."""
+    {source: record-dict-or-None} mapping, the way perform does: the rows through
+    AstroQuery's writer, then every flag in one _set_headers pass. A source left out
+    of the mapping gets flag 0, exactly as a gated-off one does in production."""
     aq = AstroQuery(l0)
     for source, record in records.items():
         aq._write_catalog_record(source, record)
+        if source in _CATALOG_SOURCES:
+            setattr(aq, f"_{source}", record)
+    aq._set_headers(l0)
 
 
 def _make_l0_pointing():

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -1,7 +1,6 @@
 """Tests for the Diagnostics framework and per-level subclasses."""
 
 import logging
-from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -141,18 +140,6 @@ class TestDiagnosticsBase:
 
 
 class TestEmptyLevels:
-    def _make_obj(self):
-        class _FakeObj:
-            headers = {"PRIMARY": {}}
-            data = {}
-
-        return _FakeObj()
-
-    def test_diag_l0_runs_cleanly(self):
-        # No RA/DEC/GAIAID -> GAIAOFF/TARGOFF both skip (fail-soft), no crash.
-        results = DiagL0(self._make_obj()).run()
-        assert results == {}
-
     def test_diag_l1_runs_cleanly(self):
         # DATE-OBS present (required) but no RECEIPT cal paths -> calibration_ages
         # returns {} (no crash). DATE-OBS itself is now a required read.
@@ -161,180 +148,62 @@ class TestEmptyLevels:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 -- pointing / identity offsets (GAIAOFF, TARGOFF)
+# DiagL0 -- pointing offsets from catalog_query (GAIAOFF, TARGOFF, OBJOFF)
 # ---------------------------------------------------------------------------
 
 _PT_RA, _PT_DEC = "01:44:01.30", "-15:55:54.0"
 
 
-def _make_l0_pointing(**overrides):
-    """A KPF0 with L0 PRIMARY pointing + DCS target + GAIAID natives.
-
-    Pass ``KEY=None`` to omit a native (used to exercise the skip paths).
-    """
-    prim = {
-        "RA": _PT_RA,
-        "DEC": _PT_DEC,
-        "MJD-OBS": 60540.6,
-        "GAIAID": "DR3 12345",
-        "TARGRA": _PT_RA,
-        "TARGDEC": _PT_DEC,
-        "TARGPMRA": 0.0,
-        "TARGPMDC": 0.0,
-        "TARGPLAX": 100.0,
-        "TARGFRAM": "FK5",
-        "TARGEPOC": 2000.0,
+def _record_at(coord, **overrides):
+    """A canonical catalog_query record placed at ``coord`` (zero PM, finite plx)."""
+    rec = {
+        "source_id": "test",
+        "ra": coord.ra.deg,
+        "dec": coord.dec.deg,
+        "pmra": 0.0,
+        "pmdec": 0.0,
+        "parallax": 100.0,
+        "rv": 0.0,
+        "frame": "icrs",
+        "epoch": 2016.0,
+        "equinox": 2000.0,
     }
-    prim.update(overrides)
+    rec.update(overrides)
+    return rec
+
+
+def _make_l0_with_catalog():
+    """A KPF0 with L0 PRIMARY pointing and a fully-populated catalog_query whose
+    gaia/simbad/wmko records all sit at the pointing (all three offsets ~ 0)."""
     l0 = KPF0()
-    for k, v in prim.items():
-        if v is not None:
-            l0.headers["PRIMARY"][k] = v
+    l0.headers["PRIMARY"]["RA"] = _PT_RA
+    l0.headers["PRIMARY"]["DEC"] = _PT_DEC
+    l0.headers["PRIMARY"]["MJD-OBS"] = 60540.6
+    pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
+    l0.catalog_query = {src: _record_at(pt) for src in ("gaia", "simbad", "wmko")}
     return l0
 
 
-def _fake_gaia_job(ra_deg, dec_deg):
-    """Stand-in for Gaia.launch_job: a one-row results Table, no network.
-
-    Zero proper motion so ``apply_space_motion`` leaves the position at
-    (ra_deg, dec_deg).
-    """
-    tbl = Table(
-        {
-            "ra": [ra_deg],
-            "dec": [dec_deg],
-            "pmra": [0.0],
-            "pmdec": [0.0],
-            "parallax": [100.0],
-            "ref_epoch": [2016.0],
-        }
-    )
-
-    class _Job:
-        def get_results(self):
-            return tbl
-
-    return _Job()
-
-
-class TestDiagL0Pointing:
-    def _gaia_at_pointing(self):
-        # Gaia source placed exactly at the pointing -> GAIAOFF ~ 0.
-        pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-        return _fake_gaia_job(pt.ra.deg, pt.dec.deg)
-
+class TestDiagL0Offsets:
     def test_offsets_written_to_quality_control(self):
-        l0 = _make_l0_pointing()
-        with patch(
-            "kpfpipe.quality_control.diagnostics.level0.Gaia.launch_job",
-            return_value=self._gaia_at_pointing(),
-        ):
-            results = DiagL0(l0).run()
-        # Pointing == target == Gaia position, so both offsets are ~0 (TARGOFF
-        # carries the ~23 mas ICRS<->FK5 frame bias); well under the 1" budget.
-        assert results["GAIAOFF"][0] < 0.1
-        assert results["TARGOFF"][0] < 0.1
-        # set_keyword routed both to QUALITY_CONTROL.
-        assert l0.headers["QUALITY_CONTROL"]["GAIAOFF"] == results["GAIAOFF"][0]
-        assert l0.headers["QUALITY_CONTROL"]["TARGOFF"] == results["TARGOFF"][0]
-
-    def test_skip_when_no_pointing(self):
-        # A calibration-like frame with no RA/DEC/target -> both metrics N/A.
-        l0 = _make_l0_pointing(RA=None, DEC=None, TARGRA=None, GAIAID=None)
+        # All three sources sit at the pointing -> every offset ~0, routed to QC.
+        l0 = _make_l0_with_catalog()
         results = DiagL0(l0).run()
-        assert "GAIAOFF" not in results
-        assert "TARGOFF" not in results
+        for key in ("GAIAOFF", "TARGOFF", "OBJOFF"):
+            assert results[key][0] < 0.1
+            assert l0.headers["QUALITY_CONTROL"][key] == results[key][0]
 
-    def test_skip_gaiaoff_when_no_gaiaid(self, caplog):
-        # Pointing + target present, GAIAID absent -> TARGOFF only, no warning.
-        l0 = _make_l0_pointing(GAIAID=None)
-        with caplog.at_level(logging.WARNING):
-            results = DiagL0(l0).run()
-        assert "GAIAOFF" not in results
-        assert "TARGOFF" in results
-        assert "GAIAOFF skipped" not in caplog.text
-
-    def test_gaia_failure_warns_and_skips(self, caplog):
-        # Gaia unreachable -> GAIAOFF warns and skips; the network-free TARGOFF
-        # still computes (fail-soft, so the L0 checkpoint does not fail).
-        l0 = _make_l0_pointing()
-        with (
-            patch(
-                "kpfpipe.quality_control.diagnostics.level0.Gaia.launch_job",
-                side_effect=ConnectionError("gaia down"),
-            ),
-            caplog.at_level(logging.WARNING),
-        ):
-            results = DiagL0(l0).run()
-        assert "GAIAOFF skipped" in caplog.text
-        assert "GAIAOFF" not in results
-        assert "TARGOFF" in results
-
-
-# ---------------------------------------------------------------------------
-# DiagL0 -- OBJECT-name offset via SIMBAD (OBJOFF)
-# ---------------------------------------------------------------------------
-
-
-def _fake_simbad(ra_deg=None, dec_deg=None, no_match=False):
-    """Stand-in for the Simbad class: Simbad() -> instance whose query_object
-    returns a one-row Table (astroquery 0.4.11 schema), or None for no match."""
-    instance = MagicMock()
-    if no_match:
-        instance.query_object.return_value = None
-    else:
-        instance.query_object.return_value = Table(
-            {
-                "ra": [ra_deg],
-                "dec": [dec_deg],
-                "pmra": [0.0],
-                "pmdec": [0.0],
-                "plx_value": [100.0],
-            }
-        )
-    return instance
-
-
-class TestDiagL0Object:
-    def test_object_offset_routed_to_quality_control(self):
-        # GAIAID absent -> GAIAOFF skips silently (no Gaia network); OBJECT set,
-        # SIMBAD placed at the pointing -> OBJOFF ~ 0, routed to QUALITY_CONTROL.
-        l0 = _make_l0_pointing(GAIAID=None)
-        l0.headers["PRIMARY"]["OBJECT"] = "10700"
+    def test_offset_reflects_catalog_separation(self):
+        # Move the Gaia record 10" north of the pointing -> GAIAOFF ~ 10", while
+        # the still-at-pointing wmko record keeps TARGOFF ~ 0.
+        l0 = _make_l0_with_catalog()
         pt = SkyCoord(_PT_RA, _PT_DEC, unit=(u.hourangle, u.deg))
-        with patch(
-            "kpfpipe.quality_control.diagnostics.level0.Simbad",
-            return_value=_fake_simbad(pt.ra.deg, pt.dec.deg),
-        ):
-            results = DiagL0(l0).run()
-        assert results["OBJOFF"][0] < 0.1
-        assert l0.headers["QUALITY_CONTROL"]["OBJOFF"] == results["OBJOFF"][0]
-
-    def test_object_name_hd_prefix(self):
-        # Bare-numeric OBJECT gets an 'HD ' prefix; named targets pass through.
-        l0 = _make_l0_pointing()
-        l0.headers["PRIMARY"]["OBJECT"] = "10700"
-        assert DiagL0(l0)._object_name() == "HD 10700"
-        l0.headers["PRIMARY"]["OBJECT"] = "tau Cet"
-        assert DiagL0(l0)._object_name() == "tau Cet"
-
-    def test_skip_when_no_object(self):
-        # No OBJECT native -> metric N/A, skip silently (no SIMBAD call).
-        l0 = _make_l0_pointing()  # helper sets no OBJECT
-        assert DiagL0(l0).object_ra_dec_offset() == {}
-
-    def test_simbad_no_match_warns_and_skips(self, caplog):
-        l0 = _make_l0_pointing()
-        l0.headers["PRIMARY"]["OBJECT"] = "NotARealStar"
-        with (
-            patch(
-                "kpfpipe.quality_control.diagnostics.level0.Simbad",
-                return_value=_fake_simbad(no_match=True),
-            ),
-            caplog.at_level(logging.WARNING),
-        ):
-            assert DiagL0(l0).object_ra_dec_offset() == {}
-        assert "OBJOFF skipped" in caplog.text
+        l0.catalog_query["gaia"] = _record_at(
+            pt.directional_offset_by(0 * u.deg, 10 * u.arcsec)
+        )
+        results = DiagL0(l0).run()
+        assert results["GAIAOFF"][0] == pytest.approx(10.0, abs=0.1)
+        assert results["TARGOFF"][0] < 0.1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_network.py
+++ b/tests/regression/test_network.py
@@ -43,7 +43,7 @@ class TestRetryRequest:
         assert func.call_count == 3
         assert sleep.call_count == 2
 
-    def test_exhausted_retries_raise_last_exception(self):
+    def test_exhausted_retries_raises_last_exception(self):
         func = MagicMock(side_effect=ConnectionError("still down"))
         with (
             _patch_sleep() as sleep,

--- a/tests/regression/test_network.py
+++ b/tests/regression/test_network.py
@@ -1,0 +1,95 @@
+"""Tests for the network retry helper in kpfpipe.utils.network.
+
+The network is never touched: every test drives ``retry_request`` with a MagicMock
+callable and patches ``time.sleep`` so the backoff schedule is inspected rather than
+waited out.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pyvo.dal import DALQueryError, DALServiceError
+
+from kpfpipe.utils.network import _RETRY_WAITS, retry_request
+
+
+def _patch_sleep():
+    """Patch the helper's time.sleep; the mock's call args are the backoff waits."""
+    return patch("kpfpipe.utils.network.time.sleep")
+
+
+def _slept(sleep_mock):
+    """The delays passed to the patched sleep, in order."""
+    return [call.args[0] for call in sleep_mock.call_args_list]
+
+
+class TestRetryRequest:
+    """Backoff schedule, transient/non-transient classification, and logging."""
+
+    def test_success_returns_immediately(self):
+        func = MagicMock(return_value="ok")
+        with _patch_sleep() as sleep:
+            assert retry_request(func, "Service") == "ok"
+        assert func.call_count == 1
+        assert sleep.call_count == 0
+
+    def test_retries_then_succeeds(self):
+        func = MagicMock(
+            side_effect=[ConnectionError("down"), ConnectionError("down"), "ok"]
+        )
+        with _patch_sleep() as sleep:
+            assert retry_request(func, "Service") == "ok"
+        assert func.call_count == 3
+        assert sleep.call_count == 2
+
+    def test_exhausted_retries_raise_last_exception(self):
+        func = MagicMock(side_effect=ConnectionError("still down"))
+        with (
+            _patch_sleep() as sleep,
+            pytest.raises(ConnectionError, match="still down"),
+        ):
+            retry_request(func, "Service")
+        # One attempt per wait, plus the final attempt outside the loop.
+        assert func.call_count == len(_RETRY_WAITS) + 1
+        assert sleep.call_count == len(_RETRY_WAITS)
+
+    @pytest.mark.parametrize(
+        "exc", [ValueError("bad input"), DALQueryError("malformed ADQL")]
+    )
+    def test_non_transient_exception_is_not_retried(self, exc):
+        # A bad query or bad input will never succeed on a second try, so it must
+        # fail at once rather than burn the full backoff.
+        func = MagicMock(side_effect=exc)
+        with _patch_sleep() as sleep, pytest.raises(type(exc)):
+            retry_request(func, "Service")
+        assert func.call_count == 1
+        assert sleep.call_count == 0
+
+    @pytest.mark.parametrize(
+        "exc", [TimeoutError("timed out"), OSError("reset"), DALServiceError("503")]
+    )
+    def test_transient_exception_types_are_retried(self, exc):
+        func = MagicMock(side_effect=[exc, "ok"])
+        with _patch_sleep():
+            assert retry_request(func, "Service") == "ok"
+        assert func.call_count == 2
+
+    def test_backoff_schedule_with_equal_jitter(self):
+        func = MagicMock(side_effect=ConnectionError("down"))
+        with _patch_sleep() as sleep, pytest.raises(ConnectionError):
+            retry_request(func, "Service")
+        delays = _slept(sleep)
+        assert len(delays) == len(_RETRY_WAITS)
+        # Equal jitter: half the nominal wait is fixed, the other half random.
+        for delay, wait in zip(delays, _RETRY_WAITS, strict=True):
+            assert wait / 2 <= delay <= wait
+        assert delays == sorted(delays)
+
+    def test_retry_logs_warning(self, caplog):
+        func = MagicMock(side_effect=[ConnectionError("down"), "ok"])
+        with _patch_sleep(), caplog.at_level(logging.WARNING):
+            retry_request(func, "Gaia DR3")
+        assert "Gaia DR3 request failed" in caplog.text
+        assert "ConnectionError" in caplog.text
+        assert "retrying in" in caplog.text

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -355,6 +355,20 @@ class TestQCBase:
         # A passing flag never warns.
         assert not any("CHKOK" in r.getMessage() for r in warnings)
 
+    def test_hdr_float_absent_empty_none_corrupt_raises(self):
+        # Absent and valueless cards degrade to None (checks skip/FAIL gracefully);
+        # a present-but-non-numeric card is malformed and raises (fail loud, so
+        # QC.run surfaces it) rather than being silently swallowed.
+        hdr = fits.Header()
+        hdr["NUM"] = 3.5
+        hdr["EMPTY"] = None  # present-but-empty (valueless) card
+        hdr["STR"] = "not-a-number"
+        assert QC._hdr_float(hdr, "NUM") == 3.5
+        assert QC._hdr_float(hdr, "MISSING") is None  # absent
+        assert QC._hdr_float(hdr, "EMPTY") is None  # valueless
+        with pytest.raises(ValueError):
+            QC._hdr_float(hdr, "STR")  # corrupt -> surfaces
+
 
 # ---------------------------------------------------------------------------
 # Task 3: QCL0 checks

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -357,8 +357,8 @@ class TestQCBase:
 
     def test_hdr_float_absent_empty_none_corrupt_raises(self):
         # Absent and valueless cards degrade to None (checks skip/FAIL gracefully);
-        # a present-but-non-numeric card is malformed and raises (fail loud, so
-        # QC.run surfaces it) rather than being silently swallowed.
+        # a present-but-non-numeric card is malformed, so it raises rather than
+        # being silently swallowed.
         hdr = fits.Header()
         hdr["NUM"] = 3.5
         hdr["EMPTY"] = None  # present-but-empty (valueless) card
@@ -619,12 +619,11 @@ class TestQCL0:
         assert QCL0.__dict__["radec_consistent"]._qc_key == "RADECOK"
 
     # --- catalog_values_sane (CATLOGOK): physical range of the canonical
-    # CATALOG_RECORD astrometry, ported from v2.12 quality_control.py TARG* checks
-    # onto the merged kpf-drp row (rather than the raw WMKO TARG* keywords).
+    # CATALOG_RECORD astrometry, the v2.12 TARG* checks moved onto the merged row.
 
     def _make_kpf0_with_canonical(self, tmp_path, **overrides):
         """KPF0 whose CATALOG_RECORD holds a merged 'kpf-drp' row; overrides patch
-        individual fields (epoch/equinox/rv/parallax/...) of a physically-sane base."""
+        individual fields of a physically-sane base."""
         from kpfpipe.modules.astro_query import AstroQuery
 
         l0 = _make_kpf0(tmp_path)
@@ -656,8 +655,8 @@ class TestQCL0:
         assert QCL0(l0).catalog_values_sane() is True
 
     def test_catalog_values_sane_fail_epoch_zero(self, tmp_path):
-        # The review's headline case: a WMKO TARGEPOC=0.0 placeholder that the merge
-        # gate (is-not-None) would pass. 0 <= 1950 -> out of range -> fail.
+        # A WMKO TARGEPOC=0.0 placeholder passes the merge's is-not-None gate, so the
+        # range check is what catches it.
         l0 = self._make_kpf0_with_canonical(tmp_path, epoch=0.0)
         assert QCL0(l0).catalog_values_sane() is False
 
@@ -699,8 +698,8 @@ class TestQCL0:
         assert QCL0(l0).catalog_values_sane() is True
 
     def test_catalog_values_sane_fail_parallax_negative(self, tmp_path):
-        # vNext addition beyond the legacy upper-bound-only check: a negative Gaia
-        # parallax (routine for faint sources) is nonphysical and must fail.
+        # A negative Gaia parallax (routine for faint sources) is nonphysical; the
+        # legacy check bounded only the upper end.
         l0 = self._make_kpf0_with_canonical(tmp_path, parallax=-0.3)
         assert QCL0(l0).catalog_values_sane() is False
 
@@ -719,7 +718,7 @@ class TestQCL0:
         assert QCL0(l0).catalog_values_sane() is True
 
     def test_catalog_values_sane_fail_pmra_too_large(self, tmp_path):
-        # vNext addition: a corrupt PM would misplace the source at the obs epoch.
+        # A corrupt PM would misplace the source at the obs epoch.
         l0 = self._make_kpf0_with_canonical(tmp_path, pmra=25.0)
         assert QCL0(l0).catalog_values_sane() is False
 

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -580,12 +580,23 @@ class TestQCL0:
 
     def test_radec_objoff_fail(self, tmp_path):
         l0 = _make_kpf0(tmp_path)
+        l0.set_keyword("TARGOFF", 0.02)  # internal pointing OK
         l0.set_keyword("OBJOFF", 6.0)  # > 5" pointing-vs-OBJECT
         assert QCL0(l0).radec_consistent() is False
 
-    def test_radec_absent_offsets_pass(self, tmp_path):
-        # A calibration-like frame writes no offsets -> nothing to check -> pass.
+    def test_radec_targoff_required_empty_fails(self, tmp_path):
+        # TARGOFF is internal pointing consistency: absent or present-but-empty fails.
         l0 = _make_kpf0(tmp_path)
+        assert QCL0(l0).radec_consistent() is False
+        l0.set_keyword("TARGOFF", None)  # present-but-empty (astrometry unavailable)
+        assert QCL0(l0).radec_consistent() is False
+
+    def test_radec_external_offsets_optional(self, tmp_path):
+        # TARGOFF within budget; GAIAOFF/OBJOFF unavailable (empty) -> still pass.
+        l0 = _make_kpf0(tmp_path)
+        l0.set_keyword("TARGOFF", 0.02)
+        l0.set_keyword("GAIAOFF", None)
+        l0.set_keyword("OBJOFF", None)
         assert QCL0(l0).radec_consistent() is True
 
     def test_radecok_key_present(self):

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -449,9 +449,11 @@ class TestQCL0:
         bad = dict(_GOOD_DATES, **{"DATE-MID": "2024-09-23T09:12:25.000"})  # mid > end
         assert QCL0(_make_kpf0(tmp_path, dates=bad)).times_consistent() is False
 
-    def test_times_duration_mismatch_fails(self, tmp_path):
+    def test_times_ignores_elapsed(self, tmp_path):
+        # DATTIMOK checks only DATE ordering now; a mismatched ELAPSED (validated by
+        # EXPTIMOK instead) no longer affects it.
         bad = dict(_GOOD_DATES, ELAPSED=99.0)  # END-BEG != ELAPSED
-        assert QCL0(_make_kpf0(tmp_path, dates=bad)).times_consistent() is False
+        assert QCL0(_make_kpf0(tmp_path, dates=bad)).times_consistent() is True
 
     def test_times_missing_keys_fail(self, tmp_path):
         # Raw L0 PRIMARY without DATE-BEG/MID/END -> cannot verify -> fail.
@@ -615,6 +617,118 @@ class TestQCL0:
 
     def test_radecok_key_present(self):
         assert QCL0.__dict__["radec_consistent"]._qc_key == "RADECOK"
+
+    # --- catalog_values_sane (CATLOGOK): physical range of the canonical
+    # CATALOG_RECORD astrometry, ported from v2.12 quality_control.py TARG* checks
+    # onto the merged kpf-drp row (rather than the raw WMKO TARG* keywords).
+
+    def _make_kpf0_with_canonical(self, tmp_path, **overrides):
+        """KPF0 whose CATALOG_RECORD holds a merged 'kpf-drp' row; overrides patch
+        individual fields (epoch/equinox/rv/parallax/...) of a physically-sane base."""
+        from kpfpipe.modules.astro_query import AstroQuery
+
+        l0 = _make_kpf0(tmp_path)
+        record = {
+            "object": "test",
+            "ra": "01:44:04.08",
+            "dec": "-15:56:14.9",
+            "pmra": 0.1,
+            "pmdec": -0.2,
+            "parallax": 100.0,
+            "rv": 10.0,
+            "frame": "icrs",
+            "epoch": 2016.0,
+            "equinox": 2000.0,
+        }
+        record.update(overrides)
+        AstroQuery(l0)._write_catalog_record("kpf-drp", record)
+        return l0
+
+    def test_catalog_values_sane_pass(self, tmp_path):
+        l0 = self._make_kpf0_with_canonical(tmp_path)
+        assert QCL0(l0).catalog_values_sane() is True
+
+    def test_catalog_values_sane_no_record_passes(self, tmp_path):
+        # Calibration/fresh L0: CATALOG_RECORD empty (AstroQuery never ran). Value
+        # sanity is N/A -> passes (presence is enforced elsewhere, not here).
+        l0 = _make_kpf0(tmp_path)
+        assert not l0.data["CATALOG_RECORD"].colnames
+        assert QCL0(l0).catalog_values_sane() is True
+
+    def test_catalog_values_sane_fail_epoch_zero(self, tmp_path):
+        # The review's headline case: a WMKO TARGEPOC=0.0 placeholder that the merge
+        # gate (is-not-None) would pass. 0 <= 1950 -> out of range -> fail.
+        l0 = self._make_kpf0_with_canonical(tmp_path, epoch=0.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_fail_epoch_high(self, tmp_path):
+        l0 = self._make_kpf0_with_canonical(tmp_path, epoch=2100.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_epoch_boundaries(self, tmp_path):
+        # Window is (1950, 2050]: 1950 fails (exclusive low), 2050 passes (inclusive).
+        assert (
+            QCL0(
+                self._make_kpf0_with_canonical(tmp_path, epoch=1950.0)
+            ).catalog_values_sane()
+            is False
+        )
+        assert (
+            QCL0(
+                self._make_kpf0_with_canonical(tmp_path, epoch=2050.0)
+            ).catalog_values_sane()
+            is True
+        )
+
+    def test_catalog_values_sane_fail_equinox_out_of_range(self, tmp_path):
+        l0 = self._make_kpf0_with_canonical(tmp_path, equinox=1900.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_rv_high_but_in_bound_passes(self, tmp_path):
+        # A fast star: |rv| = 150 is well within the 350 km/s bound (Chubak 2012).
+        l0 = self._make_kpf0_with_canonical(tmp_path, rv=150.0)
+        assert QCL0(l0).catalog_values_sane() is True
+
+    def test_catalog_values_sane_fail_rv_too_large(self, tmp_path):
+        l0 = self._make_kpf0_with_canonical(tmp_path, rv=400.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_rv_absent_passes(self, tmp_path):
+        # No catalog rv (NaN cell) -> the rv bound is skipped (check-when-present).
+        l0 = self._make_kpf0_with_canonical(tmp_path, rv=None)
+        assert QCL0(l0).catalog_values_sane() is True
+
+    def test_catalog_values_sane_fail_parallax_negative(self, tmp_path):
+        # vNext addition beyond the legacy upper-bound-only check: a negative Gaia
+        # parallax (routine for faint sources) is nonphysical and must fail.
+        l0 = self._make_kpf0_with_canonical(tmp_path, parallax=-0.3)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_fail_parallax_zero(self, tmp_path):
+        l0 = self._make_kpf0_with_canonical(tmp_path, parallax=0.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_fail_parallax_too_large(self, tmp_path):
+        # >= 1000 mas (< 1 pc) is unphysically close -- the legacy upper bound.
+        l0 = self._make_kpf0_with_canonical(tmp_path, parallax=1000.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_high_pm_in_bound_passes(self, tmp_path):
+        # Barnard's Star (~10.4"/yr, the highest real PM) is within the 15"/yr bound.
+        l0 = self._make_kpf0_with_canonical(tmp_path, pmra=10.4, pmdec=-8.0)
+        assert QCL0(l0).catalog_values_sane() is True
+
+    def test_catalog_values_sane_fail_pmra_too_large(self, tmp_path):
+        # vNext addition: a corrupt PM would misplace the source at the obs epoch.
+        l0 = self._make_kpf0_with_canonical(tmp_path, pmra=25.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catalog_values_sane_fail_pmdec_too_large(self, tmp_path):
+        l0 = self._make_kpf0_with_canonical(tmp_path, pmdec=-30.0)
+        assert QCL0(l0).catalog_values_sane() is False
+
+    def test_catlogok_key_present(self):
+        assert QCL0.__dict__["catalog_values_sane"]._qc_key == "CATLOGOK"
 
     def test_dataprl0_key_and_comment(self):
         fn = QCL0.__dict__["data_l0_red_green"]

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -30,12 +30,14 @@ _GOOD_DATES = {
 }
 
 
-def _write_l0_fixture(path, *, passing=True):
+def _write_l0_fixture(path, *, passing=True, imtype="Object"):
     """Write a minimal L0 FITS fixture at path.
 
     passing=True  → all QCL0 checks pass (valid header keywords, EXPTIME finite
                     and consistent with ELAPSED, amps present).
     passing=False → inject a failure (negative EXPTIME so EXPTIMOK fails).
+    imtype        → PRIMARY IMTYPE; a non-'Object' (calibration) frame carries no
+                    pointing/DCS target block, so qc.py skips AstroQuery for it.
     """
     primary = fits.PrimaryHDU()
     primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
@@ -45,23 +47,24 @@ def _write_l0_fixture(path, *, passing=True):
     primary.header["EXPTIME"] = 12.0 if passing else -1.0
     primary.header["OBJECT"] = "synthetic"
     primary.header["OFNAME"] = os.path.basename(path)
-    primary.header["IMTYPE"] = "Object"
+    primary.header["IMTYPE"] = imtype
     for k, v in _GOOD_DATES.items():
         primary.header[k] = v
 
-    # Pointing + DCS target (identical -> TARGOFF ~ 0) so AstroQuery resolves the
-    # wmko record and DiagL0's required TARGOFF is available offline; the external
-    # Gaia/SIMBAD lookups are disabled via config (see _write_astro_config).
-    primary.header["RA"] = "12:00:00.00"
-    primary.header["DEC"] = "+40:00:00.0"
-    primary.header["TARGRA"] = "12:00:00.00"
-    primary.header["TARGDEC"] = "+40:00:00.0"
-    primary.header["TARGFRAM"] = "FK5"
-    primary.header["TARGEQUI"] = 2000.0
-    primary.header["TARGPMRA"] = 0.0
-    primary.header["TARGPMDC"] = 0.0
-    primary.header["TARGPLAX"] = 100.0
-    primary.header["TARGEPOC"] = 2000.0
+    if imtype == "Object":
+        # Pointing + DCS target (identical -> TARGOFF ~ 0) so AstroQuery resolves the
+        # wmko record and DiagL0's required TARGOFF is available offline; the external
+        # Gaia/SIMBAD lookups are disabled via config (see _write_astro_config).
+        primary.header["RA"] = "12:00:00.00"
+        primary.header["DEC"] = "+40:00:00.0"
+        primary.header["TARGRA"] = "12:00:00.00"
+        primary.header["TARGDEC"] = "+40:00:00.0"
+        primary.header["TARGFRAM"] = "FK5"
+        primary.header["TARGEQUI"] = 2000.0
+        primary.header["TARGPMRA"] = 0.0
+        primary.header["TARGPMDC"] = 0.0
+        primary.header["TARGPLAX"] = 100.0
+        primary.header["TARGEPOC"] = 2000.0
 
     hdus = [primary]
     for chip in ["GREEN", "RED"]:
@@ -141,6 +144,23 @@ class TestQCScript:
         )
         assert "ISGOOD: FAIL" in result.stdout, (
             f"Expected 'ISGOOD: FAIL' in stdout:\n{result.stdout}"
+        )
+
+    def test_calibration_frame_skips_astroquery_no_exit_2(self, tmp_path):
+        """A calibration L0 (IMTYPE != 'Object') stays inspectable: qc.py skips
+        AstroQuery rather than erroring, so it never exits 2 on a cal frame."""
+        fixture = tmp_path / "KP.20240405.00005.00.fits"
+        _write_l0_fixture(str(fixture), passing=True, imtype="Bias")
+        cfg = _write_astro_config(tmp_path / "astro.toml")
+
+        result = _run_qc_script(fixture, level="L0", extra_args=["--config", str(cfg)])
+
+        assert result.returncode != 2, (
+            f"Calibration L0 should not exit 2\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "Skipping AstroQuery" in result.stdout, (
+            f"Expected AstroQuery-skip note in stdout:\n{result.stdout}"
         )
 
     def test_missing_file_exit_2(self, tmp_path):

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -35,6 +35,7 @@ def _write_l0_fixture(path, *, passing=True):
     """
     primary = fits.PrimaryHDU()
     primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
+    primary.header["MJD-OBS"] = 60405.04
     # Requested EXPTIME within tolerance of the elapsed time (_GOOD_DATES
     # ELAPSED = 12.07) so EXPTIMOK's ELAPSED-consistency check passes.
     primary.header["EXPTIME"] = 12.0 if passing else -1.0
@@ -43,6 +44,20 @@ def _write_l0_fixture(path, *, passing=True):
     primary.header["IMTYPE"] = "Object"
     for k, v in _GOOD_DATES.items():
         primary.header[k] = v
+
+    # Pointing + DCS target (identical -> TARGOFF ~ 0) so AstroQuery resolves the
+    # wmko record and DiagL0's required TARGOFF is available offline; the external
+    # Gaia/SIMBAD lookups are disabled via config (see _write_astro_config).
+    primary.header["RA"] = "12:00:00.00"
+    primary.header["DEC"] = "+40:00:00.0"
+    primary.header["TARGRA"] = "12:00:00.00"
+    primary.header["TARGDEC"] = "+40:00:00.0"
+    primary.header["TARGFRAM"] = "FK5"
+    primary.header["TARGEQUI"] = 2000.0
+    primary.header["TARGPMRA"] = 0.0
+    primary.header["TARGPMDC"] = 0.0
+    primary.header["TARGPLAX"] = 100.0
+    primary.header["TARGEPOC"] = 2000.0
 
     hdus = [primary]
     for chip in ["GREEN", "RED"]:
@@ -58,6 +73,19 @@ def _write_config(path, data_dirs):
     lines = ["[DATA_DIRS]"]
     lines += [f'{key} = "{value}"' for key, value in data_dirs.items()]
     path.write_text("\n".join(lines) + "\n")
+
+
+def _write_astro_config(path):
+    """A minimal config that disables AstroQuery's network lookups.
+
+    qc.py runs AstroQuery for L0; disabling Gaia/SIMBAD keeps these smoke tests
+    offline while the header-native wmko record still yields TARGOFF. get_params
+    requires the three sections to exist (empty is fine)."""
+    path.write_text(
+        "[DATA_DIRS]\n[TRACES]\n"
+        "[MODULE_ASTRO_QUERY]\nuse_gaia = false\nuse_simbad = false\n"
+    )
+    return path
 
 
 def _run_qc_script(fixture_path, level="L0", extra_args=None):
@@ -83,8 +111,9 @@ class TestQCScript:
         """All-good L0 → exit code 0, stdout contains 'ISGOOD: PASS'."""
         fixture = tmp_path / "KP.20240405.00001.00.fits"
         _write_l0_fixture(str(fixture), passing=True)
+        cfg = _write_astro_config(tmp_path / "astro.toml")
 
-        result = _run_qc_script(fixture, level="L0")
+        result = _run_qc_script(fixture, level="L0", extra_args=["--config", str(cfg)])
 
         assert result.returncode == 0, (
             f"Expected exit 0, got {result.returncode}\n"
@@ -98,8 +127,9 @@ class TestQCScript:
         """L0 with negative EXPTIME → exit code 1, stdout contains 'ISGOOD: FAIL'."""
         fixture = tmp_path / "KP.20240405.00002.00.fits"
         _write_l0_fixture(str(fixture), passing=False)
+        cfg = _write_astro_config(tmp_path / "astro.toml")
 
-        result = _run_qc_script(fixture, level="L0")
+        result = _run_qc_script(fixture, level="L0", extra_args=["--config", str(cfg)])
 
         assert result.returncode == 1, (
             f"Expected exit 1, got {result.returncode}\n"

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -87,7 +87,7 @@ def _write_astro_config(path):
     requires the three sections to exist (empty is fine)."""
     path.write_text(
         "[DATA_DIRS]\n[TRACES]\n"
-        "[MODULE_ASTRO_QUERY]\nuse_gaia = false\nuse_simbad = false\n"
+        "[MODULE_ASTRO_QUERY]\ndo_gaia_query = false\ndo_simbad_query = false\n"
     )
     return path
 

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -86,11 +86,12 @@ def _write_astro_config(path):
     """A minimal config that disables AstroQuery's network lookups.
 
     qc.py runs AstroQuery for L0; disabling Gaia/SIMBAD keeps these smoke tests
-    offline while the header-native wmko record still yields TARGOFF. get_params
-    requires the three sections to exist (empty is fine)."""
+    offline, so wmko -- the header-native row, the only one left -- must also be
+    the permitted astrometric base for the merge to succeed and TARGOFF to exist."""
     path.write_text(
         "[DATA_DIRS]\n[TRACES]\n"
         "[MODULE_ASTRO_QUERY]\ndo_gaia_query = false\ndo_simbad_query = false\n"
+        'astrometry_priority = ["wmko"]\n'
     )
     return path
 

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -87,7 +87,7 @@ def _make_l4(
     """
     kpf2 = KPF2()
     kpf2.headers["INSTRUMENT_HEADER"]["TARGTEFF"] = 5772.0
-    kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = 0.0
+    kpf2.headers["PRIMARY"]["CRV3"] = 0.0
     kpf2.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = sci_obj
     kpf2.headers["INSTRUMENT_HEADER"]["SKY-OBJ"] = sky_obj
     kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = cal_obj


### PR DESCRIPTION
  ## Summary
  
  External-catalog astrometry (Gaia / SIMBAD) and WMKO-TCS are currently resolved
  ad hoc across multiple modules, each issuing its own network query. This PR makes
  a new **`AstroQuery`** module the pipeline's single external-catalog client: it runs
  once at L0, resolves all three sources into a new `CATALOG_RECORD` extension, merges
  them into one canonical row, and overlays that row onto the EPRV `C*#` PRIMARY cards.
  `BarycentricCorrection` and `CrossCorrelation` are rewired to read those persisted
  cards instead of querying/deriving their own astrometry — removing a redundant
  network round-trip per science frame and a real divergence risk (a module resolving
  different astrometry than the values recorded on the product it writes).

  Determinism is preserved: the pinned barycorrpy reference values in
  `TestComputeBarycorrReference` are unchanged, confirming the header-derived scalars
  reproduce the previously query-derived ones.

  ## New `AstroQuery` module — the single catalog client

  - `kpfpipe/modules/astro_query.py` (new): resolves Gaia, SIMBAD, and the WMKO-TCS
    header into per-source records and merges them into a canonical `kpf-drp` row.
  - **Gaia Data Release validation** resolves DR2/DR3, with a fallback for a bare id (no
    data release specified); flexible to accommodate upcoming DR4

  - **Source precedence** `gaia > simbad > wmko`. The canonical position is the
    highest-priority source with a *complete* astrometric block
    (`ra/dec/pmra/pmdec/parallax/epoch/frame`), taken whole so one measurement is never
    spliced across catalogs; a present-but-incomplete higher-priority source is demoted
    with an auditable warning, and no complete block anywhere raises (fail-loud).
  - **Cross-source fallbacks, each flagged:** `rv` falls back to the telescope
    `TARGRADV` when the base source has none; `color`/`color_name` fall back to the
    highest-priority catalog that carries a color. Both emit a mixed-catalog warning.
  - **Frames & units:** Gaia/SIMBAD are native ICRS; the WMKO FK5(J2000) block is
    rotated to ICRS. Proper motion is stored arcsec/yr (RA incl. cos Dec), parallax mas,
    rv km/s, RA/Dec as sexagesimal ICRS strings — the canonical EPRV `C*#` schema.
  - **Schema guard:** `_verify_units` raises if a queried column's unit drifts from the
    assumed one, protecting the downstream conversions.
  - Gated to science frames by `IMTYPE`; per-source toggles live in a new
    `[MODULE_ASTRO_QUERY]` config block (`do_gaia_query`/`do_simbad_query`/`use_wmko_tcs`).

  ## `CATALOG_RECORD` extension and the `C*#` PRIMARY overlay

  - New L0 `CATALOG_RECORD` BinTableHDU (`L0-extensions.csv`) holding one row per source
    plus the merged row, with presence flags `WMKOCR`/`GAIACR`/`SIMBADCR`
    (`L0-headers.csv`). Persisted L1 -> L2 -> L4.
  - `KPF0.to_kpf1` overlays the merged canonical row onto the SCI-fiber `C*#` cards
    (`_catalog_primary_cards`), a direct copy since the record is already EPRV-formatted.
  - The keyword registry now blanks the raw `TARG*`/`GAIAID` SCI source cells so the
    overlay is the sole writer of those cards (no stale native astrometry leaks onto
    PRIMARY), and includes the catalog bases in the SKY/CAL fiber-realignment set.
  - New derived cards: **`CZ#`** (redshift from `CRV#`) and **`CCLR#`/`CCLRN#`**
    (photometric color index + its name, e.g. `Gaia BP-RP` / `B-V` / `G-J`).

  ## `BarycentricCorrection` reads persisted astrometry

  - Removed its own `_gaia_astrometry`, `_wmko_astrometry`, `_get_skycoord`, and the
    `astroquery.gaia.Gaia` / `SkyCoord` / `re` imports.
  - `_get_astrometry` now reads the `C*#` cards off PRIMARY (SCI2 reference fiber) and
    converts them into barycorrpy inputs; `_REQUIRED_CARDS` fail loudly when absent.
  - Parallax and systemic-RV sanitation warn-and-default (non-positive/absent → 0)
    rather than crashing, matching how the faithfully-persisted catalog values arrive.
  - Retired the `use_gaia_astrometry`/`use_wmko_fallback` toggles (module + TOML) and the
    `ASTRSRC` keyword; provenance is carried internally from `CSRC#`. An optional
    interactive `SkyCoord` override remains for inspection.

  ## `CrossCorrelation` centers on the canonical systemic RV

  - The stellar CCF grid center now reads PRIMARY `CRV3` — the same canonical value the
    barycentric correction uses — instead of raw `TARGRADV`, and raises for a stellar
    fiber when it is absent rather than silently centering on 0.

  ## QC and diagnostics for catalog astrometry

  - New **`CATLOGOK`** QC (`catalog_values_sane`): epoch/equinox/rv/parallax/PM within
    physical ranges; passes on calibration frames (no catalog row).
  - `radec_consistent` requires the pointing-vs-target offset (`TARGOFF`); `_hdr_float`
    hardened to fail loud on a malformed value while treating a genuinely absent card as
    `None`.
  - `DiagL0` pointing offsets (`GAIAOFF`/`TARGOFF`/`OBJOFF`) now consume `CATALOG_RECORD`.
    A record missing proper motion or parallax falls back to PM=0 / parallax=0 for the
    offset computation (logged at DEBUG; `CATALOG_RECORD` values untouched), so a
    well-resolved frame lacking a TCS parallax is no longer spuriously failed. Missing,
    malformed, or calibration-frame records warn and emit an empty offset rather than
    raising — error-raising stays the checkpoint's job.

  ## Docs, config, and tests

  - EPRV data-standard mirror gains the `CZ#` / `CCLR#` / `CCLRN#` rows; profiling suite
    updated for the rewiring; general working guidance relocated out of the project
    `CLAUDE.md`.
  - New `tests/regression/test_astro_query.py` (query contract, merge precedence,
    fallbacks, unit/frame verification) plus reworked barycentric, cross-correlation,
    data-model, QC, and diagnostics suites.

  ## Testing

  Full suite passes (`make test`): **1527 passed**. Ruff format + lint clean.