### PR TITLE
Guard the exposure meter data the barycentric correction rests on

### DIFF
--- a/kpfpipe/data_models/config/L0-headers.csv
+++ b/kpfpipe/data_models/config/L0-headers.csv
@@ -13,6 +13,8 @@ EXPTIMOK,"QC: EXPTIME finite/non-neg, matches ELAPSED",QUALITY_CONTROL,int,QCL0
 DATTIMOK,QC: Dates/times consistent (DATE-BEG/MID/END),QUALITY_CONTROL,int,QCL0
 RADECOK,QC: pointing consistent with target/catalog RA/DEC,QUALITY_CONTROL,int,QCL0
 CATLOGOK,QC: catalog epoch/equinox/rv/parallax/PM in physical range,QUALITY_CONTROL,int,QCL0
+EMTIMEOK,QC: exposure meter times consistent with shutter window,QUALITY_CONTROL,int,QCL0
+EMFLUXOK,QC: exposure meter flux not saturated or negative,QUALITY_CONTROL,int,QCL0
 TARGOFF,Pointing offset from DCS target (arcsec),QUALITY_CONTROL,float,DiagL0
 OBJOFF,Pointing offset from OBJECT (SIMBAD) position (arcsec),QUALITY_CONTROL,float,DiagL0
 GAIAOFF,Pointing offset from GAIAID position (arcsec),QUALITY_CONTROL,float,DiagL0

--- a/kpfpipe/modules/barycentric_correction.py
+++ b/kpfpipe/modules/barycentric_correction.py
@@ -126,6 +126,11 @@ class BarycentricCorrection:
                 np.array(expmeter["Date-End"]).astype(str), format="isot", scale="utc"
             )
 
+            logger.warning(
+                "Exposure meter has no corrected Beg/End dates; "
+                "falling back to uncorrected dates"
+            )
+
         if not strictly_increasing(t_beg.jd):
             raise ValueError(
                 "EXPMETER_SCI Date-Beg timestamps are not strictly increasing"

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -11,19 +11,7 @@ from kpfpipe.utils.io import load_junk_obs_ids
 _L0_REQUIRED_KEYS = ["DATE-OBS", "EXPTIME", "OBJECT", "OFNAME", "IMTYPE"]
 
 _CHIPS = ("GREEN", "RED")
-_AMPS_PER_CHIP = 4  # GREEN_AMP1..4 / RED_AMP1..4 (only a subset is read out)
 _SUPPORTED_NAMP = (2, 4)  # valid KPF readout modes (see ImageAssembly.count_amplifiers)
-_TIME_TOL_S = 0.1  # DATE-END - DATE-BEG vs ELAPSED tolerance (v2.12 quality_control.py)
-
-# Physical-range bounds for the canonical CATALOG_RECORD astrometry, ported from
-# v2.12 good_TARG_headers. The epoch/equinox window is exclusive-low, matching
-# legacy. The parallax lower bound and the PM bound are vNext additions for our Gaia
-# source: a negative Gaia parallax is routine and gives a negative distance, and the
-# highest real PM is ~10.4 arcsec/yr.
-_EPOCH_RANGE = (1950.0, 2050.0)
-_MAX_ABS_RV = 350.0  # km/s (Chubak et al. 2012, arXiv:1207.6212, Fig. 8)
-_PARALLAX_RANGE = (0.0, 1000.0)  # mas; 0 < plx < 1000 (> 0 and < 1 arcsec)
-_MAX_ABS_PM = 15.0  # arcsec/yr, per component
 
 
 def _parse_iso(value):
@@ -52,7 +40,7 @@ class QCL0(QC):
         """
         for chip in _CHIPS:
             namp = 0
-            for i in range(1, _AMPS_PER_CHIP + 1):
+            for i in range(1, 5):  # GREEN_AMP1..4 / RED_AMP1..4
                 arr = self.kpf_obj.data.get(f"{chip}_AMP{i}")
                 # KPF0 stores None-data as array(None, dtype=object); skip absent.
                 if (
@@ -99,8 +87,8 @@ class QCL0(QC):
         Bias frames legitimately have EXPTIME=0, so we don't require strictly
         positive. When the raw ELAPSED readout time is present, it must not fall
         short of the requested EXPTIME (premature readout) or exceed it by more
-        than ``_TIME_TOL_S`` (the elapsed-vs-requested check formerly done in the
-        masters frame loader); an absent ELAPSED skips only that comparison.
+        than 0.1 s (the elapsed-vs-requested check formerly done in the masters
+        frame loader); an absent ELAPSED skips only that comparison.
         """
         hdr = self.kpf_obj.headers["PRIMARY"]
         if "EXPTIME" not in hdr:
@@ -113,7 +101,7 @@ class QCL0(QC):
             return False
 
         elapsed = self._hdr_float(hdr, "ELAPSED")
-        if elapsed is not None and not (0 <= elapsed - exptime <= _TIME_TOL_S):
+        if elapsed is not None and not (0 <= elapsed - exptime <= 0.1):
             return False
         return True
 
@@ -182,18 +170,100 @@ class QCL0(QC):
         row = match[0]
         for field in ("epoch", "equinox"):
             val = self._row_float(row, field)
-            if val is not None and not (_EPOCH_RANGE[0] < val <= _EPOCH_RANGE[1]):
+            if val is not None and not (1950.0 < val <= 2050.0):
                 return False
+        # |rv| bound from Chubak et al. 2012 (arXiv:1207.6212, Fig. 8).
         rv = self._row_float(row, "rv")
-        if rv is not None and abs(rv) > _MAX_ABS_RV:
+        if rv is not None and abs(rv) > 350.0:
             return False
         plax = self._row_float(row, "parallax")
-        if plax is not None and not (_PARALLAX_RANGE[0] < plax < _PARALLAX_RANGE[1]):
+        if plax is not None and not (0.0 < plax < 1000.0):
             return False
         for field in ("pmra", "pmdec"):
             pm = self._row_float(row, field)
-            if pm is not None and abs(pm) > _MAX_ABS_PM:
+            if pm is not None and abs(pm) > 15.0:
                 return False
         return True
 
     catalog_values_sane._qc_key = "CATLOGOK"
+
+    def _em_table(self, ext):
+        """The exposure-meter table for ``ext``, or None when the frame has none.
+
+        Only science frames carry EM extensions; on a calibration ``data.get``
+        yields None.
+        """
+        table = self.kpf_obj.data.get(ext)
+        return table if table is not None and len(table) else None
+
+    def expmeter_times_consistent(self):
+        """EXPMETER_SCI brackets the shutter window to within 1 second.
+
+        Ports the exposure-meter half of v2.12 ``L0_datetime``; the header-date
+        half is DATTIMOK/EXPTIMOK. The first Date-Beg and last Date-End of the EM
+        table must match PRIMARY DATE-BEG/DATE-END, preferring the corrected
+        columns as BarycentricCorrection does. The 1 s tolerance absorbs EM dead
+        time and catches only gross errors: the flux-weighted midpoint feeds the
+        barycentric correction, where a 2.6 s timing error costs 10 cm/s.
+
+        Frames without EM data pass; a frame with EM data but no shutter window
+        to compare against fails.
+        """
+        table = self._em_table("EXPMETER_SCI")
+        if table is None:
+            return True
+        hdr = self.kpf_obj.headers["PRIMARY"]
+        beg, end = (_parse_iso(hdr.get(k)) for k in ("DATE-BEG", "DATE-END"))
+        if beg is None or end is None:
+            return False
+        suffix = "-Corr" if "Date-Beg-Corr" in table.colnames else ""
+        em_beg = _parse_iso(str(table[f"Date-Beg{suffix}"][0]))
+        em_end = _parse_iso(str(table[f"Date-End{suffix}"][-1]))
+        if em_beg is None or em_end is None:
+            return False
+        return (
+            abs((em_beg - beg).total_seconds()) <= 1.0
+            and abs((em_end - end).total_seconds()) <= 1.0
+        )
+
+    expmeter_times_consistent._qc_key = "EMTIMEOK"
+
+    def expmeter_flux_sane(self):
+        """EXPMETER_SCI/SKY flux is neither saturated nor significantly negative.
+
+        Merges v2.12 ``EM_not_saturated`` and ``EM_flux_not_negative``, applied to
+        each fiber present. Saturation: more than 1.5 channels per reading above
+        90% of the 1.93e6 reduced-spectrum saturation level, with the first and
+        last readings dropped when there are 3+ (they are partial). Negative flux:
+        20 consecutive channels whose time-summed flux is negative, the signature
+        of bias over-subtraction in the raw EM images.
+
+        Frames without EM data pass; an EM table with no wavelength channel fails.
+        """
+        for ext in ("EXPMETER_SCI", "EXPMETER_SKY"):
+            table = self._em_table(ext)
+            if table is None:
+                continue
+            # Numeric column labels are the wavelength channels; Date* are not.
+            channels = []
+            for name in table.colnames:
+                try:
+                    float(name)
+                except ValueError:
+                    continue
+                channels.append(np.asarray(table[name], dtype=float))
+            if not channels:
+                return False
+            flux = np.column_stack(channels)
+
+            readings = flux[1:-1] if len(flux) >= 3 else flux
+            saturated = np.count_nonzero(readings > 0.9 * 1.93e6)
+            if saturated > 1.5 * len(readings):
+                return False
+
+            negative = (flux.sum(axis=0) < 0).astype(int)
+            if np.any(np.convolve(negative, np.ones(20, dtype=int), "valid") == 20):
+                return False
+        return True
+
+    expmeter_flux_sane._qc_key = "EMFLUXOK"

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -43,12 +43,20 @@ _NCOLS = 10  # small column count for fast tests
 
 
 def _make_kpf0(
-    tmp_path, *, with_amps=True, exptime=60.0, obs_id="KP.20240405.00001.00", dates=None
+    tmp_path,
+    *,
+    with_amps=True,
+    exptime=60.0,
+    obs_id="KP.20240405.00001.00",
+    dates=None,
+    expmeter=None,
 ):
     """Minimal 4-amp KPF0 object with required headers.
 
     ``dates`` optionally seeds raw DATE-BEG/MID/END/ELAPSED cards on PRIMARY for
-    the DATTIMOK timing check.
+    the DATTIMOK timing check. ``expmeter`` optionally maps an EXPMETER_SCI/SKY
+    extension name to its table, for the EMTIMEOK/EMFLUXOK checks; without it the
+    frame has no EM data at all, like a calibration.
     """
     fn = str(tmp_path / f"{obs_id}.fits")
     primary = fits.PrimaryHDU()
@@ -67,6 +75,8 @@ def _make_kpf0(
             for amp in range(1, 5):
                 data = np.ones((10, 10), dtype=np.float32)
                 hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+    for name, table in (expmeter or {}).items():
+        hdus.append(fits.BinTableHDU(table, name=name))
 
     fits.HDUList(hdus).writeto(fn, overwrite=True)
     return KPF0.from_fits(fn)
@@ -79,6 +89,11 @@ _GOOD_DATES = {
     "DATE-END": "2024-09-23T09:12:21.554",
     "ELAPSED": 12.07,
 }
+
+
+# Clean exposure-meter flux for the EMFLUXOK tests: 4 readings x 25 wavelength
+# channels (more than the 20-channel negative run the check looks for).
+_EM_CLEAN_FLUX = np.full((4, 25), 1000.0)
 
 
 def _seed_required_primary(kpf, qc_cls):
@@ -734,6 +749,140 @@ class TestQCL0:
         assert fn._qc_key == "DATAPRL0"
         # The comment now lives in the registry Description (not on the method).
         assert "GREEN" in KPF0.keyword_registry.routing["DATAPRL0"][1]
+
+    # --- expmeter_times_consistent (EMTIMEOK) and expmeter_flux_sane (EMFLUXOK):
+    # the exposure-meter checks ported from v2.12 L0_datetime / EM_not_saturated /
+    # EM_flux_not_negative. Four readings tile the _GOOD_DATES shutter window.
+
+    _EM_BEGS = [
+        "2024-09-23T09:12:09.484",
+        "2024-09-23T09:12:12.484",
+        "2024-09-23T09:12:15.484",
+        "2024-09-23T09:12:18.484",
+    ]
+    _EM_ENDS = [
+        "2024-09-23T09:12:12.484",
+        "2024-09-23T09:12:15.484",
+        "2024-09-23T09:12:18.484",
+        "2024-09-23T09:12:21.554",
+    ]
+
+    def _make_kpf0_with_expmeter(
+        self,
+        tmp_path,
+        *,
+        begs=None,
+        ends=None,
+        flux=None,
+        sky_flux=None,
+        corrected=False,
+    ):
+        """KPF0 carrying an EXPMETER_SCI table (plus EXPMETER_SKY when ``sky_flux``
+        is given), built from per-reading timestamps and an (nreading, nchannel)
+        flux array with numeric (wavelength) column labels."""
+        suffix = "-Corr" if corrected else ""
+
+        def table(values):
+            columns = {
+                f"Date-Beg{suffix}": begs or self._EM_BEGS,
+                f"Date-End{suffix}": ends or self._EM_ENDS,
+            }
+            for i in range(values.shape[1]):
+                columns[str(5000.0 + i)] = values[:, i]
+            return Table(columns)
+
+        extensions = {"EXPMETER_SCI": table(_EM_CLEAN_FLUX if flux is None else flux)}
+        if sky_flux is not None:
+            extensions["EXPMETER_SKY"] = table(sky_flux)
+        return _make_kpf0(tmp_path, dates=_GOOD_DATES, expmeter=extensions)
+
+    def test_expmeter_times_consistent_pass(self, tmp_path):
+        l0 = self._make_kpf0_with_expmeter(tmp_path)
+        assert QCL0(l0).expmeter_times_consistent() is True
+
+    def test_expmeter_times_no_em_data_passes(self, tmp_path):
+        # Calibration frames carry no EM extension; there is nothing to check.
+        l0 = _make_kpf0(tmp_path, dates=_GOOD_DATES)
+        assert l0.data.get("EXPMETER_SCI") is None
+        assert QCL0(l0).expmeter_times_consistent() is True
+
+    def test_expmeter_times_within_tolerance_passes(self, tmp_path):
+        # Sub-second EM dead time is routine and must not trip the check.
+        begs = ["2024-09-23T09:12:09.984"] + self._EM_BEGS[1:]
+        l0 = self._make_kpf0_with_expmeter(tmp_path, begs=begs)
+        assert QCL0(l0).expmeter_times_consistent() is True
+
+    def test_expmeter_times_late_start_fails(self, tmp_path):
+        begs = ["2024-09-23T09:12:14.484"] + self._EM_BEGS[1:]  # 5 s after DATE-BEG
+        l0 = self._make_kpf0_with_expmeter(tmp_path, begs=begs)
+        assert QCL0(l0).expmeter_times_consistent() is False
+
+    def test_expmeter_times_early_end_fails(self, tmp_path):
+        ends = self._EM_ENDS[:-1] + ["2024-09-23T09:12:16.554"]  # 5 s before DATE-END
+        l0 = self._make_kpf0_with_expmeter(tmp_path, ends=ends)
+        assert QCL0(l0).expmeter_times_consistent() is False
+
+    def test_expmeter_times_prefers_corrected_columns(self, tmp_path):
+        # Corrected columns bracket the window; only reading them passes.
+        l0 = self._make_kpf0_with_expmeter(tmp_path, corrected=True)
+        assert "Date-Beg-Corr" in l0.data["EXPMETER_SCI"].colnames
+        assert QCL0(l0).expmeter_times_consistent() is True
+
+    def test_expmeter_times_missing_shutter_window_fails(self, tmp_path):
+        # EM data present but no DATE-BEG/DATE-END to compare against.
+        l0 = self._make_kpf0_with_expmeter(tmp_path)
+        del l0.headers["PRIMARY"]["DATE-BEG"]
+        assert QCL0(l0).expmeter_times_consistent() is False
+
+    def test_emtimeok_key_present(self):
+        assert QCL0.__dict__["expmeter_times_consistent"]._qc_key == "EMTIMEOK"
+
+    def test_expmeter_flux_sane_pass(self, tmp_path):
+        l0 = self._make_kpf0_with_expmeter(tmp_path, sky_flux=_EM_CLEAN_FLUX)
+        assert QCL0(l0).expmeter_flux_sane() is True
+
+    def test_expmeter_flux_no_em_data_passes(self, tmp_path):
+        l0 = _make_kpf0(tmp_path, dates=_GOOD_DATES)
+        assert QCL0(l0).expmeter_flux_sane() is True
+
+    def test_expmeter_flux_saturated_fails(self, tmp_path):
+        # 2 channels saturated in each of the 2 interior readings -> 4 elements,
+        # over the 1.5-per-reading allowance.
+        flux = _EM_CLEAN_FLUX.copy()
+        flux[1:3, :2] = 0.95 * 1.93e6
+        l0 = self._make_kpf0_with_expmeter(tmp_path, flux=flux)
+        assert QCL0(l0).expmeter_flux_sane() is False
+
+    def test_expmeter_flux_saturated_edge_readings_pass(self, tmp_path):
+        # The first and last readings are partial, so saturation there is dropped.
+        flux = _EM_CLEAN_FLUX.copy()
+        flux[[0, -1], :] = 0.95 * 1.93e6
+        l0 = self._make_kpf0_with_expmeter(tmp_path, flux=flux)
+        assert QCL0(l0).expmeter_flux_sane() is True
+
+    def test_expmeter_flux_negative_run_fails(self, tmp_path):
+        # 20 consecutive channels summing negative: bias over-subtraction.
+        flux = _EM_CLEAN_FLUX.copy()
+        flux[:, 5:25] = -1000.0
+        l0 = self._make_kpf0_with_expmeter(tmp_path, flux=flux)
+        assert QCL0(l0).expmeter_flux_sane() is False
+
+    def test_expmeter_flux_short_negative_run_passes(self, tmp_path):
+        # 19 consecutive is under the run length; isolated negatives are noise.
+        flux = _EM_CLEAN_FLUX.copy()
+        flux[:, 5:24] = -1000.0
+        l0 = self._make_kpf0_with_expmeter(tmp_path, flux=flux)
+        assert QCL0(l0).expmeter_flux_sane() is True
+
+    def test_expmeter_flux_checks_sky_fiber(self, tmp_path):
+        # The SKY fiber is checked too, so a bad SKY fails an otherwise clean frame.
+        sky_flux = _EM_CLEAN_FLUX.copy()
+        sky_flux[:, 5:25] = -1000.0
+        l0 = self._make_kpf0_with_expmeter(tmp_path, sky_flux=sky_flux)
+        assert QCL0(l0).expmeter_flux_sane() is False
+
+    def test_emfluxok_key_present(self):
+        assert QCL0.__dict__["expmeter_flux_sane"]._qc_key == "EMFLUXOK"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
  ## Summary

  Adds L0 quality control for the exposure-meter data that `BarycentricCorrection`
  rests on. vNext had no EM checks; v2.12 had three.
                                                                            
  - **`EMTIMEOK`** — ports v2.12 `L0_datetime`'s exposure-meter half. The first
    `Date-Beg` and last `Date-End` of `EXPMETER_SCI` must bracket PRIMARY
    `DATE-BEG`/`DATE-END` to within 1 s, preferring the corrected columns as
    `BarycentricCorrection` does. Compares against the shutter window rather than
    v2.12's per-chip `GRDATE-*`/`RDDATE-*`: the module itself extrapolates from
    `DATE-BEG`/`DATE-END`, and all six cards agree to 0.000 s on the truth frames.
  - **`EMFLUXOK`** — merges v2.12 `EM_not_saturated` and `EM_flux_not_negative`,
    applied to each fiber present. Saturation and 20-channel negative runs are
    symptoms of the same thing (unusable EM flux), so they share one flag.
    v2.12's `n_sat/(nrow·ncol) > 1.5/ncol` is rewritten as the algebraically
    identical `n_sat > 1.5·nrow`.

  Both are additive: `CheckpointL0.RAISE_FLAGS` is untouched, so a failure warns
  rather than halting, and nothing enumerates the L0 flag set positionally.

  Also on this branch:

  - `BarycentricCorrection._get_timestamps` now warns when it falls back from the
    corrected to the uncorrected `Date-Beg`/`Date-End` columns. The fallback stays
    — on the truth frames it shifts the flux-weighted midpoint by 64–70 ms,
    ≈0.25 cm/s against a 10 cm/s budget — but it should not be silent.
  - Inlines the single-use constants in `qc_flags/level0.py` as literals at their
    use sites, keeping only `_CHIPS` and `_SUPPORTED_NAMP`, and trims the comments
    down to the Chubak et al. 2012 citation.

  ## Testing

  `make test-fast`, plus the targeted files: `test_qc_flags.py` (15 new tests),
  `test_checkpoints.py`, `test_qc_script.py`, `test_data_models_l0.py`,
  `test_master_base.py`. Ruff clean.