### PR TITLE
Kpf next cleanup 20260819

### DIFF
--- a/docs/dev/EPRV_DATA_STANDARD.md
+++ b/docs/dev/EPRV_DATA_STANDARD.md
@@ -138,7 +138,7 @@ L4 PRIMARY gains: `BJDTDB`, `RV`, `RVERR`, `BERV`, `RVMETHOD`, `SYSVEL`.
 >   (`VELSTART/VELSTEP/VELNSTEP/CCFMASK`) on `CCFn`. Our code emits exactly the 0.4.0 set.
 > - **Optional columns** — KPF populates the EPRV-optional `ORDER_INDEX`, `ECHELLE_ORDER`
 >   (physical grating order, blue→red), and `WEIGHT` (per-order CCF-combination weight),
->   plus a KPF-custom `ORDER_ID` (chip/fiber/order name, 1-based per chip — the standard
+>   plus a KPF-custom `ORDER_ID` (chip/fiber/order name, 0-based per chip — the standard
 >   permits team-added columns).
 > - **Structural cards as keywords** — 0.4.0's per-extension keyword CSVs redundantly
 >   register FITS *structural* cards astropy writes on its own (`XTENSION`, `EXTNAME`) as

--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -756,16 +756,16 @@ class CrossCorrelation:
 
             # Per-orderlet RV table, one row per order (green then red). ORDER_ID
             # is a composite string label ``{CHIP}_{FIBER}_{n}`` whose ``n`` is
-            # 1-based per chip, while ORDER_INDEX holds the plain 0-based row
-            # index; ECHELLE_ORDER is the physical grating order (detector.toml,
-            # blue->red); WEIGHT is the per-order CCF weight
+            # 0-based per chip, while ORDER_INDEX holds the 0-based row index
+            # across both chips; ECHELLE_ORDER is the physical grating order
+            # (detector.toml, blue->red); WEIGHT is the per-order CCF weight
             # (ccf_order_weights.csv). RV/RV_ERR are NaN placeholders
             # RadialVelocity fills from the CCFs.
             order_id = np.array(
                 [
                     f"{chip}_{fiber}_{order}"
                     for chip in ("GREEN", "RED")
-                    for order in range(1, self.norder[chip] + 1)
+                    for order in range(self.norder[chip])
                 ]
             )
             echelle_order = np.concatenate(

--- a/kpfpipe/modules/radial_velocity.py
+++ b/kpfpipe/modules/radial_velocity.py
@@ -25,6 +25,9 @@ _DEFAULTS = {
     "rv_window": [-25.0, 25.0],
 }
 
+_SCI_FIBERS = ["SCI1", "SCI2", "SCI3"]
+_RV_SFX = {"SCI1": "1", "SCI2": "2", "SCI3": "3", "CAL": "C", "SKY": "S"}
+
 
 class RadialVelocity:
     """
@@ -73,9 +76,6 @@ class RadialVelocity:
         self._primary_berv = np.nan  # PRIMARY BERV
         self._primary_bjdtdb = np.nan  # PRIMARY BJDTDB
         self._info = None
-
-    # Science orderlets that may be summed together (shared mask and grid).
-    _SCI_FIBERS = ("SCI1", "SCI2", "SCI3")
 
     # ------------------------------------------------------------------
     # Private helpers
@@ -243,10 +243,10 @@ class RadialVelocity:
         chip = chip.upper()
         fibers = [fibers] if isinstance(fibers, str) else list(fibers)
         fibers = [f.upper() for f in fibers]
-        if len(fibers) != 1 and set(fibers) != set(self._SCI_FIBERS):
+        if len(fibers) != 1 and set(fibers) != set(_SCI_FIBERS):
             raise ValueError(
                 f"fibers must be a single fiber or exactly the three science "
-                f"fibers {list(self._SCI_FIBERS)}; got {fibers}"
+                f"fibers {_SCI_FIBERS}; got {fibers}"
             )
         for f in fibers:
             if f"{chip}_{f}" not in self._ccf:
@@ -437,10 +437,10 @@ class RadialVelocity:
         fibers = [fibers] if isinstance(fibers, str) else list(fibers)
         fibers = [f.upper() for f in fibers]
 
-        if combine_fibers and set(fibers) != set(self._SCI_FIBERS):
+        if combine_fibers and set(fibers) != set(_SCI_FIBERS):
             raise ValueError(
                 f"combine_fibers=True requires the three science fibers "
-                f"{list(self._SCI_FIBERS)}; got {fibers}"
+                f"{_SCI_FIBERS}; got {fibers}"
             )
         if not combine_fibers and len(fibers) != 1:
             raise ValueError(
@@ -573,7 +573,6 @@ class RadialVelocity:
         RV/RVERR/BERV/BJDTDB. Non-finite values are written as None (FITS
         UNDEFINED). The RVn CTYPE cards belong to CrossCorrelation.
         """
-        sfx = {"SCI1": "1", "SCI2": "2", "SCI3": "3", "CAL": "C", "SKY": "S"}
         for fiber in self._processed:
             rv_ext = f"{fiber}_RV"
             l4_obj.set_keyword("RVMETHOD", "CCF", ext=rv_ext)
@@ -584,10 +583,10 @@ class RadialVelocity:
                 n = 1 if chip == "GREEN" else 2
                 e = pf["ccd_rv_err"][chip]
                 l4_obj.set_keyword(
-                    f"CCD{n}RV{sfx[fiber]}", float(v) if np.isfinite(v) else None
+                    f"CCD{n}RV{_RV_SFX[fiber]}", float(v) if np.isfinite(v) else None
                 )
                 l4_obj.set_keyword(
-                    f"CCD{n}ERV{sfx[fiber]}", float(e) if np.isfinite(e) else None
+                    f"CCD{n}ERV{_RV_SFX[fiber]}", float(e) if np.isfinite(e) else None
                 )
 
         # PRIMARY (EPRV L4): always the RV method; the combined RV only when a
@@ -735,7 +734,7 @@ class RadialVelocity:
         # Final science RV: sum the science orderlets' CCFs per chip, fit, then
         # combine the two CCDs at the RV level (see compute_weighted_rvs). RVs are
         # already barycentric, so the reported BERV/BJDTDB are descriptive.
-        sci_req = [f for f in fibers if f in self._SCI_FIBERS]
+        sci_req = [f for f in fibers if f in _SCI_FIBERS]
         sci = [f for f in sci_req if f in self._processed]
         if not sci_req:
             # Calibration-only run: PRIMARY RV/RVERR/BERV/BJDTDB stay UNDEFINED.

--- a/kpfpipe/quality_control/diagnostics/level2.py
+++ b/kpfpipe/quality_control/diagnostics/level2.py
@@ -4,11 +4,11 @@ import numpy as np
 
 from kpfpipe.quality_control.diagnostics.base import Diagnostics
 
-_FIBERS = ("SCI1", "SCI2", "SCI3", "SKY", "CAL")
-_CHIPS = ("GREEN", "RED")
-_SCI_FIBERS = ("SCI1", "SCI2", "SCI3")
-_SNR_PERCENTILE = 95
+_CHIPS = ["GREEN", "RED"]
+_FIBERS = ["SCI1", "SCI2", "SCI3", "SKY", "CAL"]
+_SCI_FIBERS = ["SCI1", "SCI2", "SCI3"]
 _CHIP_PREFIX = {"GREEN": "G", "RED": "R"}
+_SNR_PERCENTILE = 95
 
 # Fiber -> NaN-count keyword. (FITS comment from the registry -- see ``_tag``.)
 _NAN_KEYS = {

--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -10,7 +10,7 @@ from kpfpipe.utils.io import load_junk_obs_ids
 
 _L0_REQUIRED_KEYS = ["DATE-OBS", "EXPTIME", "OBJECT", "OFNAME", "IMTYPE"]
 
-_CHIPS = ("GREEN", "RED")
+_CHIPS = ["GREEN", "RED"]
 _SUPPORTED_NAMP = (2, 4)  # valid KPF readout modes (see ImageAssembly.count_amplifiers)
 
 

--- a/kpfpipe/quality_control/qc_flags/level4.py
+++ b/kpfpipe/quality_control/qc_flags/level4.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from kpfpipe.quality_control.qc_flags.base import QC
 
-_SCI_FIBERS = ("SCI1", "SCI2", "SCI3")
+_SCI_FIBERS = ["SCI1", "SCI2", "SCI3"]
 # Columns every science RV table must carry (RV product + per-order BJD/BERV/WEIGHT).
 _REQUIRED_RV_COLUMNS = frozenset({"RV", "BJD_TDB", "BERV", "WEIGHT"})
 # Max per-order peak-to-peak range tolerated across orders (SCI2).

--- a/kpfpipe/quality_control/quicklook/level4.py
+++ b/kpfpipe/quality_control/quicklook/level4.py
@@ -233,10 +233,11 @@ class PlotL4(Plot):
                 self._norm_order(row, is_sci) + o * _ORDER_OFFSET,
                 color=colors[o],
             )
+            # Order numbers are 1-based in plot labels only; ``o`` stays 0-based.
             ax.text(
                 vgrid[-1] + 0.75,
                 1 + o * _ORDER_OFFSET - 0.10,
-                str(o),
+                str(o + 1),
                 color=colors[o],
                 va="center",
                 ha="left",
@@ -275,9 +276,10 @@ class PlotL4(Plot):
     def ccf_grid(self, chip):
         """Per-orderlet CCF grid for one chip, matching the v2.12 plot_CCF_grid
         layout: five panels (SCI1, SCI2, SCI3, CAL, SKY), each order's CCF
-        normalized and offset, colored by the default cycle and labeled by order
-        index. SCI panels add the combined-RV line + value and per-order
-        delta-RV / weight columns. Returns None if the chip has no CCF data.
+        normalized and offset, colored by the default cycle and labeled by
+        1-based order number. SCI panels add the combined-RV line + value and
+        per-order delta-RV / weight columns. Returns None if the chip has no
+        CCF data.
         """
         if not self._has_chip(chip):
             return None

--- a/kpfpipe/utils/network.py
+++ b/kpfpipe/utils/network.py
@@ -11,8 +11,8 @@ from pyvo.dal import DALServiceError
 logger = logging.getLogger(__name__)
 
 # Nominal seconds to wait before each retry; len() sets the retry count, so a call
-# is attempted len(_RETRY_WAITS) + 1 times (~44 s of waiting worst case).
-_RETRY_WAITS = (1.0, 3.0, 10.0, 30.0)
+# is attempted len(_RETRY_WAITS) + 1 times (~55 s of waiting worst case).
+_RETRY_WAITS = (1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 30.0)
 
 # Transient failures worth another attempt. OSError covers the builtin
 # ConnectionError/TimeoutError and every requests exception (RequestException

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -601,7 +601,7 @@ class TestPerform:
             np.testing.assert_array_equal(weight, expected)
 
     def test_rv_table_order_id_and_echelle_columns(self, performed):
-        # ORDER_ID is the KPF chip/fiber/order name, 1-based per chip (green then
+        # ORDER_ID is the KPF chip/fiber/order name, 0-based per chip (green then
         # red). ECHELLE_ORDER is the physical grating order (detector.toml),
         # blue->red: GREEN 137..103, RED 102..71.
         cc_module, l4 = performed
@@ -609,10 +609,10 @@ class TestPerform:
             table = l4.data[f"{fiber}_RV"]
             order_id = np.asarray(table["ORDER_ID"])
             echelle = np.asarray(table["ECHELLE_ORDER"])
-            assert order_id[0] == f"GREEN_{fiber}_1"
-            assert order_id[NORDER_GREEN - 1] == f"GREEN_{fiber}_{NORDER_GREEN}"
-            assert order_id[NORDER_GREEN] == f"RED_{fiber}_1"
-            assert order_id[-1] == f"RED_{fiber}_{NORDER_RED}"
+            assert order_id[0] == f"GREEN_{fiber}_0"
+            assert order_id[NORDER_GREEN - 1] == f"GREEN_{fiber}_{NORDER_GREEN - 1}"
+            assert order_id[NORDER_GREEN] == f"RED_{fiber}_0"
+            assert order_id[-1] == f"RED_{fiber}_{NORDER_RED - 1}"
             assert echelle[0] == 137
             assert echelle[NORDER_GREEN - 1] == 103
             assert echelle[NORDER_GREEN] == 102
@@ -679,7 +679,7 @@ class TestPerform:
             assert rv["CTYPE1"] == "Columns"
             assert "RVMETHOD" not in rv
             rv_table = hdul["RV3"].data
-            assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_1"
+            assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_0"
             assert rv_table["ECHELLE_ORDER"][0] == 137
             # The per-bin CCF variance cube round-trips as an image extension.
             assert hdul["CCF_VAR3"].data.shape == (NORDER, _NVEL)

--- a/tests/regression/test_master_order_trace.py
+++ b/tests/regression/test_master_order_trace.py
@@ -16,6 +16,7 @@ from scipy.ndimage import label
 
 import kpfpipe.modules.masters.order_trace as order_trace_module
 from kpfpipe.modules.masters import OrderTrace
+from kpfpipe.modules.spectral_extraction import SpectralExtraction
 from kpfpipe.utils.config import ConfigHandler
 
 _FIBERS = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
@@ -1212,25 +1213,28 @@ class TestRealData:
     def test_real_20240405_master_flat(self, tmp_path):
         """Trace a real vNext master flat and check it reproduces the reference.
 
-        The comparison is against the vetted reference the pipeline ships for
-        this era, which was measured from this flat -- so it pins the shipped
-        artifact to what the module produces today, rather than standing as
-        independent truth."""
+        The comparison is against the vetted reference extraction would pin to
+        this frame -- the latest trace measured before it within its instrument
+        era -- so it holds the module's output to the shipped artifact rather
+        than standing as independent truth."""
         testdata = Path(__file__).parent.parent / "testdata"
         masters = sorted(testdata.glob("**/KP.20240405.*_master_flat_L1.fits"))
         if not masters:
             pytest.skip("a 20240405 vNext master flat is not installed")
 
-        vetted = pd.read_csv(
-            Path(__file__).parents[2]
-            / "reference"
-            / "order_traces"
-            / "order_trace_20240405.csv"
-        )
-
         tracer = OrderTrace(masters[0])
         combined = tracer.make_master(output_dir=tmp_path)
         tables = {chip: combined[combined["Chip"] == chip] for chip in ("GREEN", "RED")}
+
+        # Resolve the reference through the same era lookup extraction uses. A
+        # masters product carries no JD_UTC, so date the flat from its filename.
+        datecode = masters[0].name.split(".")[1]
+        tracer._master_flat.set_keyword(
+            "JD_UTC", pd.Timestamp(datecode).to_julian_date()
+        )
+        extractor = SpectralExtraction(tracer._master_flat)
+        extractor._read_order_trace_reference()
+        vetted = pd.read_csv(extractor._order_trace_path)
 
         assert len(tables["GREEN"]) == 175
         assert len(tables["RED"]) == 160

--- a/tests/regression/test_network.py
+++ b/tests/regression/test_network.py
@@ -84,7 +84,9 @@ class TestRetryRequest:
         # Equal jitter: half the nominal wait is fixed, the other half random.
         for delay, wait in zip(delays, _RETRY_WAITS, strict=True):
             assert wait / 2 <= delay <= wait
-        assert delays == sorted(delays)
+        # Only the nominal schedule is monotonic; realized delays can cross where
+        # adjacent waits' jitter ranges overlap.
+        assert list(_RETRY_WAITS) == sorted(_RETRY_WAITS)
 
     def test_retry_logs_warning(self, caplog):
         func = MagicMock(side_effect=[ConnectionError("down"), "ok"])

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -592,7 +592,7 @@ class TestPerform:
             assert hdul["PRIMARY"].header["RVERR"] > 0
             # The seeded ORDER_ID / ECHELLE_ORDER columns round-trip alongside RV.
             rv_table = hdul["RV3"].data
-            assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_1"
+            assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_0"
             assert rv_table["ECHELLE_ORDER"][0] == 137
             assert np.all(np.isfinite(rv_table["RV"]))
 


### PR DESCRIPTION
  ## Summary

  Four unrelated cleanups.

  - **`ORDER_ID` is now 0-based** (`d514cb86`). It was the only 1-based index in the pipeline; `ORDER_INDEX`, 
  `ccf_order_weights.csv`, the order-trace CSVs, `order_trace.py`, and `spectral_extraction.py` all count from 0. The first 
  order is now `GREEN_SCI2_0`. Order numbers convert to 1-based just in time for display, so the L4 quicklook CCF grid labels 
  each trace `o + 1`. Quicklook's public APIs stay 1-based (`PlotL2.spectrum_single_order` unchanged).
  - **Fiber/chip constants made consistent** (`31d36c3c`). They had drifted into list vs tuple, module-level vs class
  attribute, and a method-local dict duplicating another file's module constant. Settled on the form the package root and
  config TOMLs already use: a module-level list. `RadialVelocity._SCI_FIBERS` moves to module scope; its local `sfx` dict
  becomes `_RV_SFX`, matching `quicklook/level4.py`.
  - **Wider network retry schedule** (`bbebb6db`), 4 waits → 7 (~44 s → ~55 s worst case).
  - **Fixed a pre-existing real-data test failure** (`625aa852`). `test_real_20240405_master_flat` opened
  `order_trace_20240405.csv` by name, but `b1752653` re-cut the trace set by instrument era and deleted that file. It now
  resolves the reference through the same era lookup extraction uses.

  ## Notes

  - `docs/dev/EPRV_DATA_STANDARD.md` documented `ORDER_ID` as 1-based; updated to match the code.
  - `test_network.py` asserted the *realized* backoff delays come out sorted. The new schedule's jitter ranges overlap
  (`wait=2.0` spans [1.0, 2.0], `wait=3.0` spans [1.5, 3.0]), which made that assertion fail ~45% of runs. Now asserts the
  nominal schedule is monotonic; the per-delay jitter bound already covers the rest.
  - The order-trace test now compares against a different night's flat within the same era (`order_trace_20240224.csv`) rather
  than the one it was measured from, and still holds the existing tolerances — median trace-center deviation < 0.5 px, max <
  1.0 px.

  ## RV impact

  None. `ORDER_ID` is a string label that nothing in the pipeline reads; no numerical path changes.

  ## Testing

  `make test`: **1717 passed**, 0 failed. Network/AstroQuery suites also run 8× consecutively to confirm the flakiness fix.