### PR TITLE
Make the regression suite trustworthy

### DIFF
--- a/kpfpipe/quality_control/qc_flags/level0.py
+++ b/kpfpipe/quality_control/qc_flags/level0.py
@@ -127,12 +127,22 @@ class QCL0(QC):
     def radec_consistent(self):
         """Pointing agrees with the target and catalog positions.
 
+        Telescope pointing is only meaningful for a science frame (IMTYPE
+        'Object'), so a calibration frame passes unconditionally: it has no
+        target, AstroQuery never runs on it, and DiagL0 therefore leaves
+        TARGOFF/OBJOFF/GAIAOFF blank -- which would otherwise fail the required
+        TARGOFF branch below.
+
         TARGOFF (pointing vs the DCS target) is internal telescope-pointing
         consistency and is required: an empty value (astrometry unavailable) or
         one >= 1" fails. OBJOFF/GAIAOFF are external catalog cross-matches with a
         looser 5" bound, checked only when present-and-valued, so a disabled or
         failed Gaia/SIMBAD lookup passes.
         """
+        imtype = self.kpf_obj.headers["PRIMARY"].get("IMTYPE")
+        if str(imtype).strip().lower() != "object":
+            return True
+
         hdr = self.kpf_obj.headers["QUALITY_CONTROL"]
         targoff = self._hdr_float(hdr, "TARGOFF")
         if targoff is None or targoff >= 1.0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,6 @@ filterwarnings = [
     # astropy truncates over-long FITS card comments; the masters INPUT_FILES
     # round-trip deliberately writes long paths, so this is expected, not a bug.
     "ignore:Card is too long, comment will be truncated:astropy.io.fits.verify.VerifyWarning",
-    # rvdata nudges when a written/read filename is off-convention. Round-trip and
-    # unit tests use throwaway tmp_path names (master.fits, rt_l4.fits, ...); the
-    # naming rules themselves are enforced by check_filename_convention and
-    # TestFilenameConsistency, so this is test-only noise (scoped to the suite).
-    "ignore:Filename .* does not follow the EPRV naming convention:UserWarning",
 ]
 # The `requires_testdata` marker is registered in tests/conftest.py
 # (pytest_configure), which also skips those tests when tests/testdata is absent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,13 @@ name = "kpfpipe"
 version = "3.0.0"
 description = "KPF Data Reduction Pipeline"
 authors = [
-    { name = "Greg Gilbert", email = "gjgilbert@caltech.edu" },
+    { name = "Greg Gilbert", email = "ggilbert@caltech.edu" },
     { name = "B.J. Fulton", email = "bjfulton@ipac.caltech.edu" },
     { name = "Andrew Howard", email = "ahoward@caltech.edu" }
 ]
 license = {text = "BSD-3-Clause"}
 requires-python = "==3.14.3"
 
-# Main dependencies
 dependencies = [
     "astropy==7.2.0",
     "astroquery==0.4.11",
@@ -25,7 +24,6 @@ dependencies = [
     "rv-data-standard==0.4.0"
 ]
 
-# Optional dependencies for development (linting, testing, formatting)
 [project.optional-dependencies]
 dev = [
     "ipykernel==7.2.0",
@@ -53,39 +51,33 @@ include = ["kpfpipe*", "tools*", "scripts*", "recipes*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-# Quiet output to economize on token/log footprint: -q collapses the progress
-# line, --no-header drops the platform/plugins banner, --tb=short trims failure
-# tracebacks to the assertion + one frame. Re-run a single failure with
-# --tb=long when you need the full frame context.
+# Quiet output; re-run a single failure with --tb=long for full frame context.
 addopts = "-q --no-header --tb=short"
+# Exempt only warnings that are expected *and* handled, and prefer
+# @pytest.mark.filterwarnings on the one test over widening this list.
 filterwarnings = [
-    # astropy truncates over-long FITS card comments; the masters INPUT_FILES
-    # round-trip deliberately writes long paths, so this is expected, not a bug.
+    "error",
+    # masters INPUT_FILES deliberately round-trips long paths.
     "ignore:Card is too long, comment will be truncated:astropy.io.fits.verify.VerifyWarning",
 ]
-# The `requires_testdata` marker is registered in tests/conftest.py
-# (pytest_configure), which also skips those tests when tests/testdata is absent.
+# Markers are registered in tests/conftest.py (pytest_configure).
 
-# Ruff is the unified formatter + linter (replaces black/isort/flake8).
-# Enforced via the pre-commit hook; see .pre-commit-config.yaml.
+# Ruff is the unified formatter + linter; enforced via .pre-commit-config.yaml.
 [tool.ruff]
 line-length = 88
-# Pinned below the runtime (3.14.3) on purpose: Pylance/Pyright doesn't yet parse
-# PEP 758's unparenthesized `except A, B:`, and at py314 `ruff format` strips the
-# parens to that form. py313 keeps the formatter on `except (A, B):` — valid under
-# every tool.
+# Pinned below the runtime (3.14.3): at py314 `ruff format` rewrites
+# `except (A, B):` to PEP 758's unparenthesized form, which Pylance can't parse.
 target-version = "py313"
-extend-exclude = ["legacy", "gjgilbert_notebooks"]
+extend-exclude = ["legacy"]
 
 [tool.ruff.lint]
 # E/W pycodestyle, F pyflakes, I import-sorting, B bugbear, UP pyupgrade,
-# G logging-format (lazy %-formatting in log calls), LOG logging (named
-# loggers only, no root-logger convenience calls).
+# G logging-format, LOG logging.
 select = ["E", "F", "W", "I", "B", "UP", "G", "LOG"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["kpfpipe"]
 
 [tool.ruff.lint.per-file-ignores]
-# Package __init__.py files re-export names; unused-import (F401) is expected.
+# __init__.py re-exports names.
 "__init__.py" = ["F401"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,11 +54,16 @@ testpaths = ["tests"]
 # Quiet output; re-run a single failure with --tb=long for full frame context.
 addopts = "-q --no-header --tb=short"
 # Exempt only warnings that are expected *and* handled, and prefer
-# @pytest.mark.filterwarnings on the one test over widening this list.
+# @pytest.mark.filterwarnings on the one test over widening this list. The
+# exception is a warning raised during garbage collection: it surfaces at an
+# arbitrary later test, so no single test owns it and only a global rule works.
 filterwarnings = [
     "error",
     # masters INPUT_FILES deliberately round-trips long paths.
     "ignore:Card is too long, comment will be truncated:astropy.io.fits.verify.VerifyWarning",
+    # astroquery.gaia opens a connection to ESA at import (astro_query.py:27) and
+    # never closes it. Print the leak; do not fail on GC timing.
+    "default::ResourceWarning",
 ]
 # Markers are registered in tests/conftest.py (pytest_configure).
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,18 +146,14 @@ def synthetic_l0_file(tmp_path_factory):
 @pytest.fixture
 def synthetic_l0_minimal(tmp_path):
     """Create an L0 file with only PRIMARY (no optional extensions)."""
-    fn = str(tmp_path / "KP.20240113.00001.00.fits")
+    # Deferred like _catalog_record_hdu above: this root conftest is imported at
+    # collection for every session, and _data_models pulls in kpfpipe.
+    from .regression._data_models import write_minimal_l0
 
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["DATE-OBS"] = "2024-01-13T00:00:01"
-    primary.header["OFNAME"] = "KP.20240113.00001.00.fits"
-
-    hdul = fits.HDUList([primary])
-    hdul.writeto(fn, overwrite=True)
-    hdul.close()
-
-    return fn
+    return write_minimal_l0(
+        tmp_path / "KP.20240113.00001.00.fits",
+        primary_cards={"DATE-OBS": "2024-01-13T00:00:01", "PROGNAME": None},
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,12 +7,45 @@ them. Fixtures are seeded for run-to-run determinism, matching the convention
 already used by ``test_quicklook_l0.py`` and ``test_master_*.py``.
 """
 
+import socket
 from pathlib import Path
 
 import numpy as np
 import pytest
 from astropy.io import fits
 from astropy.table import Table
+
+# ---------------------------------------------------------------------------
+# Offline guard -- deliberately module-scope, not a fixture
+# ---------------------------------------------------------------------------
+#
+# The regression suite is offline by contract: every external query is mocked.
+# This makes that a rule the suite enforces rather than a claim its docstrings
+# make -- a test that reaches for the wire now fails loudly, naming the address.
+#
+# It must run at import, not in a fixture: astroquery.gaia opens a connection to
+# the ESA archive when `kpfpipe.modules.astro_query` is imported
+# (astro_query.py:27, a filed production defect), and that import happens during
+# COLLECTION, before any fixture -- even a session-scoped autouse one -- can run.
+# Blocking it there is worth 1.4-2.7 s per worker process; astroquery survives
+# the refusal, printing "Status messages could not be retrieved" and carrying on
+# with the real `Gaia` object the tests patch.
+#
+# Loopback stays open so pytest-xdist, execnet and any local-socket test are
+# unaffected.
+_real_connect = socket.socket.connect
+
+
+def _no_outbound_connect(self, address, *args, **kwargs):
+    host = address[0] if isinstance(address, tuple) else address
+    if isinstance(host, str) and (
+        host.startswith("127.") or host in ("::1", "localhost")
+    ):
+        return _real_connect(self, address, *args, **kwargs)
+    raise OSError(f"the regression suite is offline; blocked connect to {address!r}")
+
+
+socket.socket.connect = _no_outbound_connect
 
 # Fixed seed so every synthetic-FITS fixture is byte-stable across runs.
 _SEED = 20240113
@@ -40,8 +73,12 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "slow: slow integration or heavy-compute test; excluded from the fast "
-        "pre-commit subset (`-m 'not slow'`), run in the full suite",
+        "slow: touches the real tests/testdata truth frames. Paired with "
+        "requires_testdata rather than overlapping it: requires_testdata says "
+        "the frames must be present, slow says the fast pre-commit subset "
+        "(`-m 'not slow'`) skips the cost of reading them. Not a timing claim -- "
+        "do not mark a synthetic test slow because it feels slow, and do not "
+        "leave a real-data test unmarked because it happens to be quick.",
     )
     config.addinivalue_line(
         "markers",
@@ -51,9 +88,15 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "quicklook: quicklook/QLP render test (slow PNG rendering, an offshoot "
-        "from the production path); excluded from the fast pre-commit subset. "
-        "Run in the full suite or focused with `-m quicklook`",
+        "quicklook: exercises kpfpipe.quality_control.quicklook -- the "
+        "PlotL0/L1/L2/L4 renderers; excluded from the fast pre-commit subset "
+        "because the PNG rendering is slow. Names the MODULE under test, not "
+        "the technique: a test elsewhere in the tree that happens to render a "
+        "figure does not get this marker, so `-m quicklook` collects exactly "
+        "the quicklook plots a developer is working on and nothing else. "
+        "(scripts/quality_control/qlp.py drives these renderers, but its test "
+        "is scripts-layer and so carries `cli`.) Run in the full suite or "
+        "focused with `-m quicklook`",
     )
 
 

--- a/tests/regression/_catalog.py
+++ b/tests/regression/_catalog.py
@@ -1,4 +1,4 @@
-"""Synthetic CATALOG_RECORD tables for the data-model tests.
+"""Synthetic CATALOG_RECORD tables for the data-model tests (not a test module).
 
 Built column by column rather than through ``AstroQuery._write_catalog_record``, so
 the pass-through tests stay independent of the module that populates the extension.

--- a/tests/regression/_catalog.py
+++ b/tests/regression/_catalog.py
@@ -48,3 +48,23 @@ def catalog_record_table(rv=-16.6):
     table["rv"] = np.array([np.nan if missing else rv] * 2, dtype=float)
     table["z"] = np.array([np.nan if missing else -5.5e-5] * 2, dtype=float)
     return table
+
+
+def seed_sci2_cards(kpf2, *, sci_obj="Target", sky_obj="Sky", cal_obj="None"):
+    """Seed the SCI2 catalog cards the CCF chain reads off a KPF2.
+
+    These are the C*#3 cards ``KPF0.to_kpf1`` overlays for the SCI2 orderlet
+    (colour + its band name, drive the CCF mask temperature; CRV3 centres the
+    velocity grid) plus the per-fiber illumination sources. CRV3 is present so
+    the module does not take its warn-and-default path.
+
+    Takes the object rather than importing a data model, so this module stays
+    import-light -- it is pulled in at collection through the data-model tests.
+    """
+    kpf2.headers["PRIMARY"]["CCLR3"] = 0.823  # G2V -> 5770 K
+    kpf2.headers["PRIMARY"]["CCLRN3"] = "Gaia BP-RP"
+    kpf2.headers["PRIMARY"]["CRV3"] = 0.0
+    kpf2.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = sci_obj
+    kpf2.headers["INSTRUMENT_HEADER"]["SKY-OBJ"] = sky_obj
+    kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = cal_obj
+    return kpf2

--- a/tests/regression/_data_models.py
+++ b/tests/regression/_data_models.py
@@ -1,0 +1,225 @@
+"""Synthetic KPF data products for the test suite (not a test module).
+
+Builders only -- nothing here asserts. ``_dtype_policy.py`` is the one contract
+module; if a cross-cutting contract needs assertions, promote it to a new
+contract module rather than growing one here.
+
+Detector-derived constants are read from the production ``DETECTOR`` table so
+they cannot drift. ``FIBERS`` is in canonical slicer order (``fiber_positions``
+in ``reference/detector.toml``); a test asserting a production default's fiber
+*ordering* is an oracle and must keep spelling the order out literally.
+
+Deliberately absent: a shared array width. Every consumer picks its own ncol for
+a stated reason (CCF clip margins, PNG size checks, overscan geometry), so width
+is always an explicit argument.
+"""
+
+import os
+
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+
+from kpfpipe import DETECTOR
+
+# --- detector-derived constants --------------------------------------------
+
+CHIPS = ("GREEN", "RED")
+NORDER_GREEN = DETECTOR["norder"]["GREEN"]
+NORDER_RED = DETECTOR["norder"]["RED"]
+NORDER_TOTAL = NORDER_GREEN + NORDER_RED
+NORDER = {"GREEN": NORDER_GREEN, "RED": NORDER_RED}
+
+# Canonical slicer order: SKY=0, SCI1=1, SCI2=2, SCI3=3, CAL=4.
+FIBERS = tuple(sorted(DETECTOR["fiber_positions"], key=DETECTOR["fiber_positions"].get))
+
+# Self-consistent raw timing cards (END - BEG == ELAPSED), for the DATTIMOK check.
+GOOD_DATES = {
+    "DATE-BEG": "2024-09-23T09:12:09.484",
+    "DATE-MID": "2024-09-23T09:12:15.519",
+    "DATE-END": "2024-09-23T09:12:21.554",
+    "ELAPSED": 12.07,
+}
+
+_DEFAULT_PRIMARY = {
+    "INSTRUME": "KPF",
+    "OBJECT": "synthetic",
+    "IMTYPE": "Bias",
+    "DATE-OBS": "2024-01-01T00:00:01",
+    "PROGNAME": "K123",
+}
+
+
+# --- L0 on-disk frames ------------------------------------------------------
+
+
+def _primary_hdu(path, primary_cards):
+    """PRIMARY with the cards every L0 needs; ``primary_cards`` overrides.
+
+    OFNAME defaults to the file's own basename, which is what keeps the write
+    from tripping ``check_filename_convention``. A card set to None is dropped,
+    so a caller can build a frame that is deliberately missing one.
+    """
+    cards = dict(_DEFAULT_PRIMARY, OFNAME=os.path.basename(str(path)))
+    cards.update(primary_cards or {})
+    primary = fits.PrimaryHDU()
+    for key, value in cards.items():
+        if value is not None:
+            primary.header[key] = value
+    return primary
+
+
+def write_amp_l0(
+    path,
+    *,
+    namps=4,
+    chips=CHIPS,
+    shape=(10, 10),
+    bias_level=None,
+    seed=42,
+    with_data=True,
+    primary_cards=None,
+    extra_hdus=(),
+):
+    """Write a synthetic raw L0 with a ``{chip}_AMP{n}`` HDU per amplifier.
+
+    Returns the path. This is a plain builder, not a fixture: the caller owns
+    its own fixture scope (a 4-amp frame at full detector size is ~140 MB, which
+    one caller deliberately writes once per module) and decides whether to
+    ``from_fits`` the result.
+
+    ``bias_level=None`` fills every amp with ones -- adequate whenever the test
+    only cares that data is present. A float instead fills with seeded Gaussian
+    noise about that level, for tests that measure the assembled image.
+    ``with_data=False`` writes ``data=None`` HDUs, which KPF0 stores as
+    ``array(None, dtype=object)`` and treats as absent.
+    """
+    rng = np.random.default_rng(seed)
+    hdus = [_primary_hdu(path, primary_cards)]
+    for chip in chips:
+        for amp in range(1, namps + 1):
+            if not with_data:
+                data = None
+            elif bias_level is None:
+                data = np.ones(shape, dtype=np.float32)
+            else:
+                data = (bias_level + rng.normal(0, 3.0, shape)).astype(np.float32)
+            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
+    hdus.extend(extra_hdus)
+    hdul = fits.HDUList(hdus)
+    hdul.writeto(str(path), overwrite=True)
+    hdul.close()
+    return str(path)
+
+
+def write_minimal_l0(path, *, primary_cards=None, extra_hdus=()):
+    """Write an L0 carrying only PRIMARY (plus any ``extra_hdus``).
+
+    The no-optional-extensions counterpart to ``write_amp_l0``, for tests about
+    the read path rather than the pixels.
+    """
+    return write_amp_l0(
+        path,
+        namps=0,
+        with_data=False,
+        primary_cards=primary_cards,
+        extra_hdus=extra_hdus,
+    )
+
+
+# --- L2 in-memory -----------------------------------------------------------
+
+
+def set_fiber_arrays(kpf2, suffix, value, *, ncol, chips=CHIPS, fibers=FIBERS):
+    """Populate ``{chip}_{fiber}_{suffix}`` with a constant for the given fibers.
+
+    ``ncol`` is required on purpose -- see the module docstring.
+    """
+    for chip in chips:
+        for fiber in fibers:
+            kpf2.set_data(
+                f"{chip}_{fiber}_{suffix}",
+                np.full((NORDER[chip], ncol), value, dtype=np.float32),
+            )
+
+
+# --- L4 in-memory -----------------------------------------------------------
+
+
+def make_l4(
+    *,
+    sci=True,
+    rv_filled=True,
+    jitter=0.0,
+    berv=0.0,
+    sci_obj=None,
+    bervrng=None,
+    bjdrng=None,
+    seed=3,
+):
+    """KPF4 with science CCF cubes and per-order RV tables.
+
+    ``jitter`` is the per-order scatter applied to BJD_TDB and BERV. It defaults
+    to 0 (every order identical). **A caller exercising the BJDOK/BERVOK gates
+    must pass 1e-7** -- that magnitude is tuned to sit well inside those gates
+    (about 1 s in BJD, 0.1 m/s in BERV), so a good product passes; re-rolling it
+    larger silently turns a passing test into a failing one. Non-zero jitter also
+    scatters RV itself by 1e-3 km/s, so the product looks like a real one.
+
+    ``rv_filled=False`` seeds NaN RVs, as a CrossCorrelation-only L4 has before
+    RadialVelocity runs. ``sci_obj`` sets INSTRUMENT_HEADER SCI-OBJ, which the
+    BERV/BJD tolerance checks honour only when it is 'target'.
+
+    Does not seed the required PRIMARY keywords; call ``seed_required_primary``
+    when the test needs KWRDPRL4 to pass.
+    """
+    from kpfpipe.data_models.level4 import KPF4
+
+    l4 = KPF4()
+    if sci:
+        rng = np.random.default_rng(seed)
+
+        def scatter(width):
+            # Always an array: a scalar here would make astropy reject the
+            # mixed scalar/array column dict.
+            if not jitter:
+                return np.zeros(NORDER_TOTAL)
+            return rng.normal(0, width, NORDER_TOTAL)
+
+        for fiber in ("SCI1", "SCI2", "SCI3"):
+            if not rv_filled:
+                rv_col = np.full(NORDER_TOTAL, np.nan)
+            else:
+                rv_col = np.zeros(NORDER_TOTAL) + scatter(1e-3)
+            l4.set_data(f"{fiber}_CCF", np.ones((NORDER_TOTAL, 5)))
+            l4.set_data(
+                f"{fiber}_RV",
+                Table(
+                    {
+                        "ORDER_INDEX": np.arange(NORDER_TOTAL),
+                        "RV": rv_col,
+                        "BJD_TDB": 2460000.0 + scatter(jitter),
+                        "BERV": berv + scatter(jitter),
+                        "WEIGHT": np.ones(NORDER_TOTAL),
+                    }
+                ),
+            )
+    if bervrng is not None:
+        l4.headers["QUALITY_CONTROL"]["BERVRNG"] = bervrng
+    if bjdrng is not None:
+        l4.headers["QUALITY_CONTROL"]["BJDRNG"] = bjdrng
+    if sci_obj is not None:
+        l4.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = sci_obj
+    return l4
+
+
+def seed_required_primary(kpf, qc_cls):
+    """Seed every PRIMARY keyword ``qc_cls`` requires, skipping ones already set.
+
+    KWRDPR* is presence-only, so sentinel values suffice; reusing the production
+    ``_required_primary_keywords`` avoids drift. ``qc_cls`` is a parameter rather
+    than an import, so this module stays free of quality_control.
+    """
+    for kw in qc_cls(kpf)._required_primary_keywords():
+        if kw not in kpf.headers["PRIMARY"]:
+            kpf.headers["PRIMARY"][kw] = ("UNKNOWN", "seeded for test")

--- a/tests/regression/_dtype_policy.py
+++ b/tests/regression/_dtype_policy.py
@@ -56,7 +56,7 @@ def assert_not_float64(arr, label):
 
 
 def assert_roundtrip_dtype(
-    model_cls, obj, ext, expected, tmp_path, name="rt.fits", expected_disk=None
+    model_cls, obj, ext, expected, tmp_path, name, expected_disk=None
 ):
     """Write ``obj`` to FITS, read it back with ``model_cls``, and assert the
     extension ``ext`` round-trips correctly.
@@ -65,8 +65,8 @@ def assert_roundtrip_dtype(
     on-disk dtype (BITPIX), defaulting to ``expected``. They differ for MASK,
     which is bool in memory but uint8 (8-bit) on disk.
 
-    ``name`` defaults to a throwaway; L2/L4 callers should pass a conventional
-    EPRV name, since those levels warn (via rvdata) on an off-convention write.
+    ``name`` is the output filename, required because every level warns on an
+    off-convention write (L2/L4 via rvdata, the rest via check_filename_convention).
     """
     expected_disk = expected if expected_disk is None else expected_disk
     out = str(tmp_path / name)

--- a/tests/regression/_dtype_policy.py
+++ b/tests/regression/_dtype_policy.py
@@ -63,7 +63,7 @@ _ROUNDTRIP_NAMES = {
     "KPF0": "KP.20240113.23249.10.fits",
     "KPF1": "kpf_L1_20240113T102656.fits",
     "KPF2": "kpf_SL2_20240101T000000.fits",
-    "KPF4": "kpf_L4_20240101T000000.fits",
+    "KPF4": "kpf_SL4_20240101T000000.fits",
     "KPFMasterL1": "KP.20240113.23249.10_master_bias_L1.fits",
     "KPFMasterL2": "KP.20240113.23249.10_master_thar_L2.fits",
 }

--- a/tests/regression/_dtype_policy.py
+++ b/tests/regression/_dtype_policy.py
@@ -64,14 +64,13 @@ def assert_roundtrip_dtype(
     ``expected`` is the in-memory dtype after re-read; ``expected_disk`` is the
     on-disk dtype (BITPIX), defaulting to ``expected``. They differ for MASK,
     which is bool in memory but uint8 (8-bit) on disk.
-    """
-    import warnings
 
+    ``name`` defaults to a throwaway; L2/L4 callers should pass a conventional
+    EPRV name, since those levels warn (via rvdata) on an off-convention write.
+    """
     expected_disk = expected if expected_disk is None else expected_disk
     out = str(tmp_path / name)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Filename .* does not follow")
-        obj.to_fits(out)
+    obj.to_fits(out)
 
     from astropy.io import fits
 

--- a/tests/regression/_dtype_policy.py
+++ b/tests/regression/_dtype_policy.py
@@ -5,6 +5,10 @@ respect in memory, in module intermediates, and on disk. EPRV mandates 64-bit fo
 ``*_WAVE``/``BJD_TDB``/``WAVE_START``/``WAVE_END`` and 8-bit for quality; the rest
 is KPF policy (float32 science arrays for speed, float64 for RV/CCF precision).
 Both directions matter: an upscale costs performance, a downscale costs RV accuracy.
+
+Builder helpers are assertion-free. ``_dtype_policy.py`` is the one contract module;
+if a cross-cutting contract genuinely needs assertions, promote it to a new contract
+module and justify the contract.
 """
 
 import numpy as np
@@ -50,8 +54,23 @@ def assert_not_float64(arr, label):
     )
 
 
+# Convention-conforming output names, one per model class, so a round-trip does not
+# have to spell one out just to dodge the off-convention write warning. Deliberately
+# literal and NOT derived from kpfpipe.utils.io.kpf_filename: the filename convention
+# is independently asserted in test_io.py, and calling production here would launder
+# that oracle. Keyed on the class name so this module imports no data model.
+_ROUNDTRIP_NAMES = {
+    "KPF0": "KP.20240113.23249.10.fits",
+    "KPF1": "kpf_L1_20240113T102656.fits",
+    "KPF2": "kpf_SL2_20240101T000000.fits",
+    "KPF4": "kpf_L4_20240101T000000.fits",
+    "KPFMasterL1": "KP.20240113.23249.10_master_bias_L1.fits",
+    "KPFMasterL2": "KP.20240113.23249.10_master_thar_L2.fits",
+}
+
+
 def assert_roundtrip_dtype(
-    model_cls, obj, ext, expected, tmp_path, name, expected_disk=None
+    model_cls, obj, ext, expected, tmp_path, name=None, expected_disk=None
 ):
     """Write ``obj`` to FITS, re-read it, and assert ``ext`` round-trips correctly.
 
@@ -59,10 +78,19 @@ def assert_roundtrip_dtype(
     on-disk dtype (BITPIX), defaulting to ``expected``. They differ for MASK,
     which is bool in memory but uint8 on disk.
 
-    ``name`` is the output filename, required because every level warns on an
-    off-convention write (L2/L4 via rvdata, the rest via check_filename_convention).
+    ``name`` overrides the output filename; it defaults to this model's entry in
+    ``_ROUNDTRIP_NAMES`` because every level warns on an off-convention write
+    (L2/L4 via rvdata, the rest via check_filename_convention).
     """
     expected_disk = expected if expected_disk is None else expected_disk
+    if name is None:
+        try:
+            name = _ROUNDTRIP_NAMES[model_cls.__name__]
+        except KeyError:
+            raise KeyError(
+                f"no conventional round-trip filename for {model_cls.__name__}; "
+                "add one to _ROUNDTRIP_NAMES or pass name= explicitly"
+            ) from None
     out = str(tmp_path / name)
     obj.to_fits(out)
 

--- a/tests/regression/_dtype_policy.py
+++ b/tests/regression/_dtype_policy.py
@@ -1,13 +1,10 @@
 """Shared dtype-provenance policy for the test suite (not a test module).
 
-Single source of truth for the float32/float64/uint8/bool matrix the pipeline
-must respect at every state — in-memory arrays, module-internal intermediates,
-and the FITS-serialized form. EPRV mandates 64-bit for ``*_WAVE``/``BJD_TDB``/
-``WAVE_START``/``WAVE_END`` and 8-bit for quality; the rest is KPF policy
-(float32 science arrays for performance, float64 for RV/CCF precision).
-
-Guard BOTH directions: never upscale float32->float64 (perf), never downscale
-float64->float32 (precision loss -> wrong RVs).
+Single source of truth for the float32/float64/uint8/bool matrix the pipeline must
+respect in memory, in module intermediates, and on disk. EPRV mandates 64-bit for
+``*_WAVE``/``BJD_TDB``/``WAVE_START``/``WAVE_END`` and 8-bit for quality; the rest
+is KPF policy (float32 science arrays for speed, float64 for RV/CCF precision).
+Both directions matter: an upscale costs performance, a downscale costs RV accuracy.
 """
 
 import numpy as np
@@ -35,10 +32,8 @@ _BITPIX = {
 def assert_dtype(arr, expected, label):
     """Assert ``arr`` has ``expected`` precision (kind + itemsize).
 
-    Compares kind/itemsize, not the exact dtype object, so byte-order is
-    ignored (FITS round-trips to big-endian, e.g. ``>f4`` is still float32).
-    The policy is about precision — float32 vs float64 vs uint8 vs bool — not
-    endianness.
+    Kind/itemsize rather than the dtype object, so byte-order is ignored: FITS
+    round-trips to big-endian, and ``>f4`` is still float32.
     """
     actual = np.asarray(arr).dtype
     exp = np.dtype(expected)
@@ -58,12 +53,11 @@ def assert_not_float64(arr, label):
 def assert_roundtrip_dtype(
     model_cls, obj, ext, expected, tmp_path, name, expected_disk=None
 ):
-    """Write ``obj`` to FITS, read it back with ``model_cls``, and assert the
-    extension ``ext`` round-trips correctly.
+    """Write ``obj`` to FITS, re-read it, and assert ``ext`` round-trips correctly.
 
     ``expected`` is the in-memory dtype after re-read; ``expected_disk`` is the
     on-disk dtype (BITPIX), defaulting to ``expected``. They differ for MASK,
-    which is bool in memory but uint8 (8-bit) on disk.
+    which is bool in memory but uint8 on disk.
 
     ``name`` is the output filename, required because every level warns on an
     off-convention write (L2/L4 via rvdata, the rest via check_filename_convention).

--- a/tests/regression/_masters.py
+++ b/tests/regression/_masters.py
@@ -1,7 +1,4 @@
-"""Shared helpers for master-frame unit tests (test_master_base, bias, dark).
-
-Not a test module (no ``test_`` prefix), so pytest does not collect it.
-"""
+"""Shared helpers for the master-frame unit tests (not a test module)."""
 
 import numpy as np
 
@@ -12,9 +9,8 @@ NROW, NCOL = 10, 10  # small arrays for unit tests
 def make_l1_arrays(rng=None, chips=CHIPS, shape=(NROW, NCOL)):
     """Return a synthetic ``stack_frames`` output dict.
 
-    Seeded for deterministic shape/dtype/sign fixtures; the values themselves
-    are not asserted numerically (real numeric behavior is pinned by the
-    regression and stacking unit tests in each module).
+    Seeded for deterministic shape/dtype/sign fixtures; the values themselves are
+    never asserted numerically, which the regression tests do instead.
     """
     if rng is None:
         rng = np.random.default_rng(42)

--- a/tests/regression/_masters.py
+++ b/tests/regression/_masters.py
@@ -1,5 +1,8 @@
 """Shared helpers for the master-frame unit tests (not a test module)."""
 
+from contextlib import contextmanager
+from unittest.mock import patch
+
 import numpy as np
 
 CHIPS = ("GREEN", "RED")
@@ -23,3 +26,37 @@ def make_l1_arrays(rng=None, chips=CHIPS, shape=(NROW, NCOL)):
         )
         arrays[f"{chip}_MASK"] = np.ones((nrow, ncol), dtype=bool)
     return arrays
+
+
+# Eight synthetic source frames -- more than every ``min_stack_size`` gate in the
+# masters modules (the largest is 5), so a stack succeeds unless a test makes it fail.
+FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
+
+# Convention-conforming master name, for tests that need a write target on disk.
+# Never asserted against production naming -- it is a destination, not an oracle.
+MASTER_NAME = "KP.20240113.23249.10_master_bias_L1.fits"
+
+
+@contextmanager
+def mocked_stack(module, arrays=None):
+    """Patch ``stack_frames`` on ``module`` to return synthetic arrays.
+
+    Stacking real frames needs real data; every unit test instead feeds
+    ``make_l1_arrays()`` straight into ``make_master_l1``. Use this directly when
+    the test needs the module object afterwards (to call ``info`` or
+    ``save_master`` on it); otherwise prefer ``make_mocked_master``.
+    """
+    value = make_l1_arrays() if arrays is None else arrays
+    with patch.object(module, "stack_frames", return_value=value):
+        yield module
+
+
+def make_mocked_master(cls, *, files=FILE_LIST, arrays=None, config=None, **kwargs):
+    """Build a master of type ``cls`` with ``stack_frames`` mocked out.
+
+    Returns the master L1. ``kwargs`` pass through to ``make_master_l1``, so a
+    caller can exercise ``master_path=`` or the per-subclass calibration flags.
+    """
+    module = cls(files) if config is None else cls(files, config=config)
+    with mocked_stack(module, arrays):
+        return module.make_master_l1(**kwargs)

--- a/tests/regression/_registry.py
+++ b/tests/regression/_registry.py
@@ -1,15 +1,11 @@
-"""
-Shared test helper: read the KPF header-keyword registry CSVs independently.
+"""Read the KPF header-keyword registry CSVs independently (not a test module).
 
-The conformance test wants an oracle for the keyword->extension routing that is
-*independent of the code under test*: it reads ``config/L{0,1,2,4}-headers.csv``
-directly here, then compares against the live table the data model exposes
+The conformance test needs an oracle for the keyword->extension routing that is
+*independent of the code under test*, so it reads ``config/L{0,1,2,4}-headers.csv``
+directly here and compares against the live table the data model exposes
 (``KPFDataModel.keyword_registry.routing``). Tests therefore never import
-``data_models.keyword_registry`` — registry data reaches tests through the model
-or through this helper.
-
-Like ``_masters.py`` / ``_dtype_policy.py``, this is not a ``test_*`` module, so
-pytest does not collect it.
+``data_models.keyword_registry``: registry data reaches them through the model or
+through this helper.
 """
 
 import importlib.resources

--- a/tests/regression/_science.py
+++ b/tests/regression/_science.py
@@ -1,0 +1,53 @@
+"""Synthetic spectra and line masks for the CCF chain (not a test module).
+
+Shared by the two modules that consume them, ``cross_correlation.py`` and
+``radial_velocity.py``. Builders only -- nothing here asserts.
+
+The narrow velocity grid is the reason these constants are shared rather than
+per-file: both integration suites need a grid small enough to be fast, wide
+enough for RadialVelocity's second-pass +/-3 sigma window (sigma ~ 4 km/s) to
+stay on-grid, and an injected RV that lands exactly on a grid point.
+"""
+
+import numpy as np
+from astropy.constants import c
+
+SPEED_OF_LIGHT_KMS = np.float64(c.to("km/s").value)
+
+RANGE_KMS = [-15.0, 15.0]
+STEP_KMS = 0.25  # matches the module default
+NVEL = round((RANGE_KMS[1] - RANGE_KMS[0]) / STEP_KMS) + 1
+V_INJECT = 1.5  # injected RV [km/s], on the grid
+MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Angstrom]
+# Wide enough that the default CCF clip (clip_edge_pixels=(500, 500)) trims the
+# order edges but leaves the 5015-5035 A mask lines well inside.
+NCOL = 2000
+
+
+def make_mask(centers, weights=None, width=1.0):
+    """Build a line-mask dict matching CrossCorrelation._build_line_mask."""
+    centers = np.asarray(centers, dtype=np.float64)
+    if weights is None:
+        weights = np.ones_like(centers)
+    half_width = centers * (width / 2.0 / SPEED_OF_LIGHT_KMS)
+    return {
+        "center": centers,
+        "weight": np.asarray(weights, dtype=np.float64),
+        "start": centers - half_width,
+        "end": centers + half_width,
+    }
+
+
+def absorption_spectrum(wave, centers, weights=None, depth=0.6, sigma_kms=4.0):
+    """Unit continuum with Gaussian absorption lines at `centers`."""
+    if weights is None:
+        weights = np.ones_like(centers)
+    flux = np.ones_like(wave)
+    for center, weight in zip(centers, weights, strict=False):
+        sigma_a = center * sigma_kms / SPEED_OF_LIGHT_KMS
+        flux -= (
+            depth
+            * (weight / np.max(weights))
+            * np.exp(-0.5 * ((wave - center) / sigma_a) ** 2)
+        )
+    return flux

--- a/tests/regression/_scripts.py
+++ b/tests/regression/_scripts.py
@@ -1,0 +1,109 @@
+"""Shared helpers for the scripts/CLI-layer tests (not a test module).
+
+Everything here serves ``@pytest.mark.cli`` modules: launching a script in a child
+process under the suite's warning policy, standing in for ConfigHandler, and
+staging a synthetic night tree on disk. Builders only -- no assertions.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from astropy.io import fits
+
+# Repo root: tests/regression/_scripts.py -> tests/regression -> tests -> repo.
+REPO_ROOT = str(Path(__file__).resolve().parents[2])
+
+# pytest's filterwarnings does not reach a child process, so mirror the pyproject
+# rules in: a child warning then becomes the non-zero exit the tests check for.
+# PYTHONWARNINGS resolves categories at interpreter startup, before astropy is
+# importable, so the astropy rule is carried by its message prefix alone.
+# TestChildWarningParity in test_qc_script.py asserts this stays in sync.
+CHILD_WARNINGS = ",".join(
+    (
+        "error",
+        "ignore:Card is too long",
+        "default::ResourceWarning",
+    )
+)
+
+# A child that reaches the network (AstroQuery, astropy's IERS auto-download) can
+# block forever, so cap every run: a hang becomes a loud TimeoutExpired instead of
+# a stalled suite. Generous enough for a slow-but-working run.
+CHILD_TIMEOUT = 120
+
+
+def run_script(script, *argv, timeout=CHILD_TIMEOUT):
+    """Run ``script`` (a repo-relative path) in a child process with ``argv``.
+
+    Takes arbitrary argv rather than named flags so the no-args and bad-config
+    cases use the same launcher as the happy path. Returns the CompletedProcess;
+    the caller asserts on returncode/stdout/stderr.
+    """
+    env = {**os.environ, "PYTHONPATH": REPO_ROOT, "PYTHONWARNINGS": CHILD_WARNINGS}
+    return subprocess.run(
+        [sys.executable, script, *map(str, argv)],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+class _FakeConfig:
+    """Stand-in for ConfigHandler in the exit-code tests (no real file read)."""
+
+    def __init__(self, path):
+        pass
+
+    def get_params(self, keys):
+        return {"KPF_DATA_INPUT": "/in", "log_dir": "/l"}
+
+
+class _NoLogDirConfig(_FakeConfig):
+    """A config with a resolvable data input but no configured log_dir."""
+
+    def get_params(self, keys):
+        return {"KPF_DATA_INPUT": "/in"}
+
+
+def write_config(path, data_dirs):
+    """Write a minimal ``[DATA_DIRS]`` TOML config at ``path``."""
+    lines = ["[DATA_DIRS]"]
+    lines += [f'{key} = "{value}"' for key, value in data_dirs.items()]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def write_l0_tree(
+    data_input,
+    datecode,
+    seconds,
+    *,
+    obj="10700",
+    imtype="Object",
+    targname=None,
+    exptime=60.0,
+    elapsed=60.0,
+):
+    """Write one PRIMARY-only L0 frame under ``{data_input}/L0/{datecode}``.
+
+    Enough header for a mini-db header scan and nothing more; returns the obs_id.
+    ``targname`` defaults to ``obj`` (calibration frames set them independently).
+    """
+    l0_dir = Path(data_input) / "L0" / datecode
+    l0_dir.mkdir(parents=True, exist_ok=True)
+    obs_id = f"KP.{datecode}.{seconds:05d}.00"
+    header = fits.Header(
+        {
+            "OBJECT": obj,
+            "IMTYPE": imtype,
+            "TARGNAME": obj if targname is None else targname,
+            "EXPTIME": exptime,
+            "ELAPSED": elapsed,
+        }
+    )
+    fits.PrimaryHDU(header=header).writeto(l0_dir / f"{obs_id}.fits")
+    return obs_id

--- a/tests/regression/conftest.py
+++ b/tests/regression/conftest.py
@@ -1,0 +1,30 @@
+"""Regression-suite fixtures.
+
+Pins matplotlib to the headless Agg backend for every module in this directory
+and closes figures after each test, so a plotting test cannot leak a window, a
+renderer, or a "More than 20 figures" warning into an unrelated test.
+
+The pin is an environment variable rather than ``matplotlib.use()`` so this file
+imports nothing: matplotlib reads ``MPLBACKEND`` at its own import time, which
+keeps the ~1 s matplotlib import off every ``make test-fast`` session that never
+plots.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Must be set before the first `import matplotlib` anywhere in the session.
+# setdefault, so an explicit MPLBACKEND from the environment still wins.
+os.environ.setdefault("MPLBACKEND", "Agg")
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close any figures a test opened, without importing pyplot for tests that
+    never plot -- the teardown is a no-op until something else has imported it."""
+    yield
+    pyplot = sys.modules.get("matplotlib.pyplot")
+    if pyplot is not None:
+        pyplot.close("all")

--- a/tests/regression/test_argparse_script.py
+++ b/tests/regression/test_argparse_script.py
@@ -1,10 +1,8 @@
 """Tests for scripts/processing/_argparse.py: the shared argparse parent parsers.
 
-Each factory returns an ``add_help=False`` parent that the three subcommand
-parsers compose via ``parents=[...]``. Drive each the way the commands do --
-compose it into a throwaway parser and parse -- asserting the flags it
-contributes, that data_dirs_parser gates ``--kpf_science_output`` on its argument,
-and that pool_parser threads the caller's ``--jobs`` help text through.
+Each factory returns an ``add_help=False`` parent that the subcommand parsers
+compose via ``parents=[...]``, so each is driven the way the commands drive it:
+composed into a throwaway parser, then parsed.
 """
 
 import argparse
@@ -56,22 +54,20 @@ class TestDataDirsParser:
         parser = argparse.ArgumentParser(
             parents=[_argparse.data_dirs_parser(science_output=False)]
         )
-        # The flag is absent from the namespace entirely...
+        # Masters produces no science output, so the flag is neither set nor accepted.
         ns = parser.parse_args(["--kpf_data_input", "/in"])
         assert not hasattr(ns, "kpf_science_output")
-        # ...and passing it is a parse error (masters produces no science output).
         with pytest.raises(SystemExit):
             parser.parse_args(["--kpf_science_output", "/s"])
 
     def test_input_dir_aliases_data_input(self):
-        # --input_dir is a plain alias: it writes the kpf_data_input dest.
         ns = _parse([_argparse.data_dirs_parser()], ["--input_dir", "/in"])
         assert ns.kpf_data_input == "/in"
 
     def test_output_dir_parses_to_its_own_dest(self):
         ns = _parse([_argparse.data_dirs_parser()], ["--output_dir", "/out"])
         assert ns.output_dir == "/out"
-        # It is a raw value here; the fan-out happens in resolve_dir_shortcuts.
+        # Still a raw value here; the fan-out happens in resolve_dir_shortcuts.
         assert ns.kpf_masters_output is None and ns.kpf_science_output is None
 
 
@@ -91,13 +87,11 @@ class TestResolveDirShortcuts:
         ns = _argparse.resolve_dir_shortcuts(
             self._parser(plot_dir=True).parse_args(["--output_dir", "/out"])
         )
-        # masters/science outputs take the root; logs and plots get their subdirs.
         assert ns.kpf_masters_output == "/out"
         assert ns.kpf_science_output == "/out"
         assert ns.log_dir == "/out/logs"
         assert ns.plot_dir == "/out/QLP/timeseries"
-        # The input dir is never touched by --output_dir.
-        assert ns.kpf_data_input is None
+        assert ns.kpf_data_input is None  # --output_dir never touches the input dir
 
     def test_explicit_flags_win(self):
         ns = _argparse.resolve_dir_shortcuts(
@@ -112,13 +106,13 @@ class TestResolveDirShortcuts:
                 ]
             )
         )
-        assert ns.kpf_masters_output == "/m"  # explicit kept
-        assert ns.plot_dir == "/p"  # explicit kept
-        # unset slots filled: science takes the root, log dir gets its subdir.
+        assert ns.kpf_masters_output == "/m"
+        assert ns.plot_dir == "/p"
         assert ns.kpf_science_output == "/out" and ns.log_dir == "/out/logs"
 
     def test_skips_absent_slots(self):
-        # masters-style parser: no science output, no plot dir -- no AttributeError.
+        # A masters-style parser has no science output or plot dir: absent slots
+        # must be skipped, not raise AttributeError.
         ns = _argparse.resolve_dir_shortcuts(
             self._parser(science_output=False).parse_args(["--output_dir", "/out"])
         )

--- a/tests/regression/test_argparse_script.py
+++ b/tests/regression/test_argparse_script.py
@@ -152,3 +152,23 @@ class TestPoolParser:
             parents=[_argparse.pool_parser(jobs_help="SENTINEL help text")]
         )
         assert "SENTINEL help text" in parser.format_help()
+
+
+class TestCacheParser:
+    """The --cache mode flag. Its parameterised default is what makes the leaf
+    `reduce` read-only while the orchestrators own cache writing -- the
+    one-writer-per-cache-file invariant documented at _scan.py:1-15."""
+
+    def test_factory_default_is_read_only(self):
+        assert _parse([_argparse.cache_parser()], []).cache == "r"
+
+    def test_orchestrator_default_is_honoured(self):
+        assert _parse([_argparse.cache_parser(default="rw")], []).cache == "rw"
+
+    @pytest.mark.parametrize("mode", ["r", "w", "rw", "wr"])
+    def test_every_choice_parses(self, mode):
+        assert _parse([_argparse.cache_parser()], ["--cache", mode]).cache == mode
+
+    def test_unknown_mode_rejected(self):
+        with pytest.raises(SystemExit):
+            _parse([_argparse.cache_parser()], ["--cache", "rr"])

--- a/tests/regression/test_astro.py
+++ b/tests/regression/test_astro.py
@@ -1,9 +1,9 @@
 """Tests for kpfpipe.utils.astro: Doppler/redshift helpers, air->vacuum, colour->Teff.
 
-Convention under test: positive radial velocity = receding = redshift (z > 0),
-so the Doppler factor f = lambda_obs / lambda_rest = 1 + z, and z carries the
-same sign as the velocity. This is the convention BarycentricCorrection relies
-on when storing BARYCORR_Z for RadialVelocity._compute_ccf_1d.
+Convention under test: positive radial velocity = receding = redshift (z > 0), so
+the Doppler factor f = lambda_obs / lambda_rest = 1 + z and z carries the sign of
+the velocity -- what BarycentricCorrection assumes when it stores BARYCORR_Z for
+CrossCorrelation._compute_ccf_1d.
 
 The colour->Teff tests are anchored on the Sun: all three catalog colour indices
 must land on the tabulated G2V temperature, since CrossCorrelation picks the same
@@ -30,14 +30,13 @@ from kpfpipe.utils.astro import (
 
 C_KMS = c.to("km/s").value
 
-# The tabulated G2V row: one star, the three colours the pipeline can be handed.
+# The tabulated G2V row, in the three colours the pipeline can be handed.
 SUN_TEFF = 5770.0
 SUN_COLORS = {"B-V": 0.650, "Gaia BP-RP": 0.823, "G-J": 4.635 - 3.60}
 
 
 class TestComputeRedshift:
     def test_sign_matches_velocity(self):
-        # Receding (v > 0) -> positive redshift; approaching -> negative.
         assert compute_redshift(+18.508 * u.km / u.s) > 0
         assert compute_redshift(-18.508 * u.km / u.s) < 0
 
@@ -51,7 +50,6 @@ class TestComputeRedshift:
         assert compute_doppler_factor(v) == pytest.approx(1.0 + compute_redshift(v))
 
     def test_unit_agnostic(self):
-        # Same physical velocity in different units -> same result.
         assert compute_redshift(-18.508 * u.km / u.s) == pytest.approx(
             compute_redshift(-18508.0 * u.m / u.s)
         )
@@ -67,12 +65,11 @@ class TestComputeRedshift:
         assert z[0] < 0 < z[2] and z[1] == pytest.approx(0.0)
 
     def test_bare_value_raises(self):
-        # Units must stay explicit; a unitless argument fails loudly.
+        # A unitless argument is ambiguous (km/s? m/s?), so it must fail loudly.
         with pytest.raises(u.UnitsError):
             compute_redshift(-18508.0)
 
     def test_factor_direction(self):
-        # Receding source is redshifted (f > 1); approaching is blueshifted.
         assert compute_doppler_factor(+18.508 * u.km / u.s) > 1.0
         assert compute_doppler_factor(-18.508 * u.km / u.s) < 1.0
 
@@ -91,7 +88,6 @@ class TestAirToVac:
 class TestColorToTeff:
     @pytest.mark.parametrize("color_name", list(SUN_COLORS))
     def test_solar_colors_agree(self, color_name):
-        # Whichever catalog supplies the colour, the Sun must come out the same.
         assert color_to_teff(SUN_COLORS[color_name], color_name) == pytest.approx(
             SUN_TEFF
         )
@@ -106,9 +102,8 @@ class TestColorToTeff:
         assert np.all(np.diff(teffs) < 0)
 
     def test_censoring_is_driven_by_the_difference(self):
-        # G-J reverses at K6V/M0V/M7V, so those rows must be censored -- but M_G
-        # and M_J are each monotonic on their own, which is why the censoring has
-        # to be applied to M_G - M_J and not to either magnitude.
+        # M_G and M_J are each monotonic on their own, but their difference is not,
+        # so the censoring has to be applied to M_G - M_J, not to either magnitude.
         m_g, m_j = _EEM["M_G"].to_numpy(), _EEM["M_J"].to_numpy()
         both = np.isfinite(m_g) & np.isfinite(m_j)
         assert np.all(np.diff(m_g[both]) >= 0)

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -1,10 +1,10 @@
 """Regression tests for the AstroQuery module.
 
 Covers ``merge_catalog_records`` (gaia/simbad/wmko -> the canonical ``kpf-drp``
-row), ``read_wmko_header`` off synthetic L0 PRIMARY TARG*, and the external
-query contract. The network is never touched: ``Gaia.launch_job``/``Simbad`` are
-mocked with one-row result Tables, so parsing, the fail-soft None+warning paths,
-and the ``_verify_units`` schema-drift guard all run offline.
+row), ``read_wmko_header`` off synthetic L0 PRIMARY TARG*, and the external query
+contract. The network is never touched: ``Gaia.launch_job``/``Simbad`` are mocked
+with one-row result Tables, so parsing, the fail-soft None+warning paths, and the
+``_verify_units`` schema-drift guard all run offline.
 """
 
 import logging
@@ -24,20 +24,20 @@ from kpfpipe.utils.network import _RETRY_WAITS
 
 
 def _ra_str(deg):
-    """RA in deg -> the EPRV C*# sexagesimal hour-angle string the schema stores."""
+    """RA in deg -> the sexagesimal hour-angle string the CRA# schema stores."""
     return Angle(deg, u.deg).to_string(unit=u.hourangle, sep=":", pad=True, precision=4)
 
 
 def _dec_str(deg):
-    """Dec in deg -> the EPRV C*# sexagesimal string the schema stores."""
+    """Dec in deg -> the sexagesimal string the CDEC# schema stores."""
     return Angle(deg, u.deg).to_string(
         unit=u.deg, sep=":", pad=True, alwayssign=True, precision=3
     )
 
 
 def _record(obj, ra=180.0, **overrides):
-    """A complete canonical record at ``ra`` in the EPRV C*# format: sexagesimal
-    RA/Dec, PM in arcsec/yr. Override a field with None to mark it missing."""
+    """A complete canonical record at ``ra``: sexagesimal RA/Dec, PM in arcsec/yr.
+    Override a field with None to mark it missing."""
     rec = {
         "object": obj,
         "ra": _ra_str(ra),
@@ -60,8 +60,8 @@ def _merge(records, targradv=None, priority=("gaia", "simbad", "wmko")):
     """Merge {source: record} the way perform does: preset each source's record on
     a fresh AstroQuery, then merge. Returns the canonical kpf-drp record dict
     (missing cells None). ``targradv`` seeds TARGRADV for the rv fallback. The
-    default ``priority`` admits all three sources so these tests exercise the merge
-    itself; the shipped policy is pinned separately in TestAstrometryPriority."""
+    default ``priority`` admits all three sources so these exercise the merge
+    itself; the shipped policy is pinned in TestAstrometryPriority."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["IMTYPE"] = "object"
     if targradv is not None:
@@ -82,7 +82,7 @@ class TestMergeCatalogRecords:
         assert row["rv"] == pytest.approx(10.0)
 
     def test_position_follows_priority(self):
-        # All three complete but at different RAs -> position from Gaia (highest).
+        # All three complete but at different RAs, so the winner is visible.
         row = _merge(
             {
                 "gaia": _record("G", ra=10.0),
@@ -117,7 +117,7 @@ class TestMergeCatalogRecords:
         assert row["color_name"] == "Gaia BP-RP"
 
     def test_color_borrowed_from_lower_priority_when_base_lacks(self, caplog):
-        # Unlike rv, a color index is independent of the astrometry, so borrowing
+        # A color index is independent of the astrometry (unlike rv), so borrowing
         # one from a lower-priority catalog is acceptable -- with a WARNING.
         with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
             row = _merge(
@@ -142,8 +142,8 @@ class TestMergeCatalogRecords:
         assert row["color_name"] is None
 
     def test_rv_not_borrowed_from_lower_priority(self):
-        # Gaia is the base and lacks rv; SIMBAD's is not borrowed, and with no
-        # TARGRADV the rv stays missing.
+        # rv must ride with the astrometric base: SIMBAD's is not borrowed, and
+        # with no TARGRADV the rv stays missing.
         row = _merge(
             {
                 "gaia": _record("G", rv=None),
@@ -155,8 +155,7 @@ class TestMergeCatalogRecords:
         assert row["rv_src"] == ""
 
     def test_rv_missing_falls_back_to_targradv(self, caplog):
-        # Base lacks rv -> fall back to the telescope TARGRADV on PRIMARY
-        # ([km/s], no conversion), tagged rv_src='wmko'.
+        # TARGRADV is already km/s, so the fallback needs no conversion.
         with caplog.at_level(logging.WARNING, logger="kpfpipe.modules.astro_query"):
             row = _merge({"gaia": _record("G", rv=None)}, targradv=-4.5)
         assert row["radec_src"] == "gaia"
@@ -175,7 +174,7 @@ class TestMergeCatalogRecords:
             }
         )
         assert row["radec_src"] == "simbad"
-        assert row["ra"] == _ra_str(20.0)  # position from SIMBAD, not Gaia
+        assert row["ra"] == _ra_str(20.0)  # SIMBAD's RA, not Gaia's
         assert row["parallax"] == pytest.approx(7.0)
         assert row["plx_src"] == "simbad"
 
@@ -192,7 +191,7 @@ class TestMergeCatalogRecords:
 
     def test_lone_source_missing_parallax_raises(self):
         # parallax is part of the astrometric block, so a sole source lacking it
-        # cannot anchor the canonical position.
+        # cannot anchor the position.
         with pytest.raises(ValueError, match="position"):
             _merge({"gaia": _record("G", parallax=None)})
 
@@ -207,7 +206,6 @@ class TestMergeCatalogRecords:
             _merge({})
 
     def test_incomplete_position_raises(self):
-        # The only candidate lacks a coherent position block (pmra missing).
         with pytest.raises(ValueError, match="position"):
             _merge({"gaia": _record("G", pmra=None)})
 
@@ -222,7 +220,7 @@ class TestMergeCatalogRecords:
         assert row["radec_src"] == "gaia"
         assert row["rv"] is None
         assert row["rv_src"] == ""  # nothing supplied rv -> empty provenance
-        assert row["parallax"] == pytest.approx(50.0)  # parallax still filled
+        assert row["parallax"] == pytest.approx(50.0)
 
 
 class TestAstrometryPriority:
@@ -234,7 +232,7 @@ class TestAstrometryPriority:
     """
 
     def test_shipped_default_bars_wmko_from_anchoring(self):
-        # The default must not let a Gaia+SIMBAD outage fall through to TCS values.
+        # A Gaia+SIMBAD outage must not fall through to TCS values.
         aq = AstroQuery(_l0_for_query())
         assert "wmko" not in aq.astrometry_priority
 
@@ -243,7 +241,6 @@ class TestAstrometryPriority:
             _merge({"wmko": _record("W")}, priority=("gaia", "simbad"))
 
     def test_priority_order_is_honored(self):
-        # Reversing the order moves the base, proving the list drives selection.
         records = {"gaia": _record("G", ra=10.0), "simbad": _record("S", ra=20.0)}
         assert _merge(records, priority=("gaia", "simbad"))["radec_src"] == "gaia"
         assert _merge(records, priority=("simbad", "gaia"))["radec_src"] == "simbad"
@@ -261,16 +258,15 @@ class TestAstrometryPriority:
 
     @pytest.mark.parametrize("bad", [(), ("gaia", "nope"), ("tcs",)])
     def test_invalid_priority_raises_at_construction(self, bad):
-        # Caught at construction: an unknown name would otherwise read as "that
-        # source had no record" and silently demote the position.
+        # An unknown name would otherwise read as "that source had no record" and
+        # silently demote the position, so it must be caught at construction.
         with pytest.raises(ValueError, match="astrometry_priority"):
             AstroQuery(_l0_for_query(), {"astrometry_priority": bad})
 
 
 class TestSingleSourceProvenance:
     def test_source_row_provenance_defaults_to_source(self):
-        # A source row holds only its own values, so all three provenance labels
-        # are its own label.
+        # A source row holds only its own values, so all three labels are its own.
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "object"
         aq = AstroQuery(l0)
@@ -325,8 +321,8 @@ class TestColor:
 
 
 class TestReadWmkoHeader:
-    """read_wmko_header builds the native wmko record from L0 PRIMARY TARG*,
-    fail-soft on absent or malformed astrometry."""
+    """read_wmko_header builds the wmko record from L0 PRIMARY TARG*, fail-soft on
+    absent or malformed astrometry."""
 
     _GOOD_TARG = {
         "TARGRA": "12:00:00.00",
@@ -350,18 +346,17 @@ class TestReadWmkoHeader:
         return l0
 
     def test_good_targ_builds_row(self):
-        # Well-formed FK5 TARG* -> a wmko record rotated to ICRS, so all sources
-        # share one frame. The WMKOCR flag is a header, written later by
-        # _set_headers (covered in TestPerform).
+        # TARG* is FK5 but the record is rotated to ICRS, so all sources share
+        # one frame.
         l0 = self._l0_targ(**self._GOOD_TARG)
         aq = AstroQuery(l0)
         aq.read_wmko_header()  # builds the wmko row and writes it in one go
         table = l0.data["CATALOG_RECORD"]
         wmko = table[table["source"] == "wmko"][0]
         assert wmko["object"] == "testtarget"
-        assert wmko["frame"] == "icrs"  # native FK5 rotated to ICRS, not relabeled
-        # Within the ~tens-of-mas FK5->ICRS frame bias of the input, but shifted
-        # from it -- a real rotation, not a copy.
+        assert wmko["frame"] == "icrs"
+        # The FK5->ICRS bias is tens of mas, so the result stays within 1 arcsec of
+        # the input yet must not equal it -- a real rotation, not a relabel.
         ra = Angle(wmko["ra"], unit=u.hourangle)
         dec = Angle(wmko["dec"], unit=u.deg)
         fk5_ra = Angle(self._GOOD_TARG["TARGRA"], unit=u.hourangle)
@@ -371,8 +366,8 @@ class TestReadWmkoHeader:
         assert wmko["ra"] != "12:00:00.0000"  # rotated, not copied
 
     def test_pmra_time_to_angle_conversion(self):
-        # TARGPMRA is DCS seconds-of-time/yr: convert to on-sky arcsec/yr via
-        # x15 x cos(dec). TARGPMDC is already arcsec/yr and passes through.
+        # TARGPMRA is DCS seconds-of-time/yr: on-sky arcsec/yr needs x15 x cos(dec).
+        # TARGPMDC is already arcsec/yr and passes through.
         dec_deg = 40.0
         rec = AstroQuery(
             self._l0_targ(**{**self._GOOD_TARG, "TARGPMRA": 0.5, "TARGPMDC": 2.0})
@@ -380,8 +375,8 @@ class TestReadWmkoHeader:
 
         expected_pmra = 0.5 * 15.0 * np.cos(np.deg2rad(dec_deg))
         assert rec["pmra"] == pytest.approx(expected_pmra)
-        assert expected_pmra != pytest.approx(0.5)  # factor actually applied
-        assert rec["pmdec"] == pytest.approx(2.0)  # dec PM unchanged
+        assert expected_pmra != pytest.approx(0.5)  # the factor really applies
+        assert rec["pmdec"] == pytest.approx(2.0)
 
     def test_builds_g_minus_j_color(self):
         # The G-J color comes straight off PRIMARY: GAIAMAG - 2MASSMAG.
@@ -392,49 +387,49 @@ class TestReadWmkoHeader:
         assert rec["color_name"] == "G-J"
 
     def test_absent_magnitude_leaves_color_none(self):
-        # A missing GAIAMAG/2MASSMAG -> no color (both fields None), not an error.
+        # A missing magnitude -> no color, not an error.
         rec = AstroQuery(self._l0_targ(**self._GOOD_TARG)).read_wmko_header()
         assert rec["color"] is None and rec["color_name"] is None
 
     def test_no_targ_returns_none_no_warning(self, caplog):
-        # No TARGRA (e.g. a science frame with no pointing) -> None, silently.
+        # No TARGRA (e.g. a frame with no pointing) -> None, and no warning.
         with caplog.at_level(logging.WARNING):
             assert AstroQuery(self._l0_targ()).read_wmko_header() is None
         assert "CATALOG_RECORD" not in caplog.text
 
     def test_malformed_targ_warns_returns_none(self, caplog):
-        # Unparseable TARG* astrometry -> warns and returns None (never raises).
+        # Unparseable TARG* astrometry warns rather than raising.
         l0 = self._l0_targ(**{**self._GOOD_TARG, "TARGDEC": "not-a-coordinate"})
         with caplog.at_level(logging.WARNING):
             assert AstroQuery(l0).read_wmko_header() is None
         assert "could not build wmko CATALOG_RECORD" in caplog.text
 
     def test_nonnumeric_numeric_fields_laundered_to_none(self):
-        # A non-numeric TARG* numeric card must be laundered to None by _scalar,
-        # or the stray value passes the merge's completeness gate as a
-        # valid-looking solution. A string is the only reachable case: astropy
-        # rejects NaN in headers, and a valueless card already reads as None.
+        # A non-numeric numeric card must launder to None, or it passes the merge's
+        # completeness gate as a valid-looking solution. A string is the only
+        # reachable case: astropy rejects NaN in headers, and a valueless card
+        # already reads as None.
         rec = AstroQuery(
             self._l0_targ(**{**self._GOOD_TARG, "TARGPLAX": "UNKNOWN"})
         ).read_wmko_header()
         assert rec["parallax"] is None
 
     def test_non_fk5_frame_raises(self):
-        # KPF pointing is always FK5; any other TARGFRAM (e.g. galactic) raises
-        # rather than being coerced onto a frame it does not have.
+        # KPF pointing is always FK5; another TARGFRAM must not be coerced onto a
+        # frame the data does not have.
         l0 = self._l0_targ(**{**self._GOOD_TARG, "TARGFRAM": "galactic"})
         with pytest.raises(ValueError, match="TARGFRAM"):
             AstroQuery(l0).read_wmko_header()
 
     def test_absent_frame_raises(self):
-        # An absent TARGFRAM cannot be verified as FK5 -> raise (never guess a frame).
+        # An absent TARGFRAM cannot be verified as FK5, and a frame is never guessed.
         targ = {k: v for k, v in self._GOOD_TARG.items() if k != "TARGFRAM"}
         with pytest.raises(ValueError, match="TARGFRAM"):
             AstroQuery(self._l0_targ(**targ)).read_wmko_header()
 
     def test_wmko_row_built_even_when_barred_from_anchoring(self):
-        # The wmko row is unconditional -- TARGOFF needs it -- but with wmko outside
-        # astrometry_priority and both catalogs off, nothing may anchor, so merge
+        # The wmko row is unconditional (TARGOFF needs it), but with wmko outside
+        # astrometry_priority and both catalogs off nothing may anchor, so the merge
         # raises rather than quietly falling back to telescope astrometry.
         aq = AstroQuery(
             self._l0_targ(**self._GOOD_TARG),
@@ -517,7 +512,7 @@ def _simbad_instance(table):
 
 
 def _l0_for_query(**primary):
-    """A fresh science L0 whose PRIMARY carries the given cards (e.g. GAIAID/OBJECT)."""
+    """A fresh science L0 whose PRIMARY carries the given cards (e.g. GAIAID)."""
     l0 = KPF0()
     l0.headers["PRIMARY"]["IMTYPE"] = "object"
     for key, value in primary.items():
@@ -539,7 +534,7 @@ class TestExternalQueries:
 
     def test_scalar_variants(self):
         # astroquery hands back masked/NaN cells for unmeasured quantities; every
-        # unusable form must coerce to a clean None, real values to float.
+        # unusable form must coerce to None, real values to float.
         assert AstroQuery._scalar(None) is None
         assert AstroQuery._scalar(np.ma.masked) is None
         assert AstroQuery._scalar(float("nan")) is None
@@ -610,10 +605,9 @@ class TestExternalQueries:
         assert rec["epoch"] == pytest.approx(2016.0)
         assert rec["frame"] == "icrs"
         assert rec["equinox"] == pytest.approx(2000.0)
-        assert rec["object"] == "Gaia DR3 12345"  # full designation -> EPRV CID#
+        assert rec["object"] == "Gaia DR3 12345"  # full designation -> CID#
         assert rec["color"] == pytest.approx(1.0)  # G_BP - G_RP
         assert rec["color_name"] == "Gaia BP-RP"
-        # Row written to CATALOG_RECORD; the GAIACR flag follows in _set_headers.
         assert "gaia" in [str(s) for s in l0.data["CATALOG_RECORD"]["source"]]
 
     def test_query_gaia_missing_rv_becomes_none(self):
@@ -630,7 +624,7 @@ class TestExternalQueries:
         assert rec["color"] is None and rec["color_name"] is None
 
     def test_record_without_color_writes_blank(self):
-        # A record that omits color/color_name writes NaN / "" for them, not an error.
+        # An omitted color writes NaN / "" rather than raising.
         record = _record("K")
         record.pop("color")
         record.pop("color_name")
@@ -648,7 +642,7 @@ class TestExternalQueries:
         assert "no usable GAIAID" in caplog.text
 
     def test_query_gaia_lookup_failure_returns_none(self, caplog):
-        # A dropped connection is transient, so the lookup is retried before it is
+        # A dropped connection is transient, so the lookup is retried before being
         # given up on; sleep is patched so the backoff is not waited out.
         aq = AstroQuery(_l0_for_query(GAIAID="DR3 12345"))
         with (
@@ -696,7 +690,6 @@ class TestExternalQueries:
         assert rec["epoch"] == pytest.approx(2000.0)
         assert rec["color"] == pytest.approx(1.0)  # Johnson B - V
         assert rec["color_name"] == "B-V"
-        # Row written; the SIMBADCR flag follows in _set_headers.
         assert "simbad" in [str(s) for s in l0.data["CATALOG_RECORD"]["source"]]
 
     def test_query_simbad_missing_photometry_leaves_color_none(self):
@@ -717,7 +710,7 @@ class TestExternalQueries:
         assert "no OBJECT name" in caplog.text
 
     def test_query_simbad_lookup_failure_returns_none(self, caplog):
-        # Retried like the Gaia failure above; see there for the sleep patch.
+        # Retried like the Gaia failure above; sleep is patched for the same reason.
         aq = AstroQuery(_l0_for_query(OBJECT="tau Cet"))
         inst = MagicMock()
         inst.query_object.side_effect = ConnectionError("simbad down")
@@ -766,10 +759,9 @@ def _adql_select_columns(query):
 class TestRequestMatchesParse:
     """Each query asks for exactly the columns its parser reads.
 
-    The mocked tables are built from _GAIA_UNITS/_SIMBAD_UNITS -- the schema the
-    parser consumes -- so they answer whatever was asked, and a request that drifts
-    from the parse (asking SIMBAD for the deprecated 'plx' while reading
-    'plx_value') leaves every other test green. These pin the request side.
+    The mocked tables are built from the parser's own _GAIA_UNITS/_SIMBAD_UNITS, so
+    they answer whatever was asked and a drifted request (asking SIMBAD for the
+    deprecated 'plx' while reading 'plx_value') leaves every other test green.
     """
 
     def test_gaia_select_list_matches_parsed_columns(self):
@@ -788,8 +780,8 @@ class TestRequestMatchesParse:
     def test_gaia_release_selects_table_and_designation(
         self, gaiaid, table, designation
     ):
-        # A source_id denotes different stars in different releases, so querying
-        # the table GAIAID names is what keeps the astrometry on the right star.
+        # A source_id denotes different stars in different releases, so the table
+        # GAIAID names is what keeps the astrometry on the right star.
         aq = AstroQuery(_l0_for_query(GAIAID=gaiaid))
         with _patch_gaia(_gaia_job(_gaia_table())) as launch_job:
             rec = aq.query_gaia()
@@ -832,7 +824,7 @@ def _release_aware_launch_job(present=(), failing=()):
 class TestBareGaiaIdResolution:
     """A GAIAID with no release prefix is verified against the archive, not assumed.
 
-    The same source_id denotes different stars in different releases, so guessing one
+    The same source_id denotes different stars in different releases, so guessing
     would silently attach another star's astrometry to the frame.
     """
 
@@ -930,8 +922,8 @@ class TestPerform:
         assert row["object"] == "Gaia DR3 12345"
 
     def test_presence_flags_written_for_every_source(self):
-        # Always all three flags, so an absent one means AstroQuery never ran
-        # (what DiagL0 warns on). wmko is 0 here: the L0 carries no TARG*.
+        # All three flags are always written, so an absent one means AstroQuery
+        # never ran (what DiagL0 warns on). wmko is 0 here: the L0 carries no TARG*.
         aq, _ = _perform()
         hdr = aq.l0_obj.headers["CATALOG_RECORD"]
         assert hdr["GAIACR"] == 1
@@ -944,8 +936,7 @@ class TestPerform:
         assert aq.l0_obj.headers["CATALOG_RECORD"]["SIMBADCR"] == 1
 
     def test_gaia_off_falls_through_to_simbad(self):
-        # The merge falls to the next source down, and the provenance follows it
-        # rather than staying stamped "gaia".
+        # The provenance must follow the merge down rather than stay "gaia".
         aq, record = _perform(do_gaia_query=False)
         assert aq._gaia is None
         row = _kpf_drp_row(record)

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -4,7 +4,8 @@ Covers ``merge_catalog_records`` (gaia/simbad/wmko -> the canonical ``kpf-drp``
 row), ``read_wmko_header`` off synthetic L0 PRIMARY TARG*, and the external query
 contract. The network is never touched: ``Gaia.launch_job``/``Simbad`` are mocked
 with one-row result Tables, so parsing, the fail-soft None+warning paths, and the
-``_verify_units`` schema-drift guard all run offline.
+``_verify_units`` schema-drift guard all run offline. That is enforced, not just
+intended -- tests/conftest.py blocks outbound connect() for the whole suite.
 """
 
 import logging
@@ -20,6 +21,7 @@ from astropy.table import Column, Table
 from kpfpipe.data_models import KPF0
 from kpfpipe.modules.astro_query import _GAIA_UNITS, _SIMBAD_UNITS, AstroQuery
 from kpfpipe.utils.astro import compute_redshift
+from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.network import _RETRY_WAITS
 
 
@@ -943,3 +945,39 @@ class TestPerform:
         assert row["ra"] == _ra_str(20.0)
         assert row["radec_src"] == "simbad"
         assert row["object"] == "tau Cet"
+
+
+class TestConstructor:
+    """The constructor's three guards. Every other AstroQuery(...) in the suite
+    passes IMTYPE='object' and either None or a plain dict, so none of these is
+    otherwise exercised."""
+
+    @staticmethod
+    def _l0(imtype):
+        l0 = KPF0()
+        if imtype is not None:
+            l0.headers["PRIMARY"]["IMTYPE"] = imtype
+        return l0
+
+    @pytest.mark.parametrize("imtype", ["Bias", "Flat", None])
+    def test_rejects_non_object_frames(self, imtype):
+        # The class docstring's headline promise. Without it, AstroQuery would
+        # fire SIMBAD lookups on OBJECT='bias' and write a bogus CATALOG_RECORD
+        # that to_kpf1 copies onto the EPRV C*# cards.
+        with pytest.raises(ValueError, match="science frames"):
+            AstroQuery(self._l0(imtype))
+
+    def test_rejects_unsupported_config_type(self):
+        with pytest.raises(TypeError, match="must be None, dict, or ConfigHandler"):
+            AstroQuery(self._l0("Object"), config=["gaia"])
+
+    def test_config_handler_branch_is_read(self, tmp_path):
+        # How the recipes construct it. A section-name typo here would be
+        # invisible: params would come back empty and _DEFAULTS would silently
+        # turn both catalog queries back on.
+        cfg = tmp_path / "aq.toml"
+        cfg.write_text(
+            "[DATA_DIRS]\n[TRACES]\n[MODULE_ASTRO_QUERY]\ndo_gaia_query = false\n"
+        )
+        aq = AstroQuery(self._l0("Object"), config=ConfigHandler(str(cfg)))
+        assert aq.do_gaia_query is False

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -1,8 +1,8 @@
 """Tests for the BarycentricCorrection module (KPF2 -> KPF2).
 
-Static-method unit tests require no fixtures. Integration tests use a
-synthetic KPF2 with a small EXPMETER_SCI table, populated SCI2_WAVE, and the
-SCI2 catalog cards on PRIMARY. barycorrpy calls are stubbed via monkeypatching.
+Static-method unit tests require no fixtures. Integration tests use a synthetic
+KPF2 with a small EXPMETER_SCI table, populated SCI2_WAVE, and the SCI2 catalog
+cards on PRIMARY; barycorrpy is stubbed except in TestComputeBarycorrReference.
 """
 
 import logging
@@ -30,15 +30,11 @@ NCOL = 50  # reduced column count for speed
 # Synthetic KPF2 fixture
 # ---------------------------------------------------------------------------
 
-# Exposure meter: 3 readings of 60s, with 60s gaps, starting at T0.
-#   Reading 0: 00:00:00 → 00:01:00
-#   Gap:       00:01:00 → 00:02:00
-#   Reading 1: 00:02:00 → 00:03:00
-#   Gap:       00:03:00 → 00:04:00
-#   Reading 2: 00:04:00 → 00:05:00
-# DATE-BEG = 00:00:00, DATE-END = 00:05:00 (shutter open for full range)
+# Exposure meter: 3 readings of 60 s at 00:00, 00:02 and 00:04, separated by 60 s
+# gaps. The shutter (DATE-BEG/DATE-END) is open 00:00:00 to 00:05:00, so it
+# exactly brackets the readings unless a test says otherwise.
 _T0 = "2024-01-01T"
-_WAVE_COLS = ["5000", "5100", "5200", "5300"]  # 100Å spacing → dispersion = 100Å
+_WAVE_COLS = ["5000", "5100", "5200", "5300"]  # 100 Angstrom spacing = dispersion
 _FLUX_VALUE = 100.0  # uniform ADU per reading
 
 # SCI2 catalog cards as KPF0.to_kpf1 writes them: ICRS, RA/Dec sexagesimal (hourangle
@@ -53,15 +49,15 @@ _CATALOG_CARDS = {
     "CPLX3": 10.0,
     "CEPCH3": 2016.0,
     "CEQNX3": 2000.0,
-    "CRV3": 0.0,  # no systemic RV; set so the module need not fall back to 0
+    "CRV3": 0.0,  # present so the module does not take its warn-and-default path
 }
 
 
 def _expmeter_table(data):
     """EXPMETER_SCI table from Date-Beg/Date-End plus flux columns.
 
-    Real EXPMETER_SCI always carries the shutter-corrected columns, and the module
-    prefers them; mirror the uncorrected ones so every expected time is unchanged.
+    The module prefers the shutter-corrected columns, which real EXPMETER_SCI
+    always carries; mirroring the uncorrected ones keeps expected times unchanged.
     """
     return Table(
         {**data, "Date-Beg-Corr": data["Date-Beg"], "Date-End-Corr": data["Date-End"]}
@@ -82,14 +78,12 @@ def _make_expmeter_table():
 def synthetic_kpf2():
     """KPF2 with synthetic EXPMETER_SCI and wavelength arrays.
 
-    SCI2_WAVE is filled with 5000.0 -- order_center = 5000 for every order,
-    so np.interp returns the per-channel value at 5000Å (i.e. the first
-    PHOTON_JD) for every order. Tests that need per-order variation
-    populate SCI2_WAVE themselves.
+    Every order's center is 5000.0, so all orders interpolate to the same
+    per-channel time. Tests needing per-order variation set SCI2_WAVE themselves.
     """
     kpf2 = KPF2()
 
-    # KPF-native keywords live in INSTRUMENT_HEADER on L2 (preserved L1 PRIMARY).
+    # KPF-native keywords live in INSTRUMENT_HEADER on L2 (the preserved L1 PRIMARY).
     kpf2.headers["INSTRUMENT_HEADER"]["DATE-BEG"] = f"{_T0}00:00:00.000"
     kpf2.headers["INSTRUMENT_HEADER"]["DATE-END"] = f"{_T0}00:05:00.000"
 
@@ -110,7 +104,7 @@ def synthetic_kpf2():
 
 
 # ---------------------------------------------------------------------------
-# Static helpers -- unchanged behavior across the split
+# Static helpers
 # ---------------------------------------------------------------------------
 
 
@@ -288,11 +282,10 @@ class TestGetNormalizedFlux:
 class TestComputeBarycorrReference:
     """The real barycorrpy handoff, pinned to a golden value.
 
-    Every perform() test stubs _compute_barycorr, so this is the only guard that
-    the real barycorrpy wiring stays correct: the ICRS ra/dec/pm/parallax, the
-    J2000 epoch, UTC->JD, Keck lat/lon/alt, and the m/s units and sign. It calls
-    barycorrpy directly (no stub) and may download JPL ephemeris on first run,
-    hence @slow. Golden values are pinned to barycorrpy==0.4.4 (see pyproject).
+    Every perform() test stubs _compute_barycorr, so this is the only guard on
+    the real wiring: ICRS ra/dec/pm/parallax, the J2000 epoch, UTC->JD, the Keck
+    site, and the m/s units and sign. It may download JPL ephemeris on first run,
+    hence @slow. Golden values are pinned to barycorrpy==0.4.4.
     """
 
     def test_matches_barycorrpy_reference(self):
@@ -313,8 +306,8 @@ class TestComputeBarycorrReference:
         # a few minutes of JD_UTC (clock + Romer light-travel delay).
         assert abs(bc_vel[0]) < 3.0e4
         assert abs(bjd_tdb[0] - t.utc.jd) < 0.01
-        # Regression pins (1 cm/s, ~0.1 s): catch any frame/unit/sign rewiring,
-        # well above barycorrpy/ephemeris/IERS numerical noise at the pinned version.
+        # Pins at 1 cm/s and ~0.1 s: tight enough to catch a frame/unit/sign
+        # rewiring, loose enough to clear ephemeris/IERS noise at the pinned version.
         assert bc_vel[0] == pytest.approx(24627.871206121636, abs=1e-2)
         assert bjd_tdb[0] == pytest.approx(2460476.873644211, abs=1e-6)
 
@@ -348,15 +341,13 @@ class TestFluxWeightedMidpointExpmeter:
         assert len(t_fwm) == len(_WAVE_COLS)
 
     def test_small_negative_flux_preserved(self, synthetic_kpf2, monkeypatch):
-        """Small negative fluctuations (background-subtraction noise near zero
-        flux) are preserved with their real weight, not floored: flooring would
-        bias the flux-weighted midpoint. Only a non-positive *channel total*
-        raises (the meaningful guard); a single negative sample does not."""
-
+        # Small negatives are background-subtraction noise near zero flux;
+        # flooring them to zero would bias the flux-weighted midpoint. Only a
+        # nonpositive channel *total* raises.
         def mock_flux(self):
             w = np.array([float(c) for c in _WAVE_COLS])
             f = np.full((3, len(_WAVE_COLS)), 100.0)
-            f[0, 0] = -20.0  # one small negative; channel total stays positive (+180)
+            f[0, 0] = -20.0  # channel total stays positive (+180)
             return w, f
 
         monkeypatch.setattr(BarycentricCorrection, "_get_normalized_flux", mock_flux)
@@ -371,9 +362,9 @@ class TestFluxWeightedMidpointExpmeter:
         )
 
         # Compare midpoints as seconds from the first reading: JD magnitudes
-        # (~2.46e6) make any relative tolerance meaningless, so reduce to O(100 s)
-        # offsets where absolute tolerances actually mean what they say.
-        f0 = np.array([-20.0, 100.0, 100.0])  # channel 0 carries the negative sample
+        # (~2.46e6) swamp any relative tolerance, so reduce to O(100 s) offsets
+        # where absolute tolerances mean what they say.
+        f0 = np.array([-20.0, 100.0, 100.0])
         floored = np.clip(f0, 0.0, None)
         ref = t_mid.jd[0]
 
@@ -381,18 +372,17 @@ class TestFluxWeightedMidpointExpmeter:
             return (np.sum(t_mid.jd * weights) / np.sum(weights) - ref) * 86400.0
 
         actual_s = (t_fwm.jd[0] - ref) * 86400.0
-        expected_s = offset_seconds(f0)  # negative-preserving weighting
-        floored_s = offset_seconds(floored)  # what flooring to zero would give
+        expected_s = offset_seconds(f0)
+        floored_s = offset_seconds(floored)
 
         assert np.isfinite(actual_s)
-        # Matches the exact negative-preserving midpoint to <1 ms...
         np.testing.assert_allclose(actual_s, expected_s, atol=1e-3)
-        # ...and is unambiguously not the floored result (the two differ by the
-        # negative sample's ~20 s pull on the earliest reading).
+        # The two weightings differ by the negative sample's ~20 s pull, so this
+        # separates the actual result from the floored one unambiguously.
         assert abs(actual_s - floored_s) > 1.0
 
     def test_zero_flux_channel_raises(self, synthetic_kpf2):
-        """A channel with zero flux across all readings → 0/0 midpoint; fail loudly."""
+        # Zero flux across all readings makes the midpoint 0/0; fail loudly.
         data = {
             "Date-Beg": [
                 "2024-01-01T00:00:00.000",
@@ -418,8 +408,8 @@ class TestFluxWeightedMidpointExpmeter:
             )
 
     def test_interpolate_shifts_midpoint_with_front_weighted_flux(self, synthetic_kpf2):
-        """Front-weighted flux: interpolation sees a bright sample at the
-        first gap (~T+90s) that pulls the FWM strictly later."""
+        # Front-weighted flux makes interpolation add a bright sample at the
+        # first gap (~T+90 s), which pulls the FWM strictly later.
         data = {
             "Date-Beg": [
                 "2024-01-01T00:00:00.000",
@@ -449,16 +439,16 @@ class TestFluxWeightedMidpointExpmeter:
             extrapolate=False,
             fix_outliers=False,
         )
-        # Shift should be sub-minute → tens of microdays, easily > 1e-9 days
+        # The shift is sub-minute (tens of microdays), comfortably clearing the
+        # 1e-7 day (~9 ms) margin below.
         assert np.mean(t_yes.jd) > np.mean(t_no.jd) + 1e-7
 
     def test_extrapolate_shifts_midpoint_when_shutter_brackets_expmeter(
         self, synthetic_kpf2
     ):
-        """DATE-BEG before t_beg[0] and DATE-END after t_end[-1] → extrapolated
-        gap samples on both sides pull the FWM. Bright first reading + faint
-        last → leading extrapolation dominates → midpoint earlier than with
-        extrapolate=False."""
+        # The shutter brackets the readings on both sides, so extrapolation adds
+        # a gap sample at each end. A bright first reading plus a 2-minute
+        # leading gap makes the leading sample dominate and pull the FWM earlier.
         data = {
             "Date-Beg": [
                 "2024-01-01T00:02:00.000",  # readings inset from shutter
@@ -474,7 +464,7 @@ class TestFluxWeightedMidpointExpmeter:
             "5100": [1000.0, 1.0, 1.0],
         }
         synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
-        # Shutter open 00:00:00 → 00:05:00; readings only 00:02:00–00:03:20
+        # Shutter open 00:00:00 to 00:05:00; readings only 00:02:00 to 00:03:20.
         synthetic_kpf2.headers["INSTRUMENT_HEADER"]["DATE-BEG"] = (
             "2024-01-01T00:00:00.000"
         )
@@ -495,8 +485,6 @@ class TestFluxWeightedMidpointExpmeter:
             extrapolate=True,
             fix_outliers=False,
         )
-        # Bright first reading + 2-minute leading shutter gap → big leading
-        # extrapolation pulls FWM clearly earlier than the no-extrap case.
         assert np.mean(t_yes.jd) < np.mean(t_no.jd) - 1e-7
 
 
@@ -510,24 +498,21 @@ class TestFluxWeightedMidpointOrders:
         assert len(t) == NORDER
 
     def test_constant_wave_gives_constant_time(self, synthetic_kpf2):
-        """SCI2_WAVE filled with 5000.0 → every order interpolates at 5000Å
-        and gets the value from the first per-channel t_fwm."""
         bc = BarycentricCorrection(synthetic_kpf2)
         _, t = bc.compute_flux_weighted_midpoint_times(output="orders", **self._KWARGS)
-        # All per-channel times are equal (uniform flux), so all per-order
-        # interpolated times equal that shared value.
+        # Uniform flux makes every per-channel time equal, and the fixture's flat
+        # SCI2_WAVE makes every order interpolate to that shared value.
         assert np.std(t.jd) < 1e-12
 
     def test_orders_get_distinct_times_when_waves_vary(self, synthetic_kpf2):
-        """Front-weighted flux + GREEN orders at 5000Å vs RED at 5100Å:
-        GREEN orders should get an earlier midpoint than RED."""
         synthetic_kpf2.set_data(
             "GREEN_SCI2_WAVE", np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float64)
         )
         synthetic_kpf2.set_data(
             "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float64)
         )
-        # Front-weighted at 5000Å, back-weighted at 5100Å
+        # Front-weighted at 5000 A (GREEN), back-weighted at 5100 A (RED), so
+        # GREEN's midpoint must land earlier than RED's.
         data = {
             "Date-Beg": [
                 "2024-01-01T00:00:00.000",
@@ -565,8 +550,8 @@ class TestFluxWeightedMidpointCcds:
         assert len(t) == 2
 
     def test_ccd_values_equal_chip_means_with_uniform_weights(self, synthetic_kpf2):
-        """With no SCI2_FLUX (uniform weights), the ccds output should equal the
-        plain per-chip means of the orders output."""
+        # With no SCI2_FLUX the order weights are uniform, so the chip summary
+        # reduces to a plain mean.
         bc = BarycentricCorrection(synthetic_kpf2)
         _, t_orders = bc.compute_flux_weighted_midpoint_times(
             output="orders", **self._KWARGS
@@ -580,8 +565,6 @@ class TestFluxWeightedMidpointCcds:
         )
 
     def test_flux_weighting_biases_ccd_time_toward_bright_orders(self, synthetic_kpf2):
-        """A bright bluest GREEN order pulls the chip summary toward its
-        (earlier) midpoint relative to the unweighted chip mean."""
         green_waves = np.linspace(5000.0, 5300.0, NORDER_GREEN, dtype=np.float64)
         synthetic_kpf2.set_data(
             "GREEN_SCI2_WAVE", np.repeat(green_waves[:, None], NCOL, axis=1)
@@ -626,8 +609,6 @@ class TestFluxWeightedMidpointCcds:
     # it one line later (nan_to_num -> zero weight), which is what this asserts.
     @pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
     def test_nan_flux_order_gets_zero_weight(self, synthetic_kpf2):
-        """A failed-extraction order (all-NaN SCI2 flux) gets zero weight rather
-        than poisoning its chip summary, so the ccds time stays finite."""
         flux = np.ones((NORDER, NCOL), dtype=float)
         flux[NORDER_GREEN] = np.nan  # first RED order failed extraction
         synthetic_kpf2.set_data("SCI2_FLUX", flux)
@@ -639,24 +620,22 @@ class TestFluxWeightedMidpointCcds:
         assert np.all(np.isfinite(t_ccds.jd))
 
     def test_all_zero_weight_chip_raises(self, synthetic_kpf2):
-        """A whole chip with zero SCI2 flux → undefined weighted mean; fail loudly."""
+        # A whole chip at zero flux makes the weighted mean undefined.
         flux = np.ones((NORDER, NCOL), dtype=float)
-        flux[NORDER_GREEN:] = 0.0  # all RED orders have zero flux
+        flux[NORDER_GREEN:] = 0.0
         synthetic_kpf2.set_data("SCI2_FLUX", flux)
         bc = BarycentricCorrection(synthetic_kpf2)
         with pytest.raises(ValueError, match="weights are zero"):
             bc.compute_flux_weighted_midpoint_times(output="ccds", **self._KWARGS)
 
     def test_green_and_red_resolve_distinct_values(self, synthetic_kpf2):
-        """With GREEN orders at 5000Å and RED orders at 5100Å plus a chromatic
-        flux gradient, 'ccds' should report distinguishable times per chip."""
         synthetic_kpf2.set_data(
             "GREEN_SCI2_WAVE", np.full((NORDER_GREEN, NCOL), 5000.0, dtype=np.float64)
         )
         synthetic_kpf2.set_data(
             "RED_SCI2_WAVE", np.full((NORDER_RED, NCOL), 5100.0, dtype=np.float64)
         )
-        # Front-weighted at 5000Å, back-weighted at 5100Å → distinct midpoints
+        # Front-weighted at 5000 A, back-weighted at 5100 A: distinct midpoints.
         data = {
             "Date-Beg": [
                 "2024-01-01T00:00:00.000",
@@ -704,7 +683,7 @@ class TestFluxWeightedMidpointFormat:
 
 
 class TestGetAstrometry:
-    """Convert the C*# cards to barycorrpy's arguments and sanitize the parallax."""
+    """Convert the C*# cards to barycorrpy's units and sanitize the parallax."""
 
     def test_converts_cards_to_barycorrpy_units(self, synthetic_kpf2):
         primary = synthetic_kpf2.headers["PRIMARY"]
@@ -737,8 +716,8 @@ class TestGetAstrometry:
     # an absent card (covered below) or a blank one, never as NaN.
     @pytest.mark.parametrize("parallax", [-0.4, 0.0, ""])
     def test_unusable_parallax_becomes_zero(self, caplog, synthetic_kpf2, parallax):
-        """A nonpositive parallax (routine for faint Gaia sources) degrades to px=0,
-        not a negative distance."""
+        # A nonpositive parallax is routine for faint Gaia sources, so it degrades
+        # to px=0 rather than becoming a negative distance.
         synthetic_kpf2.headers["PRIMARY"]["CPLX3"] = parallax
         bc = BarycentricCorrection(synthetic_kpf2)
         with caplog.at_level(logging.WARNING):
@@ -747,7 +726,7 @@ class TestGetAstrometry:
         assert "CPLX3" in caplog.text
 
     def test_missing_parallax_becomes_zero(self, caplog, synthetic_kpf2):
-        """CPLX# is Required=No, so it is absent when the catalog measured none."""
+        # CPLX# is optional, so it is absent when the catalog measured no parallax.
         del synthetic_kpf2.headers["PRIMARY"]["CPLX3"]
         bc = BarycentricCorrection(synthetic_kpf2)
         with caplog.at_level(logging.WARNING):
@@ -757,8 +736,8 @@ class TestGetAstrometry:
 
     @pytest.mark.parametrize("card", ["CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3"])
     def test_missing_position_card_raises(self, synthetic_kpf2, card):
-        """The position block is all-or-nothing: AstroQuery's merge never emits a
-        canonical row without it, so a gap means the pipeline is misordered."""
+        # The position block is all-or-nothing: AstroQuery never emits a canonical
+        # row without it, so a gap means the pipeline ran out of order.
         del synthetic_kpf2.headers["PRIMARY"][card]
         bc = BarycentricCorrection(synthetic_kpf2)
         with pytest.raises(ValueError, match=card):
@@ -786,7 +765,7 @@ class TestPerform:
         def mock_compute(astrometry, obs_times, location, rv_mps=0.0):
             n = len(np.atleast_1d(obs_times.jd))
             bc_vel = np.full(n, TestPerform.DELTA_RV_MPS, dtype=float)
-            # BJD = JD + 500s (light-travel approx); same for every order in this stub
+            # BJD = JD + 500 s stands in for the light-travel delay.
             bjd_tdb = np.atleast_1d(obs_times.jd) + 500.0 / 86400.0
             return bc_vel, bjd_tdb
 
@@ -796,9 +775,8 @@ class TestPerform:
         monkeypatch.setattr(
             BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
         )
-        # Stub _fix_expmeter_outliers: the 3×4 uniform-flux fixture triggers a
-        # degenerate triangulation inside scipy.griddata. Filter itself is
-        # exercised by TestFixExpmeterOutliers with a noisy 60×20 array.
+        # The 3x4 uniform-flux fixture triggers a degenerate triangulation inside
+        # scipy.griddata; TestFixExpmeterOutliers exercises the real filter.
         monkeypatch.setattr(
             BarycentricCorrection, "_fix_expmeter_outliers", staticmethod(passthrough)
         )
@@ -815,7 +793,7 @@ class TestPerform:
         bjd = np.asarray(kpf2.data["BJD_TDB"])
         assert bjd.shape == (NORDER,)
         assert np.all(np.isfinite(bjd))
-        assert bjd.dtype == np.float64  # EPRV: BJD_TDB is 64-bit
+        assert bjd.dtype == np.float64
 
     def test_barycorr_kms_extension_populated(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.perform()
@@ -829,10 +807,9 @@ class TestPerform:
         kpf2 = bc_monkeypatched.perform()
         z = np.asarray(kpf2.data["BARYCORR_Z"])
         assert z.shape == (NORDER,)
-        # All orders share the same delta_rv → all z values identical
         assert np.std(z) < 1e-12
-        # BARYCORR_Z is the small redshift z (~ v/c), same sign as the velocity:
-        # +30 km/s (receding) -> small positive z, not the Doppler factor (~1).
+        # BARYCORR_Z is the small redshift z (~ v/c), not the Doppler factor
+        # (~1), and carries the same sign as the velocity.
         assert z[0] == pytest.approx(
             TestPerform.DELTA_RV_MPS / c.to("m/s").value, rel=1e-4
         )
@@ -846,7 +823,7 @@ class TestPerform:
         assert_dtype(kpf2.data["BJD_TDB"], BJD, "BJD_TDB")
 
     def test_wave_arrays_untouched(self, bc_monkeypatched):
-        """BarycentricCorrection should track but not apply: WAVE arrays unchanged."""
+        # BarycentricCorrection tracks the correction; it never applies it.
         kpf2 = bc_monkeypatched.l2_obj
         orig = {
             f"{chip}_{fiber}_WAVE": kpf2.data[f"{chip}_{fiber}_WAVE"].copy()
@@ -875,13 +852,13 @@ class TestPerform:
         for key in ("CCD1BZ", "CCD2BZ"):
             assert key in z, f"{key} missing from BARYCORR_Z"
 
-        # All orders had the same delta_rv → green and red means are equal
+        # The stub gives every order the same delta_rv, so the chip means match.
         np.testing.assert_allclose(kms.get("CCD1BKMS"), kms.get("CCD2BKMS"))
         np.testing.assert_allclose(z.get("CCD1BZ"), z.get("CCD2BZ"))
 
     def test_ctype1_axis_label(self, bc_monkeypatched):
-        # These are 1-D per-order arrays: CTYPE1 names the order axis (registered
-        # content). CTYPE2 is N/A (no second axis).
+        # These are 1-D per-order arrays, so CTYPE1 names the order axis and
+        # there is no second axis to label.
         kpf2 = bc_monkeypatched.perform()
         for ext in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
             hdr = kpf2.headers[ext]
@@ -896,7 +873,6 @@ class TestPerform:
     def test_crv_converted_km_to_m_and_passed_through(
         self, synthetic_kpf2, monkeypatch
     ):
-        """CRV3 (km/s) should arrive at _compute_barycorr as m/s."""
         synthetic_kpf2.headers["PRIMARY"]["CRV3"] = 81.87  # km/s
         captured = {}
 
@@ -919,7 +895,6 @@ class TestPerform:
         assert captured["rv_mps"] == pytest.approx(81870.0)
 
     def test_missing_crv_defaults_to_zero(self, caplog, bc_monkeypatched, monkeypatch):
-        """No CRV3 on PRIMARY (no catalog rv, no TARGRADV) → rv_mps=0, warns."""
         del bc_monkeypatched.l2_obj.headers["PRIMARY"]["CRV3"]
         captured = {}
 
@@ -947,8 +922,8 @@ class TestPerform:
             assert len(getattr(bc_monkeypatched, attr)) == 2
 
     def test_real_outlier_filter_runs_end_to_end(self, synthetic_kpf2, monkeypatch):
-        """Exercise fix_expmeter_outliers=True through perform() with a
-        noisy expmeter table (3×4 uniform fixture would crash griddata)."""
+        # The real filter needs a noisy table; the 3x4 uniform fixture would
+        # crash griddata.
         rng = np.random.default_rng(0)
         ntime, nwave = 60, 20
         wave_cols = [str(5000.0 + 10 * i) for i in range(nwave)]
@@ -958,8 +933,7 @@ class TestPerform:
         }
         for wc in wave_cols:
             data[wc] = rng.normal(100.0, 2.0, ntime).astype(float)
-        # Inject a clear outlier so the filter has work to do
-        data[wave_cols[5]][30] = 1e6
+        data[wave_cols[5]][30] = 1e6  # a clear outlier, so the filter has work
         synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
         synthetic_kpf2.headers["INSTRUMENT_HEADER"]["DATE-END"] = (
             "2024-01-01T01:00:00.000"
@@ -973,7 +947,7 @@ class TestPerform:
             BarycentricCorrection, "_compute_barycorr", staticmethod(mock_compute)
         )
 
-        # No monkeypatch on _fix_expmeter_outliers -- real filter runs.
+        # _fix_expmeter_outliers is deliberately not stubbed here.
         kpf2 = BarycentricCorrection(synthetic_kpf2).perform(fix_expmeter_outliers=True)
         assert np.all(np.isfinite(np.asarray(kpf2.data["BJD_TDB"])))
 
@@ -997,8 +971,10 @@ def _user_skycoord(ra_deg=90.0):
 
 
 class TestSkycoordOverride:
-    """A user-supplied SkyCoord bypasses the PRIMARY C*# cards, so an L2 in hand can
-    be re-corrected without re-reducing from L0."""
+    """A user-supplied SkyCoord bypasses the PRIMARY C*# cards.
+
+    That lets an L2 already in hand be re-corrected without re-reducing from L0.
+    """
 
     @staticmethod
     def _capture(monkeypatch):
@@ -1031,14 +1007,14 @@ class TestSkycoordOverride:
         assert captured["epoch"] == pytest.approx(Time(2020.0, format="jyear").jd)
 
     def test_overrides_the_header_cards(self, synthetic_kpf2, monkeypatch):
-        """The fixture's CRA3 is 12h (180 deg); the override must win."""
+        # The fixture's CRA3 is 12h (180 deg); the override must win.
         captured = self._capture(monkeypatch)
         BarycentricCorrection(synthetic_kpf2).perform(skycoord=_user_skycoord())
         assert captured["ra"] == pytest.approx(90.0)
 
     def test_works_without_catalog_cards(self, synthetic_kpf2, monkeypatch):
-        """An L2 whose C*# cards are absent (AstroQuery never ran) is still
-        correctable -- the point of the escape hatch."""
+        # An L2 whose C*# cards are absent (AstroQuery never ran) is still
+        # correctable -- the point of the escape hatch.
         for card in ("CRA3", "CDEC3", "CPMR3", "CPMD3", "CEPCH3"):
             del synthetic_kpf2.headers["PRIMARY"][card]
         captured = self._capture(monkeypatch)
@@ -1060,14 +1036,14 @@ class TestSkycoordOverride:
         assert bc._astrometry_source == "user SkyCoord"
 
     def test_override_is_not_cached(self, synthetic_kpf2, monkeypatch):
-        """The override must not poison the cache, or a later header-path call would
-        silently reuse the user's values."""
+        # A cached override would make a later header-path call silently reuse
+        # the user's values.
         captured = self._capture(monkeypatch)
         bc = BarycentricCorrection(synthetic_kpf2)
         bc.perform(skycoord=_user_skycoord())
         assert bc._astrometry is None
 
-        bc.perform()  # no override -> back to the header
+        bc.perform()  # no override: back to the header
         assert captured["ra"] == pytest.approx(180.0)
 
     def test_default_reads_the_header(self, synthetic_kpf2, monkeypatch):
@@ -1078,13 +1054,13 @@ class TestSkycoordOverride:
     @pytest.mark.parametrize(
         "kwargs, error, match",
         [
-            # No proper motion -> the frame carries no velocity data.
+            # No proper motion: the frame carries no velocity data.
             (
                 {"distance": Distance(parallax=25.0 * u.mas)},
                 TypeError,
                 "no associated differentials",
             ),
-            # No distance -> .distance is a dimensionless 1.0, not convertible to pc.
+            # No distance: .distance is a dimensionless 1.0, not convertible to pc.
             (
                 {
                     "pm_ra_cosdec": 100.0 * u.mas / u.yr,
@@ -1098,8 +1074,8 @@ class TestSkycoordOverride:
     def test_incomplete_skycoord_raises(
         self, synthetic_kpf2, monkeypatch, kwargs, error, match
     ):
-        """Deliberately unvalidated: astropy raises on its own for a SkyCoord missing
-        components the correction needs."""
+        # Deliberately unvalidated: astropy raises on its own for a SkyCoord
+        # missing components the correction needs.
         self._capture(monkeypatch)
         incomplete = SkyCoord(
             ra=90.0 * u.deg,
@@ -1127,8 +1103,8 @@ class TestMissingHeader:
     """perform() should fail loudly when required header keys are absent."""
 
     def test_missing_catalog_cards_raises(self, synthetic_kpf2, monkeypatch):
-        # Stub _fix_expmeter_outliers so we don't hit the griddata degeneracy
-        # before reaching the catalog-card lookup.
+        # Stub the outlier filter so the griddata degeneracy does not fire before
+        # the catalog-card lookup under test.
         def passthrough(f, kernel_size=5):
             return f.copy()
 
@@ -1153,10 +1129,9 @@ class TestMissingHeader:
             )
 
     def test_missing_date_beg_ok_without_extrapolate(self, synthetic_kpf2):
-        """DATE-BEG is only needed when extrapolate=True."""
+        # DATE-BEG is read only to extrapolate, so this must not raise.
         del synthetic_kpf2.headers["INSTRUMENT_HEADER"]["DATE-BEG"]
         bc = BarycentricCorrection(synthetic_kpf2)
-        # Should not raise:
         bc.compute_flux_weighted_midpoint_times(
             output="expmeter",
             interpolate=False,

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -186,7 +186,7 @@ class TestExtrapolate:
         t0 = self._t(60)
         f = np.ones(4)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="t0 must be before"):
             BarycentricCorrection._extrapolate(t0, t_beg, t_end, f)
 
 
@@ -261,11 +261,6 @@ class TestGetNormalizedFlux:
         bc = BarycentricCorrection(synthetic_kpf2)
         w, _ = bc._get_normalized_flux()
         np.testing.assert_array_equal(w, [float(c) for c in _WAVE_COLS])
-
-    def test_non_numeric_columns_excluded(self, synthetic_kpf2):
-        bc = BarycentricCorrection(synthetic_kpf2)
-        _, f = bc._get_normalized_flux()
-        assert f.shape[1] == len(_WAVE_COLS)
 
     def test_gain_and_dispersion_applied(self, synthetic_kpf2):
         bc = BarycentricCorrection(synthetic_kpf2)

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -793,7 +793,7 @@ class TestPerform:
         bjd = np.asarray(kpf2.data["BJD_TDB"])
         assert bjd.shape == (NORDER,)
         assert np.all(np.isfinite(bjd))
-        assert bjd.dtype == np.float64
+        assert_dtype(bjd, BJD, "BJD_TDB")
 
     def test_barycorr_kms_extension_populated(self, bc_monkeypatched):
         kpf2 = bc_monkeypatched.perform()

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -609,6 +609,9 @@ class TestFluxWeightedMidpointCcds:
         )
         assert t_ccds.jd[0] < unweighted_green
 
+    # The all-NaN order under test makes nanpercentile warn; the weighting handles
+    # it one line later (nan_to_num -> zero weight), which is what this asserts.
+    @pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
     def test_nan_flux_order_gets_zero_weight(self, synthetic_kpf2):
         """A failed-extraction order (all-NaN SCI2 flux) gets zero weight rather
         than poisoning its chip summary, so the ccds time stays finite."""

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -53,16 +53,29 @@ _CATALOG_CARDS = {
     "CPLX3": 10.0,
     "CEPCH3": 2016.0,
     "CEQNX3": 2000.0,
+    "CRV3": 0.0,  # no systemic RV; set so the module need not fall back to 0
 }
 
 
+def _expmeter_table(data):
+    """EXPMETER_SCI table from Date-Beg/Date-End plus flux columns.
+
+    Real EXPMETER_SCI always carries the shutter-corrected columns, and the module
+    prefers them; mirror the uncorrected ones so every expected time is unchanged.
+    """
+    return Table(
+        {**data, "Date-Beg-Corr": data["Date-Beg"], "Date-End-Corr": data["Date-End"]}
+    )
+
+
 def _make_expmeter_table():
-    begs = [f"{_T0}00:00:00.000", f"{_T0}00:02:00.000", f"{_T0}00:04:00.000"]
-    ends = [f"{_T0}00:01:00.000", f"{_T0}00:03:00.000", f"{_T0}00:05:00.000"]
-    data = {"Date-Beg": begs, "Date-End": ends}
+    data = {
+        "Date-Beg": [f"{_T0}00:00:00.000", f"{_T0}00:02:00.000", f"{_T0}00:04:00.000"],
+        "Date-End": [f"{_T0}00:01:00.000", f"{_T0}00:03:00.000", f"{_T0}00:05:00.000"],
+    }
     for wc in _WAVE_COLS:
         data[wc] = np.full(3, _FLUX_VALUE)
-    return Table(data)
+    return _expmeter_table(data)
 
 
 @pytest.fixture
@@ -222,7 +235,7 @@ class TestGetTimestamps:
         assert np.all(t_mid.jd < t_end.jd)
 
     def test_non_monotonic_raises(self, synthetic_kpf2):
-        bad_table = Table(
+        bad_table = _expmeter_table(
             {
                 "Date-Beg": [
                     "2024-01-01T00:04:00.000",
@@ -394,7 +407,7 @@ class TestFluxWeightedMidpointExpmeter:
             "5000": [100.0, 100.0, 100.0],
             "5100": [0.0, 0.0, 0.0],
         }
-        synthetic_kpf2.set_data("EXPMETER_SCI", Table(data))
+        synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
         bc = BarycentricCorrection(synthetic_kpf2)
         with pytest.raises(ValueError, match="total flux"):
             bc.compute_flux_weighted_midpoint_times(
@@ -421,7 +434,7 @@ class TestFluxWeightedMidpointExpmeter:
             "5000": [1000.0, 1.0, 1.0],
             "5100": [1000.0, 1.0, 1.0],
         }
-        synthetic_kpf2.set_data("EXPMETER_SCI", Table(data))
+        synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
         bc = BarycentricCorrection(synthetic_kpf2)
 
         _, t_no = bc.compute_flux_weighted_midpoint_times(
@@ -460,7 +473,7 @@ class TestFluxWeightedMidpointExpmeter:
             "5000": [1000.0, 1.0, 1.0],
             "5100": [1000.0, 1.0, 1.0],
         }
-        synthetic_kpf2.set_data("EXPMETER_SCI", Table(data))
+        synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
         # Shutter open 00:00:00 → 00:05:00; readings only 00:02:00–00:03:20
         synthetic_kpf2.headers["INSTRUMENT_HEADER"]["DATE-BEG"] = (
             "2024-01-01T00:00:00.000"
@@ -529,7 +542,7 @@ class TestFluxWeightedMidpointOrders:
             "5000": [1000.0, 1.0, 1.0],
             "5100": [1.0, 1.0, 1000.0],
         }
-        synthetic_kpf2.set_data("EXPMETER_SCI", Table(data))
+        synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
 
         bc = BarycentricCorrection(synthetic_kpf2)
         _, t = bc.compute_flux_weighted_midpoint_times(output="orders", **self._KWARGS)
@@ -591,7 +604,7 @@ class TestFluxWeightedMidpointCcds:
             "5000": [1000.0, 1.0, 1.0],
             "5300": [1.0, 1.0, 1000.0],
         }
-        synthetic_kpf2.set_data("EXPMETER_SCI", Table(data))
+        synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
 
         bc = BarycentricCorrection(synthetic_kpf2)
         _, t_orders = bc.compute_flux_weighted_midpoint_times(
@@ -658,7 +671,7 @@ class TestFluxWeightedMidpointCcds:
             "5000": [1000.0, 1.0, 1.0],
             "5100": [1.0, 1.0, 1000.0],
         }
-        synthetic_kpf2.set_data("EXPMETER_SCI", Table(data))
+        synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
 
         bc = BarycentricCorrection(synthetic_kpf2)
         w, t = bc.compute_flux_weighted_midpoint_times(output="ccds", **self._KWARGS)
@@ -907,7 +920,7 @@ class TestPerform:
 
     def test_missing_crv_defaults_to_zero(self, caplog, bc_monkeypatched, monkeypatch):
         """No CRV3 on PRIMARY (no catalog rv, no TARGRADV) → rv_mps=0, warns."""
-        # synthetic_kpf2 fixture does not set CRV3
+        del bc_monkeypatched.l2_obj.headers["PRIMARY"]["CRV3"]
         captured = {}
 
         def mock_compute(astrometry, obs_times, location, rv_mps=0.0):
@@ -947,7 +960,7 @@ class TestPerform:
             data[wc] = rng.normal(100.0, 2.0, ntime).astype(float)
         # Inject a clear outlier so the filter has work to do
         data[wave_cols[5]][30] = 1e6
-        synthetic_kpf2.set_data("EXPMETER_SCI", Table(data))
+        synthetic_kpf2.set_data("EXPMETER_SCI", _expmeter_table(data))
         synthetic_kpf2.headers["INSTRUMENT_HEADER"]["DATE-END"] = (
             "2024-01-01T01:00:00.000"
         )

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -14,10 +14,7 @@ from kpfpipe.modules.calibration_association import CalibrationAssociation
 
 class MockL1:
     def __init__(self, date_obs="2024-04-05T11:08:33"):
-        # DATE-OBS is read from the EPRV-standard PRIMARY (identity-mapped from
-        # the native WMKO DATE-OBS); the calibration ages/paths are KPF-pipeline
-        # keywords written to PRIMARY/RECEIPT. Headers are fits.Header, mirroring
-        # the real KPF data models.
+        # Headers are fits.Header, mirroring the real KPF data models.
         primary = fits.Header()
         primary["DATE-OBS"] = date_obs
         self.obs_id = "KP.20240405.40113.57"
@@ -34,8 +31,6 @@ class MockL1:
 
     def set_keyword(self, key, value):
         # Mirror the real routing: master paths ({PREFIX}FILE) land on RECEIPT.
-        # The signed ages ({PREFIX}AGE) are written downstream by DiagL1, not by
-        # this module.
         ext = "RECEIPT" if key.endswith("FILE") else "PRIMARY"
         self.headers[ext][key] = value
 
@@ -54,7 +49,7 @@ _LEVEL_BY_CAL_TYPE = {
 
 
 def _stub_master(directory, obs_id, cal_type):
-    """Create a zero-byte stub master file with the correct naming convention."""
+    """Zero-byte stub master following the production naming convention."""
     level = _LEVEL_BY_CAL_TYPE[cal_type]
     path = directory / f"{obs_id}_master_{cal_type}_{level}.fits"
     path.touch()
@@ -79,7 +74,7 @@ class TestFindMasterFiles:
         assert result[0][1] == "20240405.03637.74"
 
     def test_searches_previous_day_by_default(self, tmp_path):
-        # Default window is [-1, 0]; a file from the previous day should appear.
+        # Default window is [-1, 0] days.
         d = tmp_path / "masters" / "20240404"
         d.mkdir(parents=True)
         _stub_master(d, "KP.20240404.79200.00", "bias")
@@ -178,9 +173,8 @@ class TestSelectNearest:
 
     def test_selects_nearest_of_two(self, tmp_path):
         mod = _make_module(tmp_path)
-        # Science frame at 40113s (~11:08 UTC).
-        # Candidate A at 03637s (~01:00 UTC) -- delta ~7.1 hours.
-        # Candidate B at 36000s (~10:00 UTC) -- delta ~1.1 hours.
+        # Timestamps are seconds of day UTC: the science frame is at 40113s, so
+        # 36000s is ~1.1 h away and 03637s ~7.1 h.
         result = mod._select_nearest(
             "2024-04-05T11:08:33",
             [
@@ -202,10 +196,8 @@ class TestSelectNearest:
 
     def test_prefers_same_day_over_previous_day(self, tmp_path):
         mod = _make_module(tmp_path)
-        # Science at 2024-04-05 02:00 UTC (7200s).
-        # Previous-day master at 23:00 HST = 23:00 local ≈ 23*3600 = 82800s
-        # on 2024-04-04.
-        # Same-day master at 00:30 UTC on 2024-04-05 (1800s).
+        # Timestamps are seconds of day UTC: science at 7200s on 04-05, with
+        # candidates 3 h earlier (82800s on 04-04) and 1.5 h earlier (1800s).
         result = mod._select_nearest(
             "2024-04-05T02:00:00",
             [
@@ -264,9 +256,8 @@ class TestPerform:
         assert "BIASDIR" not in mod.l1_obj.headers["RECEIPT"]
 
     def test_does_not_write_biasage(self, masters_dir):
-        # The signed master-obs age (BIASAGE) is now recomputed downstream by
-        # DiagL1 from the path this module writes; the module itself emits only
-        # the path. (DiagL1.calibration_ages is covered in test_diagnostics.py.)
+        # BIASAGE is recomputed downstream by DiagL1 from the path this module
+        # writes (covered in test_diagnostics.py).
         mod = _make_module(masters_dir)
         mod.perform(["bias"])
         assert "BIASAGE" not in mod.l1_obj.headers["QUALITY_CONTROL"]
@@ -280,8 +271,7 @@ class TestPerform:
             assert f"{prefix}AGE" not in mod.l1_obj.headers["QUALITY_CONTROL"]
 
     def test_sets_headers_for_thar(self, masters_dir):
-        # WLS follows the same unified convention: WLSFILE holds the full path
-        # (no WLSDIR). The WLSAGE is written downstream by DiagL1.
+        # WLSFILE holds the full path (no WLSDIR); WLSAGE comes from DiagL1.
         d = masters_dir / "masters" / "20240405"
         _stub_master(d, "KP.20240405.03637.74", "thar")
 
@@ -305,7 +295,7 @@ class TestPerform:
             mod.perform(["bias"])
 
     def test_raises_on_first_missing_cal_type(self, masters_dir):
-        # Only bias exists; dark should trigger the error.
+        # dark is removed, so it is the type that fails.
         d = masters_dir / "masters" / "20240405"
         for f in d.glob("*_master_dark_L1.fits"):
             f.unlink()
@@ -325,7 +315,7 @@ class TestPerform:
             mod.perform(["bias"])  # default window doesn't reach 2 days back
 
         mod2 = _make_module(tmp_path)
-        mod2.perform(["bias"], masters_search_window_days=[-2, 0])  # should succeed
+        mod2.perform(["bias"], masters_search_window_days=[-2, 0])
         assert "BIASFILE" in mod2.l1_obj.headers["RECEIPT"]
 
 

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -30,9 +30,12 @@ class MockL1:
         self._receipt.append((name, args, status))
 
     def set_keyword(self, key, value):
-        # Mirror the real routing: master paths ({PREFIX}FILE) land on RECEIPT.
-        ext = "RECEIPT" if key.endswith("FILE") else "PRIMARY"
-        self.headers[ext][key] = value
+        # Mirror the real routing: L1-headers.csv routes every {PREFIX}FILE
+        # master path to RECEIPT, and that is all CalibrationAssociation writes.
+        # Fail loud on anything else rather than inventing a PRIMARY fallback.
+        if not key.endswith("FILE"):
+            raise KeyError(f"{key!r} is not routed by this mock; extend it")
+        self.headers["RECEIPT"][key] = value
 
 
 def _make_module(tmp_path, date_obs="2024-04-05T11:08:33"):

--- a/tests/regression/test_calibration_association.py
+++ b/tests/regression/test_calibration_association.py
@@ -197,6 +197,28 @@ class TestSelectNearest:
         mod = _make_module(tmp_path)
         assert mod._select_nearest("2024-04-05T11:08:33", []) is None
 
+    def test_selects_a_master_taken_after_the_frame(self, tmp_path):
+        # _select_nearest minimizes |dt|, so a master observed *after* the frame
+        # wins when it is closer; the signed {PREFIX}AGE DiagL1 recomputes is
+        # what makes that intentional. A past-only filter would be a plausible
+        # "fix" that silently changes which master calibrates which frame.
+        mod = _make_module(tmp_path)
+        # Science at 40113s; candidates 3 h before (29313s) and 1 h after (43713s).
+        result = mod._select_nearest(
+            "2024-04-05T11:08:33",
+            [
+                (
+                    "/masters/KP.20240405.29313.00_master_bias_L1.fits",
+                    "20240405.29313.00",
+                ),
+                (
+                    "/masters/KP.20240405.43713.00_master_bias_L1.fits",
+                    "20240405.43713.00",
+                ),
+            ],
+        )
+        assert "KP.20240405.43713.00" in result
+
     def test_prefers_same_day_over_previous_day(self, tmp_path):
         mod = _make_module(tmp_path)
         # Timestamps are seconds of day UTC: science at 7200s on 04-05, with
@@ -253,19 +275,10 @@ class TestPerform:
         )
         assert mod.l1_obj.headers["RECEIPT"].get("BIASFILE") == expected
 
-    def test_no_biasdir_header(self, masters_dir):
-        mod = _make_module(masters_dir)
-        mod.perform(["bias"])
-        assert "BIASDIR" not in mod.l1_obj.headers["RECEIPT"]
-
-    def test_does_not_write_biasage(self, masters_dir):
-        # BIASAGE is recomputed downstream by DiagL1 from the path this module
-        # writes (covered in test_diagnostics.py).
-        mod = _make_module(masters_dir)
-        mod.perform(["bias"])
-        assert "BIASAGE" not in mod.l1_obj.headers["QUALITY_CONTROL"]
-
     def test_sets_headers_for_dark_and_flat(self, masters_dir):
+        # {PREFIX}AGE is recomputed downstream by DiagL1 from the path this
+        # module writes (covered in test_diagnostics.py), so it must be absent
+        # here; likewise {PREFIX}DIR, since {PREFIX}FILE holds the full path.
         mod = _make_module(masters_dir)
         mod.perform(["bias", "dark", "flat"])
         for prefix in ("BIAS", "DARK", "FLAT"):
@@ -314,7 +327,7 @@ class TestPerform:
         _stub_master(d, "KP.20240403.03637.74", "bias")
 
         mod = _make_module(tmp_path)
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="No 'bias' master found"):
             mod.perform(["bias"])  # default window doesn't reach 2 days back
 
         mod2 = _make_module(tmp_path)

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -21,11 +21,13 @@ from astropy.table import Table
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
+from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.quality_control.checkpoints import (
     Checkpoint,
     CheckpointL0,
+    CheckpointL1,
     CheckpointL2,
     CheckpointL4,
 )
@@ -101,13 +103,6 @@ class TestQCFlags:
             CheckpointL2(l2).qc_flags()
         assert not caplog.records
 
-    def test_absent_flag_is_ignored(self, caplog):
-        # A flag the QC stage never wrote is absent -> neither warns nor raises.
-        l2 = KPF2()
-        with caplog.at_level(logging.WARNING):
-            CheckpointL2(l2).qc_flags()
-        assert not caplog.records
-
     def test_summary_lists_all_failing_flags_cross_level(self, caplog):
         # The ISGOOD summary names every failing flag on QUALITY_CONTROL,
         # including one propagated from a lower level (RNOK from L1).
@@ -123,17 +118,6 @@ class TestQCFlags:
             CheckpointL2(l2).qc_flags()
         assert "L2VAROK" in caplog.text
         assert "RNOK" in caplog.text
-
-    def test_registry_qc_flag_sets_scoping(self):
-        from kpfpipe.data_models.keyword_registry import keyword_registry as reg
-
-        # ISGOOD is the cross-level aggregate: in the full set, in no per-level set.
-        assert "ISGOOD" in reg.qc_flag_keywords
-        assert all("ISGOOD" not in s for s in reg.qc_flag_keywords_by_level.values())
-        # Representative checks live under their own level.
-        assert "RNOK" in reg.qc_flag_keywords_by_level["L1"]
-        assert "DATAPRL2" in reg.qc_flag_keywords_by_level["L2"]
-        assert "RNOK" not in reg.qc_flag_keywords_by_level["L2"]
 
 
 class TestRunFoldsDiagnosticsAndQC:
@@ -190,6 +174,84 @@ class TestRunFoldsDiagnosticsAndQC:
             chk.run()
         assert chk.qc_results == {}
         assert not caplog.records
+
+
+# ---------------------------------------------------------------------------
+# CheckpointL1 -- folds DiagL1 + QCL1, then validates the assembled FFI product
+# ---------------------------------------------------------------------------
+
+
+def _make_l1(*, ccd=True, shape=(8, 8)):
+    """KPF1 good enough for CheckpointL1.run(): GREEN/RED CCD + VAR arrays, the
+    applied-calibration flags on RECEIPT, and the read-noise and master-age
+    keywords on QUALITY_CONTROL, all inside the ranges QCL1 accepts.
+
+    Built in memory. Not the same as test_qc_flags.py's ``_make_kpf1``, which
+    deliberately round-trips through from_fits to reproduce the sparse-PRIMARY
+    case its KWRDPRL1 test needs; here the skeleton PRIMARY is what is wanted.
+    """
+    l1 = KPF1()
+    l1.headers["PRIMARY"]["DATE-OBS"] = "2024-04-05T01:00:37"
+    if ccd:
+        for chip in ("GREEN", "RED"):
+            l1.set_data(f"{chip}_CCD", np.ones(shape, dtype=np.float32))
+            l1.set_data(f"{chip}_VAR", np.ones(shape, dtype=np.float32))
+
+    receipt = l1.headers["RECEIPT"]
+    for kw in ("OSCANSUB", "BIASSUB", "DARKSUB", "FLATDIV"):
+        receipt[kw] = (True, "applied")
+
+    qc = l1.headers["QUALITY_CONTROL"]
+    qc["BIASAGE"] = (1.0, "Age of bias master [days]")
+    qc["DARKAGE"] = (5.0, "Age of dark master [days]")
+    qc["FLATAGE"] = (10.0, "Age of flat master [days]")
+    for i in range(1, 5):
+        qc[f"RNGREEN{i}"] = (3.5, "RN e-")
+        qc[f"RNRED{i}"] = (4.0, "RN e-")
+        qc[f"RNNGGR{i}"] = (1.0, "RNNG")
+        qc[f"RNNGRD{i}"] = (1.0, "RNNG")
+
+    for kw in CheckpointL1.QC(l1)._required_primary_keywords():
+        if kw not in l1.headers["PRIMARY"]:
+            l1.headers["PRIMARY"][kw] = ("UNKNOWN", "seeded for test")
+    return l1
+
+
+class TestCheckpointL1:
+    def test_run_good_product_passes_and_writes_flags(self, caplog):
+        l1 = _make_l1()
+        with caplog.at_level(logging.WARNING):
+            CheckpointL1(l1).run()
+        assert not caplog.records
+        qc = l1.headers["QUALITY_CONTROL"]
+        assert qc["DATAPRL1"] == 1
+        assert qc["KWRDPRL1"] == 1
+        assert qc["ISGOOD"] == 1
+
+    def test_run_raises_when_ccd_data_missing(self):
+        # DATAPRL1 is fatal (in RAISE_FLAGS): no GREEN/RED CCD -> run() raises.
+        l1 = _make_l1(ccd=False)
+        with pytest.raises(ValueError, match="DATAPRL1 = 0"):
+            CheckpointL1(l1).run()
+
+    def test_run_raises_when_required_keyword_missing(self):
+        # KWRDPRL1 is fatal (in RAISE_FLAGS): a missing required PRIMARY keyword
+        # -> KWRDPRL1 = 0 -> run() raises.
+        l1 = _make_l1()
+        req = sorted(CheckpointL1.QC(l1)._required_primary_keywords())
+        del l1.headers["PRIMARY"][req[0]]
+        with pytest.raises(ValueError, match="KWRDPRL1 = 0"):
+            CheckpointL1(l1).run()
+
+    def test_run_warns_when_read_noise_out_of_range(self, caplog):
+        # RNOK is not a RAISE_FLAG, so an out-of-range amp lands in the ISGOOD
+        # summary rather than raising.
+        l1 = _make_l1()
+        l1.headers["QUALITY_CONTROL"]["RNGREEN1"] = (99.0, "RN e-")
+        with caplog.at_level(logging.WARNING):
+            CheckpointL1(l1).run()
+        assert "ISGOOD=0" in caplog.text
+        assert "RNOK" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -1,12 +1,11 @@
 """Tests for the Checkpoint layer (quality_control/checkpoints).
 
-Checkpoints are the third QC stage: they READ the 0/1 QC flags and the product
+Checkpoints are the third QC stage: they read the 0/1 QC flags and the product
 headers, then warn or raise (never write). This pins:
 
   - ``unregistered_keywords`` -- raises on a card not registered for a governed
     extension (including a raw WMKO native leaked onto an EPRV PRIMARY); skips the
-    raw WMKO L0 PRIMARY; passes a clean product. (Migrated from the old
-    ``QC._validate_headers`` tests.)
+    raw WMKO L0 PRIMARY; passes a clean product.
   - ``qc_flags`` -- a failed (0) flag named in the level's ``RAISE_FLAGS`` raises;
     any other failed flag warns; all-pass is silent.
 
@@ -36,11 +35,9 @@ _NORDER_TOTAL = DETECTOR["norder"]["GREEN"] + DETECTOR["norder"]["RED"]
 
 class TestUnregisteredKeywords:
     def test_clean_product_passes(self, caplog):
-        # Fresh KPF2: EPRV-seeded PRIMARY (all registered) + empty governed
-        # extensions -> no unregistered card, and no QC flags present -> qc_flags
-        # is a no-op, so the checkpoint methods are silent. (run() is not used
-        # here: it folds in QC, which a bare product can't satisfy -- the fold is
-        # covered by TestRunFoldsDiagnosticsAndQC.)
+        # A fresh KPF2 has no unregistered card and no QC flags, so both methods
+        # are silent. run() is not used here: it folds in QC, which a bare product
+        # cannot satisfy.
         l2 = KPF2()
         with caplog.at_level(logging.WARNING):
             chk = CheckpointL2(l2)
@@ -56,9 +53,9 @@ class TestUnregisteredKeywords:
 
     def test_native_wmko_leak_on_primary_raises(self):
         l2 = KPF2()
-        # GAIAID is a raw WMKO native (kept in INSTRUMENT_HEADER, never on PRIMARY).
-        # It is not a registered PRIMARY keyword, so it fails the general
-        # unregistered-keyword check (no dedicated WMKO-leak branch needed).
+        # GAIAID is a raw WMKO native (kept in INSTRUMENT_HEADER, never on
+        # PRIMARY), so the general unregistered-keyword check catches it -- no
+        # dedicated WMKO-leak branch needed.
         l2.headers["PRIMARY"]["GAIAID"] = (12345, "leaked native")
         with pytest.raises(ValueError, match="unregistered keyword 'GAIAID'"):
             CheckpointL2(l2).unregistered_keywords()
@@ -112,10 +109,8 @@ class TestQCFlags:
         assert not caplog.records
 
     def test_summary_lists_all_failing_flags_cross_level(self, caplog):
-        # The ISGOOD summary is the cross-level roll-up: it names every failing
-        # flag on QUALITY_CONTROL by bare keyword, including one propagated from a
-        # lower level (RNOK from L1). Per-flag detail with comments is the QC
-        # stage's job (see test_qc_flags), so the checkpoint need not repeat it.
+        # The ISGOOD summary names every failing flag on QUALITY_CONTROL,
+        # including one propagated from a lower level (RNOK from L1).
         l2 = KPF2()
         l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")  # avoid raise
         l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (
@@ -205,11 +200,11 @@ class TestRunFoldsDiagnosticsAndQC:
 def _make_l4(*, sci=True):
     """KPF4 good enough for CheckpointL4.run(): science CCF + RV tables (with
     BJD_TDB/BERV/WEIGHT for DiagL4) and the required PRIMARY keywords seeded so
-    KWRDPRL4 passes. (Timing consistency is an L0 check, DATTIMOK, not L4.)
+    KWRDPRL4 passes.
 
     SCI-OBJ is 'target' (star-illuminated) so the BJDOK/BERVOK gates apply, and the
-    per-order BJD/BERV jitter is kept well inside those range gates (1 s / 0.1 m/s)
-    so a good product passes."""
+    per-order BJD/BERV jitter is kept well inside those gates (1 s / 0.1 m/s) so a
+    good product passes."""
     l4 = KPF4()
     l4.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = "target"
     if sci:
@@ -240,7 +235,7 @@ class TestCheckpointL4:
             CheckpointL4(l4).run()
         assert not caplog.records
         qc = l4.headers["QUALITY_CONTROL"]
-        # Folded DiagL4 metrics + QCL4 flags both landed on QUALITY_CONTROL.
+        # The folded DiagL4 metrics and QCL4 flags both land on QUALITY_CONTROL.
         assert qc["BERVMEAN"] is not None and qc["BJDMEAN"] is not None
         assert qc["DATAPRL4"] == 1
         assert qc["ISGOOD"] == 1

--- a/tests/regression/test_checkpoints.py
+++ b/tests/regression/test_checkpoints.py
@@ -17,13 +17,11 @@ import logging
 
 import numpy as np
 import pytest
-from astropy.table import Table
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
-from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.quality_control.checkpoints import (
     Checkpoint,
     CheckpointL0,
@@ -32,7 +30,16 @@ from kpfpipe.quality_control.checkpoints import (
     CheckpointL4,
 )
 
+from ._data_models import (
+    GOOD_DATES,
+    make_l4,
+    seed_required_primary,
+    set_fiber_arrays,
+    write_amp_l0,
+)
+
 _NORDER_TOTAL = DETECTOR["norder"]["GREEN"] + DETECTOR["norder"]["RED"]
+_NCOL = 8  # DiagL2 metrics are pixel aggregates; detector width is moot here
 
 
 class TestUnregisteredKeywords:
@@ -102,6 +109,21 @@ class TestQCFlags:
         with caplog.at_level(logging.WARNING):
             CheckpointL2(l2).qc_flags()
         assert not caplog.records
+
+    def test_lower_level_fatal_flag_warns_not_raises(self, caplog):
+        # DATAPRL1 is fatal at L1 but is not an L2 flag, so an L2 checkpoint must
+        # warn about it, not abort: the L1 checkpoint already had its chance to
+        # raise. The fatal scan reads qc_flag_keywords_by_level[LEVEL] while the
+        # warning summary reads the full cross-level set; collapsing the two
+        # would turn every upstream warn into a downstream pipeline abort, and
+        # every other test in this file would still pass.
+        l2 = KPF2()
+        l2.headers["QUALITY_CONTROL"]["DATAPRL2"] = (1, "data present")
+        l2.headers["QUALITY_CONTROL"]["KWRDPRL2"] = (1, "required present")
+        l2.headers["QUALITY_CONTROL"]["DATAPRL1"] = (0, "L1 data (propagated)")
+        with caplog.at_level(logging.WARNING):
+            CheckpointL2(l2).qc_flags()  # must not raise
+        assert "DATAPRL1" in caplog.text
 
     def test_summary_lists_all_failing_flags_cross_level(self, caplog):
         # The ISGOOD summary names every failing flag on QUALITY_CONTROL,
@@ -174,6 +196,89 @@ class TestRunFoldsDiagnosticsAndQC:
             chk.run()
         assert chk.qc_results == {}
         assert not caplog.records
+
+
+# ---------------------------------------------------------------------------
+# CheckpointL0 / CheckpointL2 -- the two run() seams the recipe drives
+# ---------------------------------------------------------------------------
+#
+# recipes/kpf_drp_science.py calls CheckpointL0(l0).run() and CheckpointL2(l2).run()
+# on the production path, but neither was exercised in process anywhere, so
+# QCL0.run() and QCL2.run() never ran outside a full recipe or the CLI suite that
+# `make test-fast` excludes. That left the DiagL2 -> QCL2 handshake unpinned:
+# DiagL2 writes NANSCI*/ZEROFRAC and QCL2 reads them back by name, and renaming a
+# key on one side (QCL2 returns False for a value it cannot find) kept the whole
+# suite green while L2NANOK went to 0 on every real frame.
+
+
+def _make_l2(*, populate=True):
+    """KPF2 good enough for CheckpointL2.run(): clean FLUX/VAR on every fiber and
+    the required PRIMARY keywords seeded so KWRDPRL2 passes."""
+    l2 = KPF2()
+    if populate:
+        set_fiber_arrays(l2, "FLUX", 1.0, ncol=_NCOL)
+        set_fiber_arrays(l2, "VAR", 0.25, ncol=_NCOL)
+    seed_required_primary(l2, CheckpointL2.QC)
+    return l2
+
+
+class TestCheckpointL2:
+    def test_run_composes_diagnostics_into_qc(self):
+        l2 = _make_l2()
+        CheckpointL2(l2).run()
+        qc = l2.headers["QUALITY_CONTROL"]
+        # The metrics DiagL2 measured...
+        assert qc["NANSCI1"] == 0
+        assert qc["ZEROFRAC"] == pytest.approx(0.0)
+        # ...are the ones QCL2 read back, by name. This is the seam.
+        assert qc["L2NANOK"] == 1
+        assert qc["L2FLXOK"] == 1
+        assert qc["ISGOOD"] == 1
+
+    def test_run_detects_real_nan_pixels_through_the_seam(self):
+        # Half of SCI1's pixels are NaN. DiagL2 must count them and QCL2 must
+        # fail on the count it wrote -- neither half proves that alone.
+        l2 = _make_l2()
+        flux = l2.data["GREEN_SCI1_FLUX"]
+        flux[:, : _NCOL // 2] = np.nan
+        CheckpointL2(l2).run()
+        qc = l2.headers["QUALITY_CONTROL"]
+        assert qc["NANSCI1"] > 0
+        assert qc["L2NANOK"] == 0
+        assert qc["ISGOOD"] == 0
+
+    def test_run_raises_when_extraction_missing(self):
+        # DATAPRL2 is fatal (in RAISE_FLAGS): no extracted flux -> run() raises.
+        with pytest.raises(ValueError, match="DATAPRL2 = 0"):
+            CheckpointL2(_make_l2(populate=False)).run()
+
+
+class TestCheckpointL0:
+    def test_run_good_product_passes_and_writes_flags(self, tmp_path, caplog):
+        # A calibration frame: no target to resolve, so no AstroQuery and no
+        # network. This is the only in-process exercise of QCL0.run().
+        fn = str(tmp_path / "KP.20240405.00001.00.fits")
+        write_amp_l0(
+            fn,
+            namps=4,
+            shape=(10, 10),
+            primary_cards={
+                "DATE-OBS": "2024-04-05T01:00:37",
+                "MJD-OBS": 60405.04,
+                "EXPTIME": 12.0,
+                "OBJECT": "synthetic",
+                "IMTYPE": "Bias",
+                "PROGNAME": None,
+                **GOOD_DATES,
+            },
+        )
+        l0 = KPF0.from_fits(fn)
+        with caplog.at_level(logging.WARNING):
+            CheckpointL0(l0).run()
+        qc = l0.headers["QUALITY_CONTROL"]
+        assert qc["DATAPRL0"] == 1
+        assert qc["KWRDPRL0"] == 1
+        assert qc["ISGOOD"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -260,33 +365,18 @@ class TestCheckpointL1:
 
 
 def _make_l4(*, sci=True):
-    """KPF4 good enough for CheckpointL4.run(): science CCF + RV tables (with
-    BJD_TDB/BERV/WEIGHT for DiagL4) and the required PRIMARY keywords seeded so
-    KWRDPRL4 passes.
+    """KPF4 good enough for CheckpointL4.run(), from the shared builder.
 
-    SCI-OBJ is 'target' (star-illuminated) so the BJDOK/BERVOK gates apply, and the
-    per-order BJD/BERV jitter is kept well inside those gates (1 s / 0.1 m/s) so a
-    good product passes."""
-    l4 = KPF4()
-    l4.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = "target"
-    if sci:
-        rng = np.random.default_rng(3)
-        for fiber in ("SCI1", "SCI2", "SCI3"):
-            l4.set_data(f"{fiber}_CCF", np.ones((_NORDER_TOTAL, 5)))
-            l4.set_data(
-                f"{fiber}_RV",
-                Table(
-                    {
-                        "ORDER_INDEX": np.arange(_NORDER_TOTAL),
-                        "RV": rng.normal(0, 1e-3, _NORDER_TOTAL),
-                        "BJD_TDB": 2460000.0 + rng.normal(0, 1e-7, _NORDER_TOTAL),
-                        "BERV": 7.9 + rng.normal(0, 1e-7, _NORDER_TOTAL),
-                        "WEIGHT": np.ones(_NORDER_TOTAL),
-                    }
-                ),
-            )
-    for kw in CheckpointL4.QC(l4)._required_primary_keywords():
-        l4.headers["PRIMARY"][kw] = ("UNKNOWN", "seeded for test")
+    The arguments are load-bearing and must not be trimmed to the defaults:
+    ``jitter=1e-7`` gives the per-order BJD/BERV scatter DiagL4 measures (about
+    1 s and 0.1 m/s, well inside the BJDOK/BERVOK gates), and ``sci_obj="target"``
+    is what makes those gates apply at all. Without the jitter this stops being
+    the suite's only composed DiagL4 -> QCL4 seam and becomes header-stuffing;
+    passing ``bervrng=``/``bjdrng=`` instead would write the metrics directly and
+    do the same damage.
+    """
+    l4 = make_l4(sci=sci, jitter=1e-7, berv=7.9, sci_obj="target", seed=3)
+    seed_required_primary(l4, CheckpointL4.QC)
     return l4
 
 
@@ -298,7 +388,18 @@ class TestCheckpointL4:
         assert not caplog.records
         qc = l4.headers["QUALITY_CONTROL"]
         # The folded DiagL4 metrics and QCL4 flags both land on QUALITY_CONTROL.
-        assert qc["BERVMEAN"] is not None and qc["BJDMEAN"] is not None
+        # Exact values, not presence: `is not None` accepts 0, nan or a string,
+        # and this is the only assertion in the suite that the folded DiagL4
+        # stage produced correct numbers. The fixture's per-order scatter is
+        # 1e-7 about berv=7.9 and bjd=2460000.0, so the weighted means are known.
+        assert qc["BERVMEAN"] == pytest.approx(7.9, abs=1e-5)
+        assert qc["BJDMEAN"] == pytest.approx(2460000.0, abs=1e-5)
+        # And the dispersion metrics are nonzero, which is what makes this the
+        # composed seam: DiagL4 measured real per-order scatter and QCL4 gated on
+        # what it measured. Dropping the fixture's jitter would leave every other
+        # assertion here green while the seam quietly became a constant.
+        assert qc["BERVRNG"] > 0.0
+        assert qc["BJDRNG"] > 0.0
         assert qc["DATAPRL4"] == 1
         assert qc["ISGOOD"] == 1
 

--- a/tests/regression/test_cli.py
+++ b/tests/regression/test_cli.py
@@ -1,11 +1,9 @@
 """Tests for tools/cli.py: the ``kpfpipe`` subcommand dispatcher.
 
 tools/cli.py is a thin, git-style router: it maps the first argument to a
-subcommand implementation under ``scripts/processing/`` and forwards the
-remaining argv verbatim. These tests verify the routing (each command reaches
-its handler with the untouched remainder), the usage banner, and the
-unknown-command error -- the subcommands' own parsing is tested in
-test_reduce_script.py / test_masters_script.py / test_science_script.py.
+subcommand under ``scripts/processing/`` and forwards the remaining argv verbatim.
+Only the routing, usage banner, and unknown-command error are covered here; the
+subcommands' own parsing lives in test_{reduce,masters,science}_script.py.
 """
 
 import pytest
@@ -53,8 +51,8 @@ class TestUnknownCommand:
         assert "unknown command" in err and "frobnicate" in err
 
     def test_plot_timeseries_is_not_a_command(self, capsys):
-        # The plotter is invoked only via `scripts.plots.plot_timeseries` (as a
-        # script and from the timeseries stage); it is deliberately not a CLI command.
+        # The plotter runs only via `scripts.plots.plot_timeseries` (as a script and
+        # from the timeseries stage); it is deliberately not a CLI command.
         assert "plot-timeseries" not in cli._COMMANDS
         with pytest.raises(SystemExit) as exc:
             cli.main(["plot-timeseries", "--target", "10700"])

--- a/tests/regression/test_config.py
+++ b/tests/regression/test_config.py
@@ -21,7 +21,7 @@ class TestConfigHandler:
 
     def test_get_params_default_sections(self, tmp_path):
         cfg = _write_toml(tmp_path, '[DATA_DIRS]\nroot = "/data"\n[TRACES]\nn = 3\n')
-        params = ConfigHandler(cfg).get_params()  # sections=None -> defaults
+        params = ConfigHandler(cfg).get_params()  # sections=None -> default sections
         assert params == {"root": "/data", "n": 3}
 
     def test_get_params_flattens_nested_dict(self, tmp_path):

--- a/tests/regression/test_config.py
+++ b/tests/regression/test_config.py
@@ -1,6 +1,7 @@
 """Tests for kpfpipe.utils.config: ConfigHandler TOML loading and section overrides."""
 
 import logging
+import tomllib
 
 import pytest
 
@@ -68,3 +69,19 @@ class TestConfigHandler:
         assert params == {"n": 1}
         assert "'TRACES' loaded (1 entries)" in caplog.text
         assert "'EMPTY' present but empty" in caplog.text
+
+
+class TestConfigHandlerFailures:
+    """The two failure modes load_config's docstring promises. Fail-loud on a bad
+    config is a charter guardrail: returning {} for a missing file, or falling
+    back to defaults on a decode error, would silently run the pipeline against
+    the wrong tree."""
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            ConfigHandler(str(tmp_path / "absent.toml"))
+
+    def test_malformed_toml_raises(self, tmp_path):
+        cfg = _write_toml(tmp_path, "[BAD\nx = ")
+        with pytest.raises(tomllib.TOMLDecodeError):
+            ConfigHandler(cfg)

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -14,62 +14,34 @@ import re
 
 import numpy as np
 import pytest
-from astropy.constants import c
 from astropy.io import fits
 
 from kpfpipe.data_models.level2 import KPF2, NORDER_GREEN, NORDER_RED
 from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.modules.cross_correlation import CrossCorrelation
 
-from ._dtype_policy import CCF, assert_dtype
+from ._catalog import seed_sci2_cards
+from ._dtype_policy import CCF, RV_FLOAT, assert_dtype
+from ._science import (
+    MASK_CENTERS,
+    NCOL,
+    NVEL,
+    RANGE_KMS,
+    SPEED_OF_LIGHT_KMS,
+    V_INJECT,
+    absorption_spectrum,
+    make_mask,
+)
 
 NORDER = NORDER_GREEN + NORDER_RED
-SPEED_OF_LIGHT_KMS = np.float64(c.to("km/s").value)
+# Fiber order is the module's own config-overridable default, not the canonical
+# slicer order -- spelled out so a reordering in production shows up here.
 _FIBERS = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]
-
-# Narrow CCF grid for fast integration tests.
-_RANGE_KMS = [-15.0, 15.0]
-_STEP_KMS = 0.25  # matches the module default
-_NVEL = round((_RANGE_KMS[1] - _RANGE_KMS[0]) / _STEP_KMS) + 1
-_V_INJECT = 1.5  # injected RV [km/s], on the grid
-_MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Angstrom]
-# Wide enough that the default compute_ccfs clip (clip_edge_pixels=(500, 500))
-# trims the order edges but leaves the 5015-5035 A mask lines well inside.
-NCOL = 2000
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_mask(centers, weights=None, width=1.0):
-    """Build a line-mask dict matching _build_line_mask's structure."""
-    centers = np.asarray(centers, dtype=np.float64)
-    if weights is None:
-        weights = np.ones_like(centers)
-    half_width = centers * (width / 2.0 / SPEED_OF_LIGHT_KMS)
-    return {
-        "center": centers,
-        "weight": np.asarray(weights, dtype=np.float64),
-        "start": centers - half_width,
-        "end": centers + half_width,
-    }
-
-
-def _absorption_spectrum(wave, centers, weights=None, depth=0.6, sigma_kms=4.0):
-    """Unit continuum with Gaussian absorption lines at `centers`."""
-    if weights is None:
-        weights = np.ones_like(centers)
-    flux = np.ones_like(wave)
-    for center, weight in zip(centers, weights, strict=False):
-        sigma_a = center * sigma_kms / SPEED_OF_LIGHT_KMS
-        flux -= (
-            depth
-            * (weight / np.max(weights))
-            * np.exp(-0.5 * ((wave - center) / sigma_a) ** 2)
-        )
-    return flux
 
 
 # ---------------------------------------------------------------------------
@@ -81,10 +53,10 @@ class TestComputeCCF:
     def _order(self, v_dip=0.0, z=0.0):
         wave = np.linspace(5000.0, 5050.0, 2000)
         centers = np.linspace(5008.0, 5042.0, 20)
-        mask = _make_mask(centers)
+        mask = make_mask(centers)
         # Observed absorption that the CCF should align at velocity step v_dip.
         lam_obs = centers * (1.0 + v_dip / SPEED_OF_LIGHT_KMS) / (1.0 + z)
-        flux = _absorption_spectrum(wave, lam_obs)
+        flux = absorption_spectrum(wave, lam_obs)
         var = flux.copy()  # photon-noise proxy
         vel = np.arange(-402, 403) * 0.25
         return wave, flux, var, mask, vel
@@ -130,7 +102,7 @@ class TestComputeCCF:
         wave = np.linspace(6000.0, 6050.0, 2000)
         flux = np.ones_like(wave)
         var = flux.copy()  # photon-noise proxy
-        mask = _make_mask(np.linspace(5008.0, 5042.0, 20))  # all outside the order
+        mask = make_mask(np.linspace(5008.0, 5042.0, 20))  # all outside the order
         vel = np.arange(-402, 403) * 0.25
         ccf, _ = CrossCorrelation._compute_ccf_1d(wave, flux, var, mask, vel, 0.0)
         assert not np.any(ccf)
@@ -165,12 +137,7 @@ class TestComputeCCF:
 def header_kpf2():
     """KPF2 with only the header keywords the build/dispatch helpers need."""
     kpf2 = KPF2()
-    kpf2.headers["PRIMARY"]["CCLR3"] = 0.823  # G2V -> 5770 K
-    kpf2.headers["PRIMARY"]["CCLRN3"] = "Gaia BP-RP"
-    kpf2.headers["PRIMARY"]["CRV3"] = 0.0
-    kpf2.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = "Target"
-    kpf2.headers["INSTRUMENT_HEADER"]["SKY-OBJ"] = "Sky"
-    kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = "None"
+    seed_sci2_cards(kpf2)
     return kpf2
 
 
@@ -385,20 +352,15 @@ class TestBuildVelocityGrid:
 
 
 def _build_cc_kpf2():
-    """KPF2 with identical per-order synthetic spectra (absorption at _MASK_CENTERS
-    shifted by _V_INJECT) for every orderlet and zero barycentric correction."""
+    """KPF2 with identical per-order synthetic spectra (absorption at MASK_CENTERS
+    shifted by V_INJECT) for every orderlet and zero barycentric correction."""
     kpf2 = KPF2()
-    kpf2.headers["PRIMARY"]["CCLR3"] = 0.823  # G2V -> 5770 K
-    kpf2.headers["PRIMARY"]["CCLRN3"] = "Gaia BP-RP"
-    kpf2.headers["PRIMARY"]["CRV3"] = 0.0
     # Illumination sources: SCI on a star, SKY on sky, CAL dark (skipped).
-    kpf2.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = "Target"
-    kpf2.headers["INSTRUMENT_HEADER"]["SKY-OBJ"] = "Sky"
-    kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = "None"
+    seed_sci2_cards(kpf2)
 
     wave_1d = np.linspace(5000.0, 5050.0, NCOL)
-    lam_obs = _MASK_CENTERS * (1.0 + _V_INJECT / SPEED_OF_LIGHT_KMS)  # z = 0
-    flux_1d = _absorption_spectrum(wave_1d, lam_obs)
+    lam_obs = MASK_CENTERS * (1.0 + V_INJECT / SPEED_OF_LIGHT_KMS)  # z = 0
+    flux_1d = absorption_spectrum(wave_1d, lam_obs)
 
     for chip, n in [("GREEN", NORDER_GREEN), ("RED", NORDER_RED)]:
         for fiber in _FIBERS:
@@ -419,8 +381,8 @@ def _build_cc_kpf2():
 
 
 def _stub_line_mask(mp):
-    """Patch _build_line_mask to the fixed _MASK_CENTERS top-hat mask."""
-    mask = _make_mask(_MASK_CENTERS)
+    """Patch _build_line_mask to the fixed MASK_CENTERS top-hat mask."""
+    mask = make_mask(MASK_CENTERS)
     mp.setattr(
         CrossCorrelation,
         "_build_line_mask",
@@ -435,9 +397,9 @@ def cc_kpf2():
 
 @pytest.fixture
 def cc_module(cc_kpf2, monkeypatch):
-    """CrossCorrelation on a narrow grid with the line mask stubbed to _MASK_CENTERS."""
+    """CrossCorrelation on a narrow grid with the line mask stubbed to MASK_CENTERS."""
     _stub_line_mask(monkeypatch)
-    return CrossCorrelation(cc_kpf2, config={"ccf_window": _RANGE_KMS})
+    return CrossCorrelation(cc_kpf2, config={"ccf_window": RANGE_KMS})
 
 
 @pytest.fixture(scope="module")
@@ -450,7 +412,7 @@ def performed():
     scope. No consuming test mutates the module or the L4."""
     with pytest.MonkeyPatch.context() as mp:
         _stub_line_mask(mp)
-        cc = CrossCorrelation(_build_cc_kpf2(), config={"ccf_window": _RANGE_KMS})
+        cc = CrossCorrelation(_build_cc_kpf2(), config={"ccf_window": RANGE_KMS})
         return cc, cc.perform()
 
 
@@ -458,17 +420,17 @@ class TestComputeCCFPublic:
     def test_returns_velocity_and_ccf(self, cc_module):
         res = cc_module.compute_ccfs("GREEN", "SCI2")
         assert set(res) == {"velocity", "ccf"}
-        assert res["velocity"].shape == (_NVEL,)
-        assert res["ccf"].shape == (NORDER_GREEN, _NVEL)
+        assert res["velocity"].shape == (NVEL,)
+        assert res["ccf"].shape == (NORDER_GREEN, NVEL)
 
     def test_red_chip_shape(self, cc_module):
         res = cc_module.compute_ccfs("RED", "SCI1")
-        assert res["ccf"].shape == (NORDER_RED, _NVEL)
+        assert res["ccf"].shape == (NORDER_RED, NVEL)
 
     def test_dip_at_injected_velocity(self, cc_module):
         res = cc_module.compute_ccfs("GREEN", "SCI2")
         vel, ccf = res["velocity"], res["ccf"]
-        assert vel[np.argmin(ccf[0])] == pytest.approx(_V_INJECT, abs=0.3)
+        assert vel[np.argmin(ccf[0])] == pytest.approx(V_INJECT, abs=0.3)
 
     def test_caches_ccf(self, cc_module):
         res = cc_module.compute_ccfs("GREEN", "SCI2")
@@ -476,16 +438,16 @@ class TestComputeCCFPublic:
 
     def test_lowercase_chip_accepted(self, cc_module):
         res = cc_module.compute_ccfs("green", "sci2")
-        assert res["ccf"].shape == (NORDER_GREEN, _NVEL)
+        assert res["ccf"].shape == (NORDER_GREEN, NVEL)
 
     def test_missing_barycorr_z_raises(self, cc_kpf2, monkeypatch):
         monkeypatch.setattr(
             CrossCorrelation,
             "_build_line_mask",
-            lambda self, chip, fiber, mask_width=None: _make_mask(_MASK_CENTERS),
+            lambda self, chip, fiber, mask_width=None: make_mask(MASK_CENTERS),
         )
         cc_kpf2.set_data("BARYCORR_Z", np.array([]))
-        cc = CrossCorrelation(cc_kpf2, config={"ccf_window": _RANGE_KMS})
+        cc = CrossCorrelation(cc_kpf2, config={"ccf_window": RANGE_KMS})
         with pytest.raises(ValueError, match="BARYCORR_Z"):
             cc.compute_ccfs("GREEN", "SCI2")
 
@@ -513,9 +475,9 @@ class TestPerform:
         cc_module, l4 = performed
         assert isinstance(l4, KPF4)
         for fiber in self._ILLUMINATED:
-            assert l4.data[f"{fiber}_CCF"].shape == (NORDER, _NVEL)
+            assert l4.data[f"{fiber}_CCF"].shape == (NORDER, NVEL)
             assert_dtype(l4.data[f"{fiber}_CCF"], CCF, f"{fiber}_CCF")
-            assert l4.data[f"{fiber}_CCF_VAR"].shape == (NORDER, _NVEL)
+            assert l4.data[f"{fiber}_CCF_VAR"].shape == (NORDER, NVEL)
             table = l4.data[f"{fiber}_RV"]
             assert len(table) == NORDER
             assert set(table.columns) >= {
@@ -530,9 +492,8 @@ class TestPerform:
                 "RV_ERR",
                 "WEIGHT",
             }
-            assert table["BJD_TDB"].dtype == np.float64
-            assert table["WAVE_START"].dtype == np.float64
-            assert table["WAVE_END"].dtype == np.float64
+            for column in ("BJD_TDB", "WAVE_START", "WAVE_END"):
+                assert_dtype(table[column], RV_FLOAT, column)
             assert np.issubdtype(table["ORDER_INDEX"].dtype, np.integer)
             assert np.issubdtype(table["ECHELLE_ORDER"].dtype, np.integer)
 
@@ -554,8 +515,8 @@ class TestPerform:
 
     def test_ccf_chip_halves_populated(self, performed):
         cc_module, l4 = performed
-        assert l4.data["GREEN_SCI2_CCF"].shape == (NORDER_GREEN, _NVEL)
-        assert l4.data["RED_SCI2_CCF"].shape == (NORDER_RED, _NVEL)
+        assert l4.data["GREEN_SCI2_CCF"].shape == (NORDER_GREEN, NVEL)
+        assert l4.data["RED_SCI2_CCF"].shape == (NORDER_RED, NVEL)
         assert np.any(l4.data["GREEN_SCI2_CCF"])
         assert np.any(l4.data["RED_SCI2_CCF"])
 
@@ -565,7 +526,7 @@ class TestPerform:
         cc_module, l4 = performed
         for chip, norder in (("GREEN", NORDER_GREEN), ("RED", NORDER_RED)):
             var = l4.data[f"{chip}_SCI2_CCF_VAR"]
-            assert var.shape == (norder, _NVEL)
+            assert var.shape == (norder, NVEL)
             np.testing.assert_array_equal(var, cc_module._ccf_var[f"{chip}_SCI2"])
         assert np.any(l4.data["GREEN_SCI2_CCF_VAR"])
 
@@ -575,7 +536,7 @@ class TestPerform:
         vel = cc_module._velocity_grid["RED_SCI2"]
         for fiber in self._ILLUMINATED:
             ccf0 = np.asarray(l4.data[f"{fiber}_CCF"])[0]
-            assert vel[np.argmin(ccf0)] == pytest.approx(_V_INJECT, abs=0.3)
+            assert vel[np.argmin(ccf0)] == pytest.approx(V_INJECT, abs=0.3)
 
     def test_rv_table_weight_column_matches_order_weights(self, performed):
         # The per-order CCF-combination weights (ccf_order_weights.csv, column
@@ -619,9 +580,9 @@ class TestPerform:
         ccf_hdr = l4.headers["SCI2_CCF"]
         assert ccf_hdr["CTYPE1"] == "Velocity"
         assert ccf_hdr["CTYPE2"] == "Order-N"
-        assert ccf_hdr["VELNSTEP"] == _NVEL
+        assert ccf_hdr["VELNSTEP"] == NVEL
         assert ccf_hdr["VELSTEP"] == pytest.approx(0.25)
-        assert ccf_hdr["VELSTART"] == pytest.approx(_RANGE_KMS[0])  # center 0
+        assert ccf_hdr["VELSTART"] == pytest.approx(RANGE_KMS[0])  # center 0
         assert ccf_hdr["CCFMASK"] == "G2_espresso"  # BP-RP 0.823 -> 5770 K -> G2
         assert ccf_hdr["VELMASK"] == pytest.approx(cc_module.ccf_mask_width)
         rv_hdr = l4.headers["SCI2_RV"]
@@ -663,8 +624,8 @@ class TestPerform:
         l4.to_fits(str(path))
         with fits.open(path) as hdul:
             ccf = hdul["CCF3"].header
-            assert ccf["VELNSTEP"] == _NVEL
-            assert ccf["VELSTART"] == pytest.approx(_RANGE_KMS[0])
+            assert ccf["VELNSTEP"] == NVEL
+            assert ccf["VELSTART"] == pytest.approx(RANGE_KMS[0])
             assert ccf.comments["VELSTART"]  # comment preserved
             rv = hdul["RV3"].header
             assert rv["CTYPE1"] == "Columns"
@@ -673,7 +634,7 @@ class TestPerform:
             assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_0"
             assert rv_table["ECHELLE_ORDER"][0] == 137
             # The per-bin CCF variance cube round-trips as an image extension.
-            assert hdul["CCF_VAR3"].data.shape == (NORDER, _NVEL)
+            assert hdul["CCF_VAR3"].data.shape == (NORDER, NVEL)
 
 
 class TestConstructor:

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -1,13 +1,12 @@
 """Tests for the CrossCorrelation module (KPF2 -> KPF4: per-orderlet CCFs).
 
-Mirrors the CCF-side coverage of test_radial_velocity.py against the standalone
-CrossCorrelation module. Static-method unit tests (_compute_ccf_1d) build
-synthetic spectra with no fixtures. Build-helper tests use a header-only KPF2 and
-read the real on-disk line masks. Integration tests (compute_ccfs/perform) use a
-synthetic KPF2 with absorption injected at a monkeypatched line mask, and a
-narrow velocity grid for speed. CrossCorrelation writes the CCF cubes, the per-bin
-CCF variance cubes, and the metadata-seeded RV tables (RV/RV_ERR left NaN for
-RadialVelocity); it does not fit RVs or write any PRIMARY/combined-RV keywords.
+_compute_ccf_1d unit tests build synthetic spectra; build-helper tests use a
+header-only KPF2 and the real on-disk line masks; integration tests
+(compute_ccfs/perform) use a synthetic KPF2 with absorption injected at a
+monkeypatched line mask and a narrow velocity grid for speed. CrossCorrelation
+writes the CCF cubes, the per-bin CCF variance cubes, and the metadata-seeded RV
+tables (RV/RV_ERR left NaN for RadialVelocity); it does not fit RVs or write any
+PRIMARY/combined-RV keywords.
 """
 
 import logging
@@ -26,16 +25,16 @@ from ._dtype_policy import CCF, assert_dtype
 
 NORDER = NORDER_GREEN + NORDER_RED
 SPEED_OF_LIGHT_KMS = np.float64(c.to("km/s").value)
-_FIBERS = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]  # all orderlets
+_FIBERS = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]
 
 # Narrow CCF grid for fast integration tests.
 _RANGE_KMS = [-15.0, 15.0]
 _STEP_KMS = 0.25  # matches the module default
 _NVEL = round((_RANGE_KMS[1] - _RANGE_KMS[0]) / _STEP_KMS) + 1
 _V_INJECT = 1.5  # injected RV [km/s], on the grid
-_MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Å]
+_MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Angstrom]
 # Wide enough that the default compute_ccfs clip (clip_edge_pixels=(500, 500))
-# trims the order edges but leaves the 5015-5035 Å mask lines well inside.
+# trims the order edges but leaves the 5015-5035 A mask lines well inside.
 NCOL = 2000
 
 
@@ -308,19 +307,19 @@ class TestStellarMaskName:
             CrossCorrelation(header_kpf2)._resolve_stellar_mask()
 
     def test_ignores_instrument_header_targteff(self, header_kpf2):
-        """The catalog colour wins; the raw DCS temperature is no longer consulted."""
+        # The catalog colour wins; the raw DCS temperature is not consulted.
         header_kpf2.headers["INSTRUMENT_HEADER"]["TARGTEFF"] = 4000.0
         assert CrossCorrelation(header_kpf2)._resolve_stellar_mask() == "G2_espresso"
 
     def test_missing_crv_warns_and_centers_on_zero(self, header_kpf2, caplog):
-        """Many targets have no catalog rv; center on 0, but say so."""
+        # Many targets have no catalog rv; center on 0, but say so.
         del header_kpf2.headers["PRIMARY"]["CRV3"]
         with caplog.at_level(logging.WARNING):
             assert CrossCorrelation(header_kpf2)._get_systemic_rv() == 0.0
         assert "CRV3" in caplog.text
 
     def test_ignores_instrument_header_targradv(self, header_kpf2):
-        """The canonical catalog rv wins; the raw DCS value is no longer consulted."""
+        # The canonical catalog rv wins; the raw DCS value is not consulted.
         header_kpf2.headers["INSTRUMENT_HEADER"]["TARGRADV"] = -42.0
         header_kpf2.headers["PRIMARY"]["CRV3"] = 7.5
         assert CrossCorrelation(header_kpf2)._get_systemic_rv() == pytest.approx(7.5)
@@ -431,8 +430,6 @@ def _stub_line_mask(mp):
 
 @pytest.fixture
 def cc_kpf2():
-    """KPF2 with identical per-order synthetic spectra (absorption at _MASK_CENTERS
-    shifted by _V_INJECT) for every orderlet and zero barycentric correction."""
     return _build_cc_kpf2()
 
 
@@ -447,12 +444,10 @@ def cc_module(cc_kpf2, monkeypatch):
 def performed():
     """Run the default full perform() once and share the (module, L4) read-only.
 
-    Every TestPerform test below inspects a different facet of the *same*
-    default-args L4 (shapes, RV columns, CCF/RV header cards, the injected dip);
-    recomputing it per test cost ~0.9s x ~9 tests. The line-mask stub only has to
-    be live during perform(), so a MonkeyPatch context (the function-scoped
-    monkeypatch fixture can't reach module scope) wraps the build. No consuming
-    test mutates the module or the L4, so the shared object stays read-only."""
+    Every TestPerform test inspects a different facet of the same default-args L4,
+    and recomputing it per test cost ~0.9s each. A MonkeyPatch context wraps the
+    build because the function-scoped monkeypatch fixture cannot reach module
+    scope. No consuming test mutates the module or the L4."""
     with pytest.MonkeyPatch.context() as mp:
         _stub_line_mask(mp)
         cc = CrossCorrelation(_build_cc_kpf2(), config={"ccf_window": _RANGE_KMS})
@@ -503,12 +498,10 @@ class TestComputeCCFPublic:
             cc_module.compute_ccfs("GREEN", "SCI2")
 
     def test_clip_edge_pixels_zero_keeps_all(self, cc_module):
-        # clip_edge_pixels=[0, 0] is a no-op (no pixels removed).
         full = cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[0, 0])["ccf"]
         assert np.any(full)
 
     def test_clip_edge_pixels_too_large_raises(self, cc_module):
-        # Clipping more pixels than the order has fails loudly.
         with pytest.raises(ValueError, match="removes all"):
             cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[NCOL, NCOL])
 
@@ -577,7 +570,7 @@ class TestPerform:
         assert np.any(l4.data["GREEN_SCI2_CCF_VAR"])
 
     def test_dip_at_injected_velocity_illuminated_orderlets(self, performed):
-        # The CCFs dip at the injected velocity (no RV fit here, just the CCF).
+        # No RV fit is involved here -- only the CCF minimum.
         cc_module, l4 = performed
         vel = cc_module._velocity_grid["RED_SCI2"]
         for fiber in self._ILLUMINATED:
@@ -620,8 +613,8 @@ class TestPerform:
 
     def test_ccf_and_rv_headers(self, performed):
         # CrossCorrelation stamps the CCF EPRV keywords and the RV table-structure
-        # CTYPE cards, but NOT the RV-processing descriptors (those are
-        # RadialVelocity's, Phase 2) or any PRIMARY combined RV.
+        # CTYPE cards, but not the RV-processing descriptors (RadialVelocity's)
+        # or any PRIMARY combined RV.
         cc_module, l4 = performed
         ccf_hdr = l4.headers["SCI2_CCF"]
         assert ccf_hdr["CTYPE1"] == "Velocity"
@@ -643,7 +636,6 @@ class TestPerform:
         assert l4.headers["PRIMARY"].get("RVMETHOD") != "CCF"
 
     def test_thar_mask_recorded_for_cal(self, cc_module):
-        # A ThAr-illuminated CAL fiber records CCFMASK='thar'.
         cc_module.l2_obj.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = "Th_gold"
         l4 = cc_module.perform(fibers=["CAL"])
         assert l4.headers["CAL_CCF"]["CCFMASK"] == "thar"
@@ -658,7 +650,6 @@ class TestPerform:
         assert len(l4.data["CAL_RV"]) == 0
 
     def test_explicit_chips_and_fibers(self, cc_module):
-        # A single chip / single fiber writes only that chip's CCF rows.
         l4 = cc_module.perform(chips=["GREEN"], fibers=["SCI2"])
         assert np.any(l4.data["GREEN_SCI2_CCF"])
         assert not np.any(l4.data["RED_SCI2_CCF"])

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -351,32 +351,56 @@ class TestBuildVelocityGrid:
 # ---------------------------------------------------------------------------
 
 
-def _build_cc_kpf2():
-    """KPF2 with identical per-order synthetic spectra (absorption at MASK_CENTERS
-    shifted by V_INJECT) for every orderlet and zero barycentric correction."""
+def _build_cc_kpf2(berv=None, wave_offsets=None, bjd=None):
+    """KPF2 with per-order synthetic spectra (absorption at MASK_CENTERS shifted
+    by V_INJECT) for every orderlet.
+
+    ``berv`` (length NORDER, km/s) puts each order in its own barycentric frame:
+    BARYCORR_Z/_KMS carry it and the observed lines are placed at
+    ``MASK_CENTERS * (1 + V_INJECT/c) / (1 + z)``, the convention
+    ``_compute_ccf_1d`` implements (it divides the mask shift by ``1 + z``).
+    Recovering V_INJECT then requires the module to have removed the right
+    order's z. ``wave_offsets`` (length NORDER, Angstrom) gives each order its
+    own wavelength span, and ``bjd`` its own timestamp. All default to the
+    degenerate all-orders-identical, zero-barycorr case.
+    """
     kpf2 = KPF2()
     # Illumination sources: SCI on a star, SKY on sky, CAL dark (skipped).
     seed_sci2_cards(kpf2)
 
-    wave_1d = np.linspace(5000.0, 5050.0, NCOL)
-    lam_obs = MASK_CENTERS * (1.0 + V_INJECT / SPEED_OF_LIGHT_KMS)  # z = 0
-    flux_1d = absorption_spectrum(wave_1d, lam_obs)
+    berv = np.zeros(NORDER) if berv is None else np.asarray(berv, dtype=float)
+    offsets = (
+        np.zeros(NORDER)
+        if wave_offsets is None
+        else np.asarray(wave_offsets, dtype=float)
+    )
+    bjd = np.zeros(NORDER) if bjd is None else np.asarray(bjd, dtype=float)
+    z = berv / SPEED_OF_LIGHT_KMS
 
-    for chip, n in [("GREEN", NORDER_GREEN), ("RED", NORDER_RED)]:
+    wave_1d = np.linspace(5000.0, 5050.0, NCOL)
+    rows = {}
+    for order in range(NORDER):
+        lam_obs = (
+            MASK_CENTERS * (1.0 + V_INJECT / SPEED_OF_LIGHT_KMS) / (1.0 + z[order])
+            + offsets[order]
+        )
+        wave = wave_1d + offsets[order]
+        rows[order] = (wave, absorption_spectrum(wave, lam_obs))
+
+    for chip, start, n in [
+        ("GREEN", 0, NORDER_GREEN),
+        ("RED", NORDER_GREEN, NORDER_RED),
+    ]:
+        wave = np.stack([rows[start + i][0] for i in range(n)]).astype(np.float64)
+        flux = np.stack([rows[start + i][1] for i in range(n)]).astype(np.float64)
         for fiber in _FIBERS:
-            kpf2.set_data(
-                f"{chip}_{fiber}_WAVE", np.tile(wave_1d, (n, 1)).astype(np.float64)
-            )
-            kpf2.set_data(
-                f"{chip}_{fiber}_FLUX", np.tile(flux_1d, (n, 1)).astype(np.float64)
-            )
-            kpf2.set_data(
-                f"{chip}_{fiber}_VAR", np.tile(flux_1d, (n, 1)).astype(np.float64)
-            )
+            kpf2.set_data(f"{chip}_{fiber}_WAVE", wave.copy())
+            kpf2.set_data(f"{chip}_{fiber}_FLUX", flux.copy())
+            kpf2.set_data(f"{chip}_{fiber}_VAR", flux.copy())
     # Per-order barycentric extensions (populated together by BarycentricCorrection).
-    kpf2.set_data("BARYCORR_Z", np.zeros(NORDER))
-    kpf2.set_data("BARYCORR_KMS", np.zeros(NORDER))
-    kpf2.set_data("BJD_TDB", np.zeros(NORDER))
+    kpf2.set_data("BARYCORR_Z", z)
+    kpf2.set_data("BARYCORR_KMS", berv)
+    kpf2.set_data("BJD_TDB", bjd)
     return kpf2
 
 
@@ -451,6 +475,34 @@ class TestComputeCCFPublic:
         with pytest.raises(ValueError, match="BARYCORR_Z"):
             cc.compute_ccfs("GREEN", "SCI2")
 
+    def test_barycorr_z_removed_per_order(self, monkeypatch):
+        # The plumbing under test is L2 BARYCORR_Z -> {chip}_BARYCORR_Z slice ->
+        # barycorr_z[order]. A single constant z would survive a green/red slice
+        # swap or an order off-by-one, so every order gets its own BERV.
+        _stub_line_mask(monkeypatch)
+        berv = -5.0 + 0.05 * np.arange(NORDER)
+        cc = CrossCorrelation(
+            _build_cc_kpf2(berv=berv), config={"ccf_window": RANGE_KMS}
+        )
+        for chip in ("GREEN", "RED"):
+            res = cc.compute_ccfs(chip, "SCI2")
+            vel, ccf = res["velocity"], res["ccf"]
+            recovered = vel[np.argmin(ccf, axis=1)]
+            np.testing.assert_allclose(recovered, V_INJECT, atol=0.3)
+
+    def test_barycorr_z_sign_is_pinned(self, monkeypatch):
+        # Negating only BARYCORR_Z (leaving the spectra alone) must displace the
+        # recovered velocity by about -2*BERV. A sign flip, or BARYCORR_KMS used
+        # where the dimensionless z belongs, lands here.
+        _stub_line_mask(monkeypatch)
+        berv = np.full(NORDER, -5.0)
+        kpf2 = _build_cc_kpf2(berv=berv)
+        kpf2.set_data("BARYCORR_Z", -np.asarray(kpf2.data["BARYCORR_Z"]))
+        cc = CrossCorrelation(kpf2, config={"ccf_window": RANGE_KMS})
+        res = cc.compute_ccfs("GREEN", "SCI2")
+        recovered = res["velocity"][np.argmin(res["ccf"][0])]
+        assert recovered == pytest.approx(V_INJECT - 2 * berv[0], abs=0.3)
+
     def test_all_zero_ccf_raises(self, cc_module):
         # No usable signal across the whole orderlet -> fail loudly instead of
         # silently returning an all-zero CCF cube.
@@ -460,8 +512,27 @@ class TestComputeCCFPublic:
             cc_module.compute_ccfs("GREEN", "SCI2")
 
     def test_clip_edge_pixels_zero_keeps_all(self, cc_module):
+        # "Not all zero" would also hold for an implementation that ignored the
+        # argument; the unclipped CCF must differ from a heavily clipped one.
         full = cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[0, 0])["ccf"]
+        # 800 of the 2000 pixels is 20 A of the 50 A order, enough to cut past
+        # the bluest mask lines; a smaller clip leaves every line inside and the
+        # CCF genuinely unchanged.
+        clipped = cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[800, 0])[
+            "ccf"
+        ]
         assert np.any(full)
+        assert not np.allclose(full, clipped)
+
+    def test_clip_edge_pixels_ends_are_distinguished(self, cc_module):
+        # clip_edge_pixels is [short_wavelength_end, long_wavelength_end]; on this
+        # ascending fixture pixel 0 is the short end, so clipping one end must not
+        # produce the same CCF as clipping the other. (The descending branch at
+        # cross_correlation.py:512 is unreachable in production and is not covered
+        # here -- see the dead-code defect report.)
+        blue = cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[800, 0])["ccf"]
+        red = cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[0, 800])["ccf"]
+        assert not np.allclose(blue, red)
 
     def test_clip_edge_pixels_too_large_raises(self, cc_module):
         with pytest.raises(ValueError, match="removes all"):
@@ -571,6 +642,28 @@ class TestPerform:
             assert echelle[NORDER_GREEN - 1] == 103
             assert echelle[NORDER_GREEN] == 102
             assert echelle[-1] == 71
+
+    def test_rv_table_metadata_columns_match_the_l2(self, monkeypatch):
+        # BJD_TDB/BERV are copied from the L2 barycentric extensions and
+        # WAVE_START/WAVE_END are the per-order first/last wavelength. With the
+        # shared fixture every order carries the same wave and a zero barycorr,
+        # so a wave[:, 0]/wave[:, -1] swap or a green/red row slip is invisible;
+        # here each order gets its own span and timestamp.
+        _stub_line_mask(monkeypatch)
+        berv = -5.0 + 0.05 * np.arange(NORDER)
+        bjd = 2460000.0 + np.arange(NORDER)
+        offsets = 5.0 * np.arange(NORDER)
+        cc = CrossCorrelation(
+            _build_cc_kpf2(berv=berv, wave_offsets=offsets, bjd=bjd),
+            config={"ccf_window": RANGE_KMS},
+        )
+        l4 = cc.perform(chips=["GREEN"], fibers=["SCI2"])
+        table = l4.data["GREEN_SCI2_RV"]
+        wave = np.asarray(cc.l2_obj.data["GREEN_SCI2_WAVE"])
+        np.testing.assert_allclose(table["WAVE_START"], wave[:, 0])
+        np.testing.assert_allclose(table["WAVE_END"], wave[:, -1])
+        np.testing.assert_allclose(table["BJD_TDB"], bjd[:NORDER_GREEN])
+        np.testing.assert_allclose(table["BERV"], berv[:NORDER_GREEN])
 
     def test_ccf_and_rv_headers(self, performed):
         # CrossCorrelation stamps the CCF EPRV keywords and the RV table-structure

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -20,8 +20,6 @@ PRIMARY-header validation no longer lives on the data models (it moved to the
 checkpoints layer, ``quality_control/checkpoints/base.py``).
 """
 
-import warnings
-
 import pytest
 from astropy.io import fits
 
@@ -346,10 +344,8 @@ class TestQualityControlPropagation:
         l1.set_keyword("OSCANSUB", 1)
         l1.set_keyword("BIASFILE", "/m/bias_L1.fits")
         fn = str(tmp_path / "kpf_L1_20240101T000000.fits")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            l1.to_fits(fn)
-            back = KPF1.from_fits(fn)
+        l1.to_fits(fn)
+        back = KPF1.from_fits(fn)
         assert back.headers["QUALITY_CONTROL"]["RNGREEN1"] == 4.2
         assert back.headers["QUALITY_CONTROL"].comments["RNGREEN1"] == (
             "Read noise GREEN amp 1 [e-]"

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -312,6 +312,20 @@ class TestKeywordRegistry:
         assert table.loc["DATALVL", "Default"] == "UNKNOWN"
         assert reg.eprv_primary_seed["DATALVL"][0] == "UNKNOWN"
 
+    def test_kpf_row_may_not_claim_the_eprv_sentinel(self):
+        # 'EPRV' is the discriminator every derived lookup keys on, so a KPF CSV
+        # row claiming it would silently misclassify itself as EPRV-sourced --
+        # a KPF keyword routed to PRIMARY, or a corrupted L1 seed.
+        import pandas as pd
+
+        from kpfpipe.data_models.keyword_registry import KeywordRegistry
+
+        df = pd.DataFrame(
+            [{"Keyword": "FOO", "Description": "d", "PopulatedBy": "EPRV"}]
+        )
+        with pytest.raises(ValueError, match="reserved as the EPRV-row discriminator"):
+            KeywordRegistry._parse_kpf_keyword_config(df, "fake.csv", lambda r: "L0")
+
 
 class TestQualityControlPropagation:
     """QUALITY_CONTROL + RECEIPT header cards survive to_fits and L0->L1->L2."""

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -169,6 +169,19 @@ class TestRegistryConformance:
             kw = str(row["Keyword"]).strip()
             assert routing[kw][1] == str(row["Description"]).strip()
 
+    def test_qc_flag_keyword_sets_are_scoped_by_level(self):
+        # Relocated from test_checkpoints.py: this is registry scoping, not
+        # Checkpoint behaviour, and it reaches the registry through the model
+        # rather than importing data_models.keyword_registry (see _registry.py).
+        reg = KPF1.keyword_registry
+        # ISGOOD is the cross-level aggregate: in the full set, in no per-level set.
+        assert "ISGOOD" in reg.qc_flag_keywords
+        assert all("ISGOOD" not in s for s in reg.qc_flag_keywords_by_level.values())
+        # Representative checks live under their own level.
+        assert "RNOK" in reg.qc_flag_keywords_by_level["L1"]
+        assert "DATAPRL2" in reg.qc_flag_keywords_by_level["L2"]
+        assert "RNOK" not in reg.qc_flag_keywords_by_level["L2"]
+
     def test_per_extension_keyword_expands_across_orderlets(self):
         # A "CCF*" Extension registers the keyword on CCF1..CCF5 while staying
         # out of routing.

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -1,23 +1,9 @@
-"""
-Tests for shared KPFDataModel behaviour (data_models/base.py).
+"""Tests for shared KPFDataModel behaviour (data_models/base.py).
 
-KPF stores every extension header as an ``astropy.io.fits.Header``, so reads use
-``header.get(key)`` / ``header[key]`` and writes use ``header[key] = (value,
-comment)`` natively. These tests pin the contract every model inherits from the
-shared base: (1) headers are ``fits.Header`` from construction onward, and (2) a
-commented PRIMARY card survives ``to_fits`` -> ``from_fits`` with its comment
-intact -- the regression guard for lossless-PRIMARY serialization (rvdata's base
-``_create_hdul`` copies a ``fits.Header`` directly, preserving its comments, as
-of rvdata >=0.4.0).
-
-KPF1 is the representative vehicle for the inherited base path. All KPF models
-serialize PRIMARY through rvdata's comment-preserving base ``_create_hdul``;
+KPF1 is the vehicle for the contract every model inherits: extension headers are
+``fits.Header`` from construction onward, and a commented PRIMARY card survives
+``to_fits`` -> ``from_fits`` (rvdata >=0.4.0 copies the ``fits.Header`` directly).
 KPF2/KPF4 round-trip guards live in test_data_models_l{2,4}.py.
-
-The WMKO->EPRV conversion (``KPF0._map_header``) is exercised end-to-end by the
-to_kpf1/to_kpf2 tests in test_data_models_l{1,2,4}.py.
-PRIMARY-header validation no longer lives on the data models (it moved to the
-checkpoints layer, ``quality_control/checkpoints/base.py``).
 """
 
 import pytest
@@ -40,12 +26,6 @@ class TestHeaderStorage:
 
 
 class TestPrimaryCommentRoundTrip:
-    """A commented PRIMARY write survives to_fits -> from_fits with its comment.
-
-    rvdata's base _create_hdul (>=0.4.0) copies a fits.Header directly when
-    serializing PRIMARY, preserving its keyword comments through the round-trip.
-    """
-
     def test_primary_comment_round_trips(self, tmp_path):
         l1 = KPF1()
         l1.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
@@ -65,10 +45,8 @@ class TestUndefinedRoundTrip:
     def test_none_value_round_trips_as_undefined(self, tmp_path):
         l1 = KPF1()
         l1.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
-        # radial_velocity writes None for a non-finite fit; astropy stores it as
-        # an UNDEFINED card. The value must round-trip as a blank/undefined card
-        # (read back as None), never as a finite number. RV is the EPRV combined
-        # RV on PRIMARY, written None on a failed fit.
+        # radial_velocity writes None for a non-finite fit; it must round-trip as
+        # an undefined card, never as a finite number.
         l1.headers["PRIMARY"]["RV"] = None
 
         fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
@@ -87,11 +65,10 @@ class TestSetKeyword:
         l1 = KPF1()
         l1.set_keyword("RNGREEN1", 3.5)
         assert l1.headers["QUALITY_CONTROL"]["RNGREEN1"] == 3.5
-        # comment comes from the registry Description, not the caller.
+        # The comment comes from the registry Description, not the caller.
         assert l1.headers["QUALITY_CONTROL"].comments["RNGREEN1"] == (
             "Read noise GREEN amp 1 [e-]"
         )
-        # it does NOT leak onto PRIMARY.
         assert "RNGREEN1" not in l1.headers["PRIMARY"]
 
     def test_routes_to_receipt(self):
@@ -116,8 +93,7 @@ class TestSetKeyword:
 
     def test_targeted_ext_writes_eprv_per_extension_card(self):
         # EPRV per-extension cards (VELSTART on every CCF#, RVMETHOD on every RV#)
-        # have no single routed home; ext= targets one, alias-resolved, with the
-        # registry Description as the comment.
+        # have no single routed home, so ext= picks one, alias-resolved.
         l4 = KPF4()
         l4.set_keyword("VELSTART", -100.0, ext="SCI2_CCF")  # SCI2_CCF -> CCF3
         l4.set_keyword("RVMETHOD", "CCF", ext="SCI2_RV")  # SCI2_RV -> RV3
@@ -126,8 +102,8 @@ class TestSetKeyword:
         assert l4.headers["RV3"]["RVMETHOD"] == "CCF"
 
     def test_targeted_ext_writes_kpf_multi_home_card(self):
-        # A KPF per-extension keyword (VELMASK, registered as CCF* -> CCF1..5) has
-        # no single routed home, so it is ext=-only like the EPRV per-ext cards.
+        # VELMASK is registered as CCF* -> CCF1..5, so like the EPRV per-extension
+        # cards it has no routed home and is ext=-only.
         l4 = KPF4()
         l4.set_keyword("VELMASK", 1.0, ext="SCI2_CCF")  # SCI2_CCF -> CCF3
         assert l4.headers["CCF3"]["VELMASK"] == 1.0
@@ -138,7 +114,6 @@ class TestSetKeyword:
             l4.set_keyword("VELMASK", 1.0)  # no home extension without ext=
 
     def test_targeted_ext_unregistered_for_extension_raises(self):
-        # A keyword not registered for the targeted extension fails loud.
         l4 = KPF4()
         with pytest.raises(KeyError, match="not registered for extension"):
             l4.set_keyword("VELSTART", 1.0, ext="SCI2_RV")  # VELSTART is CCF-only
@@ -149,7 +124,7 @@ class TestSetKeyword:
             l1.set_keyword("BOGUSKEY", 1)
 
     def test_missing_extension_raises_valueerror(self):
-        # KPF1 has no BARYCORR_KMS extension, so routing CCD1BKMS there fails loud.
+        # KPF1 has no BARYCORR_KMS extension for CCD1BKMS to route to.
         l1 = KPF1()
         with pytest.raises(ValueError, match="does not exist"):
             l1.set_keyword("CCD1BKMS", 1.0)
@@ -158,8 +133,8 @@ class TestSetKeyword:
 class TestRegistryConformance:
     """The routing table the model exposes agrees with the registry CSV column.
 
-    Oracle: ``read_kpf_header_registry`` reads config/L*-headers.csv directly
-    (tests/regression/_registry.py), independent of the code under test.
+    Oracle: ``read_kpf_header_registry`` reads config/L*-headers.csv directly,
+    independent of the code under test.
     """
 
     def test_routing_matches_extension_column(self):
@@ -176,8 +151,8 @@ class TestRegistryConformance:
         assert not mismatches, f"routing != registry Extension column: {mismatches}"
 
     def test_single_home_routable_per_extension_not(self):
-        # Single-home KPF keywords route to their home; per-extension keywords
-        # (Extension "CCF*") are ext=-only and excluded from routing.
+        # Per-extension keywords (Extension "CCF*") are ext=-only, so they are
+        # excluded from routing; every single-home keyword is in it.
         routing = KPF1.keyword_registry.routing
         for _, row in read_kpf_header_registry().iterrows():
             kw = str(row["Keyword"]).strip()
@@ -195,8 +170,8 @@ class TestRegistryConformance:
             assert routing[kw][1] == str(row["Description"]).strip()
 
     def test_per_extension_keyword_expands_across_orderlets(self):
-        # A "CCF*" Extension registers the keyword on CCF1..CCF5 (allowed +
-        # comment) while staying out of routing.
+        # A "CCF*" Extension registers the keyword on CCF1..CCF5 while staying
+        # out of routing.
         reg = KPF1.keyword_registry
         for n in range(1, 6):
             assert "VELMASK" in reg.allowed[f"CCF{n}"]
@@ -224,7 +199,6 @@ class TestKeywordRegistry:
         ]
 
     def test_unions_kpf_and_eprv(self):
-        # KPF-registered (RNGREEN1) and EPRV (RV) keywords both present.
         keys = KPF1.keyword_registry.registered
         assert "RNGREEN1" in keys and "RV" in keys
 
@@ -239,9 +213,8 @@ class TestKeywordRegistry:
         assert "RV" in KPF1.keyword_registry.allowed["PRIMARY"]
 
     def test_required_keyed_by_minimal_level(self):
-        # required maps keyword -> the minimal Level it is Required at. The EPRV
-        # L2 PRIMARY set is tagged Level 1 (KPF requires it from L1; see
-        # keyword_registry._build_rows), so KWRDPRL1 needs no L1->L2 cap.
+        # required maps keyword -> the minimal Level it is Required at; the EPRV
+        # L2 PRIMARY set is tagged Level 1 because KPF requires it from L1.
         primary_required = KPF1.keyword_registry.required["PRIMARY"]
         assert primary_required.get("RV") == 4  # L4-only required
         assert primary_required.get("INSTRUME") == 1  # required from L1
@@ -279,7 +252,7 @@ class TestKeywordRegistry:
         assert "EXTNAME" not in reg.registered
 
     def test_default_units_populated_for_eprv_blank_for_kpf(self):
-        # The new table columns carry EPRV CSV values for EPRV rows, "" for KPF.
+        # Default and Units carry the EPRV CSV values for EPRV rows, "" for KPF.
         table = KPF1.keyword_registry.table.set_index("Keyword")
         assert table.loc["INSTRUME", "Default"] == "UNKNOWN"  # EPRV row
         assert table.loc["RNGREEN1", "Default"] == ""  # KPF row
@@ -295,25 +268,23 @@ class TestKeywordRegistry:
         assert value is False and comment  # Boolean parsed, comment present
 
     def test_eprv_primary_datatypes_cover_emitted_keywords(self):
-        # Datatypes use rvdata vocab (so parse_value_to_datatype works) and cover
-        # the keywords _map_header emits; KPF int/str spellings never appear here.
+        # Datatypes use rvdata vocab so parse_value_to_datatype works, and cover
+        # the keywords _map_header emits.
         dt = KPF1.keyword_registry.eprv_primary_datatypes
         assert dt["INSTRUME"] == "String" and dt["NUMTRACE"] == "UInt"
         assert "RNGREEN1" not in dt  # KPF keyword, not EPRV PRIMARY
 
     def test_header_map_sanitized_on_load(self):
-        # header_map holds only genuine static native->EPRV mappings: unregistered
-        # targets (PARANG) and non-native keywords (sourced from seed/model/transform)
-        # are dropped, so _map_header needs no filter or per-keyword correction.
+        # header_map holds only static native->EPRV mappings: unregistered targets
+        # (PARANG) and non-native keywords are dropped, so _map_header needs no
+        # filter or per-keyword correction.
         std = set(KPF1.keyword_registry.header_map["STANDARD"].astype(str).str.strip())
         assert not ({"PARANG", "PARANG2"} & std)
         assert not ({"NUMORDER", "DATALVL", "DRPTAG", "JD_UTC"} & std)
 
     def test_default_overrides_sanitize_the_table(self):
-        # NUMORDER/DRPTAG corrections are applied once, to the table Default during
-        # the __init__ sanitize phase (not as a _map_header or build-step fixup):
-        # NUMORDER -> 67 (header_map says 65), DRPTAG -> version. So both the table
-        # and the seed derived from it carry the corrected values.
+        # NUMORDER/DRPTAG are corrected once, on the table Default, so both the
+        # table and the seed derived from it carry the corrected values.
         import importlib.metadata
 
         reg = KPF1.keyword_registry
@@ -324,18 +295,13 @@ class TestKeywordRegistry:
         assert table.loc["DRPTAG", "Default"] == version
         assert reg.eprv_primary_seed["NUMORDER"][0] == 67
         assert reg.eprv_primary_seed["DRPTAG"][0] == version
-        # DATALVL is NOT overridden -- it stays the EPRV placeholder, set to the
-        # data level by KPF1.__init__.
+        # DATALVL is not overridden -- KPF1.__init__ sets it from the data level.
         assert table.loc["DATALVL", "Default"] == "UNKNOWN"
         assert reg.eprv_primary_seed["DATALVL"][0] == "UNKNOWN"
 
 
 class TestQualityControlPropagation:
-    """QUALITY_CONTROL + RECEIPT header cards survive to_fits and L0->L1->L2.
-
-    (The KPF2 QUALITY_CONTROL round-trip lives in test_data_models_l2.py, since
-    KPF2 serializes through the RV2 read path.)
-    """
+    """QUALITY_CONTROL + RECEIPT header cards survive to_fits and L0->L1->L2."""
 
     def test_l1_quality_control_receipt_roundtrip(self, tmp_path):
         l1 = KPF1()
@@ -356,11 +322,10 @@ class TestQualityControlPropagation:
 
     def test_propagation_l0_to_l1_to_l2(self):
         l0 = KPF0()
-        # seed an L0 QC flag (QCL0 routes these to QUALITY_CONTROL).
+        # QCL0 routes L0 QC flags to QUALITY_CONTROL.
         l0.set_keyword("NOTJUNK", 1)
         l1 = l0.to_kpf1()
         assert l1.headers["QUALITY_CONTROL"]["NOTJUNK"] == 1
-        # add an L1 RECEIPT card; both QUALITY_CONTROL and RECEIPT must reach L2.
         l1.set_keyword("OSCANSUB", 1)
         l1.set_keyword("RNGREEN1", 4.0)
         l2 = l1.to_kpf2()

--- a/tests/regression/test_data_models_base.py
+++ b/tests/regression/test_data_models_base.py
@@ -51,7 +51,7 @@ class TestPrimaryCommentRoundTrip:
         l1.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
         l1.headers["PRIMARY"]["BIASAGE"] = (-0.5, "[day] bias age")
 
-        fn = str(tmp_path / "header_roundtrip_l1.fits")
+        fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
         l1.to_fits(fn)
 
         prim = KPF1.from_fits(fn).headers["PRIMARY"]
@@ -71,7 +71,7 @@ class TestUndefinedRoundTrip:
         # RV on PRIMARY, written None on a failed fit.
         l1.headers["PRIMARY"]["RV"] = None
 
-        fn = str(tmp_path / "header_undefined_l1.fits")
+        fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
         l1.to_fits(fn)
 
         prim = KPF1.from_fits(fn).headers["PRIMARY"]

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -64,7 +64,7 @@ class TestKPF0:
         assert len(l0.receipt) >= 1
         assert "from_fits" in l0.receipt["FUNCTION"].values
 
-        out_fn = str(tmp_path / "receipt_test.fits")
+        out_fn = str(tmp_path / "KP.20240113.00002.00.fits")
         l0.to_fits(out_fn)
         assert "to_fits" in l0.receipt["FUNCTION"].values
 
@@ -106,6 +106,7 @@ class TestKPF0ErrorPaths:
         primary.header["INSTRUME"] = "KPF"
         primary.header["DATE-OBS"] = "2024-01-13T00:00:02"
         primary.header["OFNAME"] = "KP.20240113.00002.00.fits"
+        primary.header["PROGNAME"] = "K123"
         hdul = fits.HDUList([primary, *extra_hdus])
         hdul.writeto(fn, overwrite=True)
         hdul.close()
@@ -147,7 +148,7 @@ class TestKPF0ErrorPaths:
 
     def test_to_fits_creates_parent_dirs(self, synthetic_l0_file, tmp_path):
         l0 = KPF0.from_fits(synthetic_l0_file)
-        out = str(tmp_path / "nested" / "sub" / "out.fits")
+        out = str(tmp_path / "nested" / "sub" / "KP.20240113.00002.00.fits")
         l0.to_fits(out)
         assert os.path.isfile(out)
 
@@ -232,6 +233,7 @@ class TestKPF0CatalogRecord:
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
         primary.header["OFNAME"] = "KP.20240405.00001.00.fits"
+        primary.header["PROGNAME"] = "K123"
         primary.header["OBJECT"] = "testtarget"
         primary.header["IMTYPE"] = "Object"
         primary.header["TARGRA"] = "12:00:00.00"
@@ -258,6 +260,7 @@ class TestCatalogRecordMissingValues:
         l0 = KPF0()
         l0.headers["PRIMARY"]["INSTRUME"] = "KPF"
         l0.headers["PRIMARY"]["OFNAME"] = "KP.20240405.00002.00.fits"
+        l0.headers["PRIMARY"]["PROGNAME"] = "K123"
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
         l0.set_data("CATALOG_RECORD", catalog_record_table(rv=rv))
         l0.to_fits(fn)

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -1,8 +1,4 @@
-"""
-Tests for the KPF0 (raw CCD / L0) data model.
-
-Uses synthetic FITS fixtures — no real KPF data needed.
-"""
+"""Tests for the KPF0 (raw CCD / L0) data model, on synthetic FITS fixtures."""
 
 import importlib.metadata
 import logging
@@ -38,9 +34,8 @@ class TestKPF0:
         assert l0.level == 0
         assert l0.obs_id == "KP.20240113.00001.00"
         assert "PRIMARY" in l0.extensions
-        # Real KPF0 objects always carry QUALITY_CONTROL, RECEIPT, and CATALOG_RECORD
-        # extensions (RECEIPT is the registry home of the DRP-RUN provenance cards,
-        # stamped at read; CATALOG_RECORD holds AstroQuery's astrometry).
+        # Every KPF0 carries QUALITY_CONTROL, RECEIPT (home of the provenance
+        # cards stamped at read) and CATALOG_RECORD (AstroQuery's astrometry).
         assert "QUALITY_CONTROL" in l0.extensions
         assert "RECEIPT" in l0.extensions
         assert "CATALOG_RECORD" in l0.extensions
@@ -69,9 +64,9 @@ class TestKPF0:
         assert "to_fits" in l0.receipt["FUNCTION"].values
 
     def test_receipt_survives_roundtrip(self, synthetic_l0_file, tmp_path):
-        """The processing history must reach the FITS RECEIPT extension, not just
-        live in memory; KPFDataModel._create_hdul syncs it (and creates the
-        extension, which L0's default extension set lacks)."""
+        # The history must reach the FITS RECEIPT extension, not just live in
+        # memory; _create_hdul syncs it and creates the extension, which L0's
+        # default extension set lacks.
         l0 = KPF0.from_fits(synthetic_l0_file)
         l0.receipt_add_entry("image_assembly", "", "PASS")
         out_fn = str(tmp_path / "KP.20240113.23249.10.fits")
@@ -132,8 +127,7 @@ class TestKPF0ErrorPaths:
         rec_hdu = fits.BinTableHDU(data=receipt, name="RECEIPT")
         fn = self._minimal_l0(tmp_path, extra_hdus=[rec_hdu])
         l0 = KPF0.from_fits(fn)
-        # An empty receipt is seeded with the standard columns; from_fits then
-        # appends its own entry.
+        # An empty receipt is seeded with the standard columns.
         assert "CODE_RELEASE" in l0.receipt.columns
         assert "from_fits" in l0.receipt["FUNCTION"].values
 
@@ -153,8 +147,7 @@ class TestKPF0ErrorPaths:
         assert os.path.isfile(out)
 
     def test_from_fits_raises_on_unparseable_filename(self, tmp_path):
-        """A filename carrying no obs_id fails loud on read (get_obs_id) rather
-        than silently reading with obs_id=None."""
+        # Fail loud rather than silently read with obs_id=None.
         fn = str(tmp_path / "not_a_kpf_name.fits")
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
@@ -165,8 +158,6 @@ class TestKPF0ErrorPaths:
     def test_to_fits_warns_on_nonconforming_name_but_writes(
         self, caplog, synthetic_l0_file, tmp_path
     ):
-        """to_fits runs the warn-only filename advisory: a non-conforming output
-        name warns but the write still proceeds."""
         l0 = KPF0.from_fits(synthetic_l0_file)
         out = str(tmp_path / "not_kpf_convention.fits")
         with caplog.at_level(logging.WARNING):
@@ -176,10 +167,9 @@ class TestKPF0ErrorPaths:
 
 
 class TestKPF0Provenance:
-    """from_fits stamps the WMKO DRP-RUN provenance cards onto the L0 RECEIPT
-    (their registry home; config/L0-headers.csv PopulatedBy = KPF0.from_fits).
-    PRIMARY (and its INSTRUMENT_HEADER snapshot) is left raw; to_kpf1 forwards the
-    RECEIPT header downstream."""
+    """from_fits stamps the DRP provenance cards onto the L0 RECEIPT, their
+    registry home. PRIMARY (and its INSTRUMENT_HEADER snapshot) is left raw;
+    to_kpf1 forwards the RECEIPT header downstream."""
 
     def test_from_fits_stamps_version_and_status(self, synthetic_l0_file):
         receipt = KPF0.from_fits(synthetic_l0_file).headers["RECEIPT"]
@@ -187,13 +177,12 @@ class TestKPF0Provenance:
         assert receipt.get("DRPSTATU") == "File ingested into KPF-DRP"
 
     def test_from_fits_maps_native_program_ids(self, synthetic_l0_file):
-        """The native OFNAME/PROGNAME cards map to the KOAID/PROGID RECEIPT cards."""
+        # The native OFNAME/PROGNAME cards map to KOAID/PROGID on RECEIPT.
         receipt = KPF0.from_fits(synthetic_l0_file).headers["RECEIPT"]
         assert receipt.get("PROGID") == "K123"
         assert receipt.get("KOAID") == "KP.20240113.23249.10.fits"
 
     def test_from_fits_stamps_origid_from_obs_id(self, synthetic_l0_file):
-        """ORIGID is inferred from the resolved obs_id and stamped onto RECEIPT."""
         l0 = KPF0.from_fits(synthetic_l0_file)
         assert l0.obs_id == "KP.20240113.23249.10"
         assert l0.headers["RECEIPT"].get("ORIGID") == "KP.20240113.23249.10"
@@ -202,8 +191,6 @@ class TestKPF0Provenance:
     def test_from_fits_defaults_progid_to_unknown_and_warns(
         self, caplog, synthetic_l0_minimal
     ):
-        """A file lacking PROGNAME defaults PROGID to UNKNOWN and warns; KOAID is
-        still mapped from the present OFNAME."""
         with caplog.at_level(logging.WARNING):
             l0 = KPF0.from_fits(synthetic_l0_minimal)
         assert "PROGNAME absent" in caplog.text
@@ -212,8 +199,8 @@ class TestKPF0Provenance:
         assert receipt.get("KOAID") == "KP.20240113.00001.00.fits"
 
     def test_from_fits_raises_when_ofname_absent(self, tmp_path):
-        """A file lacking OFNAME cannot set KOAID (the archive obs_id) and must
-        fail loud rather than stamp a placeholder."""
+        # Without OFNAME there is no KOAID (the archive obs_id), so fail loud
+        # rather than stamp a placeholder.
         fn = str(tmp_path / "KP.20240113.00003.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
@@ -228,7 +215,7 @@ class TestKPF0CatalogRecord:
     AstroQuery is its sole writer."""
 
     def test_read_leaves_catalog_record_empty(self, tmp_path):
-        """A raw L0 read, even with TARG* present, leaves it empty and unflagged."""
+        # TARG* is present and the extension still comes back empty and unflagged.
         fn = str(tmp_path / "KP.20240405.00001.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
@@ -251,7 +238,7 @@ class TestCatalogRecordMissingValues:
 
     Astropy's FITS reader returns a NaN float cell masked, and a masked cell is not
     NaN, so a missing-value check would read it as present; ``KPFDataModel.from_fits``
-    fills those cells back. L0 is the vehicle -- it is where AstroQuery writes.
+    fills those cells back. L0 is the vehicle because it is where AstroQuery writes.
     """
 
     @staticmethod
@@ -276,9 +263,9 @@ class TestCatalogRecordMissingValues:
         assert row["rv"] == pytest.approx(-16.6)
 
     def test_missing_value_leaves_catalog_card_blank(self, tmp_path):
-        """The regression this normalization exists for: a masked cell defeats the
-        'skip missing' branch in KPF0._catalog_primary_cards, so the C*# card is
-        written as 'nan' and the L1 write then raises."""
+        # The regression the normalization exists for: a masked cell defeats the
+        # 'skip missing' branch in KPF0._catalog_primary_cards, so the C*# card
+        # is written as 'nan' and the L1 write then raises.
         l0 = self._l0_written_and_read(tmp_path, rv=None)
         l1 = l0.to_kpf1()
         assert not l1.headers["PRIMARY"].get("CRV2")

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -51,9 +51,7 @@ class TestKPF0:
         l0.to_fits(out_fn)
 
         l0_reread = KPF0.from_fits(out_fn)
-        np.testing.assert_array_almost_equal(
-            l0_reread.data["GREEN_AMP1"], original_green, decimal=4
-        )
+        np.testing.assert_array_equal(l0_reread.data["GREEN_AMP1"], original_green)
         assert l0_reread.headers["PRIMARY"]["INSTRUME"] == "KPF"
 
     def test_receipt_tracking(self, synthetic_l0_file, tmp_path):
@@ -83,14 +81,14 @@ class TestKPF0:
         assert l0.generate_standard_filename() == "KP.20240113.23249.10.fits"
 
     def test_file_not_found(self):
-        with pytest.raises(IOError):
+        with pytest.raises(IOError, match="does not exist"):
             KPF0.from_fits("/nonexistent/path.fits")
 
     def test_non_fits_file(self, tmp_path):
         fn = str(tmp_path / "not_a_fits.txt")
         with open(fn, "w") as f:
             f.write("hello")
-        with pytest.raises(IOError):
+        with pytest.raises(IOError, match="must be FITS files"):
             KPF0.from_fits(fn)
 
 

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -12,6 +12,8 @@ from astropy.table import Table
 from kpfpipe.data_models.level0 import KPF0
 
 from ._catalog import catalog_record_table
+from ._data_models import write_minimal_l0
+from ._dtype_policy import assert_not_float64
 
 # synthetic_l0_file and synthetic_l0_minimal fixtures live in tests/conftest.py
 
@@ -50,7 +52,7 @@ class TestKPF0:
 
         l0_reread = KPF0.from_fits(out_fn)
         np.testing.assert_array_almost_equal(
-            l0_reread.data["GREEN_AMP1"], original_green
+            l0_reread.data["GREEN_AMP1"], original_green, decimal=4
         )
         assert l0_reread.headers["PRIMARY"]["INSTRUME"] == "KPF"
 
@@ -96,16 +98,11 @@ class TestKPF0ErrorPaths:
     """Malformed-input, provenance, and write-path guards."""
 
     def _minimal_l0(self, tmp_path, extra_hdus=()):
-        fn = str(tmp_path / "KP.20240113.00002.00.fits")
-        primary = fits.PrimaryHDU()
-        primary.header["INSTRUME"] = "KPF"
-        primary.header["DATE-OBS"] = "2024-01-13T00:00:02"
-        primary.header["OFNAME"] = "KP.20240113.00002.00.fits"
-        primary.header["PROGNAME"] = "K123"
-        hdul = fits.HDUList([primary, *extra_hdus])
-        hdul.writeto(fn, overwrite=True)
-        hdul.close()
-        return fn
+        return write_minimal_l0(
+            tmp_path / "KP.20240113.00002.00.fits",
+            primary_cards={"DATE-OBS": "2024-01-13T00:00:02"},
+            extra_hdus=extra_hdus,
+        )
 
     def test_raises_on_unknown_extension(self, tmp_path):
         weird = fits.ImageHDU(data=np.zeros((4, 4), dtype=np.float32), name="MYSTERY")
@@ -271,3 +268,25 @@ class TestCatalogRecordMissingValues:
         assert not l1.headers["PRIMARY"].get("CRV2")
         assert l1.headers["PRIMARY"]["CRA2"] == "01:44:04.0000"
         l1.to_fits(str(tmp_path / "kpf_L1_20240405T000000.fits"))
+
+
+class TestDtypeProvenance:
+    """L0 is the raw product: whatever the detector wrote is what we keep.
+
+    There is no single L0 dtype to assert -- amp data arrives as the instrument
+    recorded it -- so the policy here is one-directional: reading a frame must
+    never upcast it, because every downstream array inherits that width.
+    """
+
+    def test_amp_data_not_upcast_on_read(self, synthetic_l0_file):
+        l0 = KPF0.from_fits(synthetic_l0_file)
+        for ext in ("GREEN_AMP1", "GREEN_AMP2", "RED_AMP1", "CA_HK"):
+            assert_not_float64(l0.data[ext], ext)
+
+    def test_amp_data_not_upcast_on_round_trip(self, synthetic_l0_file, tmp_path):
+        l0 = KPF0.from_fits(synthetic_l0_file)
+        out_fn = str(tmp_path / "KP.20240113.23249.10.fits")
+        l0.to_fits(out_fn)
+        reread = KPF0.from_fits(out_fn)
+        for ext in ("GREEN_AMP1", "RED_AMP1"):
+            assert_not_float64(reread.data[ext], f"{ext} after round-trip")

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -1,8 +1,6 @@
-"""
-Tests for the KPF1 (assembled FFI / L1) data model, the L0->L1 transform,
-and the KPFMasterL1 calibration product.
-
-Uses synthetic FITS fixtures — no real KPF data needed.
+"""Tests for the KPF1 (assembled FFI / L1) data model, the L0->L1 transform, and
+the KPFMasterL1 calibration product. Synthetic FITS fixtures throughout -- no real
+KPF data needed.
 """
 
 import importlib.metadata
@@ -34,8 +32,8 @@ from ._catalog import SOURCES, catalog_record_table
 
 @pytest.fixture(scope="module")
 def synthetic_masters_l1_file(tmp_path_factory):
-    """Create a minimal synthetic Masters L1 FITS file (module-scoped read-only
-    source: consumers only from_fits() read it)."""
+    """Minimal synthetic Masters L1 FITS file (module-scoped: consumers only read
+    it via from_fits)."""
     rng = np.random.default_rng(20240113)
     fn = str(
         tmp_path_factory.mktemp("ml1") / "KP.20240113.23249.10_master_bias_L1.fits"
@@ -109,10 +107,9 @@ class TestKPF1:
         assert "to_fits" in l1.receipt["FUNCTION"].values
 
     def test_receipt_survives_roundtrip(self, synthetic_l1_file, tmp_path):
-        """The processing history must be written to the FITS RECEIPT extension,
-        not just held in memory. rvdata's _create_hdul serializes
-        self.data["RECEIPT"], so KPFDataModel._create_hdul syncs self.receipt
-        into it before writing; without that the receipt is silently lost."""
+        # rvdata's _create_hdul serializes self.data["RECEIPT"], so
+        # KPFDataModel._create_hdul syncs self.receipt into it before writing;
+        # without that the in-memory history is silently lost on write.
         l1 = KPF1.from_fits(synthetic_l1_file)
         l1.receipt_add_entry("image_assembly", "", "PASS")
         out_fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
@@ -153,8 +150,7 @@ class TestKPF1:
     def test_to_fits_warns_on_nonconforming_name_but_writes(
         self, caplog, synthetic_l1_file, tmp_path
     ):
-        """L1 to_fits runs the same warn-only filename advisory as L0: a
-        non-conforming output name warns but the write still proceeds."""
+        # The filename advisory is warn-only, as at L0: the write still proceeds.
         l1 = KPF1.from_fits(synthetic_l1_file)
         out = str(tmp_path / "not_kpf_convention.fits")
         with caplog.at_level(logging.WARNING):
@@ -166,8 +162,7 @@ class TestKPF1:
 class TestL1PrimarySeed:
     """KPF1.__init__ seeds the EPRV Required PRIMARY skeleton from the registry,
     mirroring rvdata's RV2.__init__ (which KPF2/KPF4 inherit but KPF1 cannot, as
-    L1 is not an EPRV level). This makes KWRDPRL1 a meaningful presence check.
-    """
+    L1 is not an EPRV level). This makes KWRDPRL1 a meaningful presence check."""
 
     @staticmethod
     def _required_l1_primary():
@@ -209,14 +204,14 @@ class TestL1PrimarySeed:
         )
 
     def test_converted_l1_has_all_required(self, synthetic_l0_file):
-        # The original goal: a converted L1 carries every EPRV-Required PRIMARY
-        # keyword, so QCL1's KWRDPRL1 presence check is meaningful (and passes).
+        # A converted L1 carries every EPRV-Required PRIMARY keyword, which is
+        # what makes QCL1's KWRDPRL1 presence check meaningful.
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()
         assert self._required_l1_primary() <= set(l1.headers["PRIMARY"])
 
     def test_native_overlay_is_typed(self, synthetic_l0_file):
         # _map_header coerces native/header_map-default values to their EPRV
-        # DataType (was raw strings) and preserves the seeded comment.
+        # DataType and preserves the seeded comment.
         prim = KPF0.from_fits(synthetic_l0_file).to_kpf1().headers["PRIMARY"]
         assert prim["NUMTRACE"] == 5 and isinstance(prim["NUMTRACE"], int)
         assert isinstance(prim["OBSALT"], float)
@@ -236,8 +231,7 @@ class TestHeaderMapFiberRealignment:
     """rvdata's header_map numbers per-trace keywords CAL-first (1=CAL..5=SKY);
     _load_header_map realigns them to KPF's SKY-first numbering (1=SKY..5=CAL) by
     swapping index 1<->5 for the fiber-indexed families. Keywords that also end in
-    1/5 but are not fiber-indexed (EXSNR wavelength bands) must be left alone.
-    """
+    1/5 but are not fiber-indexed (EXSNR wavelength bands) must be left alone."""
 
     @staticmethod
     def _source(standard):
@@ -395,7 +389,6 @@ class TestToKpf1:
         assert "mixed sources" not in caplog.text
 
     def test_to_kpf1_converts_native_to_eprv(self, synthetic_l0_file):
-        """to_kpf1 renames WMKO natives to their EPRV PRIMARY counterparts."""
         l0 = KPF0.from_fits(synthetic_l0_file)
         l1 = l0.to_kpf1()
         prim = l1.headers["PRIMARY"]
@@ -408,7 +401,7 @@ class TestToKpf1:
         assert "GROBSERV" not in prim
 
     def test_to_kpf1_preserves_raw_header_in_instrument_header(self, synthetic_l0_file):
-        """INSTRUMENT_HEADER is a pure verbatim copy of the raw L0 PRIMARY."""
+        # INSTRUMENT_HEADER is a verbatim copy of the raw L0 PRIMARY.
         l0 = KPF0.from_fits(synthetic_l0_file)
         l1 = l0.to_kpf1()
         assert "INSTRUMENT_HEADER" in l1.extensions
@@ -423,9 +416,9 @@ class TestToKpf1:
         assert "DRPSTATU" not in inst
 
     def test_to_kpf1_filters_non_registry_headermap_keys(self, tmp_path):
-        """_map_header emits only registered keywords; header_map's non-standard
-        STANDARD keys (e.g. PARANG <- PARANTEL) are dropped, not leaked onto the
-        EPRV PRIMARY. The raw value survives verbatim in INSTRUMENT_HEADER."""
+        # _map_header emits only registered keywords, so header_map's non-standard
+        # STANDARD keys (here PARANG <- PARANTEL) are dropped rather than leaked
+        # onto the EPRV PRIMARY; the raw value survives in INSTRUMENT_HEADER.
         fn = str(tmp_path / "KP.20240113.00009.00.fits")
         p = fits.PrimaryHDU()
         p.header["INSTRUME"] = "KPF"
@@ -438,7 +431,6 @@ class TestToKpf1:
         assert l1.headers["INSTRUMENT_HEADER"]["PARANTEL"] == 108.03
 
     def test_to_kpf1_fixes_value_bugs(self, synthetic_l0_file):
-        """NUMORDER, JD_UTC, and the DRP version keywords are corrected/stamped."""
         l0 = KPF0.from_fits(synthetic_l0_file)
         l1 = l0.to_kpf1()
         prim = l1.headers["PRIMARY"]
@@ -447,14 +439,14 @@ class TestToKpf1:
         assert prim.get("JD_UTC") == pytest.approx(2460322.93537, abs=1e-3)
         version = importlib.metadata.version("kpfpipe")
         assert prim.get("DRPTAG") == version  # EPRV version keyword stays on PRIMARY
-        # DRPVERNO (WMKO DRP-RUN-11) now lives on RECEIPT, not PRIMARY.
+        # DRPVERNO lives on RECEIPT, not PRIMARY.
         assert prim.get("DRPVERNO") is None
         assert l1.headers["RECEIPT"].get("DRPVERNO") == version
 
     def test_map_header_is_pure_tabular_except_jd_utc(self, synthetic_l0_file):
-        """The above values are correct on the L1 PRIMARY, but _map_header itself
-        no longer special-cases NUMORDER/DRPTAG/DATALVL (those ride the seed /
-        model level); JD_UTC is the one transform it still performs."""
+        # Those values are correct on the L1 PRIMARY, but _map_header itself does
+        # not special-case NUMORDER/DRPTAG/DATALVL (they ride the seed / model
+        # level); JD_UTC is the one transform it performs.
         out = KPF0.from_fits(synthetic_l0_file)._map_header()
         assert "NUMORDER" not in out  # seeded (registry _DEFAULT_OVERRIDES)
         assert "DRPTAG" not in out  # seeded (registry _DEFAULT_OVERRIDES)
@@ -462,8 +454,8 @@ class TestToKpf1:
         assert "JD_UTC" in out  # the one per-frame transform kept in _map_header
 
     def test_to_kpf1_forwards_program_ids(self, synthetic_l0_file):
-        """Native PROGID/KOAID stamped to the L0 RECEIPT at read carry onto the L1
-        RECEIPT via the RECEIPT-header forward (no longer onto PRIMARY)."""
+        # PROGID/KOAID are stamped to the L0 RECEIPT at read and forwarded to the
+        # L1 RECEIPT, never onto PRIMARY.
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()
         receipt = l1.headers["RECEIPT"]
         assert receipt.get("PROGID") == "K123"
@@ -471,8 +463,8 @@ class TestToKpf1:
         assert "PROGID" not in l1.headers["PRIMARY"]
 
     def test_to_kpf1_forwards_drpstatus(self, synthetic_l0_file):
-        """DRPSTATU stamped at read carries onto the L1 RECEIPT; the to_kpf1 receipt
-        is denylisted, so the ingest default survives until the first real module."""
+        # The to_kpf1 receipt is denylisted, so the ingest-time DRPSTATU survives
+        # until the first real module runs.
         receipt = KPF0.from_fits(synthetic_l0_file).to_kpf1().headers["RECEIPT"]
         assert receipt.get("DRPSTATU") == "File ingested into KPF-DRP"
 
@@ -495,7 +487,7 @@ class TestToKpf1:
         l1 = l0.to_kpf1()
         assert "GREEN_CCD" in l1.extensions
         assert "RED_CCD" in l1.extensions
-        # Extensions exist but data is empty (not populated yet)
+        # Extensions exist but ImageAssembly has not populated them yet.
         assert len(l1.data["GREEN_CCD"]) == 0
         assert len(l1.data["RED_CCD"]) == 0
 
@@ -519,10 +511,9 @@ class TestToKpf1:
 
 
 class TestCatalogRecordPassthrough:
-    """AstroQuery's CATALOG_RECORD rows + presence flags ride L0 -> L1 unchanged.
+    """AstroQuery's CATALOG_RECORD rows and presence flags ride L0 -> L1 unchanged.
 
-    (The L1 -> L2 and L2 -> L4 hops have the same class in
-    test_data_models_l{2,4}.py.)
+    The L1 -> L2 and L2 -> L4 hops have the same class in test_data_models_l{2,4}.py.
     """
 
     @staticmethod
@@ -534,16 +525,16 @@ class TestCatalogRecordPassthrough:
         return l0
 
     def test_rows_and_flags_reach_l1(self):
-        """Beyond the C*# overlay, L1 keeps the whole table (every source row, not
-        just the merged one) and the flags, so the astrometry stays auditable."""
+        # Beyond the C*# overlay, L1 keeps every source row -- not just the merged
+        # one -- so the astrometry stays auditable.
         l1 = self._l0_with_catalog().to_kpf1()
         assert [str(s) for s in l1.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
         assert l1.headers["CATALOG_RECORD"]["GAIACR"] == 1
 
     def test_catalog_record_roundtrip(self, tmp_path):
-        """CATALOG_RECORD is registered in L1-extensions.csv, so an L1 carrying it
-        reads back (an unlisted extension raises 'Non-standard extension'), and the
-        missing rv reads back NaN, not masked."""
+        # CATALOG_RECORD is registered in L1-extensions.csv, so it reads back at
+        # all (an unlisted extension raises), and a missing rv comes back NaN
+        # rather than masked.
         fn = str(tmp_path / "kpf_L1_20240405T000000.fits")
         self._l0_with_catalog(rv=None).to_kpf1().to_fits(fn)
         back = KPF1.from_fits(fn)
@@ -556,7 +547,7 @@ class TestCatalogRecordPassthrough:
 class TestDrpStatus:
     """DRPSTATU advances to '<Module Name> module complete' via the
     receipt_add_entry override; data-model conversion/IO receipts are denylisted
-    so it names the last real science/masters stage (DRP-RUN-20)."""
+    so it names the last real science/masters stage."""
 
     def test_module_receipt_updates_status(self, synthetic_l0_file):
         l1 = KPF0.from_fits(synthetic_l0_file).to_kpf1()

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -95,7 +95,7 @@ class TestKPF1:
 
         l1_reread = KPF1.from_fits(out_fn)
         np.testing.assert_array_almost_equal(
-            l1_reread.data["GREEN_CCD"], original_green
+            l1_reread.data["GREEN_CCD"], original_green, decimal=4
         )
 
     def test_receipt_tracking(self, synthetic_l1_file, tmp_path):
@@ -517,7 +517,7 @@ class TestCatalogRecordPassthrough:
     """
 
     @staticmethod
-    def _l0_with_catalog(rv=-16.6):
+    def _l0_with_catalog_table(rv=-16.6):
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
         l0.set_data("CATALOG_RECORD", catalog_record_table(rv=rv))
@@ -527,7 +527,7 @@ class TestCatalogRecordPassthrough:
     def test_rows_and_flags_reach_l1(self):
         # Beyond the C*# overlay, L1 keeps every source row -- not just the merged
         # one -- so the astrometry stays auditable.
-        l1 = self._l0_with_catalog().to_kpf1()
+        l1 = self._l0_with_catalog_table().to_kpf1()
         assert [str(s) for s in l1.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
         assert l1.headers["CATALOG_RECORD"]["GAIACR"] == 1
 
@@ -536,7 +536,7 @@ class TestCatalogRecordPassthrough:
         # all (an unlisted extension raises), and a missing rv comes back NaN
         # rather than masked.
         fn = str(tmp_path / "kpf_L1_20240405T000000.fits")
-        self._l0_with_catalog(rv=None).to_kpf1().to_fits(fn)
+        self._l0_with_catalog_table(rv=None).to_kpf1().to_fits(fn)
         back = KPF1.from_fits(fn)
         assert [str(s) for s in back.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
         assert back.headers["CATALOG_RECORD"]["GAIACR"] == 1
@@ -617,7 +617,7 @@ class TestKPFMasterL1:
         m.to_fits(out_fn)
 
         m2 = KPFMasterL1.from_fits(out_fn)
-        np.testing.assert_array_almost_equal(m2.data["GREEN_IMG"], original)
+        np.testing.assert_array_almost_equal(m2.data["GREEN_IMG"], original, decimal=4)
 
     def test_datalvl_header_in_fits(self, synthetic_masters_l1_file, tmp_path):
         m = KPFMasterL1.from_fits(synthetic_masters_l1_file)

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -17,7 +17,6 @@ from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.data_models.masters.base import KPFMasterModel
-from kpfpipe.modules.astro_query import AstroQuery
 from kpfpipe.utils.astro import compute_redshift
 
 from ._catalog import SOURCES, catalog_record_table
@@ -94,9 +93,7 @@ class TestKPF1:
         l1.to_fits(out_fn)
 
         l1_reread = KPF1.from_fits(out_fn)
-        np.testing.assert_array_almost_equal(
-            l1_reread.data["GREEN_CCD"], original_green, decimal=4
-        )
+        np.testing.assert_array_equal(l1_reread.data["GREEN_CCD"], original_green)
 
     def test_receipt_tracking(self, synthetic_l1_file, tmp_path):
         l1 = KPF1.from_fits(synthetic_l1_file)
@@ -313,6 +310,11 @@ class TestToKpf1:
     @staticmethod
     def _l0_with_catalog(record):
         # A science KPF0 carrying a canonical 'kpf-drp' CATALOG_RECORD row, no network.
+        # Deferred, not for a cycle: astro_query pulls in astroquery, and this
+        # module would otherwise pay that import at collection in every worker
+        # for the sake of one test. Mirrors tests/conftest.py's _catalog_record_hdu.
+        from kpfpipe.modules.astro_query import AstroQuery
+
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
         AstroQuery(l0)._write_catalog_record("kpf-drp", record)
@@ -617,7 +619,7 @@ class TestKPFMasterL1:
         m.to_fits(out_fn)
 
         m2 = KPFMasterL1.from_fits(out_fn)
-        np.testing.assert_array_almost_equal(m2.data["GREEN_IMG"], original, decimal=4)
+        np.testing.assert_array_equal(m2.data["GREEN_IMG"], original)
 
     def test_datalvl_header_in_fits(self, synthetic_masters_l1_file, tmp_path):
         m = KPFMasterL1.from_fits(synthetic_masters_l1_file)
@@ -635,12 +637,20 @@ class TestKPFMasterL1:
             m.generate_standard_filename() == "KP.20240113.23249.10_master_bias_L1.fits"
         )
 
-    def test_generate_filename_requires_inputs(self):
+    def test_generate_filename_requires_mastype(self):
         # A master can never produce a non-compliant name: with no recorded
         # inputs / type, generate_standard_filename raises rather than falling
-        # back to a KOAID-less name.
-        with pytest.raises(ValueError):
+        # back to a KOAID-less name. MASTYPE is checked first.
+        with pytest.raises(ValueError, match="MASTYPE"):
             KPFMasterL1().generate_standard_filename()
+
+    def test_generate_filename_requires_inputs(self):
+        # The second guard, reachable only once MASTYPE is set -- what a
+        # partially-failed stack leaves behind.
+        m = KPFMasterL1()
+        m.set_keyword("MASTYPE", "bias")
+        with pytest.raises(ValueError, match="INPUT_FILES"):
+            m.generate_standard_filename()
 
     def test_no_warning_on_known_extensions(self, caplog, synthetic_masters_l1_file):
         with caplog.at_level(logging.WARNING):

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -92,7 +92,7 @@ class TestKPF1:
         l1 = KPF1.from_fits(synthetic_l1_file)
         original_green = l1.data["GREEN_CCD"].copy()
 
-        out_fn = str(tmp_path / "roundtrip_l1.fits")
+        out_fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
         l1.to_fits(out_fn)
 
         l1_reread = KPF1.from_fits(out_fn)
@@ -104,7 +104,7 @@ class TestKPF1:
         l1 = KPF1.from_fits(synthetic_l1_file)
         assert len(l1.receipt) >= 1
 
-        out_fn = str(tmp_path / "receipt_l1.fits")
+        out_fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
         l1.to_fits(out_fn)
         assert "to_fits" in l1.receipt["FUNCTION"].values
 
@@ -115,7 +115,7 @@ class TestKPF1:
         into it before writing; without that the receipt is silently lost."""
         l1 = KPF1.from_fits(synthetic_l1_file)
         l1.receipt_add_entry("image_assembly", "", "PASS")
-        out_fn = str(tmp_path / "roundtrip_l1.fits")
+        out_fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
         l1.to_fits(out_fn)
 
         modules = KPF1.from_fits(out_fn).receipt["FUNCTION"].values
@@ -129,7 +129,7 @@ class TestKPF1:
 
     def test_datalvl_header(self, synthetic_l1_file, tmp_path):
         l1 = KPF1.from_fits(synthetic_l1_file)
-        out_fn = str(tmp_path / "datalvl_test.fits")
+        out_fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
         l1.to_fits(out_fn)
 
         with fits.open(out_fn) as hdul:
@@ -430,6 +430,7 @@ class TestToKpf1:
         p = fits.PrimaryHDU()
         p.header["INSTRUME"] = "KPF"
         p.header["OFNAME"] = "KP.20240113.00009.00.fits"
+        p.header["PROGNAME"] = "K123"
         p.header["PARANTEL"] = 108.03  # header_map maps PARANTEL -> non-standard PARANG
         fits.HDUList([p]).writeto(fn)
         l1 = KPF0.from_fits(fn).to_kpf1()
@@ -621,7 +622,7 @@ class TestKPFMasterL1:
         m = KPFMasterL1.from_fits(synthetic_masters_l1_file)
         original = m.data["GREEN_IMG"].copy()
 
-        out_fn = str(tmp_path / "roundtrip_ml1.fits")
+        out_fn = str(tmp_path / "KP.20240113.23249.10_master_bias_L1.fits")
         m.to_fits(out_fn)
 
         m2 = KPFMasterL1.from_fits(out_fn)
@@ -629,7 +630,7 @@ class TestKPFMasterL1:
 
     def test_datalvl_header_in_fits(self, synthetic_masters_l1_file, tmp_path):
         m = KPFMasterL1.from_fits(synthetic_masters_l1_file)
-        out_fn = str(tmp_path / "datalvl_ml1.fits")
+        out_fn = str(tmp_path / "KP.20240113.23249.10_master_bias_L1.fits")
         m.to_fits(out_fn)
         with fits.open(out_fn) as hdul:
             assert hdul["PRIMARY"].header["DATALVL"] == "ML1"

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -167,7 +167,7 @@ class TestToKPF2:
         kpf2 = converted_l1.to_kpf2()
         assert kpf2.headers["PRIMARY"].get("DATALVL") == "L2"
         origin = kpf2.headers["PRIMARY"].get("ORIGIN")
-        assert origin is not None
+        assert origin == "Keck"
 
     def test_to_kpf2_carries_instrument_header(self, converted_l1):
         # INSTRUMENT_HEADER holds the raw natives, forwarded unchanged from L1.
@@ -221,6 +221,22 @@ class TestToKPF2:
         assert (
             kpf2.headers["RECEIPT"].get("DRPSTATU")
             == "Barycentric Correction module complete"
+        )
+
+    def test_receipt_and_drpstatus_survive_roundtrip(self, tmp_path):
+        # KPF2 reads through rvdata's RV2._read, a different path from KPF0/1,
+        # so the L0/L1 round-trip twins cover none of this.
+        kpf2 = KPF2()
+        kpf2.headers["PRIMARY"]["DATE-OBS"] = "2024-01-01T00:00:00"
+        kpf2.receipt_add_entry("spectral_extraction", "", "PASS")
+        fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
+        kpf2.to_fits(fn)
+
+        back = KPF2.from_fits(fn)
+        assert "spectral_extraction" in back.receipt["FUNCTION"].values
+        assert (
+            back.headers["RECEIPT"].get("DRPSTATU")
+            == "Spectral Extraction module complete"
         )
 
     def test_to_kpf2_propagates_origid(self, tmp_path):
@@ -295,6 +311,13 @@ class TestAliasedOrderedDict:
         assert aliased["B"] == 2
         aliased.register_alias("C", "A")
         assert aliased["C"] == 1
+
+    def test_delete_via_alias(self):
+        d = AliasedOrderedDict()
+        d["CANONICAL"] = 1
+        d.register_alias("ALIAS", "CANONICAL")
+        del d["ALIAS"]
+        assert "CANONICAL" not in d
 
     def test_identity_via_alias(self):
         d = AliasedOrderedDict()
@@ -472,7 +495,7 @@ class TestKPFMasterL2:
     def test_kind_required_and_validated(self):
         with pytest.raises(TypeError):
             KPFMasterL2()  # kind is required, no default
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="kind must be one of"):
             KPFMasterL2(kind="bogus")
 
     def test_aliases_work(self):
@@ -518,6 +541,25 @@ class TestKPFMasterL2:
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
         assert "from_fits" in m.receipt["FUNCTION"].values
 
+    def test_from_fits_rejects_unreadable_input(self, tmp_path):
+        with pytest.raises(OSError, match="does not exist"):
+            KPFMasterL2.from_fits(str(tmp_path / "absent.fits"))
+        not_fits = tmp_path / "master.txt"
+        not_fits.write_text("not a FITS file")
+        with pytest.raises(OSError, match="must be FITS files"):
+            KPFMasterL2.from_fits(str(not_fits))
+
+    def test_from_fits_requires_a_known_mastype(self, tmp_path):
+        # MASTYPE picks the extension manifest, so an unmappable one must not
+        # fall back to a default kind -- a flat read under the WLS schema would
+        # land extracted spectra in TRACE*_WAVE.
+        fn = str(tmp_path / "KP.20240113.23249.10_master_bogus_L2.fits")
+        primary = fits.PrimaryHDU()
+        primary.header["MASTYPE"] = "bogus"
+        fits.HDUList([primary]).writeto(fn, overwrite=True)
+        with pytest.raises(ValueError, match="cannot infer KPFMasterL2 kind"):
+            KPFMasterL2.from_fits(fn)
+
     def test_round_trip(self, synthetic_masters_l2_file, tmp_path):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
         original = m.data["TRACE3_WAVE"].copy()
@@ -526,9 +568,7 @@ class TestKPFMasterL2:
         m.to_fits(out_fn)
 
         m2 = KPFMasterL2.from_fits(out_fn)
-        np.testing.assert_array_almost_equal(
-            m2.data["TRACE3_WAVE"], original, decimal=4
-        )
+        np.testing.assert_array_equal(m2.data["TRACE3_WAVE"], original)
 
     def test_datalvl_header_in_fits(self, synthetic_masters_l2_file, tmp_path):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -541,7 +541,7 @@ class TestKPFMasterL2:
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
         original = m.data["TRACE3_WAVE"].copy()
 
-        out_fn = str(tmp_path / "roundtrip_ml2.fits")
+        out_fn = str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
         m.to_fits(out_fn)
 
         m2 = KPFMasterL2.from_fits(out_fn)
@@ -549,7 +549,7 @@ class TestKPFMasterL2:
 
     def test_datalvl_header_in_fits(self, synthetic_masters_l2_file, tmp_path):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)
-        out_fn = str(tmp_path / "datalvl_ml2.fits")
+        out_fn = str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
         m.to_fits(out_fn)
         with fits.open(out_fn) as hdul:
             assert hdul["PRIMARY"].header["DATALVL"] == "ML2"
@@ -572,7 +572,7 @@ class TestKPFMasterL2:
         m.set_input_files(files, "thar")
         m.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
 
-        out_fn = str(tmp_path / "ml2_input_files.fits")
+        out_fn = str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
         m.to_fits(out_fn)
 
         m2 = KPFMasterL2.from_fits(out_fn)

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -446,8 +446,9 @@ class TestDtypeProvenance:
 
     def test_roundtrip_preserves_precision(self, tmp_path):
         kpf2 = self._populated()
-        assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_FLUX", FLUX, tmp_path)
-        assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_WAVE", WAVE, tmp_path)
+        name = "kpf_SL2_20240101T000000.fits"
+        assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_FLUX", FLUX, tmp_path, name=name)
+        assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_WAVE", WAVE, tmp_path, name=name)
 
     def test_chip_prefix_wave_write_enforces_min_bit_depth(self, caplog):
         """A float32 WAVE written via a chip-prefix key (which bypasses rvdata's

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -7,7 +7,6 @@ Uses synthetic FITS fixtures — no real KPF data needed.
 """
 
 import logging
-import warnings
 from collections import OrderedDict
 
 import numpy as np
@@ -86,10 +85,8 @@ class TestKPF2QualityControlRoundTrip:
         l2.set_keyword("NANSCI1", 7)
         l2.set_keyword("CCD1BKMS", -3.21)
         fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            l2.to_fits(fn)
-            back = KPF2.from_fits(fn)
+        l2.to_fits(fn)
+        back = KPF2.from_fits(fn)
         assert back.headers["QUALITY_CONTROL"]["NANSCI1"] == 7
         assert back.headers["BARYCORR_KMS"]["CCD1BKMS"] == -3.21
 
@@ -101,10 +98,8 @@ class TestKPF2QualityControlRoundTrip:
         l2 = KPF2()
         l2.set_keyword("ORIGID", "KP.20240101.00000.00")  # 0 s of day = 00:00:00
         fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            l2.to_fits(fn)
-            back = KPF2.from_fits(fn)
+        l2.to_fits(fn)
+        back = KPF2.from_fits(fn)
         assert back.obs_id == "KP.20240101.00000.00"
         assert back.generate_standard_filename() == "kpf_SL2_20240101T000000.fits"
 
@@ -136,10 +131,8 @@ class TestCatalogRecordPassthrough:
         RV2._read, so only the from_fits chokepoint can normalize it."""
         l2 = self._l1_with_catalog(rv=None).to_kpf2()
         fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            l2.to_fits(fn)
-            back = KPF2.from_fits(fn)
+        l2.to_fits(fn)
+        back = KPF2.from_fits(fn)
         assert [str(s) for s in back.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
         assert back.headers["CATALOG_RECORD"]["GAIACR"] == 1
         rv = back.data["CATALOG_RECORD"][0]["rv"]
@@ -148,10 +141,8 @@ class TestCatalogRecordPassthrough:
     def test_empty_catalog_record_roundtrips(self, tmp_path):
         """An L2 that never saw AstroQuery (empty table) still writes and reads."""
         fn = str(tmp_path / "kpf_SL2_20240101T000001.fits")
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            KPF2().to_fits(fn)
-            back = KPF2.from_fits(fn)
+        KPF2().to_fits(fn)
+        back = KPF2.from_fits(fn)
         assert "CATALOG_RECORD" in back.extensions
         assert len(back.data["CATALOG_RECORD"]) == 0
 

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -526,7 +526,9 @@ class TestKPFMasterL2:
         m.to_fits(out_fn)
 
         m2 = KPFMasterL2.from_fits(out_fn)
-        np.testing.assert_array_almost_equal(m2.data["TRACE3_WAVE"], original)
+        np.testing.assert_array_almost_equal(
+            m2.data["TRACE3_WAVE"], original, decimal=4
+        )
 
     def test_datalvl_header_in_fits(self, synthetic_masters_l2_file, tmp_path):
         m = KPFMasterL2.from_fits(synthetic_masters_l2_file)

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -1,9 +1,6 @@
-"""
-Tests for the KPF2 (extracted spectra / L2) data model, the L1->L2 transform,
-the AliasedOrderedDict extension-alias machinery, and the KPFMasterL2
-calibration product.
-
-Uses synthetic FITS fixtures — no real KPF data needed.
+"""Tests for the KPF2 (extracted spectra / L2) data model, the L1->L2 transform,
+the AliasedOrderedDict extension-alias machinery, and the KPFMasterL2 calibration
+product. Synthetic FITS fixtures only -- no real KPF data needed.
 """
 
 import logging
@@ -39,8 +36,7 @@ NORDER = NORDER_GREEN + NORDER_RED
 
 @pytest.fixture(scope="module")
 def synthetic_masters_l2_file(tmp_path_factory):
-    """Create a minimal synthetic Masters L2 FITS file (module-scoped read-only
-    source: consumers only from_fits() read it)."""
+    """Minimal synthetic Masters L2 FITS file; module-scoped and read-only."""
     rng = np.random.default_rng(20240113)
     fn = str(
         tmp_path_factory.mktemp("ml2") / "KP.20240113.23249.10_master_thar_L2.fits"
@@ -68,8 +64,8 @@ def synthetic_masters_l2_file(tmp_path_factory):
 
 @pytest.fixture
 def converted_l1(synthetic_l0_file):
-    """An L1 produced via KPF0.to_kpf1 — already EPRV-standard PRIMARY plus a
-    populated INSTRUMENT_HEADER (the input to_kpf2 expects in production)."""
+    """An L1 from KPF0.to_kpf1: EPRV-standard PRIMARY plus a populated
+    INSTRUMENT_HEADER, the input to_kpf2 expects in production."""
     return KPF0.from_fits(synthetic_l0_file).to_kpf1()
 
 
@@ -77,7 +73,7 @@ class TestKPF2QualityControlRoundTrip:
     """The KPF-custom QUALITY_CONTROL extension survives KPF2's RV2 read path.
 
     register_rvdata_extension teaches rvdata's definition-driven L2 reader about
-    QUALITY_CONTROL; without it from_fits raises KeyError on that HDU.
+    QUALITY_CONTROL; without it, from_fits raises KeyError on that HDU.
     """
 
     def test_quality_control_and_barycorr_roundtrip(self, tmp_path):
@@ -91,10 +87,9 @@ class TestKPF2QualityControlRoundTrip:
         assert back.headers["BARYCORR_KMS"]["CCD1BKMS"] == -3.21
 
     def test_from_fits_recovers_obs_id_from_origid(self, tmp_path):
-        """An L2's timestamp-based filename does not embed the obs_id, so from_fits
-        recovers it from the ORIGID card on RECEIPT (the original L0 obs_id, ridden
-        forward). This keeps obs_id populated on the from_fits construction path so
-        generate_standard_filename (which delegates to kpf_filename) works."""
+        # An L2's timestamp-based filename does not embed the obs_id, so from_fits
+        # recovers it from RECEIPT's ORIGID; that keeps generate_standard_filename
+        # working on the from_fits construction path.
         l2 = KPF2()
         l2.set_keyword("ORIGID", "KP.20240101.00000.00")  # 0 s of day = 00:00:00
         fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
@@ -107,8 +102,7 @@ class TestKPF2QualityControlRoundTrip:
 class TestCatalogRecordPassthrough:
     """CATALOG_RECORD rides L1 -> L2 and survives KPF2's RV2 read path.
 
-    Same mechanism as QUALITY_CONTROL above: register_rvdata_extension teaches
-    rvdata's definition-driven L2 reader about the KPF-only extension.
+    Same register_rvdata_extension mechanism as QUALITY_CONTROL above.
     """
 
     @staticmethod
@@ -127,8 +121,8 @@ class TestCatalogRecordPassthrough:
         assert l2.headers["CATALOG_RECORD"]["GAIACR"] == 1
 
     def test_catalog_record_roundtrip(self, tmp_path):
-        """The missing rv reads back NaN, not masked -- L2 reads through rvdata's
-        RV2._read, so only the from_fits chokepoint can normalize it."""
+        # The missing rv reads back NaN, not masked -- L2 reads through rvdata's
+        # RV2._read, so only the from_fits chokepoint can normalize it.
         l2 = self._l1_with_catalog(rv=None).to_kpf2()
         fn = str(tmp_path / "kpf_SL2_20240101T000000.fits")
         l2.to_fits(fn)
@@ -139,7 +133,7 @@ class TestCatalogRecordPassthrough:
         assert rv is not np.ma.masked and np.isnan(rv)
 
     def test_empty_catalog_record_roundtrips(self, tmp_path):
-        """An L2 that never saw AstroQuery (empty table) still writes and reads."""
+        # An L2 that never saw AstroQuery carries an empty table.
         fn = str(tmp_path / "kpf_SL2_20240101T000001.fits")
         KPF2().to_fits(fn)
         back = KPF2.from_fits(fn)
@@ -154,7 +148,7 @@ class TestToKPF2:
         assert isinstance(kpf2, KPF2)
 
     def test_to_kpf2_passes_through_eprv_primary(self, converted_l1):
-        """Conversion happened in to_kpf1; to_kpf2 forwards the EPRV PRIMARY."""
+        # The keyword conversion happened in to_kpf1; to_kpf2 only forwards it.
         kpf2 = converted_l1.to_kpf2()
         prim = kpf2.headers["PRIMARY"]
         assert prim.get("EXPTIME") == 300.0  # from ELAPSED, set in to_kpf1
@@ -176,13 +170,12 @@ class TestToKPF2:
         assert origin is not None
 
     def test_to_kpf2_carries_instrument_header(self, converted_l1):
-        """INSTRUMENT_HEADER (raw natives) is forwarded unchanged from L1."""
+        # INSTRUMENT_HEADER holds the raw natives, forwarded unchanged from L1.
         kpf2 = converted_l1.to_kpf2()
         assert kpf2.headers["INSTRUMENT_HEADER"]["INSTRUME"] == "KPF"
         assert kpf2.headers["INSTRUMENT_HEADER"]["ELAPSED"] == 300.0
 
     def test_to_kpf2_maps_passthrough_extensions(self, tmp_path):
-        """Build an L1 with TELEMETRY and CA_HK, verify they map to KPF2 extensions."""
         fn = str(tmp_path / "l1_with_extras.fits")
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
@@ -221,8 +214,8 @@ class TestToKPF2:
         assert "to_kpf2" in kpf2.receipt["FUNCTION"].values
 
     def test_to_kpf2_receipt_updates_drpstatus(self, synthetic_l1_file):
-        """The DRPSTATU receipt override is active on KPF2 too (it subclasses
-        RV2, not KPFDataModel, so it carries its own override)."""
+        # KPF2 subclasses RV2, not KPFDataModel, so it carries its own copy of the
+        # DRPSTATU receipt override.
         kpf2 = KPF1.from_fits(synthetic_l1_file).to_kpf2()
         kpf2.receipt_add_entry("barycentric_correction", "", "PASS")
         assert (
@@ -231,8 +224,8 @@ class TestToKPF2:
         )
 
     def test_to_kpf2_propagates_origid(self, tmp_path):
-        """ORIGID is stamped at L0 and rides the RECEIPT header through to_kpf2;
-        it is not (re)written at L2, and stays off PRIMARY."""
+        # ORIGID is stamped at L0 and rides RECEIPT through to_kpf2; it is not
+        # rewritten at L2, and stays off PRIMARY.
         fn = str(tmp_path / "KP.20240113.23249.10_L1.fits")
         primary = fits.PrimaryHDU()
         primary.header["INSTRUME"] = "KPF"
@@ -304,7 +297,6 @@ class TestAliasedOrderedDict:
         assert aliased["C"] == 1
 
     def test_identity_via_alias(self):
-        """Alias access returns the exact same object (not a copy)."""
         d = AliasedOrderedDict()
         arr = np.zeros((4, 4))
         d["CANONICAL"] = arr
@@ -320,7 +312,6 @@ class TestKPF2Aliases:
 
     def test_extension_alias_resolves(self):
         kpf2 = KPF2()
-        # CA_HK should resolve to ANCILLARY_SPECTRUM
         assert "CA_HK" in kpf2.extensions
         assert kpf2.data["CA_HK"] is kpf2.data["ANCILLARY_SPECTRUM"]
 
@@ -337,7 +328,6 @@ class TestKPF2Aliases:
 
     def test_all_trace_aliases_registered(self):
         kpf2 = KPF2()
-        # Check all 5 fibers x 4 suffixes = 20 aliases
         for fiber, trace in [
             ("SKY", 1),
             ("SCI1", 2),
@@ -352,7 +342,7 @@ class TestKPF2Aliases:
                 assert kpf2.data[alias] is kpf2.data[canonical]
 
     def test_chip_prefix_access(self):
-        """Test GREEN_/RED_ prefix returns correct slices of concatenated trace."""
+        # A GREEN_/RED_ prefix slices the concatenated (GREEN then RED) trace.
         kpf2 = KPF2()
         n_pix = 100
         rng = np.random.default_rng(42)
@@ -367,14 +357,12 @@ class TestKPF2Aliases:
         np.testing.assert_array_equal(red, trace_data[NORDER_GREEN:])
 
     def test_chip_prefix_contains(self):
-        """GREEN_SCI2_FLUX should be 'in' the data dict."""
         kpf2 = KPF2()
         assert "GREEN_SCI2_FLUX" in kpf2.data
         assert "RED_CAL_WAVE" in kpf2.data
         assert "GREEN_NONEXISTENT" not in kpf2.data
 
     def test_chip_prefix_all_fibers(self):
-        """All chip+fiber+suffix combinations should work."""
         kpf2 = KPF2()
         for fiber in ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]:
             for suffix in ["FLUX", "WAVE", "VAR", "BLAZE"]:
@@ -382,7 +370,6 @@ class TestKPF2Aliases:
                 assert f"RED_{fiber}_{suffix}" in kpf2.data
 
     def test_chip_prefix_write_populates_slices(self):
-        """Writing via chip-prefix should fill the correct slice of the trace."""
         kpf2 = KPF2()
         n_pix = 100
         green_data = np.ones((NORDER_GREEN, n_pix), dtype=np.float32)
@@ -397,7 +384,7 @@ class TestKPF2Aliases:
         np.testing.assert_array_equal(full[NORDER_GREEN:], red_data)
 
     def test_chip_prefix_write_allocates_on_first_write(self):
-        """Writing GREEN first should allocate the full (67, ncol) trace."""
+        # A GREEN-only write must still allocate the full GREEN+RED trace.
         kpf2 = KPF2()
         n_pix = 100
         assert len(kpf2.data["TRACE3_FLUX"]) == 0
@@ -408,7 +395,6 @@ class TestKPF2Aliases:
         assert kpf2.data["TRACE3_FLUX"].shape == (NORDER_GREEN + NORDER_RED, n_pix)
 
     def test_chip_prefix_write_via_set_data(self):
-        """set_data() should route chip-prefix keys through __setitem__."""
         kpf2 = KPF2()
         n_pix = 50
         green_data = np.arange(NORDER_GREEN * n_pix, dtype=np.float32).reshape(
@@ -420,8 +406,8 @@ class TestKPF2Aliases:
 
 
 class TestDtypeProvenance:
-    """The data-model storage layer preserves dtype (no coercion); FITS
-    round-trip preserves precision (float32 -> BITPIX -32, float64 -> -64)."""
+    """Storage preserves dtype (no coercion) and the FITS round-trip preserves
+    precision (float32 -> BITPIX -32, float64 -> -64)."""
 
     def _populated(self):
         kpf2 = KPF2()
@@ -442,10 +428,8 @@ class TestDtypeProvenance:
         assert_roundtrip_dtype(KPF2, kpf2, "TRACE3_WAVE", WAVE, tmp_path, name=name)
 
     def test_chip_prefix_wave_write_enforces_min_bit_depth(self, caplog):
-        """A float32 WAVE written via a chip-prefix key (which bypasses rvdata's
-        base set_data) is still upcast to float64 with the MinBitDepth warning —
-        the chip-split path enforces the born-64 WAVE policy like the canonical
-        path does."""
+        # A chip-prefix write bypasses rvdata's base set_data, so check it still
+        # enforces the born-64 WAVE policy (upcast plus MinBitDepth warning).
         kpf2 = KPF2()
         with caplog.at_level(logging.WARNING):
             kpf2.set_data(
@@ -455,8 +439,8 @@ class TestDtypeProvenance:
         assert_dtype(kpf2.data["TRACE3_WAVE"], WAVE, "underlying TRACE3_WAVE")
 
     def test_chip_prefix_flux_write_keeps_float32(self, caplog):
-        """FLUX has no MinBitDepth requirement, so a float32 chip-prefix write is
-        kept as-is (no upcast, no warning) — the enforcement is WAVE/QUALITY-only."""
+        # MinBitDepth enforcement is WAVE/QUALITY-only, so float32 FLUX is kept
+        # as-is: no upcast, no warning.
         kpf2 = KPF2()
         with caplog.at_level(logging.WARNING):
             kpf2.set_data(
@@ -468,8 +452,6 @@ class TestDtypeProvenance:
 
 class TestKPFMasterL2:
     def test_wls_extensions_created(self):
-        # A WLS master carries the shared extensions plus TRACE*_WAVE, and not the
-        # flat-only TRACE*_FLUX/VAR/BLAZE.
         m = KPFMasterL2(kind="wls")
         for ext in ["PRIMARY", "RECEIPT", "QUALITY_CONTROL", "INPUT_FILES"]:
             assert ext in m.extensions
@@ -479,7 +461,6 @@ class TestKPFMasterL2:
                 assert f"TRACE{n}_{suffix}" not in m.extensions
 
     def test_flat_extensions_created(self):
-        # A flat master carries TRACE*_FLUX/VAR/BLAZE and not TRACE*_WAVE.
         m = KPFMasterL2(kind="flat")
         for ext in ["PRIMARY", "RECEIPT", "QUALITY_CONTROL", "INPUT_FILES"]:
             assert ext in m.extensions
@@ -598,24 +579,21 @@ class TestKPFMasterL2:
 class TestKPF2HeaderStorage:
     """KPF2-specific header storage and the KPF2._create_hdul serialization path.
 
-    KPF2 stores headers as fits.Header (like all KPF models) but overrides
-    _create_hdul via RV2, a distinct code path from the inherited base one tested
-    in test_data_models_base.py.
+    KPF2 stores headers as fits.Header like every KPF model, but overrides
+    _create_hdul via RV2 -- a distinct path from the inherited base one covered in
+    test_data_models_base.py.
     """
 
     def test_fresh_l2_headers_are_fits_headers(self):
         kpf2 = KPF2()
         assert isinstance(kpf2.headers["PRIMARY"], fits.Header)
-        # A non-PRIMARY extension header too (created via create_extension).
         assert isinstance(kpf2.headers["TRACE1_FLUX"], fits.Header)
 
     def test_l2_primary_comment_round_trips(self, tmp_path):
-        # Guards the KPF2._create_hdul override (not the inherited base path):
-        # a commented PRIMARY card must survive to_fits -> from_fits.
         kpf2 = KPF2()
-        # A non-EPRV PRIMARY card: rvdata rewrites its own L2-defined keywords from
-        # the definition (dropping any KPF comment), so an arbitrary card is what
-        # exercises the KPF comment-preservation override rather than that rewrite.
+        # Guards the KPF2._create_hdul comment-preservation override. The card must
+        # be non-EPRV: rvdata rewrites its own L2-defined keywords from the
+        # definition, dropping any KPF comment on them.
         kpf2.headers["PRIMARY"]["HDRCMNT"] = ("kept", "comment must survive to_fits")
 
         fn = str(tmp_path / "kpf_SL2_20240113T102656.fits")

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -1,8 +1,7 @@
-"""
-Tests for the KPF4 (RVs and CCFs / L4) data model, the L2->L4 transform,
-the KPFMasterL4 stub, and top-level data-model package imports.
+"""Tests for the KPF4 (RVs and CCFs / L4) data model, the L2->L4 transform, the
+KPFMasterL4 stub, and top-level data-model package imports.
 
-Uses synthetic FITS fixtures — no real KPF data needed.
+Synthetic FITS fixtures only -- no real KPF data needed.
 """
 
 import numpy as np
@@ -54,8 +53,7 @@ class TestToKPF4:
         assert len(kpf4.data["RV1"]) == 0
 
     def test_program_ids_survive_transform_and_validate(self, synthetic_l1_file):
-        """PROGID/KOAID on the L1 RECEIPT survive L1->L2->L4 via the RECEIPT-header
-        forward (their registry home is RECEIPT, not PRIMARY)."""
+        # PROGID/KOAID live on RECEIPT, not PRIMARY, and ride the RECEIPT forward.
         l1 = KPF1.from_fits(synthetic_l1_file)
         l1.headers["RECEIPT"]["PROGID"] = "U999"
         l1.headers["RECEIPT"]["KOAID"] = "KP.20201122.34567.89"
@@ -72,8 +70,7 @@ class TestToKPF4:
         assert "QUALITY_CONTROL" in KPF4().extensions
 
     def test_to_kpf4_forwards_quality_control_and_receipt_headers(self):
-        """QUALITY_CONTROL + RECEIPT header cards (the accumulated L0/L1/L2 QC and
-        provenance history) are forwarded onto L4, like to_kpf2 does for L1->L2."""
+        # The accumulated L0/L1/L2 QC and provenance history must reach L4.
         kpf2 = KPF2()
         kpf2.set_keyword("NANSCI1", 7)  # DiagL2 metric -> QUALITY_CONTROL
         kpf2.headers["QUALITY_CONTROL"]["DATAPRL0"] = (1, "L0 flag (propagated)")
@@ -110,8 +107,7 @@ class TestCatalogRecordPassthrough:
         assert "CATALOG_RECORD" in KPF4().extensions
 
     def test_rows_and_flags_reach_l4(self):
-        """The rows, not just the flags, are copied onto L4, so the astrometry stays
-        with the RV product it fed."""
+        # The rows, not just the flags, so the astrometry stays with the RV it fed.
         kpf4 = self._l2_with_catalog().to_kpf4()
         assert [str(s) for s in kpf4.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
         assert kpf4.headers["CATALOG_RECORD"]["GAIACR"] == 1
@@ -162,7 +158,6 @@ class TestKPF4:
         np.testing.assert_array_equal(kpf4.data["RED_SCI2_CCF"], red)
 
     def test_ccf_var_chip_prefix_views(self):
-        # CCF_VAR behaves exactly like CCF: a writable, chip-sliced image cube.
         kpf4 = KPF4()
         green = np.ones((NORDER_GREEN, 5))
         red = 2 * np.ones((NORDER - NORDER_GREEN, 5))
@@ -173,7 +168,6 @@ class TestKPF4:
         np.testing.assert_array_equal(kpf4.data["RED_SCI2_CCF_VAR"], red)
 
     def test_ccf_var_survives_round_trip(self, tmp_path):
-        # The CCF_VAR image cube serializes and reloads like CCF.
         kpf4 = KPF2().to_kpf4()
         ccf = np.arange(NORDER * 5, dtype=float).reshape(NORDER, 5)
         var = ccf + 0.5

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -15,6 +15,7 @@ from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.data_models.masters import KPFMasterL4
 
 from ._catalog import SOURCES, catalog_record_table
+from ._dtype_policy import BJD, CCF, RV_FLOAT, assert_dtype, assert_roundtrip_dtype
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
 NORDER_RED = DETECTOR["norder"]["RED"]
@@ -147,25 +148,16 @@ class TestKPF4:
         # bare RV is not an alias (RV is trace-mapped, not a 1:1 alias)
         assert kpf4.data._resolve("RV") == "RV"
 
-    def test_ccf_chip_prefix_views(self):
+    @pytest.mark.parametrize("suffix", ["CCF", "CCF_VAR"])
+    def test_ccf_chip_prefix_views(self, suffix):
         kpf4 = KPF4()
         green = np.ones((NORDER_GREEN, 5))
         red = 2 * np.ones((NORDER - NORDER_GREEN, 5))
-        kpf4.set_data("GREEN_SCI2_CCF", green)
-        kpf4.set_data("RED_SCI2_CCF", red)
-        assert kpf4.data["SCI2_CCF"].shape == (NORDER, 5)
-        np.testing.assert_array_equal(kpf4.data["GREEN_SCI2_CCF"], green)
-        np.testing.assert_array_equal(kpf4.data["RED_SCI2_CCF"], red)
-
-    def test_ccf_var_chip_prefix_views(self):
-        kpf4 = KPF4()
-        green = np.ones((NORDER_GREEN, 5))
-        red = 2 * np.ones((NORDER - NORDER_GREEN, 5))
-        kpf4.set_data("GREEN_SCI2_CCF_VAR", green)
-        kpf4.set_data("RED_SCI2_CCF_VAR", red)
-        assert kpf4.data["SCI2_CCF_VAR"].shape == (NORDER, 5)
-        np.testing.assert_array_equal(kpf4.data["GREEN_SCI2_CCF_VAR"], green)
-        np.testing.assert_array_equal(kpf4.data["RED_SCI2_CCF_VAR"], red)
+        kpf4.set_data(f"GREEN_SCI2_{suffix}", green)
+        kpf4.set_data(f"RED_SCI2_{suffix}", red)
+        assert kpf4.data[f"SCI2_{suffix}"].shape == (NORDER, 5)
+        np.testing.assert_array_equal(kpf4.data[f"GREEN_SCI2_{suffix}"], green)
+        np.testing.assert_array_equal(kpf4.data[f"RED_SCI2_{suffix}"], red)
 
     def test_ccf_var_survives_round_trip(self, tmp_path):
         kpf4 = KPF2().to_kpf4()
@@ -227,18 +219,59 @@ class TestKPFMasterStubs:
         assert issubclass(KPFMasterL4, KPF4)
 
 
-class TestImports:
-    def test_data_models_import(self):
-        from kpfpipe.data_models import KPF0, KPF1, KPF2, KPF4
+class TestDtypeProvenance:
+    """EPRV mandates 64-bit for the L4 product: the CCF cubes and the RV table's
+    WAVE_START/WAVE_END/BJD_TDB. A downscale anywhere here costs RV accuracy, so
+    assert both the in-memory dtype and what survives the FITS round-trip."""
 
-        assert KPF0 is not None
-        assert KPF1 is not None
-        assert KPF2 is not None
-        assert KPF4 is not None
+    @staticmethod
+    def _populated():
+        kpf4 = KPF2().to_kpf4()
+        kpf4.set_data("SCI2_CCF", np.ones((NORDER, 5), dtype=np.float64))
+        kpf4.set_data(
+            "SCI2_RV",
+            pd.DataFrame(
+                {
+                    "ORDER_INDEX": np.arange(NORDER),
+                    "RV": np.zeros(NORDER, dtype=np.float64),
+                    "RV_ERR": np.full(NORDER, 1e-3, dtype=np.float64),
+                    "WAVE_START": np.full(NORDER, 4500.0, dtype=np.float64),
+                    "WAVE_END": np.full(NORDER, 8700.0, dtype=np.float64),
+                    "BJD_TDB": np.full(NORDER, 2460000.0, dtype=np.float64),
+                }
+            ),
+        )
+        return kpf4
 
-    def test_masters_data_models_import(self):
-        from kpfpipe.data_models.masters import KPFMasterL1, KPFMasterL2, KPFMasterL4
+    def test_ccf_cube_is_float64(self):
+        assert_dtype(self._populated().data["SCI2_CCF"], CCF, "SCI2_CCF in-mem")
 
-        assert KPFMasterL1 is not None
-        assert KPFMasterL2 is not None
-        assert KPFMasterL4 is not None
+    @pytest.mark.parametrize("column", ["RV", "RV_ERR", "WAVE_START", "WAVE_END"])
+    def test_rv_table_columns_are_float64(self, column):
+        table = self._populated().data["SCI2_RV"]
+        assert_dtype(table[column], RV_FLOAT, f"SCI2_RV {column} in-mem")
+
+    def test_bjd_tdb_is_float64(self):
+        table = self._populated().data["SCI2_RV"]
+        assert_dtype(table["BJD_TDB"], BJD, "SCI2_RV BJD_TDB in-mem")
+
+    def test_ccf_cube_survives_round_trip_as_float64(self, tmp_path):
+        # assert_roundtrip_dtype reads BITPIX off the raw HDU, so it needs the
+        # on-disk extension name (SCI2_CCF is an alias for CCF3).
+        assert_roundtrip_dtype(
+            KPF4,
+            self._populated(),
+            "CCF3",
+            CCF,
+            tmp_path,
+            name="kpf_SL4_20240101T000003.fits",
+        )
+
+    @pytest.mark.parametrize(
+        "column", ["RV", "RV_ERR", "WAVE_START", "WAVE_END", "BJD_TDB"]
+    )
+    def test_rv_table_survives_round_trip_as_float64(self, tmp_path, column):
+        path = str(tmp_path / "kpf_SL4_20240101T000004.fits")
+        self._populated().to_fits(path)
+        table = KPF4.from_fits(path).data["SCI2_RV"]
+        assert_dtype(table[column], RV_FLOAT, f"SCI2_RV {column} after round-trip")

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -87,7 +87,7 @@ class TestToKPF4:
         kpf2 = KPF2()
         kpf2.set_keyword("NANSCI1", 7)
         kpf4 = kpf2.to_kpf4()
-        path = tmp_path / "rt_l4.fits"
+        path = tmp_path / "kpf_SL4_20240101T000000.fits"
         kpf4.to_fits(str(path))
         back = KPF4.from_fits(str(path))
         assert "QUALITY_CONTROL" in back.extensions
@@ -117,7 +117,7 @@ class TestCatalogRecordPassthrough:
         assert kpf4.headers["CATALOG_RECORD"]["GAIACR"] == 1
 
     def test_catalog_record_roundtrip(self, tmp_path):
-        path = tmp_path / "rt_l4_catalog.fits"
+        path = tmp_path / "kpf_SL4_20240101T000001.fits"
         self._l2_with_catalog().to_kpf4().to_fits(str(path))
         back = KPF4.from_fits(str(path))
         assert [str(s) for s in back.data["CATALOG_RECORD"]["source"]] == list(SOURCES)
@@ -179,7 +179,7 @@ class TestKPF4:
         var = ccf + 0.5
         kpf4.set_data("SCI2_CCF", ccf)
         kpf4.set_data("SCI2_CCF_VAR", var)
-        path = tmp_path / "rt_ccf_var.fits"
+        path = tmp_path / "kpf_SL4_20240101T000002.fits"
         kpf4.to_fits(str(path))
         back = KPF4.from_fits(str(path))
         assert "CCF_VAR3" in back.extensions

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -65,6 +65,21 @@ class TestToKPF4:
         assert receipt.get("KOAID") == "KP.20201122.34567.89"
         assert "PROGID" not in l4.headers["PRIMARY"]
 
+    def test_receipt_and_drpstatus_survive_roundtrip(self, tmp_path):
+        # KPF4 reads through rvdata's RV4._read, a different path from KPF0/1,
+        # so the L0/L1 round-trip twins cover none of this.
+        l4 = KPF2().to_kpf4()
+        l4.headers["PRIMARY"]["DATE-OBS"] = "2024-01-01T00:00:00"
+        l4.receipt_add_entry("radial_velocity", "", "PASS")
+        fn = str(tmp_path / "kpf_SL4_20240101T000000.fits")
+        l4.to_fits(fn)
+
+        back = KPF4.from_fits(fn)
+        assert "radial_velocity" in back.receipt["FUNCTION"].values
+        assert (
+            back.headers["RECEIPT"].get("DRPSTATU") == "Radial Velocity module complete"
+        )
+
     def test_kpf4_has_quality_control_extension(self):
         # KPF4 must create QUALITY_CONTROL (RV4 does not) so to_kpf4 has a
         # destination and the accumulated QC history reaches L4.
@@ -212,7 +227,7 @@ class TestKPF4:
 
 class TestKPFMasterStubs:
     def test_master_l4_not_implemented(self):
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match="not yet implemented"):
             KPFMasterL4()
 
     def test_master_l4_inherits_kpf4(self):
@@ -243,16 +258,15 @@ class TestDtypeProvenance:
         )
         return kpf4
 
-    def test_ccf_cube_is_float64(self):
-        assert_dtype(self._populated().data["SCI2_CCF"], CCF, "SCI2_CCF in-mem")
-
-    @pytest.mark.parametrize("column", ["RV", "RV_ERR", "WAVE_START", "WAVE_END"])
-    def test_rv_table_columns_are_float64(self, column):
-        table = self._populated().data["SCI2_RV"]
-        assert_dtype(table[column], RV_FLOAT, f"SCI2_RV {column} in-mem")
-
-    def test_bjd_tdb_is_float64(self):
-        table = self._populated().data["SCI2_RV"]
+    def test_populated_l4_is_born_float64(self):
+        # One in-memory check, not one per column: it localizes a break to
+        # set_data, which the round-trip tests below cannot distinguish from a
+        # FITS-layer break.
+        kpf4 = self._populated()
+        assert_dtype(kpf4.data["SCI2_CCF"], CCF, "SCI2_CCF in-mem")
+        table = kpf4.data["SCI2_RV"]
+        for column in ("RV", "RV_ERR", "WAVE_START", "WAVE_END"):
+            assert_dtype(table[column], RV_FLOAT, f"SCI2_RV {column} in-mem")
         assert_dtype(table["BJD_TDB"], BJD, "SCI2_RV BJD_TDB in-mem")
 
     def test_ccf_cube_survives_round_trip_as_float64(self, tmp_path):
@@ -267,11 +281,9 @@ class TestDtypeProvenance:
             name="kpf_SL4_20240101T000003.fits",
         )
 
-    @pytest.mark.parametrize(
-        "column", ["RV", "RV_ERR", "WAVE_START", "WAVE_END", "BJD_TDB"]
-    )
-    def test_rv_table_survives_round_trip_as_float64(self, tmp_path, column):
+    def test_rv_table_survives_round_trip_as_float64(self, tmp_path):
         path = str(tmp_path / "kpf_SL4_20240101T000004.fits")
         self._populated().to_fits(path)
         table = KPF4.from_fits(path).data["SCI2_RV"]
-        assert_dtype(table[column], RV_FLOAT, f"SCI2_RV {column} after round-trip")
+        for column in ("RV", "RV_ERR", "WAVE_START", "WAVE_END", "BJD_TDB"):
+            assert_dtype(table[column], RV_FLOAT, f"SCI2_RV {column} after round-trip")

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -287,6 +287,10 @@ class TestDiagL0Contingency:
         assert results["TARGOFF"][0] is None
         assert "incomplete wmko record in CATALOG_RECORD" in caplog.text
 
+    # No usable parallax means no distance on the SkyCoord, and ERFA warns that it
+    # overrode the distance while propagating -- the documented consequence of the
+    # PM=0/parallax=0 fallback under test, not a fault.
+    @pytest.mark.filterwarnings('ignore:ERFA function "pmsafe":erfa.ErfaWarning')
     @pytest.mark.parametrize("bad_plx", [None, 0.0, -5.0])
     def test_missing_or_nonpositive_parallax_falls_back(self, bad_plx, caplog):
         # Gaia DR3 reports parallax <= 0 (or none) for faint sources; the offset falls

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -539,9 +539,13 @@ class TestDiagL2Snr:
         kpf2 = _make_kpf2_nan_pixels()  # all FLUX ones
         set_fiber_arrays(kpf2, "VAR", 0.25, ncol=_NCOL_TEST)
         DiagL2(kpf2).run()
+        # FLUX = 1, VAR = 0.25 -> per-fiber SNR = 1/sqrt(0.25) = 2.0 exactly, and
+        # the three summed SCI orderlets give 3/sqrt(0.75) = 3.464.
+        qc = kpf2.headers["QUALITY_CONTROL"]
         for key in self._SNR_KEYS:
-            assert key in kpf2.headers["QUALITY_CONTROL"], f"missing {key}"
-            assert kpf2.headers["QUALITY_CONTROL"].get(key) > 0
+            assert key in qc, f"missing {key}"
+            expected = 3.464 if key.endswith("SCI") else 2.0
+            assert qc.get(key) == pytest.approx(expected, abs=0.01), key
 
     def test_single_fiber_snr_value(self):
         # SKY flux=2, var=0.04 -> SNR = 2/sqrt(0.04) = 10.0 in every pixel.
@@ -671,6 +675,21 @@ class TestDiagL4:
         assert qc["BJDMEAN"] == pytest.approx(15.0)
         assert qc["BJDRNG"] == pytest.approx(864000.0)
         assert qc["BERVMEAN"] == pytest.approx(0.2)
+
+    def test_all_zero_weights_skips_metrics(self):
+        # w.sum() <= 0 makes _weighted_dispersion return None and the metrics are
+        # skipped entirely. That is load-bearing: absent BERVRNG/BJDRNG make
+        # QCL4.berv_within_tolerance / bjd_within_tolerance return False on a
+        # target frame, so this producing half must stay in step with the QC half.
+        l4 = _l4_with_sci2_rv([10.0, 20.0], [0.1, 0.3], [0.0, 0.0])
+        assert DiagL4(l4).run() == {}
+
+    def test_non_finite_samples_dropped(self):
+        # A NaN BJD is masked out rather than poisoning the mean; the surviving
+        # order is the answer.
+        l4 = _l4_with_sci2_rv([10.0, np.nan], [0.1, 0.3], [1.0, 1.0])
+        DiagL4(l4).run()
+        assert l4.headers["QUALITY_CONTROL"]["BJDMEAN"] == pytest.approx(10.0)
 
     def test_skips_without_sci2_rv_table(self):
         # No SCI2 RV table (e.g. unilluminated science) -> no metrics written.

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -22,6 +22,8 @@ from kpfpipe.quality_control.diagnostics import (
     Diagnostics,
 )
 
+from ._data_models import set_fiber_arrays
+
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
 NORDER_RED = DETECTOR["norder"]["RED"]
 _NCOL_TEST = 8  # DiagL2 metrics are pixel aggregates, so the real detector width
@@ -437,8 +439,13 @@ class TestDiagL1CalibrationAges:
 # ---------------------------------------------------------------------------
 
 
-def _make_kpf2_with_flux(nan_frac=0.0, zero_frac=0.0, populate=True):
+def _make_kpf2_nan_pixels(nan_frac=0.0, zero_frac=0.0, populate=True):
     """Minimal KPF2 with FLUX at controllable NaN and zero fractions.
+
+    Injects real NaN/zero PIXELS, because DiagL2 measures them. Not the same as
+    test_qc_flags.py's ``_make_kpf2_nan_headers``, which writes NaN-count/ZEROFRAC
+    HEADERS over clean arrays for QCL2 to read -- the opposite mechanism. Do not
+    merge them; each would destroy the other's test.
 
     A bare KPF2() already exposes the FLUX extensions DiagL2 reads, so no FITS
     round-trip is needed. Each extension is (norder[chip], _NCOL_TEST) ones, then
@@ -467,14 +474,14 @@ def _make_kpf2_with_flux(nan_frac=0.0, zero_frac=0.0, populate=True):
 
 class TestDiagL2NanCounts:
     def test_writes_all_five_keys_with_zero_when_clean(self):
-        kpf2 = _make_kpf2_with_flux(nan_frac=0.0)
+        kpf2 = _make_kpf2_nan_pixels(nan_frac=0.0)
         DiagL2(kpf2).run()
         for key in _NAN_KEYS:
             assert key in kpf2.headers["QUALITY_CONTROL"], f"missing {key}"
             assert kpf2.headers["QUALITY_CONTROL"].get(key) == 0
 
     def test_counts_injected_nans_per_fiber(self):
-        kpf2 = _make_kpf2_with_flux(nan_frac=0.0)
+        kpf2 = _make_kpf2_nan_pixels(nan_frac=0.0)
         # Inject one NaN into GREEN_SCI1_FLUX; expect NANSCI1==1, others==0.
         kpf2.data["GREEN_SCI1_FLUX"][0, 0] = np.nan
         DiagL2(kpf2).run()
@@ -484,7 +491,7 @@ class TestDiagL2NanCounts:
 
     def test_writes_keys_even_when_no_data(self):
         # The header schema stays consistent: all five keys present, value 0.
-        kpf2 = _make_kpf2_with_flux(populate=False)
+        kpf2 = _make_kpf2_nan_pixels(populate=False)
         DiagL2(kpf2).run()
         for key in _NAN_KEYS:
             assert kpf2.headers["QUALITY_CONTROL"].get(key) == 0
@@ -492,20 +499,20 @@ class TestDiagL2NanCounts:
 
 class TestDiagL2ZeroFlux:
     def test_zerofrac_written_when_data_present(self):
-        kpf2 = _make_kpf2_with_flux(zero_frac=0.0)  # all ones
+        kpf2 = _make_kpf2_nan_pixels(zero_frac=0.0)  # all ones
         DiagL2(kpf2).run()
         assert "ZEROFRAC" in kpf2.headers["QUALITY_CONTROL"]
         assert kpf2.headers["QUALITY_CONTROL"].get("ZEROFRAC") == pytest.approx(0.0)
 
     def test_zerofrac_one_when_all_zero(self):
-        kpf2 = _make_kpf2_with_flux(zero_frac=1.0)
+        kpf2 = _make_kpf2_nan_pixels(zero_frac=1.0)
         DiagL2(kpf2).run()
         assert kpf2.headers["QUALITY_CONTROL"].get("ZEROFRAC") == pytest.approx(1.0)
 
     def test_zerofrac_half_when_half_zero(self):
         # A deterministic even/odd pattern (every array has an even pixel count)
         # makes ZEROFRAC exactly 0.5, independent of array size and seed.
-        kpf2 = _make_kpf2_with_flux(zero_frac=0.0)  # all ones
+        kpf2 = _make_kpf2_nan_pixels(zero_frac=0.0)  # all ones
         for chip in ("GREEN", "RED"):
             for fiber in _FIBERS:
                 arr = np.ones_like(np.asarray(kpf2.data[f"{chip}_{fiber}_FLUX"]))
@@ -515,20 +522,9 @@ class TestDiagL2ZeroFlux:
         assert kpf2.headers["QUALITY_CONTROL"].get("ZEROFRAC") == pytest.approx(0.5)
 
     def test_zerofrac_skipped_when_no_data(self):
-        kpf2 = _make_kpf2_with_flux(populate=False)
+        kpf2 = _make_kpf2_nan_pixels(populate=False)
         DiagL2(kpf2).run()
         assert "ZEROFRAC" not in kpf2.headers["QUALITY_CONTROL"]
-
-
-def _set_fiber_arrays(kpf2, suffix, value, chips=("GREEN", "RED"), fibers=_FIBERS):
-    """Populate {chip}_{fiber}_{suffix} with a constant for the given fibers."""
-    norder = {"GREEN": NORDER_GREEN, "RED": NORDER_RED}
-    for chip in chips:
-        for fiber in fibers:
-            kpf2.set_data(
-                f"{chip}_{fiber}_{suffix}",
-                np.full((norder[chip], _NCOL_TEST), value, dtype=np.float32),
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -540,8 +536,8 @@ class TestDiagL2Snr:
     _SNR_KEYS = ("GSNRSCI", "GSNRSKY", "GSNRCAL", "RSNRSCI", "RSNRSKY", "RSNRCAL")
 
     def test_keys_written_when_flux_and_var_present(self):
-        kpf2 = _make_kpf2_with_flux()  # all FLUX ones
-        _set_fiber_arrays(kpf2, "VAR", 0.25)
+        kpf2 = _make_kpf2_nan_pixels()  # all FLUX ones
+        set_fiber_arrays(kpf2, "VAR", 0.25, ncol=_NCOL_TEST)
         DiagL2(kpf2).run()
         for key in self._SNR_KEYS:
             assert key in kpf2.headers["QUALITY_CONTROL"], f"missing {key}"
@@ -549,9 +545,9 @@ class TestDiagL2Snr:
 
     def test_single_fiber_snr_value(self):
         # SKY flux=2, var=0.04 -> SNR = 2/sqrt(0.04) = 10.0 in every pixel.
-        kpf2 = _make_kpf2_with_flux()
-        _set_fiber_arrays(kpf2, "FLUX", 2.0, fibers=("SKY",))
-        _set_fiber_arrays(kpf2, "VAR", 0.04, fibers=("SKY",))
+        kpf2 = _make_kpf2_nan_pixels()
+        set_fiber_arrays(kpf2, "FLUX", 2.0, fibers=("SKY",), ncol=_NCOL_TEST)
+        set_fiber_arrays(kpf2, "VAR", 0.04, fibers=("SKY",), ncol=_NCOL_TEST)
         DiagL2(kpf2).run()
         assert kpf2.headers["QUALITY_CONTROL"].get("GSNRSKY") == pytest.approx(
             10.0, abs=0.01
@@ -563,9 +559,13 @@ class TestDiagL2Snr:
     def test_summed_sci_snr_value(self):
         # Each SCI fiber flux=2, var=0.04 -> summed flux=6, var=0.12;
         # SNR = 6/sqrt(0.12) ~= 17.32.
-        kpf2 = _make_kpf2_with_flux()
-        _set_fiber_arrays(kpf2, "FLUX", 2.0, fibers=("SCI1", "SCI2", "SCI3"))
-        _set_fiber_arrays(kpf2, "VAR", 0.04, fibers=("SCI1", "SCI2", "SCI3"))
+        kpf2 = _make_kpf2_nan_pixels()
+        set_fiber_arrays(
+            kpf2, "FLUX", 2.0, fibers=("SCI1", "SCI2", "SCI3"), ncol=_NCOL_TEST
+        )
+        set_fiber_arrays(
+            kpf2, "VAR", 0.04, fibers=("SCI1", "SCI2", "SCI3"), ncol=_NCOL_TEST
+        )
         DiagL2(kpf2).run()
         assert kpf2.headers["QUALITY_CONTROL"].get("GSNRSCI") == pytest.approx(
             17.32, abs=0.05
@@ -574,15 +574,17 @@ class TestDiagL2Snr:
     def test_summed_sci_skipped_when_a_sci_var_missing(self):
         # VAR for SCI1/SCI2 only (SCI3 var stays empty) -> summed-SCI skipped,
         # but SKY (var present) is still computed.
-        kpf2 = _make_kpf2_with_flux()
-        _set_fiber_arrays(kpf2, "VAR", 0.25, fibers=("SCI1", "SCI2", "SKY", "CAL"))
+        kpf2 = _make_kpf2_nan_pixels()
+        set_fiber_arrays(
+            kpf2, "VAR", 0.25, fibers=("SCI1", "SCI2", "SKY", "CAL"), ncol=_NCOL_TEST
+        )
         DiagL2(kpf2).run()
         assert "GSNRSCI" not in kpf2.headers["QUALITY_CONTROL"]
         assert "GSNRSKY" in kpf2.headers["QUALITY_CONTROL"]
 
     def test_skipped_without_var(self):
         # Default fixture leaves VAR empty -> no SNR keys at all.
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_pixels()
         DiagL2(kpf2).run()
         for key in self._SNR_KEYS:
             assert key not in kpf2.headers["QUALITY_CONTROL"]
@@ -607,7 +609,7 @@ class TestDiagL2OrderletFluxRatios:
 
     def test_keys_written_and_unity_when_uniform(self):
         # All fibers flux=1 (default) -> every inter-fiber ratio == 1.0.
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_pixels()
         DiagL2(kpf2).run()
         for key in self._RATIO_KEYS:
             assert key in kpf2.headers["QUALITY_CONTROL"], f"missing {key}"
@@ -615,8 +617,10 @@ class TestDiagL2OrderletFluxRatios:
 
     def test_ratio_value(self):
         # GREEN SCI1 flux=2 over SCI2 flux=1 -> GFR12 == 2.0.
-        kpf2 = _make_kpf2_with_flux()
-        _set_fiber_arrays(kpf2, "FLUX", 2.0, chips=("GREEN",), fibers=("SCI1",))
+        kpf2 = _make_kpf2_nan_pixels()
+        set_fiber_arrays(
+            kpf2, "FLUX", 2.0, chips=("GREEN",), fibers=("SCI1",), ncol=_NCOL_TEST
+        )
         DiagL2(kpf2).run()
         assert kpf2.headers["QUALITY_CONTROL"].get("GFR12") == pytest.approx(2.0)
 

--- a/tests/regression/test_diagnostics.py
+++ b/tests/regression/test_diagnostics.py
@@ -24,8 +24,8 @@ from kpfpipe.quality_control.diagnostics import (
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
 NORDER_RED = DETECTOR["norder"]["RED"]
-_NCOL_TEST = 8  # small, even column count for synthetic FLUX/VAR (DiagL2 reads
-# only per-fiber NaN counts and zero-flux ratios, so real detector width is moot)
+_NCOL_TEST = 8  # DiagL2 metrics are pixel aggregates, so the real detector width
+# is moot; an even count keeps the half-zeroed ZEROFRAC test exact
 
 _FIBERS = ("SCI1", "SCI2", "SCI3", "SKY", "CAL")
 _NAN_KEYS = ("NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL")
@@ -43,9 +43,9 @@ class TestDiagnosticsBase:
             data = {}
 
             def set_keyword(self, key, value):
-                # Mirror the real routing: set_keyword writes the value only
-                # (the comment comes from the registry). The base test keys are
-                # not in any registry, so the stub just lands them on PRIMARY.
+                # The real set_keyword writes the value only (the comment comes
+                # from the registry); these test keys are in no registry, so the
+                # stub just lands them on PRIMARY.
                 self.headers["PRIMARY"][key] = value
 
         return _FakeObj()
@@ -136,15 +136,14 @@ class TestDiagnosticsBase:
 
 
 # ---------------------------------------------------------------------------
-# DiagL0 with no pointing (e.g. a calibration frame) and DiagL1 with no
-# calibrations are each a clean no-op
+# DiagL1 with no calibrations is a clean no-op
 # ---------------------------------------------------------------------------
 
 
 class TestEmptyLevels:
     def test_diag_l1_runs_cleanly(self):
-        # DATE-OBS present (required) but no RECEIPT cal paths -> calibration_ages
-        # returns {} (no crash). DATE-OBS itself is now a required read.
+        # DATE-OBS present (a required read) but no RECEIPT cal paths ->
+        # calibration_ages returns {} rather than crashing.
         results = DiagL1(_make_kpf1_with_calibrations()).run()
         assert results == {}
 
@@ -181,9 +180,9 @@ def _record_at(coord, **overrides):
 
 
 def _set_catalog_record(l0, records):
-    """Write l0's CATALOG_RECORD rows + presence flags from a
-    {source: record-dict-or-None} mapping, the way perform does. A source left out of
-    the mapping gets flag 0, exactly as a gated-off one does in production."""
+    """Write l0's CATALOG_RECORD rows and presence flags from a
+    {source: record-dict-or-None} mapping, the way perform does. A source left out
+    of the mapping gets flag 0, exactly as a gated-off one does in production."""
     aq = AstroQuery(l0)
     for source, record in records.items():
         aq._write_catalog_record(source, record)
@@ -362,9 +361,8 @@ class TestDiagL0Contingency:
 def _make_kpf1_with_calibrations(date_obs="2024-04-05T11:08:33", files=None):
     """A KPF1 carrying a PRIMARY DATE-OBS and RECEIPT master paths.
 
-    Mirrors the finished-L1 state DiagL1 reads: CalibrationAssociation has
-    written each ``{PREFIX}FILE`` to RECEIPT (via set_keyword) and to_kpf1 has
-    populated the EPRV PRIMARY (DATE-OBS).
+    Mirrors the finished-L1 state DiagL1 reads: CalibrationAssociation has written
+    each ``{PREFIX}FILE`` to RECEIPT and to_kpf1 has populated the EPRV PRIMARY.
     """
     l1 = KPF1()
     l1.headers["PRIMARY"]["DATE-OBS"] = date_obs
@@ -440,14 +438,12 @@ class TestDiagL1CalibrationAges:
 
 
 def _make_kpf2_with_flux(nan_frac=0.0, zero_frac=0.0, populate=True):
-    """Build a minimal KPF2 and populate FLUX extensions with controllable NaN
-    and zero fractions across all (chip, fiber) pairs.
+    """Minimal KPF2 with FLUX at controllable NaN and zero fractions.
 
-    A bare KPF2() already exposes the FLUX extensions DiagL2 reads (no FITS
-    round-trip needed -- mirrors test_qc_flags._make_kpf2_with_flux). Each FLUX
-    extension has shape (norder[chip], _NCOL_TEST), initialized to ones, then a
-    fraction replaced with NaN, then a fraction with 0.0. With populate=False no
-    FLUX arrays are set -- the "no data populated" schema cases.
+    A bare KPF2() already exposes the FLUX extensions DiagL2 reads, so no FITS
+    round-trip is needed. Each extension is (norder[chip], _NCOL_TEST) ones, then
+    nan_frac of the pixels replaced with NaN and zero_frac with 0.0.
+    populate=False sets no FLUX arrays -- the "no data populated" schema cases.
     """
     kpf2 = KPF2()
     if not populate:
@@ -487,8 +483,7 @@ class TestDiagL2NanCounts:
             assert kpf2.headers["QUALITY_CONTROL"].get(key) == 0
 
     def test_writes_keys_even_when_no_data(self):
-        """KPF2 with no FLUX extensions populated should still write all 5
-        keys with value 0 (consistent header schema)."""
+        # The header schema stays consistent: all five keys present, value 0.
         kpf2 = _make_kpf2_with_flux(populate=False)
         DiagL2(kpf2).run()
         for key in _NAN_KEYS:
@@ -508,22 +503,18 @@ class TestDiagL2ZeroFlux:
         assert kpf2.headers["QUALITY_CONTROL"].get("ZEROFRAC") == pytest.approx(1.0)
 
     def test_zerofrac_half_when_half_zero(self):
-        """Exactly half of every fiber's flux pixels zeroed → ZEROFRAC == 0.5.
-
-        Deterministic even/odd pattern (each array has an even pixel count), so
-        the result is exact and independent of array size and seed.
-        """
+        # A deterministic even/odd pattern (every array has an even pixel count)
+        # makes ZEROFRAC exactly 0.5, independent of array size and seed.
         kpf2 = _make_kpf2_with_flux(zero_frac=0.0)  # all ones
         for chip in ("GREEN", "RED"):
             for fiber in _FIBERS:
                 arr = np.ones_like(np.asarray(kpf2.data[f"{chip}_{fiber}_FLUX"]))
-                arr.reshape(-1)[::2] = 0.0  # every other pixel → exactly 50%
+                arr.reshape(-1)[::2] = 0.0
                 kpf2.set_data(f"{chip}_{fiber}_FLUX", arr)
         DiagL2(kpf2).run()
         assert kpf2.headers["QUALITY_CONTROL"].get("ZEROFRAC") == pytest.approx(0.5)
 
     def test_zerofrac_skipped_when_no_data(self):
-        """KPF2 with no populated FLUX extensions → no ZEROFRAC key written."""
         kpf2 = _make_kpf2_with_flux(populate=False)
         DiagL2(kpf2).run()
         assert "ZEROFRAC" not in kpf2.headers["QUALITY_CONTROL"]

--- a/tests/regression/test_dispatch_script.py
+++ b/tests/regression/test_dispatch_script.py
@@ -1,14 +1,10 @@
 """Tests for scripts/processing/_dispatch.py: the shared fan-out engine.
 
-Covers the job-sizing helpers (cores-based and the masters cap, including the
-never-below-one clamp), the ``run_stage`` dispatch in both modes (fail-soft:
-attempt all, return the failed set; fail-fast: any failure aborts the run with
-exit 1), the per-job timeout kill (a wedged fan-out job is killed and counted as a
-failure while the canary keeps its own larger timeout), the failure sentinel, and
-the ``_run_one`` interrupt guards (both the pre-launch guard and the
-launch-vs-track race re-check). Trivial subprocess stubs -- no real testdata
-needed. The launch throttle (``launch_interval``) defaults to 0 here so the
-dispatch tests stay fast and free of thread-timing flakiness.
+Covers the job-sizing helpers, the ``run_stage`` dispatch in both modes (fail-soft:
+attempt all, return the failed set; fail-fast: any failure aborts with exit 1), the
+per-job timeout kill, the failure sentinel, and the ``_run_one`` interrupt guards.
+Trivial subprocess stubs -- no real testdata needed. ``launch_interval`` defaults to
+0 here so the dispatch tests stay fast and free of thread-timing flakiness.
 """
 
 import logging
@@ -107,8 +103,8 @@ class TestRunStageFailSoft:
         assert self._run(tasks, tmp_path) == set()
 
     def test_failed_canary_still_fans_out_and_is_reported(self, tmp_path, caplog):
-        # A bad canary does not stop the rest; it is collected. The narration now
-        # flows through the batch logger, so assert against caplog, not stdout.
+        # A bad canary does not stop the rest; it is collected. Narration flows
+        # through the batch logger, so assert against caplog, not stdout.
         caplog.set_level(logging.INFO)
         tasks = [("a", _FAIL), ("b", _OK), ("c", _OK)]
         assert self._run(tasks, tmp_path) == {"a"}
@@ -152,9 +148,8 @@ class TestRunStageFailFast:
 
 class TestRunStageTimeout:
     def test_slow_fanout_job_is_killed_and_counts_as_failure(self, tmp_path):
-        # A fanned-out job that overruns job_timeout is a wedged subprocess: it is
-        # killed and reported as a failure, so one stuck unit can't hang the batch.
-        # The canary is fast; the 30s sleeper is the fan-out job, bounded to 1s.
+        # A job that overruns job_timeout is killed and reported as a failure, so
+        # one stuck unit can't hang the batch. The 30s sleeper is bounded to 1s.
         start = time.monotonic()
         failed = f.run_stage(
             "job",
@@ -169,8 +164,7 @@ class TestRunStageTimeout:
 
     def test_canary_uses_canary_timeout_not_job_timeout(self, tmp_path):
         # job_timeout bounds only the fan-out; the canary keeps its own, larger
-        # limit, so a canary slower than job_timeout is not killed by it (else the
-        # cold-cache canary would die on every real run).
+        # limit, else the cold-cache canary would die on every real run.
         slow_canary = [sys.executable, "-c", "import time; time.sleep(2)"]
         failed = f.run_stage(
             "job",
@@ -191,7 +185,7 @@ class TestRunStageTimeout:
 
 class TestReportFailures:
     def test_prints_header_hint_and_stderr_tail(self, tmp_path, caplog):
-        # The sentinels now flow through the batch logger, so assert on caplog.
+        # The sentinels flow through the batch logger, so assert on caplog.
         caplog.set_level(logging.INFO)
         failures = [("science", "KP.x", 1, "boom line 1\nboom line 2")]
         f._report_failures(failures, str(tmp_path), header="WARNING: 1 failed")
@@ -209,12 +203,9 @@ class TestRunOneInterrupt:
         assert f._run_one(_OK) == (130, "")
 
     def test_interrupt_in_launch_window_kills_child(self, monkeypatch):
-        # Reproduce the launch-vs-track race: the interrupt lands after Popen but
-        # before the child is tracked. Wrapping Popen to set _interrupted models
-        # exactly that -- the top-of-function guard is clear, so launch proceeds,
-        # and the post-track re-check must catch it, kill the child, and return 130
-        # (a missed child would otherwise run its full 30s sleep untracked).
-        # (_interrupted is reset by the autouse fixture, so it can't leak.)
+        # The launch-vs-track race: the interrupt lands after Popen but before the
+        # child is tracked, so the top-of-function guard is clear and the post-track
+        # re-check must catch it -- else the child runs its full 30s sleep untracked.
         real_popen = f.subprocess.Popen
         launched = []
 

--- a/tests/regression/test_dispatch_script.py
+++ b/tests/regression/test_dispatch_script.py
@@ -8,6 +8,8 @@ Trivial subprocess stubs -- no real testdata needed. ``launch_interval`` default
 """
 
 import logging
+import os
+import signal
 import sys
 import time
 
@@ -70,13 +72,16 @@ class TestDefaultMastersJobs:
         assert f._default_masters_jobs() == f._default_science_jobs() == 8
 
     def test_unknown_ram_uses_cores_floor_only(self, monkeypatch):
-        monkeypatch.setattr(f.os, "cpu_count", lambda: 256)
+        # 8 cores, not 256: at 256 the cores floor is 64 and never binds, so the
+        # fixed cap answers and this test cannot see the branch it names.
+        monkeypatch.setattr(f.os, "cpu_count", lambda: 8)
 
         def _raise(_name):
             raise ValueError("SC_PHYS_PAGES unavailable")
 
         monkeypatch.setattr(f.os, "sysconf", _raise)
-        assert f._default_masters_jobs() == f._MASTERS_JOBS
+        assert f._default_masters_jobs() == 8
+        assert f._default_masters_jobs() < f._MASTERS_JOBS
 
     def test_never_below_one(self, monkeypatch):
         # Tiny RAM would floor the cap to 0; the helper clamps to 1 (max(1, ...)),
@@ -147,35 +152,46 @@ class TestRunStageFailFast:
 
 
 class TestRunStageTimeout:
+    # The timeouts here are sub-second floats on purpose: _run_one hands `timeout`
+    # straight to Popen.communicate(), which takes floats, so whole-second values
+    # buy nothing but wall clock.
+
     def test_slow_fanout_job_is_killed_and_counts_as_failure(self, tmp_path):
         # A job that overruns job_timeout is killed and reported as a failure, so
-        # one stuck unit can't hang the batch. The 30s sleeper is bounded to 1s.
+        # one stuck unit can't hang the batch. The 30s sleeper is bounded to 0.3s.
         start = time.monotonic()
         failed = f.run_stage(
             "job",
             [("canary", _OK), ("slow", _SLEEP)],
             2,
             str(tmp_path),
-            job_timeout=1,
+            job_timeout=0.3,
             abort_on_failure=False,
         )
         assert failed == {"slow"}
-        assert time.monotonic() - start < 15  # killed at ~1s, not the full 30s
+        assert time.monotonic() - start < 5  # killed at ~0.3s, not the full 30s
+
+    def test_timed_out_job_returns_the_124_sentinel(self, tmp_path):
+        # `failed == {"slow"}` above cannot tell a timeout kill from a job that
+        # crashed for any other reason; 124 and its note are what say "killed".
+        rc, err = f._run_one(_SLEEP, timeout=0.3)
+        assert rc == 124
+        assert "timed out after" in err
 
     def test_canary_uses_canary_timeout_not_job_timeout(self, tmp_path):
         # job_timeout bounds only the fan-out; the canary keeps its own, larger
         # limit, else the cold-cache canary would die on every real run.
-        slow_canary = [sys.executable, "-c", "import time; time.sleep(2)"]
+        slow_canary = [sys.executable, "-c", "import time; time.sleep(0.5)"]
         failed = f.run_stage(
             "job",
             [("canary", slow_canary), ("b", _OK)],
             2,
             str(tmp_path),
-            job_timeout=1,
+            job_timeout=0.2,
             canary_timeout=30,
             abort_on_failure=False,
         )
-        assert failed == set()  # the 2s canary survived a 1s job_timeout
+        assert failed == set()  # the 0.5s canary survived a 0.2s job_timeout
 
 
 # ---------------------------------------------------------------------------
@@ -219,3 +235,96 @@ class TestRunOneInterrupt:
         rc, _ = f._run_one(_SLEEP, timeout=None)
         assert rc == 130
         assert launched and launched[0].poll() is not None  # child killed + reaped
+
+
+# ---------------------------------------------------------------------------
+# run_stage -- interrupt teardown
+# ---------------------------------------------------------------------------
+
+
+class TestRunStageInterrupt:
+    """The module's stated reason for existing (`run_stage`'s docstring: an
+    interrupt leaves no orphaned subprocesses). No real processes are spawned:
+    _run_one is replaced by the interrupt itself, and the escalation test drives
+    fakes, so nothing here can outlive the test."""
+
+    def test_interrupt_tears_down_children_and_exits_130(self, monkeypatch, tmp_path):
+        torn_down = []
+
+        def _interrupt(*_a, **_k):
+            raise KeyboardInterrupt
+
+        monkeypatch.setattr(f, "_run_one", _interrupt)
+        monkeypatch.setattr(f, "_terminate_all_children", lambda: torn_down.append(1))
+
+        with pytest.raises(SystemExit) as exc:
+            f.run_stage("job", [("a", _OK)], 2, str(tmp_path))
+
+        assert exc.value.code == 130
+        assert f._interrupted.is_set()  # stops the pool launching anything more
+        assert torn_down == [1]
+
+    def test_terminate_escalates_sigterm_then_sigkill(self, monkeypatch):
+        # A child that dies on SIGTERM is left alone; one still alive after the
+        # grace period gets SIGKILL. Dropping the escalation would leave a wedged
+        # recipe running after the orchestrator exits.
+        signalled = []
+
+        class _FakeProc:
+            def __init__(self, pid, survives):
+                self.pid = pid
+                self._survives = survives
+
+            def wait(self, timeout=None):
+                return 0
+
+            def poll(self):
+                return None if self._survives else 0
+
+        dies, survives = _FakeProc(101, False), _FakeProc(102, True)
+        monkeypatch.setattr(f, "_live_procs", {dies, survives})
+        monkeypatch.setattr(
+            f.os, "killpg", lambda pid, sig: signalled.append((pid, sig))
+        )
+
+        f._terminate_all_children(grace=0.0)
+
+        # Both children are SIGTERMed first (in set order), then only the
+        # survivor is SIGKILLed -- assert the sequence, not a sorted set, since
+        # TERM-before-KILL is the property under test.
+        assert set(signalled[:2]) == {(101, signal.SIGTERM), (102, signal.SIGTERM)}
+        assert signalled[2:] == [(102, signal.SIGKILL)]
+
+
+# ---------------------------------------------------------------------------
+# configure_runtime
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureRuntime:
+    def test_installs_sigterm_handler_and_pins_blas_threads(self, monkeypatch):
+        # `f.signal` IS the singleton signal module, so this patch is
+        # process-wide for the test's duration -- containment comes from
+        # monkeypatch's TEARDOWN, not from any lexical scoping. Do not simplify
+        # it away, and do not let this test install a real handler: a leaked
+        # SIGTERM handler would turn an xdist worker's own shutdown into a
+        # KeyboardInterrupt.
+        installed = []
+        monkeypatch.setattr(
+            f.signal, "signal", lambda sig, handler: installed.append((sig, handler))
+        )
+        monkeypatch.setenv("OMP_NUM_THREADS", "8")  # an explicit operator setting
+        for var in (
+            "OPENBLAS_NUM_THREADS",
+            "MKL_NUM_THREADS",
+            "NUMEXPR_NUM_THREADS",
+            "VECLIB_MAXIMUM_THREADS",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        f.configure_runtime()
+
+        assert installed == [(signal.SIGTERM, f._handle_termination_signal)]
+        assert os.environ["OMP_NUM_THREADS"] == "8"  # setdefault: the caller wins
+        assert os.environ["MKL_NUM_THREADS"] == "1"
+        assert os.environ["VECLIB_MAXIMUM_THREADS"] == "1"

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -1,10 +1,8 @@
-"""
-Regression tests for image assembly (L0 → L1).
+"""Regression tests for image assembly (L0 -> L1).
 
 The 2-amp regression and round-trip tests are marked ``slow`` and read real L0
-FITS frames from the gitignored ``tests/testdata/L0/20240405`` tree (paths
-hard-coded below). The 4-amp, dtype-provenance, orientation, and expmeter tests
-run on synthetic data generated into ``tmp_path`` and need no external frames.
+FITS frames from the gitignored ``tests/testdata/L0/20240405`` tree. Every other
+test runs on synthetic data and needs no external frames.
 """
 
 import os
@@ -40,10 +38,10 @@ L0_FLAT = str(TESTDATA_L0_DIR / "KP.20240405.00020.86.fits")
 
 @pytest.fixture(scope="module")
 def synthetic_4amp_l0(tmp_path_factory):
-    """Create a synthetic L0 FITS file with 4-amp readout on both CCDs.
+    """Synthetic L0 with 4-amp readout on both CCDs.
 
-    Module-scoped read-only source: every consumer only from_fits() reads it, so
-    the ~140 MB write happens once instead of per test."""
+    Module-scoped and read-only, so the ~140 MB write happens once, not per test.
+    """
     fn = str(tmp_path_factory.mktemp("l0_4amp") / "KP.20240101.00001.00.fits")
     rng = np.random.default_rng(42)
 
@@ -110,7 +108,6 @@ class TestImageAssemblyBias:
         assert np.all(l1.data["RED_VAR"] >= 0)
 
     def test_bias_near_zero(self, l1_bias):
-        """After overscan subtraction, a bias frame should be near zero."""
         l1, _ = l1_bias
         assert abs(np.nanmedian(l1.data["GREEN_CCD"])) < 5.0
         assert abs(np.nanmedian(l1.data["RED_CCD"])) < 5.0
@@ -130,19 +127,19 @@ class TestImageAssemblyBias:
 
     def test_read_noise_in_header(self, l1_bias):
         l1, _ = l1_bias
-        # 2-amp mode: expect RNGREEN1, RNGREEN2, RNRED1, RNRED2
+        # 2-amp mode names the amps RNGREEN1/2 and RNRED1/2.
         assert "RNGREEN1" in l1.headers["QUALITY_CONTROL"]
         assert "RNRED1" in l1.headers["QUALITY_CONTROL"]
 
     def test_read_noise_reasonable(self, l1_bias):
-        """Read noise should be between 1 and 20 electrons for KPF."""
+        # 1-20 e- brackets any physically sane KPF read noise.
         _, ia = l1_bias
         for channel_ext, rn in ia.readnoise.items():
             assert 1.0 < rn < 20.0, f"Read noise for {channel_ext} = {rn} e-"
 
     def test_rnng_in_header(self, l1_bias):
         l1, _ = l1_bias
-        # 2-amp mode: expect RNNGGR1, RNNGGR2, RNNGRD1, RNNGRD2
+        # 2-amp mode names the amps RNNGGR1/2 and RNNGRD1/2.
         assert "RNNGGR1" in l1.headers["QUALITY_CONTROL"]
         assert "RNNGRD1" in l1.headers["QUALITY_CONTROL"]
 
@@ -179,12 +176,11 @@ class TestImageAssemblyFlat:
         return ia.perform()
 
     def test_flat_has_signal(self, l1_flat):
-        """A flat lamp should have significant positive signal."""
         assert np.nanmedian(l1_flat.data["GREEN_CCD"]) > 100.0
         assert np.nanmedian(l1_flat.data["RED_CCD"]) > 100.0
 
     def test_flat_variance_exceeds_readnoise(self, l1_flat):
-        """Variance should include photon noise (larger than read noise alone)."""
+        # Photon noise dominates read noise in a flat, so VAR is well above it.
         assert np.nanmedian(l1_flat.data["GREEN_VAR"]) > 10.0
         assert np.nanmedian(l1_flat.data["RED_VAR"]) > 10.0
 
@@ -195,13 +191,12 @@ class TestImageAssemblyFlat:
 
 
 class TestImageAssembly4Amp:
-    """Test 4-amp mode assembly using synthetic data."""
-
     @pytest.fixture(scope="class")
     def l1_4amp(self, synthetic_4amp_l0):
-        """Assemble the synthetic 4-amp L0 once; shared read-only across the class.
+        """Assemble the synthetic 4-amp L0 once, shared read-only across the class.
 
-        perform() itself counts amplifiers, so ia.namp/ia.dims are populated."""
+        perform() counts the amplifiers, so ia.namp/ia.dims come back populated.
+        """
         l0 = KPF0.from_fits(synthetic_4amp_l0)
         ia = ImageAssembly(l0)
         return ia.perform(), ia
@@ -221,7 +216,6 @@ class TestImageAssembly4Amp:
     def test_4amp_read_noise_all_amps(self, l1_4amp):
         l1, ia = l1_4amp
 
-        # 4-amp mode: should have 8 read noise measurements
         assert len(ia.readnoise) == 8
         for channel_ext in [
             "GREEN_AMP1",
@@ -235,7 +229,6 @@ class TestImageAssembly4Amp:
         ]:
             assert channel_ext in ia.readnoise
 
-        # All 8 RN keywords in header
         for key in [
             "RNGREEN1",
             "RNGREEN2",
@@ -249,7 +242,6 @@ class TestImageAssembly4Amp:
             assert key in l1.headers["QUALITY_CONTROL"]
 
     def test_4amp_bias_near_zero(self, l1_4amp):
-        """Synthetic bias with known noise should be near zero after overscan."""
         l1, _ = l1_4amp
         assert abs(np.nanmedian(l1.data["GREEN_CCD"])) < 10.0
         assert abs(np.nanmedian(l1.data["RED_CCD"])) < 10.0
@@ -266,8 +258,6 @@ class TestImageAssembly4Amp:
 
 
 class TestDtypeProvenance:
-    """L1 CCD/VAR are float32; L0 amps never upscale to float64."""
-
     def test_l1_ccd_var_float32_and_roundtrip(self, synthetic_4amp_l0, tmp_path):
         l0 = KPF0.from_fits(synthetic_4amp_l0)
         l1 = ImageAssembly(l0).perform()
@@ -292,41 +282,36 @@ class TestOrientFFI:
     """Unit tests for the static FFI orientation helper.
 
     orient_ffi is the single source of truth for FFI orientation, shared by
-    stitch_ffi and the L0 quicklook. Flux and variance (and downstream wave)
-    frames are all run through it, so the correctness of the co-orientation
-    hinges entirely on this method applying the same deterministic flip.
+    stitch_ffi and the L0 quicklook. Flux and variance frames all run through it,
+    so co-orientation hinges on it applying the same deterministic flip.
     """
 
     # A small asymmetric array makes every flip unambiguous.
-    #   [[1, 2, 3],
-    #    [4, 5, 6]]
     BASE = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
 
     def test_red_flips_columns_only(self):
-        """RED: dispersion columns blue->red means a left-right flip only."""
+        # RED disperses blue->red across columns, so only a left-right flip.
         out = ImageAssembly.orient_ffi(self.BASE, "RED", 2)
         expected = np.array([[3, 2, 1], [6, 5, 4]], dtype=np.float32)
         np.testing.assert_array_equal(out, expected)
 
     def test_green_flips_both_axes(self):
-        """GREEN: raw image is inverted vs RED, so rows flip as well."""
+        # GREEN's raw image is inverted relative to RED, so rows flip as well.
         out = ImageAssembly.orient_ffi(self.BASE, "GREEN", 2)
         expected = np.array([[6, 5, 4], [3, 2, 1]], dtype=np.float32)
         np.testing.assert_array_equal(out, expected)
 
     def test_green_read_out_on_four_amps_flips_columns_only(self):
-        """4-amp GREEN arrives with its rows already running bottom-up."""
+        # 4-amp GREEN arrives with its rows already running bottom-up.
         out = ImageAssembly.orient_ffi(self.BASE, "GREEN", 4)
         np.testing.assert_array_equal(out, np.flip(self.BASE, axis=1))
 
     def test_green_is_red_plus_row_flip(self):
-        """GREEN orientation is exactly the RED orientation flipped in rows."""
         red = ImageAssembly.orient_ffi(self.BASE, "RED", 2)
         green = ImageAssembly.orient_ffi(self.BASE, "GREEN", 2)
         np.testing.assert_array_equal(green, np.flip(red, axis=0))
 
     def test_chip_name_is_case_insensitive(self):
-        """Lowercase / mixed-case chip names orient identically to uppercase."""
         for name in ("green", "Green", "GREEN"):
             np.testing.assert_array_equal(
                 ImageAssembly.orient_ffi(self.BASE, name, 2),
@@ -339,22 +324,19 @@ class TestOrientFFI:
             )
 
     def test_does_not_mutate_input(self):
-        """orient_ffi must not modify the caller's array in place."""
         original = self.BASE.copy()
         ImageAssembly.orient_ffi(self.BASE, "GREEN", 2)
         np.testing.assert_array_equal(self.BASE, original)
 
     def test_double_application_is_identity(self):
-        """Flips are involutions: orienting twice returns the original."""
         for chip in ("GREEN", "RED"):
             once = ImageAssembly.orient_ffi(self.BASE, chip, 2)
             twice = ImageAssembly.orient_ffi(once, chip, 2)
             np.testing.assert_array_equal(twice, self.BASE)
 
     def test_flux_and_wave_are_co_oriented(self):
-        """The load-bearing property: two distinct frames of the same shape
-        (e.g. flux and its wavelength/variance counterpart) receive the
-        identical index remapping, so they stay pixel-aligned afterwards."""
+        # The load-bearing property: frames of the same shape get the identical
+        # index remapping, so flux and its wave/var counterpart stay aligned.
         flux = np.arange(12, dtype=np.float32).reshape(3, 4)
         # Index markers track where each (row, col) lands under the transform.
         rows = np.broadcast_to(np.arange(3)[:, None], (3, 4)).astype(np.float32)
@@ -364,22 +346,19 @@ class TestOrientFFI:
             f = ImageAssembly.orient_ffi(flux, chip, 2)
             r = ImageAssembly.orient_ffi(rows, chip, 2)
             c = ImageAssembly.orient_ffi(cols, chip, 2)
-            # For every output pixel, the flux value matches the flux that
-            # originally lived at the (row, col) the markers report.
             for i in range(3):
                 for j in range(4):
                     src_row, src_col = int(r[i, j]), int(c[i, j])
                     assert f[i, j] == flux[src_row, src_col]
 
     def test_unknown_chip_treated_as_non_green(self):
-        """Any non-GREEN chip (incl. unexpected names) flips columns only."""
         out = ImageAssembly.orient_ffi(self.BASE, "BLUE", 2)
         expected = np.flip(self.BASE, axis=1)
         np.testing.assert_array_equal(out, expected)
 
 
 # ---------------------------------------------------------------------------
-# Expmeter wavelength unit conversion (nm → Å at L0 → L1)
+# Expmeter wavelength unit conversion (nm -> Angstrom at L0 -> L1)
 # ---------------------------------------------------------------------------
 
 
@@ -387,9 +366,7 @@ class TestOrientFFI:
 def synthetic_4amp_l0_with_expmeter(tmp_path):
     """Synthetic 4-amp L0 with EXPMETER_SCI/SKY tables labeled in nm.
 
-    The wavelength column labels mirror real KPF expmeter native units
-    (e.g. '498.12' nm). The detector amp data is the same minimal 4-amp
-    scaffold used by `synthetic_4amp_l0`.
+    The column labels mirror real KPF expmeter native units (e.g. '498.12' nm).
     """
     fn = str(tmp_path / "KP.20240101.00002.00.fits")
     rng = np.random.default_rng(7)
@@ -411,7 +388,6 @@ def synthetic_4amp_l0_with_expmeter(tmp_path):
             data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
             hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
 
-    # EXPMETER tables: Date-Beg/Date-End + a handful of channels in nm
     wave_nm_labels = ["498.12", "604.38", "710.62", "816.88"]
     nrows = 3
     for ext_name in ["EXPMETER_SCI", "EXPMETER_SKY"]:
@@ -436,7 +412,7 @@ def synthetic_4amp_l0_with_expmeter(tmp_path):
 
 
 def _expmeter_table():
-    """Synthetic EXPMETER table: nm-labeled wavelength columns + non-numeric cols."""
+    """Synthetic EXPMETER table: nm-labeled wavelength columns plus non-numeric ones."""
     return Table(
         {
             "498.12": np.full(3, 100.0, dtype=np.float32),
@@ -450,12 +426,11 @@ def _expmeter_table():
 
 
 class TestExpmeterWavelengthConversion:
-    """L0 → L1 relabels EXPMETER_SCI/SKY wavelength columns from nm to Å.
+    """L0 -> L1 relabels EXPMETER_SCI/SKY wavelength columns from nm to Angstroms.
 
-    The conversion is a discrete static step, so it is unit-tested directly on a
-    synthetic table — a full ImageAssembly.perform() (~1s) is needless for a column
-    rename. ``test_conversion_applied_by_perform`` guards that perform() still wires
-    it in, so the science-path coverage is preserved.
+    The conversion is a discrete static step, so it is unit-tested on a synthetic
+    table rather than through a full perform() (~1s) for a column rename.
+    ``test_conversion_applied_by_perform`` guards that perform() still wires it in.
     """
 
     def _convert(self, **exts):
@@ -465,7 +440,6 @@ class TestExpmeterWavelengthConversion:
         return l1
 
     def test_sci_columns_converted_to_angstroms(self):
-        # nm labels (498.12, ...) → Å (4981.2, ...).
         cols = (
             self._convert(EXPMETER_SCI=_expmeter_table()).data["EXPMETER_SCI"].colnames
         )
@@ -494,7 +468,6 @@ class TestExpmeterWavelengthConversion:
         assert "Date-End" in cols
 
     def test_values_preserved(self):
-        # Underlying flux values shouldn't be touched by the rename.
         l1 = self._convert(EXPMETER_SCI=_expmeter_table())
         np.testing.assert_array_equal(
             np.asarray(l1.data["EXPMETER_SCI"]["4981.2"]),
@@ -502,12 +475,11 @@ class TestExpmeterWavelengthConversion:
         )
 
     def test_no_error_when_expmeter_absent(self):
-        # Missing key and an explicit None are both no-ops (biases carry no expmeter).
+        # Biases carry no expmeter: a missing key and an explicit None are no-ops.
         self._convert()
         self._convert(EXPMETER_SCI=None)
 
     def test_conversion_applied_by_perform(self, synthetic_4amp_l0_with_expmeter):
-        """Integration: perform() wires in the conversion (guards the science path)."""
         l0 = KPF0.from_fits(synthetic_4amp_l0_with_expmeter)
         l1 = ImageAssembly(l0).perform()
         assert "4981.2" in l1.data["EXPMETER_SCI"].colnames
@@ -520,8 +492,6 @@ class TestExpmeterWavelengthConversion:
 
 @pytest.mark.slow
 class TestImageAssemblyRoundTrip:
-    """Test that L1 can be written to FITS and read back."""
-
     def test_write_and_read_back(self):
         l0 = KPF0.from_fits(L0_BIAS)
         ia = ImageAssembly(l0)

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -58,6 +58,7 @@ def synthetic_4amp_l0(tmp_path_factory):
     primary.header["IMTYPE"] = "Bias"
     primary.header["DATE-OBS"] = "2024-01-01T00:00:01"
     primary.header["OFNAME"] = os.path.basename(fn)
+    primary.header["PROGNAME"] = "K123"
 
     hdus = [primary]
     for chip in ["GREEN", "RED"]:
@@ -272,7 +273,14 @@ class TestDtypeProvenance:
         l1 = ImageAssembly(l0).perform()
         for ext in ("GREEN_CCD", "GREEN_VAR", "RED_CCD", "RED_VAR"):
             assert_dtype(l1.data[ext], L1_IMAGE, ext)
-        assert_roundtrip_dtype(KPF1, l1, "GREEN_CCD", L1_IMAGE, tmp_path)
+        assert_roundtrip_dtype(
+            KPF1,
+            l1,
+            "GREEN_CCD",
+            L1_IMAGE,
+            tmp_path,
+            name="kpf_L1_20240113T102656.fits",
+        )
 
     def test_l0_amps_not_float64(self, synthetic_4amp_l0):
         l0 = KPF0.from_fits(synthetic_4amp_l0)
@@ -395,6 +403,7 @@ def synthetic_4amp_l0_with_expmeter(tmp_path):
     primary.header["IMTYPE"] = "Bias"
     primary.header["DATE-OBS"] = "2024-01-01T00:00:01"
     primary.header["OFNAME"] = os.path.basename(fn)
+    primary.header["PROGNAME"] = "K123"
 
     hdus = [primary]
     for chip in ["GREEN", "RED"]:
@@ -519,7 +528,7 @@ class TestImageAssemblyRoundTrip:
         l1 = ia.perform()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "test_l1.fits")
+            fn = os.path.join(tmpdir, "kpf_L1_20240113T102656.fits")
             l1.to_fits(fn)
 
             l1_read = KPF1.from_fits(fn)
@@ -539,7 +548,7 @@ class TestImageAssemblyRoundTrip:
         l1 = ia.perform()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "test_l1.fits")
+            fn = os.path.join(tmpdir, "kpf_L1_20240113T102656.fits")
             l1.to_fits(fn)
 
             l1_read = KPF1.from_fits(fn)

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -5,8 +5,6 @@ FITS frames from the gitignored ``tests/testdata/L0/20240405`` tree. Every other
 test runs on synthetic data and needs no external frames.
 """
 
-import os
-import tempfile
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -19,6 +17,7 @@ from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.modules.image_assembly import ImageAssembly
 
+from ._data_models import write_amp_l0
 from ._dtype_policy import (
     L1_IMAGE,
     assert_dtype,
@@ -42,33 +41,14 @@ def synthetic_4amp_l0(tmp_path_factory):
 
     Module-scoped and read-only, so the ~140 MB write happens once, not per test.
     """
-    fn = str(tmp_path_factory.mktemp("l0_4amp") / "KP.20240101.00001.00.fits")
-    rng = np.random.default_rng(42)
-
     # 4-amp dimensions: 2040 imaging rows + 30 parallel overscan,
     # 4 prescan + 2040 imaging cols + 50 serial overscan
-    nrow, ncol = 2070, 2094
-    bias_level = 1000.0
-
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["OBJECT"] = "synthetic-4amp"
-    primary.header["IMTYPE"] = "Bias"
-    primary.header["DATE-OBS"] = "2024-01-01T00:00:01"
-    primary.header["OFNAME"] = os.path.basename(fn)
-    primary.header["PROGNAME"] = "K123"
-
-    hdus = [primary]
-    for chip in ["GREEN", "RED"]:
-        for amp in range(1, 5):
-            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
-            hdu = fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}")
-            hdus.append(hdu)
-
-    hdul = fits.HDUList(hdus)
-    hdul.writeto(fn, overwrite=True)
-    hdul.close()
-    return fn
+    return write_amp_l0(
+        tmp_path_factory.mktemp("l0_4amp") / "KP.20240101.00001.00.fits",
+        shape=(2070, 2094),
+        bias_level=1000.0,
+        primary_cards={"OBJECT": "synthetic-4amp"},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +57,7 @@ def synthetic_4amp_l0(tmp_path_factory):
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestImageAssemblyBias:
     """Regression tests using a bias frame (no signal, 2-amp mode)."""
 
@@ -95,7 +76,7 @@ class TestImageAssemblyBias:
     def test_ccd_shape(self, l1_bias, chip):
         l1, _ = l1_bias
         assert l1.data[f"{chip}_CCD"].shape == (4080, 4080)
-        assert l1.data[f"{chip}_CCD"].dtype == np.float32
+        assert_dtype(l1.data[f"{chip}_CCD"], L1_IMAGE, f"{chip}_CCD")
 
     def test_variance_frames_exist(self, l1_bias):
         l1, _ = l1_bias
@@ -113,8 +94,14 @@ class TestImageAssemblyBias:
         assert abs(np.nanmedian(l1.data["RED_CCD"])) < 5.0
 
     def test_primary_header_carried_forward(self, l1_bias):
-        l1, _ = l1_bias
-        assert l1.headers["PRIMARY"]["INSTRUME"] == "KPF"
+        # INSTRUME is stamped by from_fits on any KPF file, so asserting it
+        # cannot catch an assembly bug. DATE-OBS comes from the source frame,
+        # so compare the L1 card against the L0 it was assembled from.
+        l1, ia = l1_bias
+        assert (
+            l1.headers["PRIMARY"]["DATE-OBS"]
+            == ia.l0_obj.headers["PRIMARY"]["DATE-OBS"]
+        )
 
     def test_obs_id_carried_forward(self, l1_bias):
         l1, _ = l1_bias
@@ -166,6 +153,7 @@ class TestImageAssemblyBias:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestImageAssemblyFlat:
     """Regression tests using a flat lamp frame (has signal)."""
 
@@ -368,28 +356,9 @@ def synthetic_4amp_l0_with_expmeter(tmp_path):
 
     The column labels mirror real KPF expmeter native units (e.g. '498.12' nm).
     """
-    fn = str(tmp_path / "KP.20240101.00002.00.fits")
-    rng = np.random.default_rng(7)
-
-    nrow, ncol = 2070, 2094
-    bias_level = 1000.0
-
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["OBJECT"] = "synthetic-expmeter"
-    primary.header["IMTYPE"] = "Bias"
-    primary.header["DATE-OBS"] = "2024-01-01T00:00:01"
-    primary.header["OFNAME"] = os.path.basename(fn)
-    primary.header["PROGNAME"] = "K123"
-
-    hdus = [primary]
-    for chip in ["GREEN", "RED"]:
-        for amp in range(1, 5):
-            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
-            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
-
     wave_nm_labels = ["498.12", "604.38", "710.62", "816.88"]
     nrows = 3
+    expmeter_hdus = []
     for ext_name in ["EXPMETER_SCI", "EXPMETER_SKY"]:
         cols = [
             fits.Column(
@@ -405,10 +374,16 @@ def synthetic_4amp_l0_with_expmeter(tmp_path):
                     name=w, format="E", array=np.full(nrows, 100.0, dtype=np.float32)
                 )
             )
-        hdus.append(fits.BinTableHDU.from_columns(cols, name=ext_name))
+        expmeter_hdus.append(fits.BinTableHDU.from_columns(cols, name=ext_name))
 
-    fits.HDUList(hdus).writeto(fn, overwrite=True)
-    return fn
+    return write_amp_l0(
+        tmp_path / "KP.20240101.00002.00.fits",
+        shape=(2070, 2094),
+        bias_level=1000.0,
+        seed=7,
+        primary_cards={"OBJECT": "synthetic-expmeter"},
+        extra_hdus=expmeter_hdus,
+    )
 
 
 def _expmeter_table():
@@ -439,19 +414,11 @@ class TestExpmeterWavelengthConversion:
         ImageAssembly._convert_expmeter_wavelengths_to_angstroms(l1)
         return l1
 
-    def test_sci_columns_converted_to_angstroms(self):
-        cols = (
-            self._convert(EXPMETER_SCI=_expmeter_table()).data["EXPMETER_SCI"].colnames
-        )
+    @pytest.mark.parametrize("ext", ["EXPMETER_SCI", "EXPMETER_SKY"])
+    def test_columns_converted_to_angstroms(self, ext):
+        cols = self._convert(**{ext: _expmeter_table()}).data[ext].colnames
         for expected in ("4981.2", "6043.8", "7106.2", "8168.8"):
             assert expected in cols, f"missing Å column {expected!r}; got {cols}"
-
-    def test_sky_columns_converted_to_angstroms(self):
-        cols = (
-            self._convert(EXPMETER_SKY=_expmeter_table()).data["EXPMETER_SKY"].colnames
-        )
-        for expected in ("4981.2", "6043.8", "7106.2", "8168.8"):
-            assert expected in cols
 
     def test_nm_labels_removed(self):
         cols = (
@@ -491,35 +458,27 @@ class TestExpmeterWavelengthConversion:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestImageAssemblyRoundTrip:
-    def test_write_and_read_back(self):
-        l0 = KPF0.from_fits(L0_BIAS)
-        ia = ImageAssembly(l0)
-        l1 = ia.perform()
+    @pytest.fixture(scope="class")
+    def assembled(self):
+        return ImageAssembly(KPF0.from_fits(L0_BIAS)).perform()
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "kpf_L1_20240113T102656.fits")
-            l1.to_fits(fn)
+    def test_write_and_read_back(self, assembled, tmp_path):
+        fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
+        assembled.to_fits(fn)
+        l1_read = KPF1.from_fits(fn)
 
-            l1_read = KPF1.from_fits(fn)
-
-            assert l1_read.data["GREEN_CCD"].shape == (4080, 4080)
-            assert l1_read.data["RED_CCD"].shape == (4080, 4080)
+        for chip in ("GREEN", "RED"):
+            ext = f"{chip}_CCD"
+            assert l1_read.data[ext].shape == (4080, 4080)
             np.testing.assert_array_almost_equal(
-                l1_read.data["GREEN_CCD"], l1.data["GREEN_CCD"], decimal=4
-            )
-            np.testing.assert_array_almost_equal(
-                l1_read.data["RED_CCD"], l1.data["RED_CCD"], decimal=4
+                l1_read.data[ext], assembled.data[ext], decimal=4
             )
 
-    def test_roundtrip_preserves_header(self):
-        l0 = KPF0.from_fits(L0_BIAS)
-        ia = ImageAssembly(l0)
-        l1 = ia.perform()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "kpf_L1_20240113T102656.fits")
-            l1.to_fits(fn)
-
-            l1_read = KPF1.from_fits(fn)
-            assert l1_read.headers["PRIMARY"]["INSTRUME"] == "KPF"
+    def test_roundtrip_preserves_obs_id(self, assembled, tmp_path):
+        # INSTRUME is guaranteed by from_fits, so it cannot catch an assembly
+        # bug; obs_id is carried by the write path this test exercises.
+        fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
+        assembled.to_fits(fn)
+        assert KPF1.from_fits(fn).obs_id == assembled.obs_id

--- a/tests/regression/test_image_assembly.py
+++ b/tests/regression/test_image_assembly.py
@@ -251,6 +251,10 @@ class TestDtypeProvenance:
         l1 = ImageAssembly(l0).perform()
         for ext in ("GREEN_CCD", "GREEN_VAR", "RED_CCD", "RED_VAR"):
             assert_dtype(l1.data[ext], L1_IMAGE, ext)
+        # BITPIX and the re-read dtype are shape-independent, so the round-trip
+        # runs on a corner of each array rather than 270 MB of full detector.
+        for ext in ("GREEN_CCD", "GREEN_VAR", "RED_CCD", "RED_VAR"):
+            l1.data[ext] = l1.data[ext][:16, :16]
         assert_roundtrip_dtype(
             KPF1,
             l1,
@@ -453,6 +457,90 @@ class TestExpmeterWavelengthConversion:
 
 
 # ---------------------------------------------------------------------------
+# Overscan methods and the config-typo guards (synthetic, no perform())
+# ---------------------------------------------------------------------------
+
+
+class TestOverscanMethods:
+    """The three ``_oscan_*`` kernels and the OSCANSUB provenance flag.
+
+    ``rowmedian`` is the configured default, so it is the only method the
+    real-frame tests above ever run; ``median`` and ``zero`` are equally
+    selectable in production and are exercised here on a hand-built amp.
+    """
+
+    @pytest.fixture
+    def ia(self, tmp_path):
+        """ImageAssembly on a tiny 4-amp frame, with the geometry set by hand.
+
+        ``dims``/``prescan`` normally come from count_amplifiers(); setting
+        them directly keeps the overscan slicing arithmetic in view.
+        """
+        path = write_amp_l0(tmp_path / "KP.20240101.00001.00.fits", shape=(12, 12))
+        module = ImageAssembly(KPF0.from_fits(path))
+        module.namp["GREEN"] = 4
+        module.dims["GREEN"] = (8, 8)
+        module.prescan = 2
+        return module
+
+    def _set_serial_overscan(self, ia, values):
+        """Write ``values`` into GREEN_AMP1's serial overscan strip (cols 10:12)."""
+        amp = np.array(ia.l0_obj.data["GREEN_AMP1"], dtype=np.float32)
+        amp[:8, 10:] = values
+        ia.l0_obj.data["GREEN_AMP1"] = amp
+
+    def test_zero_returns_scalar_zero(self, ia):
+        assert ia._oscan_zero("GREEN", 1) == 0.0
+
+    def test_median_is_the_strip_median(self, ia):
+        self._set_serial_overscan(ia, 7.0)
+        assert ia._oscan_median("GREEN", 1) == pytest.approx(7.0)
+
+    def test_rowmedian_is_per_row_and_column_shaped(self, ia):
+        # A row ramp: row i of the overscan strip holds the value i.
+        self._set_serial_overscan(ia, np.arange(8, dtype=np.float32)[:, None])
+        bias = ia._oscan_rowmedian("GREEN", 1)
+        assert bias.shape == (8, 1)
+        np.testing.assert_array_equal(bias[:, 0], np.arange(8))
+
+    def test_unsupported_method_raises(self, ia):
+        # The dispatch is getattr(self, f"_oscan_{method}"), so a config typo
+        # must name itself rather than surface as a bare AttributeError.
+        with pytest.raises(AttributeError, match="Unsupported overscan"):
+            ia.subtract_overscan("GREEN", method="rowmedain")
+
+    @pytest.mark.parametrize(
+        "method, expected", [("rowmedian", 1), ("median", 1), ("zero", 0)]
+    )
+    def test_oscansub_flag_tracks_method(self, ia, method, expected):
+        # OSCANSUB is a provenance card: 'zero' subtracts nothing and must say so.
+        ia.overscan_method = method
+        l1 = KPF1()
+        ia._set_headers(l1)
+        assert l1.headers["RECEIPT"].get("OSCANSUB") == expected
+
+
+class TestAmplifierGuards:
+    """The two fail-loud guards on an unexpected readout geometry."""
+
+    def test_one_amp_mode_raises(self, tmp_path):
+        path = write_amp_l0(
+            tmp_path / "KP.20240101.00001.00.fits", namps=1, shape=(10, 10)
+        )
+        module = ImageAssembly(KPF0.from_fits(path))
+        with pytest.raises(ValueError, match="Only 2-amp and 4-amp"):
+            module.count_amplifiers("GREEN")
+
+    def test_unexpected_flip_entry_raises(self, tmp_path):
+        path = write_amp_l0(tmp_path / "KP.20240101.00001.00.fits", shape=(10, 10))
+        module = ImageAssembly(KPF0.from_fits(path))
+        module.count_amplifiers("GREEN")
+        module.orientation["GREEN_AMP1"] = "sideways"
+        with pytest.raises(ValueError, match="unexpected 'flip' entry"):
+            module.orient_channels("GREEN")
+
+
+# ---------------------------------------------------------------------------
 # FITS round-trip tests (real data)
 # ---------------------------------------------------------------------------
 
@@ -476,9 +564,6 @@ class TestImageAssemblyRoundTrip:
                 l1_read.data[ext], assembled.data[ext], decimal=4
             )
 
-    def test_roundtrip_preserves_obs_id(self, assembled, tmp_path):
         # INSTRUME is guaranteed by from_fits, so it cannot catch an assembly
         # bug; obs_id is carried by the write path this test exercises.
-        fn = str(tmp_path / "kpf_L1_20240113T102656.fits")
-        assembled.to_fits(fn)
-        assert KPF1.from_fits(fn).obs_id == assembled.obs_id
+        assert l1_read.obs_id == assembled.obs_id

--- a/tests/regression/test_image_processing.py
+++ b/tests/regression/test_image_processing.py
@@ -159,7 +159,7 @@ class TestInit:
         assert ip.chips == ["GREEN"]
 
     def test_invalid_config_raises(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="config must be"):
             ImageProcessing(MockL1(), config=42)
 
     def test_paths_none_before_perform(self):
@@ -497,27 +497,6 @@ class TestPerformDark:
         mod = _make_module(dark_file="missing.fits", dark_dir=str(tmp_path))
         with pytest.raises(FileNotFoundError, match="missing.fits"):
             mod.perform(bias=False)
-
-
-# ---------------------------------------------------------------------------
-# TestVarianceBudget -- bias/dark add only a small fraction to the error budget
-# ---------------------------------------------------------------------------
-
-
-class TestVarianceBudget:
-    def test_bias_and_dark_contribution_is_small(self, tmp_path):
-        _write_master_bias(str(tmp_path / "master_bias.fits"))
-        _write_master_dark(str(tmp_path / "master_dark.fits"))
-        mod = _make_module(
-            bias_file="master_bias.fits",
-            bias_dir=str(tmp_path),
-            dark_file="master_dark.fits",
-            dark_dir=str(tmp_path),
-        )
-        mod.perform()
-        added = mod.l1_obj.data["GREEN_VAR"] - _VAR_VALUE
-        assert np.all(added > 0)
-        assert np.all(added < 0.01 * _VAR_VALUE)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_image_processing.py
+++ b/tests/regression/test_image_processing.py
@@ -1,8 +1,7 @@
-"""
-Tests for the ImageProcessing module (L1 bias and dark subtraction).
+"""Tests for the ImageProcessing module (L1 bias and dark subtraction).
 
-Unit tests use synthetic arrays and MockL1 objects; no real data or FITS
-files are required except where a master file must exist on disk.
+Synthetic arrays and a MockL1 throughout; the only FITS files are the minimal
+masters written into tmp_path, since some paths require one on disk.
 """
 
 import os
@@ -34,12 +33,9 @@ _EXPTIME = 4.0  # != 1 so dark scaling is observable
 class MockL1:
     def __init__(self):
         self.obs_id = "KP.20240405.40113.57"
-        # Dark scaling reads the EPRV-standard PRIMARY EXPTIME (the actual
-        # elapsed time, mapped from native WMKO ELAPSED), so the mock sets it on
-        # PRIMARY. KPF-pipeline keyword routing sends the calibration flags/paths
-        # to RECEIPT (BIASSUB/DARKSUB, BIAS/DARKFILE), so a real L1 always has
-        # RECEIPT and QUALITY_CONTROL extensions; the mock mirrors that. Headers
-        # are fits.Header, like the real models.
+        # Mirrors a real L1: dark scaling reads the EPRV-standard PRIMARY EXPTIME,
+        # and keyword routing puts the calibration flags/paths (BIASSUB/DARKSUB,
+        # BIAS/DARKFILE) on RECEIPT.
         primary = fits.Header()
         primary["EXPTIME"] = _EXPTIME
         self.headers = {
@@ -57,8 +53,7 @@ class MockL1:
         self._receipt = []
 
     def set_keyword(self, key, value):
-        # Mirror KPFDataModel.set_keyword routing for the keywords this module
-        # writes: BIASSUB/DARKSUB live on RECEIPT (their registry home).
+        # Mirrors KPFDataModel.set_keyword routing: BIASSUB/DARKSUB live on RECEIPT.
         ext = "RECEIPT" if key in ("BIASSUB", "DARKSUB") else "PRIMARY"
         self.headers[ext][key] = value
 
@@ -82,7 +77,7 @@ def _make_module(bias_file=None, bias_dir=None, dark_file=None, dark_dir=None):
 
 
 def _write_master(path, value, snr):
-    """Write a minimal master FITS file (per-chip IMG = value, SNR = snr)."""
+    """Write a minimal master FITS file: per-chip IMG = value, SNR = snr."""
     hdus = [fits.PrimaryHDU()]
     for chip in ("GREEN", "RED"):
         hdus.append(
@@ -99,24 +94,20 @@ def _write_master(path, value, snr):
 
 
 def _write_master_bias(path):
-    """Write a minimal master bias FITS file to path."""
     _write_master(path, _BIAS_VALUE, _BIAS_SNR)
 
 
 def _write_master_dark(path):
-    """Write a minimal master dark FITS file to path."""
     _write_master(path, _DARK_VALUE, _DARK_SNR)
 
 
 def _master_bias(tmp_path):
-    """Write and load a master bias as a KPFMasterL1 object."""
     path = str(tmp_path / "master_bias.fits")
     _write_master_bias(path)
     return KPFMasterL1.from_fits(path)
 
 
 def _master_dark(tmp_path):
-    """Write and load a master dark as a KPFMasterL1 object."""
     path = str(tmp_path / "master_dark.fits")
     _write_master_dark(path)
     return KPFMasterL1.from_fits(path)
@@ -128,8 +119,8 @@ def _master_dark(tmp_path):
 
 
 class TestDtypeProvenance:
-    """L1 CCD/VAR must stay float32 through bias AND dark subtraction -- the
-    dark*exptime(float64) scaling is the prime upcast trap."""
+    """L1 CCD/VAR must stay float32 through bias and dark subtraction; the
+    dark * exptime (float64) scaling is the prime upcast trap."""
 
     def _module_bias_dark(self, tmp_path):
         _write_master_bias(str(tmp_path / "master_bias.fits"))
@@ -335,7 +326,6 @@ class TestPerform:
         np.testing.assert_allclose(
             mod_with_bias.l1_obj.data["GREEN_CCD"], _CCD_VALUE - _BIAS_VALUE
         )
-        # RED_CCD should be untouched
         np.testing.assert_allclose(mod_with_bias.l1_obj.data["RED_CCD"], _CCD_VALUE)
 
     def test_raises_when_headers_missing(self):
@@ -346,12 +336,9 @@ class TestPerform:
     def test_bias_false_skips_subtraction(self):
         mod = _make_module()  # no BIASFILE needed when bias is off
         result = mod.perform(bias=False, dark=False)
-        # CCDs untouched
         np.testing.assert_allclose(result.data["GREEN_CCD"], _CCD_VALUE)
         np.testing.assert_allclose(result.data["RED_CCD"], _CCD_VALUE)
-        # BIASSUB header reflects the choice
         assert result.headers["RECEIPT"]["BIASSUB"] == 0
-        # No bias path recorded
         assert mod._bias_path is None
 
     def test_darksub_header_false_when_dark_off(self, mod_with_bias):
@@ -363,7 +350,6 @@ class TestPerform:
             mod_with_bias.perform(flat=True)
 
     def test_bias_filepath_overrides_headers(self, tmp_path):
-        # explicit filepath should be used even when headers point elsewhere
         bias_path = str(tmp_path / "explicit_bias.fits")
         _write_master_bias(bias_path)
         mod = _make_module(bias_file="wrong.fits", bias_dir="/wrong/dir")
@@ -374,7 +360,7 @@ class TestPerform:
         assert mod._bias_path == bias_path
 
     def test_bias_master_l1_object_used_directly(self, tmp_path):
-        # supplying a KPFMasterL1 instance should bypass disk I/O entirely
+        # A preloaded KPFMasterL1 bypasses disk I/O entirely.
         bias_path = str(tmp_path / "preloaded_bias.fits")
         _write_master_bias(bias_path)
         preloaded = KPFMasterL1.from_fits(bias_path)
@@ -382,7 +368,7 @@ class TestPerform:
         result = mod.perform(bias=preloaded, dark=False)
         np.testing.assert_allclose(result.data["GREEN_CCD"], _CCD_VALUE - _BIAS_VALUE)
         assert result.headers["RECEIPT"]["BIASSUB"] == 1
-        # _bias_path should reflect the in-memory object's filename
+        # _bias_path comes from the in-memory object's own filename.
         assert mod._bias_path == bias_path
 
     def test_bias_invalid_type_raises_type_error(self):
@@ -391,7 +377,7 @@ class TestPerform:
             mod.perform(bias=42)
 
     def test_flat_master_l1_raises_not_implemented(self, mod_with_bias, tmp_path):
-        # KPFMasterL1 instance should also trip the flat stub.
+        # A KPFMasterL1 instance must trip the flat stub too, not just flat=True.
         flat_path = str(tmp_path / "master_flat.fits")
         _write_master_bias(flat_path)
         flat_master = KPFMasterL1.from_fits(flat_path)
@@ -399,13 +385,11 @@ class TestPerform:
             mod_with_bias.perform(flat=flat_master)
 
     def test_bias_file_not_on_disk_raises(self, tmp_path):
-        # BIASFILE names a file not on disk -> FileNotFoundError.
         mod = _make_module(bias_file="missing.fits", bias_dir=str(tmp_path))
         with pytest.raises(FileNotFoundError, match="missing.fits"):
             mod.perform(dark=False)
 
     def test_bias_explicit_path_missing_raises(self, tmp_path):
-        # An explicit bias path that does not exist -> FileNotFoundError.
         mod = _make_module()
         with pytest.raises(FileNotFoundError):
             mod.perform(bias=str(tmp_path / "nonexistent.fits"), dark=False)
@@ -437,7 +421,7 @@ class TestPerformDark:
         )
 
     def test_defaults_apply_bias_and_dark(self, mod_with_bias_dark):
-        # No explicit toggles: the _DEFAULTS now enable bias and dark.
+        # No explicit toggles: _DEFAULTS enables both bias and dark.
         mod_with_bias_dark.perform()
         expected = _CCD_VALUE - _BIAS_VALUE - _DARK_VALUE * _EXPTIME
         np.testing.assert_allclose(
@@ -448,7 +432,7 @@ class TestPerformDark:
 
     def test_bias_then_dark_combined(self, mod_with_bias_dark):
         mod_with_bias_dark.perform(bias=True, dark=True)
-        # bias removed first, then exposure-scaled dark.
+        # Bias comes off first, then the exposure-scaled dark.
         expected = _CCD_VALUE - _BIAS_VALUE - _DARK_VALUE * _EXPTIME
         np.testing.assert_allclose(
             mod_with_bias_dark.l1_obj.data["GREEN_CCD"], expected
@@ -501,13 +485,11 @@ class TestPerformDark:
         )
 
     def test_dark_missing_header_raises(self):
-        # No DARKFILE header -> FileNotFoundError naming DARKFILE.
         mod = _make_module()
         with pytest.raises(FileNotFoundError, match="DARKFILE"):
             mod.perform(bias=False)
 
     def test_dark_file_not_on_disk_raises(self, tmp_path):
-        # DARKFILE names a file not on disk -> FileNotFoundError.
         mod = _make_module(dark_file="missing.fits", dark_dir=str(tmp_path))
         with pytest.raises(FileNotFoundError, match="missing.fits"):
             mod.perform(bias=False)
@@ -609,8 +591,8 @@ class TestCalibrationGuard:
 
 class TestMasterCache:
     def test_resolve_caches_within_instance(self, tmp_path):
-        # Resolving the same calibration twice (e.g. once per chip) reuses the
-        # cached master object instead of re-reading from disk.
+        # Resolving the same calibration twice (once per chip) must reuse the
+        # cached master rather than re-read from disk.
         path = str(tmp_path / "master_bias.fits")
         _write_master_bias(path)
         mod = _make_module()
@@ -620,7 +602,6 @@ class TestMasterCache:
         assert mod._bias_ml1 is first
 
     def test_separate_instances_do_not_share(self, tmp_path):
-        # The cache is per instance -- there is no class-level sharing.
         path = str(tmp_path / "master_bias.fits")
         _write_master_bias(path)
         a = _make_module()
@@ -628,7 +609,6 @@ class TestMasterCache:
         assert a._resolve_master("bias", path) is not b._resolve_master("bias", path)
 
     def test_load_master_reads_master_from_disk(self, tmp_path):
-        # _load_master returns a valid master with the on-disk data.
         path = str(tmp_path / "master_bias.fits")
         _write_master_bias(path)
         master = ImageProcessing._load_master(path)
@@ -637,8 +617,8 @@ class TestMasterCache:
         np.testing.assert_allclose(master.data["GREEN_SNR"], _BIAS_SNR)
 
     def test_load_master_is_stateless(self, tmp_path):
-        # Deliberate contract: caching lives in _resolve_master, not here, so
-        # each call re-reads rather than returning a shared object.
+        # Deliberate contract: caching lives in _resolve_master, so each call here
+        # re-reads rather than returning a shared object.
         path = str(tmp_path / "master_bias.fits")
         _write_master_bias(path)
         assert ImageProcessing._load_master(path) is not ImageProcessing._load_master(

--- a/tests/regression/test_image_processing.py
+++ b/tests/regression/test_image_processing.py
@@ -53,9 +53,13 @@ class MockL1:
         self._receipt = []
 
     def set_keyword(self, key, value):
-        # Mirrors KPFDataModel.set_keyword routing: BIASSUB/DARKSUB live on RECEIPT.
-        ext = "RECEIPT" if key in ("BIASSUB", "DARKSUB") else "PRIMARY"
-        self.headers[ext][key] = value
+        # Mirrors KPFDataModel.set_keyword routing: L1-headers.csv routes both
+        # keys ImageProcessing writes to RECEIPT. Anything else is unregistered
+        # here, so fail loud rather than inventing a PRIMARY fallback the real
+        # router would never take.
+        if key not in ("BIASSUB", "DARKSUB"):
+            raise KeyError(f"{key!r} is not routed by this mock; extend it")
+        self.headers["RECEIPT"][key] = value
 
     def receipt_add_entry(self, name, args, status):
         self._receipt.append((name, args, status))

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -29,6 +29,8 @@ from kpfpipe.utils.io import (
 )
 from kpfpipe.utils.kpf import get_timestamp, utc_to_hst
 
+from ._scripts import write_l0_tree
+
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 
 
@@ -294,6 +296,7 @@ class TestBuildCalibrationStacks:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestBuildCalibrationStacksRealData:
     @pytest.fixture(scope="class")
     def fh(self):
@@ -329,6 +332,7 @@ class TestBuildCalibrationStacksRealData:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestBuildMiniDatabaseDatecodeType:
     """build_mini_database accepts an int datecode as well as a 'YYYYMMDD' string."""
 
@@ -707,6 +711,7 @@ class TestKpfDirectory:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestBuildMiniDatabase:
     @pytest.fixture(scope="class")
     def mini_db(self):
@@ -752,20 +757,16 @@ def _write_l0_frame(tmp_path, datecode, obs_id):
     """Write a minimal L0 FITS (PRIMARY only) into L0/{datecode} so
     build_mini_database has a real header to scan; returns the FileHandler.
     Safe to call repeatedly per night to stage multiple frames."""
-    from astropy.io import fits
-
-    l0_dir = tmp_path / "L0" / datecode
-    l0_dir.mkdir(parents=True, exist_ok=True)
-    header = fits.Header(
-        {
-            "TARGNAME": "bias",
-            "IMTYPE": "Bias",
-            "OBJECT": "autocal-bias",
-            "EXPTIME": 0.0,
-            "ELAPSED": 0.0,
-        }
+    write_l0_tree(
+        tmp_path,
+        datecode,
+        int(obs_id.split(".")[2]),
+        obj="autocal-bias",
+        imtype="Bias",
+        targname="bias",
+        exptime=0.0,
+        elapsed=0.0,
     )
-    fits.PrimaryHDU(header=header).writeto(l0_dir / f"{obs_id}.fits")
     return FileHandler({"KPF_DATA_INPUT": str(tmp_path)})
 
 

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -18,6 +18,7 @@ from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.data_models.level4 import KPF4
+from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.utils.io import (
     FileHandler,
     datecode_dirs_in_range,
@@ -189,13 +190,7 @@ class TestBuildCalibrationStacks:
     def test_two_bias_clusters_returned_separately(self):
         lists = _cluster("bias", _make_mini_db())
         assert len(lists) == 2
-
-    def test_bias_cluster_a_files(self):
-        lists = _cluster("bias", _make_mini_db())
         assert lists[0] == sorted(_BIAS_A)
-
-    def test_bias_cluster_b_files(self):
-        lists = _cluster("bias", _make_mini_db())
         assert lists[1] == sorted(_BIAS_B)
 
     def test_files_are_sorted(self):
@@ -206,6 +201,13 @@ class TestBuildCalibrationStacks:
         # Both bias clusters hold 5 files, so min_stack_size=6 drops everything.
         with pytest.raises(ValueError, match="no cluster with at least"):
             _cluster("bias", _make_mini_db(), min_stack_size=6)
+
+    def test_stacks_require_a_mini_database(self):
+        # Forgetting build_mini_database(datecode) must give a readable error,
+        # not a TypeError from inside pandas. All three groupby modes funnel
+        # through _select_frames, so this one guard covers them all.
+        with pytest.raises(ValueError, match="no mini database"):
+            FileHandler({}).build_calibration_stacks("bias")
 
     def test_raises_when_no_frames_found(self):
         with pytest.raises(ValueError, match="No 'flat' calibration frames found"):
@@ -280,13 +282,7 @@ class TestBuildCalibrationStacks:
         # Morning and evening ThArs differ in OBJECT suffix and are >2 hr apart.
         lists = _cluster("thar", _make_mini_db())
         assert len(lists) == 2
-
-    def test_thar_morn_cluster(self):
-        lists = _cluster("thar", _make_mini_db())
         assert lists[0] == sorted(_THAR_MORN)
-
-    def test_thar_eve_cluster(self):
-        lists = _cluster("thar", _make_mini_db())
         assert lists[1] == sorted(_THAR_EVE)
 
 
@@ -399,10 +395,6 @@ class TestKpfFilepath:
         )
         assert path == "/data/masters/20240405/KP.20240405.14000.00_master_flat_L1.fits"
 
-    def test_master_bare_filename(self):
-        name = kpf_filepath("KP.20240405.03600.00", "L1", master="bias")
-        assert name == "KP.20240405.03600.00_master_bias_L1.fits"
-
     def test_science_l0(self):
         path = kpf_filepath("KP.20240405.49597.71", "L0", data_root="/data")
         assert path == "/data/L0/20240405/KP.20240405.49597.71.fits"
@@ -412,15 +404,6 @@ class TestKpfFilepath:
         # 49597 s of day = 13:46:37.
         path = kpf_filepath("KP.20240405.49597.71", "L1", data_root="/data")
         assert path == "/data/L1/20240405/kpf_L1_20240405T134637.fits"
-
-    def test_science_bare_filename_l0(self):
-        name = kpf_filepath("KP.20240405.49597.71", "L0")
-        assert name == "KP.20240405.49597.71.fits"
-
-    def test_science_bare_filename_l1(self):
-        # 49597 s of day = 13:46:37.
-        name = kpf_filepath("KP.20240405.49597.71", "L1")
-        assert name == "kpf_L1_20240405T134637.fits"
 
     def test_science_l2(self):
         # 40113 s of day = 11:08:33.
@@ -439,7 +422,9 @@ class TestKpfFilepath:
         path = kpf_filepath("KP.20240405.00000.00", "L2", data_root="/data")
         assert path == "/data/L2/20240405/kpf_SL2_20240405T000000.fits"
 
-    def test_science_bare_filename_l2(self):
+    def test_omitted_data_root_returns_bare_filename(self):
+        # kpf_filepath's own branch: with no data_root it returns kpf_filename's
+        # result unjoined. The per-level filename literals live in TestKpfFilename.
         name = kpf_filepath("KP.20240405.40113.57", "L2")
         assert name == "kpf_SL2_20240405T110833.fits"
 
@@ -448,10 +433,6 @@ class TestKpfFilepath:
             "KP.20240405.03600.00", "L2", data_root="/data", master="thar"
         )
         assert path == "/data/masters/20240405/KP.20240405.03600.00_master_thar_L2.fits"
-
-    def test_invalid_obs_id_raises(self):
-        with pytest.raises(ValueError, match="valid observation ID"):
-            kpf_filepath("20240405", "L1")
 
     def test_invalid_data_root_empty_string_raises(self):
         with pytest.raises(
@@ -583,6 +564,22 @@ class TestFilenameConsistency:
         obj = self._make(level)
         expected = os.path.basename(kpf_filepath(self.OBS_ID, level))
         assert obj.generate_standard_filename() == expected
+
+    @pytest.mark.parametrize("level", ["L0", "L1", "L2", "L4"])
+    def test_generated_name_passes_the_convention_check(self, level):
+        # The name generator (kpf_filename's f-strings) and the name validator
+        # (independent regexes, plus rvdata's EPRV check for L2/L4) are never
+        # otherwise compared. The test above pins the two *generators* against
+        # each other; both call kpf_filename, so only this pins the generator
+        # against the validator. For L0/L1/masters a mismatch is a log warning
+        # and the write proceeds, so the drift would be silent.
+        obj = self._make(level)
+        assert obj.check_filename_convention(obj.generate_standard_filename())
+
+    def test_generated_master_name_passes_the_convention_check(self):
+        master = KPFMasterL1()
+        master.set_input_files([f"{self.OBS_ID}.fits"], "bias")
+        assert master.check_filename_convention(master.generate_standard_filename())
 
 
 # ---------------------------------------------------------------------------
@@ -735,6 +732,13 @@ class TestBuildMiniDatabase:
         # No junk list ships in tests/testdata, so every frame is ISJUNK=False.
         assert "ISJUNK" in mini_db.columns
         assert not mini_db["ISJUNK"].any()
+
+
+class TestBuildMiniDatabaseErrors:
+    """build_mini_database's two loud-failure paths. Deliberately unmarked: these
+    run on tmp_path with no frames at all, so they belong in the fast subset --
+    under the class marks above they were excluded from it and skipped outright
+    whenever tests/testdata was absent."""
 
     def test_empty_directory_raises(self, tmp_path):
         (tmp_path / "L0" / "20240405").mkdir(parents=True)
@@ -961,5 +965,5 @@ class TestJunkExclusion:
     def test_exclude_junk_without_column_raises(self):
         # A mini database built before ISJUNK existed must fail loudly.
         db = _mini_db(_rows(_JUNK_BIAS, "autocal-bias", "Bias")).drop(columns="ISJUNK")
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError, match="ISJUNK"):
             _cluster("bias", db, min_stack_size=1)

--- a/tests/regression/test_io.py
+++ b/tests/regression/test_io.py
@@ -2,8 +2,8 @@
 clustering, masters finder), the product-path builders (kpf_directory /
 kpf_filename / kpf_filepath), and junk-frame exclusion.
 
-Unit tests use synthetic DataFrames and temp directories — no real data needed.
-Integration tests (slow) use real L0 data from tests/testdata/L0/20240405/.
+Unit tests use synthetic DataFrames and temp directories; the slow integration
+tests use real L0 data from tests/testdata/L0/20240405/.
 """
 
 import logging
@@ -36,27 +36,27 @@ TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 # Synthetic test data setup (unit tests only)
 # ---------------------------------------------------------------------------
 
-# Synthetic filenames: KP.YYYYMMDD.SSSSS.FF.fits
-# Two bias clusters separated by a >2hr gap; one dark cluster; two ThAr clusters
-# (morning and evening) with different OBJECT suffixes; science frames.
+# Filenames are KP.YYYYMMDD.SSSSS.FF.fits; the seconds-of-day fields set the gaps
+# the clustering keys on: two bias clusters >2 hr apart, one dark cluster, morning
+# and evening ThAr clusters with different OBJECT suffixes, and science frames.
 _BIAS_A = [
     f"/data/L0/20240405/KP.20240405.0{3600 + i * 100:04d}.00.fits" for i in range(5)
-]  # 03600–04000
+]  # 03600-04000
 _BIAS_B = [
     f"/data/L0/20240405/KP.20240405.{14000 + i * 100:05d}.00.fits" for i in range(5)
-]  # 14000–14400
+]  # 14000-14400
 _DARK_A = [
     f"/data/L0/20240405/KP.20240405.{18000 + i * 100:05d}.00.fits" for i in range(3)
-]  # 18000–18200
+]  # 18000-18200
 _THAR_MORN = [
     f"/data/L0/20240405/KP.20240405.{60000 + i * 100:05d}.00.fits" for i in range(5)
-]  # 60000–60400
+]  # 60000-60400
 _THAR_EVE = [
     f"/data/L0/20240405/KP.20240405.{75000 + i * 100:05d}.00.fits" for i in range(5)
-]  # 75000–75400
+]  # 75000-75400
 _SCI_A = [
     f"/data/L0/20240405/KP.20240405.{50000 + i * 100:05d}.00.fits" for i in range(2)
-]  # 50000–50100
+]  # 50000-50100
 
 
 def _rows(files, obj, imtype, targname=None):
@@ -71,9 +71,8 @@ def _mini_db(rows, *, exptime=60.0, junk=()):
     """Assemble a synthetic mini database from row dicts.
 
     Adds the derived columns build_calibration_stacks needs: EXPTIME/ELAPSED, the
-    UTC/HST timestamps (parsed from each FILENAME), and ISJUNK (the FILENAMEs in
-    `junk` are flagged True). This is the single assembly path for every layout
-    fixture below.
+    UTC/HST timestamps (parsed from each FILENAME), and ISJUNK (FILENAMEs in
+    `junk` flagged True).
     """
     df = pd.DataFrame(rows)
     df["EXPTIME"] = exptime
@@ -97,7 +96,7 @@ def _make_mini_db():
 
 _BIAS_SMALL = [
     f"/data/L0/20240405/KP.20240405.{30000 + i * 100:05d}.00.fits" for i in range(2)
-]  # 30000–30100, a >2hr gap after _BIAS_A → a separate 2-file cluster
+]  # 30000-30100; >2 hr after _BIAS_A, so a separate 2-file cluster
 
 
 def _mixed_bias_db():
@@ -108,8 +107,8 @@ def _mixed_bias_db():
 def _midnight_bias_db(n_before=5, n_after=5):
     """Bias frames straddling HST midnight (UTC 36000) within one UTC directory.
 
-    The before/after groups are <cluster_gap_seconds apart, so only the HST-day
-    boundary can separate them. Returns (df, before_files, after_files).
+    The before/after groups are less than cluster_gap_seconds apart, so only the
+    HST-day boundary can separate them. Returns (df, before_files, after_files).
     """
     before = [
         f"/data/L0/20240405/KP.20240405.{35400 + i * 100:05d}.00.fits"  # HST 20240404
@@ -124,11 +123,11 @@ def _midnight_bias_db(n_before=5, n_after=5):
 
 
 def _cross_midnight_gap_db(n_before=2, n_after=2):
-    """Sparse dark clusters on opposite HST days, split by a >2 h gap.
+    """Sparse dark clusters on opposite HST days, split by a >2 hr gap.
 
-    Mirrors a real sparse-dark night (e.g. 20240806): a pre-midnight group and a
-    post-midnight group, each below the dark min_stack_size and separated by both
-    the gap and HST midnight. Returns (df, before_files, after_files).
+    Mirrors a real sparse-dark night (e.g. 20240806): each group is below the dark
+    min_stack_size and separated by both the gap and HST midnight. Returns
+    (df, before_files, after_files).
     """
     before = [
         f"/data/L0/20240405/KP.20240405.{34000 + i * 100:05d}.00.fits"  # HST 20240404
@@ -148,11 +147,10 @@ def _cross_midnight_gap_db(n_before=2, n_after=2):
 
 
 def _cluster(cal_type, mini_db, **kwargs):
-    """Cluster a synthetic mini_db through the (instance-method) API.
+    """Cluster a synthetic mini_db through the instance-method API.
 
-    build_calibration_stacks reads the handler's carried mini database
-    (``self._mini_db``); these logic tests set a synthetic one on a bare handler
-    the same way ``build_mini_database`` would.
+    build_calibration_stacks reads the handler's carried ``self._mini_db``; these
+    logic tests set a synthetic one the way ``build_mini_database`` would.
     """
     fh = FileHandler({})
     fh._mini_db = mini_db
@@ -160,15 +158,14 @@ def _cluster(cal_type, mini_db, **kwargs):
 
 
 class TestSecondsSinceJ2000:
-    """FileHandler._seconds_since_j2000 is the monotonic sort/gap scalar the
-    clustering builds on; exercised directly via a config-free handler."""
+    """The monotonic sort/gap scalar the clustering builds on."""
 
     def test_basic(self):
         # J2000.0 itself: 2000-01-01 12:00 UTC = '20000101.43200.00'
         assert FileHandler({})._seconds_since_j2000("20000101.43200.00") == 0
 
     def test_monotonic_across_year_boundary(self):
-        # Dec 31 23:59:00 -> Jan 1 00:00:00 should differ by 60s exactly.
+        # Dec 31 23:59:00 -> Jan 1 00:00:00 must differ by exactly 60 s.
         fh = FileHandler({})
         end = fh._seconds_since_j2000("20231231.86340.00")
         start_next_year = fh._seconds_since_j2000("20240101.00000.00")
@@ -184,8 +181,8 @@ class TestSecondsSinceJ2000:
 
 
 class TestBuildCalibrationStacks:
-    """Clustering depends only on the mini database, so these exercise it with
-    synthetic DataFrames (no files on disk) set on a bare handler."""
+    """Clustering depends only on the mini database, so these use synthetic
+    DataFrames with no files on disk."""
 
     def test_two_bias_clusters_returned_separately(self):
         lists = _cluster("bias", _make_mini_db())
@@ -204,8 +201,7 @@ class TestBuildCalibrationStacks:
             assert lst == sorted(lst)
 
     def test_raises_when_no_cluster_meets_min(self):
-        # min_stack_size=6: both bias clusters (5 files each) fall below and are
-        # dropped, leaving nothing → raises.
+        # Both bias clusters hold 5 files, so min_stack_size=6 drops everything.
         with pytest.raises(ValueError, match="no cluster with at least"):
             _cluster("bias", _make_mini_db(), min_stack_size=6)
 
@@ -214,7 +210,7 @@ class TestBuildCalibrationStacks:
             _cluster("flat", _make_mini_db())
 
     def test_raises_when_only_cluster_below_min(self):
-        # dark cluster has only 3 files; min_stack_size=5 → dropped → raises.
+        # The only dark cluster holds 3 files, below min_stack_size=5.
         with pytest.raises(ValueError, match="no cluster with at least"):
             _cluster("dark", _make_mini_db(), min_stack_size=5)
 
@@ -225,9 +221,7 @@ class TestBuildCalibrationStacks:
         assert lists[0] == sorted(_BIAS_A)
 
     def test_default_min_stack_size_is_noop(self):
-        # The default min_stack_size=1 is a no-op filter: a lone 2-frame cluster
-        # survives with no explicit threshold (distinguishing it from any nonzero
-        # default that would drop it).
+        # The default min_stack_size=1 must not drop a lone 2-frame cluster.
         db = _mini_db(_rows(_BIAS_SMALL, "autocal-bias", "Bias"))
         lists = _cluster("bias", db)
         assert len(lists) == 1
@@ -238,16 +232,14 @@ class TestBuildCalibrationStacks:
             _cluster("bias", _make_mini_db(), groupby="bogus")
 
     def test_time_of_day_ignores_hst_boundary(self):
-        # time_of_day splits on time gaps alone: frames <gap apart but on opposite
-        # sides of HST midnight now share one cluster (there is no midnight split).
+        # time_of_day splits on time gaps alone, never on the HST-day boundary.
         db, before, after = _midnight_bias_db()
         lists = _cluster("bias", db, min_stack_size=5)
         assert len(lists) == 1
         assert lists[0] == sorted(before + after)
 
     def test_hst_day_splits_at_midnight(self):
-        # groupby='hst_day' puts each HST calendar day in its own stack, even when
-        # the frames are <gap apart across HST midnight.
+        # hst_day splits at midnight even when the frames are less than a gap apart.
         db, before, after = _midnight_bias_db()
         lists = _cluster("bias", db, min_stack_size=5, groupby="hst_day")
         assert len(lists) == 2
@@ -255,21 +247,19 @@ class TestBuildCalibrationStacks:
         assert lists[1] == sorted(after)
 
     def test_obs_night_single_stack_spans_midnight(self):
-        # groupby='obs_night' groups the whole loaded night into one stack,
-        # spanning both a >2 h gap and HST midnight (the 20240806 sparse-dark case).
+        # obs_night spans both a >2 hr gap and HST midnight (the sparse-dark case).
         db, before, after = _cross_midnight_gap_db()
         lists = _cluster("dark", db, min_stack_size=3, groupby="obs_night")
         assert len(lists) == 1
         assert lists[0] == sorted(before + after)
 
     def test_max_stack_size_truncates_to_earliest(self):
-        # Each bias cluster holds 5 files; max_stack_size=3 keeps the earliest 3.
+        # Each bias cluster holds 5 files, so the earliest 3 survive.
         lists = _cluster("bias", _make_mini_db(), max_stack_size=3)
         assert lists[0] == sorted(_BIAS_A)[:3]
         assert lists[1] == sorted(_BIAS_B)[:3]
 
     def test_max_stack_size_noop_when_within_limit(self):
-        # A ceiling at or above the cluster size leaves every stack intact.
         lists = _cluster("bias", _make_mini_db(), max_stack_size=5)
         assert lists[0] == sorted(_BIAS_A)
         assert lists[1] == sorted(_BIAS_B)
@@ -285,8 +275,7 @@ class TestBuildCalibrationStacks:
             _cluster("bogus", _make_mini_db())
 
     def test_thar_returns_two_clusters(self):
-        # Morning and evening ThArs have different OBJECT suffixes and are >2hr
-        # apart; each forms its own cluster.
+        # Morning and evening ThArs differ in OBJECT suffix and are >2 hr apart.
         lists = _cluster("thar", _make_mini_db())
         assert len(lists) == 2
 
@@ -308,7 +297,6 @@ class TestBuildCalibrationStacks:
 class TestBuildCalibrationStacksRealData:
     @pytest.fixture(scope="class")
     def fh(self):
-        # A handler with the night loaded — the recipe's usage pattern.
         handler = FileHandler({"KPF_DATA_INPUT": str(TESTDATA_DIR)})
         handler.build_mini_database("20240405")
         return handler
@@ -326,14 +314,12 @@ class TestBuildCalibrationStacksRealData:
         assert lists[0] == sorted(lists[0])
 
     def test_dark_raises_on_undersized_clusters(self, fh):
-        # The testdata has two dark clusters of 2 and 3 frames — both below
-        # min_stack_size=5 and dropped, leaving nothing → raises.
+        # The testdata's dark clusters hold 2 and 3 frames, below min_stack_size=5.
         with pytest.raises(ValueError, match="no cluster with at least"):
             fh.build_calibration_stacks("dark", min_stack_size=5)
 
     def test_dark_obs_night_single_stack(self, fh):
-        # The recipe's dark usage: the night's 5 dark frames span two HST days
-        # (2 + 3), and groupby='obs_night' groups them into one nightly stack.
+        # The night's 5 dark frames span two HST days (2 + 3); obs_night merges them.
         lists = fh.build_calibration_stacks(
             "dark", min_stack_size=3, groupby="obs_night"
         )
@@ -362,8 +348,7 @@ class TestBuildMiniDatabaseDatecodeType:
 
 
 class TestDatecodeDirsInRange:
-    """The datecode-range discovery helper used by the masters orchestrator to
-    expand a ``--date_range`` against the L0 tree. Synthetic tmp trees only."""
+    """Expands a masters ``--date_range`` against the L0 tree."""
 
     def test_filters_by_range_and_sorts(self, tmp_path):
         for name in ["20240101", "20240115", "20240201", "notadate", "20231231"]:
@@ -379,8 +364,7 @@ class TestDatecodeDirsInRange:
 
 
 class TestReadTokenFile:
-    """The --dates / --obs_ids reference-file reader: one token per line,
-    whitespace stripped, blank lines skipped."""
+    """The --dates / --obs_ids reference-file reader."""
 
     def test_reads_one_per_line_stripping_blanks(self, tmp_path):
         f = tmp_path / "nights.txt"
@@ -420,8 +404,8 @@ class TestKpfFilepath:
         assert path == "/data/L0/20240405/KP.20240405.49597.71.fits"
 
     def test_science_l1(self):
-        # Science L1 keeps the KPF "kpf_L1" prefix (no EPRV "S": no L1 standard).
-        # KP.20240405.49597.71 → 49597s = 13:46:37
+        # L1 keeps the "kpf_L1" prefix: the EPRV standard defines no L1.
+        # 49597 s of day = 13:46:37.
         path = kpf_filepath("KP.20240405.49597.71", "L1", data_root="/data")
         assert path == "/data/L1/20240405/kpf_L1_20240405T134637.fits"
 
@@ -430,12 +414,12 @@ class TestKpfFilepath:
         assert name == "KP.20240405.49597.71.fits"
 
     def test_science_bare_filename_l1(self):
-        # 49597s = 13:46:37; L1 keeps the "kpf_L1" prefix (no EPRV "S")
+        # 49597 s of day = 13:46:37.
         name = kpf_filepath("KP.20240405.49597.71", "L1")
         assert name == "kpf_L1_20240405T134637.fits"
 
     def test_science_l2(self):
-        # KP.20240405.40113.57 → 40113s = 11:08:33
+        # 40113 s of day = 11:08:33.
         path = kpf_filepath("KP.20240405.40113.57", "L2", data_root="/data")
         assert path == "/data/L2/20240405/kpf_SL2_20240405T110833.fits"
 
@@ -444,12 +428,10 @@ class TestKpfFilepath:
         assert path == "/data/L4/20240405/kpf_SL4_20240405T110833.fits"
 
     def test_science_l2_midnight_boundary(self):
-        # 3600s = 01:00:00
         path = kpf_filepath("KP.20240405.03600.00", "L2", data_root="/data")
         assert path == "/data/L2/20240405/kpf_SL2_20240405T010000.fits"
 
     def test_science_l2_zero_seconds(self):
-        # 0s = 00:00:00
         path = kpf_filepath("KP.20240405.00000.00", "L2", data_root="/data")
         assert path == "/data/L2/20240405/kpf_SL2_20240405T000000.fits"
 
@@ -480,7 +462,6 @@ class TestKpfFilepath:
             kpf_filepath("KP.20240405.40113.57", "L2", data_root=12345)
 
     def test_composes_directory_and_filename(self):
-        # kpf_filepath is exactly kpf_directory joined with kpf_filename.
         obs_id = "KP.20240405.40113.57"
         assert kpf_filepath(obs_id, "L2", data_root="/data") == os.path.join(
             kpf_directory(kind="science", data_root="/data", level="L2", obs_id=obs_id),
@@ -498,13 +479,13 @@ class TestKpfFilename:
         assert kpf_filename("KP.20240405.49597.71", "L0") == "KP.20240405.49597.71.fits"
 
     def test_science_l1(self):
-        # 49597 s = 13:46:37; L1 keeps the "kpf_L1" prefix (no EPRV "S").
+        # 49597 s of day = 13:46:37; L1 keeps the "kpf_L1" prefix (no EPRV L1).
         assert (
             kpf_filename("KP.20240405.49597.71", "L1") == "kpf_L1_20240405T134637.fits"
         )
 
     def test_science_l2(self):
-        # 40113 s = 11:08:33; L2 uses the EPRV "kpf_SL2" prefix.
+        # 40113 s of day = 11:08:33; L2 uses the EPRV "kpf_SL2" prefix.
         assert (
             kpf_filename("KP.20240405.40113.57", "L2") == "kpf_SL2_20240405T110833.fits"
         )
@@ -543,10 +524,8 @@ class TestKpfFilename:
 
 
 class TestFindMasters:
-    """`FileHandler.find_masters` (the masters finder) and `kpf_filepath` (the
-    masters writer) build the same path independently. These guard that the two
-    inline f-strings can't drift — same directory and `_master_{type}_{level}`
-    filename, with the KOAID wildcarded in the finder."""
+    """`find_masters` and `kpf_filepath` build the master path from independent
+    f-strings; these guard that the two cannot drift."""
 
     def test_returns_empty_when_no_masters(self, tmp_path):
         fh = FileHandler({"KPF_MASTERS_OUTPUT": str(tmp_path)})
@@ -565,8 +544,6 @@ class TestFindMasters:
         [("bias", "L1"), ("dark", "L1"), ("flat", "L1"), ("thar", "L2")],
     )
     def test_finds_kpf_filepath_output(self, tmp_path, cal_type, level):
-        # The finder must locate a master written at the kpf_filepath path with
-        # only the KOAID wildcarded — same directory, same filename convention.
         obs_id = "KP.20240405.03600.00"
         root = str(tmp_path)
         written = kpf_filepath(obs_id, level, data_root=root, master=cal_type)
@@ -582,13 +559,12 @@ class TestFindMasters:
 
 
 class TestFilenameConsistency:
-    """`kpf_filepath` (the pipeline's path builder, from an obs_id string) and a
-    data model's `generate_standard_filename` (the to_fits fallback) build the same
-    product basename. Every level now routes both through `kpf_filename` -- the
-    single source for the naming rule -- so this contract guards that each model
-    carries its `obs_id` and delegates at the right level, and that the string and
-    object builders can never silently diverge (the kind of bug behind the old
-    `kpf_SL1` mix-up). All four levels are exercised.
+    """The string builder `kpf_filepath` and the object builder
+    `generate_standard_filename` must produce the same basename at every level.
+
+    Both route through `kpf_filename`, so this guards that each model carries its
+    `obs_id` and delegates at the right level rather than diverging silently (the
+    kind of bug behind the old `kpf_SL1` mix-up).
     """
 
     OBS_ID = "KP.20240405.49597.71"  # 49597 s of day = 13:46:37 UT
@@ -624,7 +600,7 @@ class TestKpfDirectory:
         assert path == "/data/masters/20240405"
 
     def test_masters_by_datecode(self):
-        # masters needs only the datecode, so a bare datecode works (the CLI path).
+        # masters needs only the datecode, so the CLI can pass a bare one.
         path = kpf_directory(kind="masters", data_root="/data", datecode="20240405")
         assert path == "/data/masters/20240405"
 
@@ -743,8 +719,7 @@ class TestBuildMiniDatabase:
             assert col in mini_db.columns
 
     def test_no_cluster_columns(self, mini_db):
-        # CAL_START/CAL_END were moved out of the mini_db; cluster detection
-        # now happens at build_calibration_stacks time.
+        # Cluster detection belongs to build_calibration_stacks, not the mini_db.
         assert "CAL_START" not in mini_db.columns
         assert "CAL_END" not in mini_db.columns
 
@@ -774,9 +749,9 @@ class TestBuildMiniDatabase:
 
 
 def _write_l0_frame(tmp_path, datecode, obs_id):
-    """Write a minimal L0 FITS (PRIMARY header only) into the L0/{datecode} tree
-    so build_mini_database has a real header to scan; returns the FileHandler.
-    Safe to call more than once per night to stage multiple frames."""
+    """Write a minimal L0 FITS (PRIMARY only) into L0/{datecode} so
+    build_mini_database has a real header to scan; returns the FileHandler.
+    Safe to call repeatedly per night to stage multiple frames."""
     from astropy.io import fits
 
     l0_dir = tmp_path / "L0" / datecode
@@ -795,10 +770,9 @@ def _write_l0_frame(tmp_path, datecode, obs_id):
 
 
 def _seed_cache(tmp_path, datecode, filenames):
-    """Seed the on-disk mini-db cache CSV (the full real schema, one row per
-    filename) and return its path. OBJECT is populated so the row survives the
-    readable-frame clean; the other columns are left blank -- enough for the
-    row-count / freshness / cache-hit (FILENAME) assertions."""
+    """Seed the on-disk mini-db cache CSV (full schema, one row per filename) and
+    return its path. OBJECT is populated so the row survives the readable-frame
+    clean; the rest is blank, which the assertions here do not read."""
     cache = tmp_path / "vNext" / "mini_db" / f"{datecode}_L0.csv"
     cache.parent.mkdir(parents=True, exist_ok=True)
     cols = "FILENAME,TARGNAME,IMTYPE,OBJECT,EXPTIME,ELAPSED,UTC,HST,ISJUNK"
@@ -808,8 +782,8 @@ def _seed_cache(tmp_path, datecode, filenames):
 
 
 def _touch_newer(cache, l0_dir):
-    """Bump `cache`'s mtime past every input under `l0_dir` (each file's
-    mtime/ctime and the directory's mtime), so the freshness guardrail passes."""
+    """Bump `cache`'s mtime past every input under `l0_dir` so the freshness
+    guardrail passes."""
     newest = os.stat(l0_dir).st_mtime
     for entry in os.scandir(l0_dir):
         st = entry.stat()
@@ -824,7 +798,6 @@ class TestMiniDatabaseCache:
 
         cache = tmp_path / "vNext" / "mini_db" / "20240405_L0.csv"
         assert cache.is_file()
-        # The cache round-trips the built DataFrame's columns and rows.
         cached = pd.read_csv(cache)
         assert list(cached.columns) == list(db.columns)
         assert len(cached) == len(db)
@@ -841,9 +814,9 @@ class TestMiniDatabaseCache:
         assert stat.S_IMODE(cache.parent.stat().st_mode) == 0o777
 
     def test_unreadable_frame_recorded_in_cache_not_in_memory(self, caplog, tmp_path):
-        # An unreadable frame is omitted from the in-memory db (useless for
-        # stacking) but still recorded in the on-disk cache, so the cache mirrors
-        # the directory and its row-count guardrail treats it as current, not stale.
+        # An unreadable frame is useless for stacking, so it is dropped in memory,
+        # but the cache still records it: the row-count guardrail compares against
+        # the directory listing and would otherwise call the cache stale forever.
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
         _write_l0_frame(tmp_path, "20240405", "KP.20240405.02000.00")
         corrupt = tmp_path / "L0" / "20240405" / "KP.20240405.03000.00.fits"
@@ -857,15 +830,14 @@ class TestMiniDatabaseCache:
         cache = tmp_path / "vNext" / "mini_db" / "20240405_L0.csv"
         assert len(pd.read_csv(cache)) == 3  # on-disk: one row per file present
 
-        # The count guardrail now sees 3 == 3, so the cache reads back as current.
+        # 3 == 3, so the cache reads back as current.
         cached = fh._read_mini_db_cache("20240405")
         assert cached is not None and len(cached) == 3
-        # A full read-mode build is a cache hit and still cleans to the readable set.
+        # A cache hit still cleans down to the readable set.
         assert len(fh.build_mini_database("20240405", cache="r")) == 2
 
     def test_cache_write_failure_leaves_no_partial_or_temp(self, tmp_path, monkeypatch):
-        # The atomic write (temp file + os.replace) cleans up on failure: a to_csv
-        # error re-raises, leaving no partial cache CSV and no orphaned .tmp file.
+        # The atomic write (temp file + os.replace) must clean up on failure.
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
 
         def _boom(self, *a, **k):
@@ -876,13 +848,12 @@ class TestMiniDatabaseCache:
             fh.build_mini_database("20240405", cache="w")
 
         cache_dir = tmp_path / "vNext" / "mini_db"
-        assert not (cache_dir / "20240405_L0.csv").exists()  # no partial cache
-        assert list(cache_dir.glob("*.tmp")) == []  # temp file removed
+        assert not (cache_dir / "20240405_L0.csv").exists()
+        assert list(cache_dir.glob("*.tmp")) == []
 
     def test_cache_read_reads_current_cache_without_scanning(self, tmp_path):
-        # A current cache (row count matches disk, newer than every input) is
-        # loaded verbatim, not rescanned. Prove it by seeding a SENTINEL FILENAME
-        # a real scan would never produce, then asserting it survives.
+        # A current cache is loaded verbatim, not rescanned: the seeded sentinel
+        # FILENAME is one no real scan could produce, so its survival proves it.
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
         cache = _seed_cache(tmp_path, "20240405", ["/sentinel.fits"])
         _touch_newer(cache, tmp_path / "L0" / "20240405")
@@ -891,18 +862,16 @@ class TestMiniDatabaseCache:
         assert db["FILENAME"].tolist() == ["/sentinel.fits"]
 
     def test_cache_read_only_does_not_write(self, tmp_path, caplog):
-        # "r" reads a current cache but, on a miss, never writes one back.
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
         with caplog.at_level(logging.DEBUG, logger="kpfpipe.utils.io"):
             db = fh.build_mini_database("20240405", cache="r")
 
-        assert len(db) == 1  # scanned fresh (no cache to read)
-        assert not (tmp_path / "vNext" / "mini_db").exists()  # and none written
-        assert "cache miss" in caplog.text  # cold-cache read logged at DEBUG
+        assert len(db) == 1  # scanned fresh: there was no cache to read
+        assert not (tmp_path / "vNext" / "mini_db").exists()  # and none written back
+        assert "cache miss" in caplog.text
 
     def test_cache_write_only_does_not_read(self, tmp_path):
-        # "w" writes the scan result but ignores an existing cache on read: the
-        # seeded sentinel is overwritten by a real scan, not loaded.
+        # "w" writes the scan result but ignores an existing cache on read.
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
         cache = _seed_cache(tmp_path, "20240405", ["/sentinel.fits"])
         _touch_newer(cache, tmp_path / "L0" / "20240405")
@@ -912,7 +881,7 @@ class TestMiniDatabaseCache:
         assert pd.read_csv(cache)["FILENAME"].tolist() == db["FILENAME"].tolist()
 
     def test_cache_stale_row_count_rescans(self, tmp_path):
-        # Cache lists one frame but two are on disk -> count guardrail rejects it.
+        # One frame in the cache, two on disk -> the count guardrail rejects it.
         fh = _write_l0_frame(tmp_path, "20240405", "KP.20240405.01000.00")
         _write_l0_frame(tmp_path, "20240405", "KP.20240405.02000.00")
         cache = _seed_cache(tmp_path, "20240405", ["/sentinel.fits"])
@@ -964,7 +933,7 @@ class TestJunkExclusion:
         assert "junk exclusion is a no-op" in caplog.text
 
     def test_load_junk_parses_wmko_format(self, tmp_path):
-        # WMKO layout: a title line, an 'observation_id' header, one obs_id/row.
+        # WMKO layout: a title line, an 'observation_id' header, one obs_id per row.
         ref = tmp_path / "vNext" / "reference"
         ref.mkdir(parents=True)
         (ref / "junk_obs.csv").write_text(

--- a/tests/regression/test_kpf.py
+++ b/tests/regression/test_kpf.py
@@ -71,7 +71,6 @@ class TestKpfTimestampToEprv:
         assert kpf_timestamp_to_eprv_timestamp("20240405.03600.00") == "20240405T010000"
 
     def test_frame_field_dropped(self):
-        # Frame field should not appear in output
         result = kpf_timestamp_to_eprv_timestamp("20240405.40113.57")
         assert "57" not in result
         assert "." not in result

--- a/tests/regression/test_logger.py
+++ b/tests/regression/test_logger.py
@@ -17,12 +17,11 @@ _UT_FROZEN = time.struct_time((2026, 7, 2, 14, 3, 22, 2, 183, 0))
 
 @pytest.fixture(autouse=True)
 def _teardown():
-    """Always tear down after each test.
+    """Tear down after each test.
 
-    Critical for the captureWarnings bridge: pytest wraps every test in
-    ``catch_warnings``, so ``captureWarnings(False)`` must run inside the
-    same test context or ``logging._warnings_showwarning`` goes stale and a
-    later ``captureWarnings(True)`` silently no-ops.
+    pytest wraps every test in ``catch_warnings``, so ``captureWarnings(False)``
+    must run inside the same test context or ``logging._warnings_showwarning``
+    goes stale and a later ``captureWarnings(True)`` silently no-ops.
     """
     yield
     kpflog.teardown_logging()
@@ -103,7 +102,7 @@ class TestSetupLogging:
         before = len(root.handlers)
         first = kpflog.setup_logging(str(tmp_path), "science", "t", console=False)
         kpflog.setup_logging(str(tmp_path), "masters", "20240923", console=False)
-        assert len(root.handlers) == before + 1  # one file handler, never two
+        assert len(root.handlers) == before + 1
         (handler,) = [h for h in root.handlers if h.name == "kpfpipe_file"]
         assert handler.baseFilename != first  # the survivor is the second file
 
@@ -134,8 +133,8 @@ class TestSetupLogging:
 
 
 class TestSetupBatchLogging:
-    """The batch-orchestrator sibling: a per-invocation ``_batch_`` log echoed
-    to stdout so an operator can watch fan-out progress live."""
+    """A per-invocation ``_batch_`` log echoed to stdout so an operator can watch
+    fan-out progress live."""
 
     def test_creates_batch_file_and_returns_path(self, tmp_path):
         path = kpflog.setup_batch_logging(str(tmp_path), "masters")
@@ -150,7 +149,6 @@ class TestSetupBatchLogging:
         assert "dispatching 3 job(s)" in _read(path)
 
     def test_console_echo_is_stdout(self, tmp_path):
-        # The live-echo contract: batch progress mirrors to stdout (not stderr).
         kpflog.setup_batch_logging(str(tmp_path), "science")
         (console,) = [
             h for h in logging.getLogger().handlers if h.name == "kpfpipe_console"
@@ -158,7 +156,6 @@ class TestSetupBatchLogging:
         assert console.stream is sys.stdout
 
     def test_filter_on_console_only_not_file(self, tmp_path):
-        # The batch console carries _BatchConsoleFilter; the log file stays raw.
         kpflog.setup_batch_logging(str(tmp_path), "science")
         root = logging.getLogger()
         (console,) = [h for h in root.handlers if h.name == "kpfpipe_console"]
@@ -169,29 +166,28 @@ class TestSetupBatchLogging:
         assert not file_h.filters
 
     def test_library_info_off_console_but_kept_in_file(self, tmp_path, capsys):
-        # The whole point: library INFO chatter is trimmed from the live terminal
-        # echo, while the driver's own narration and any WARNING still show -- and
-        # the batch log file keeps every record regardless.
-        # A neutral third-party name (not astropy, whose logger sets
-        # propagate=False and so never reaches the root handlers).
+        # Library INFO chatter is trimmed from the live terminal echo while the
+        # driver's narration and any WARNING still show; the file keeps everything.
+        # thirdparty.io is a neutral name -- astropy sets propagate=False on its
+        # logger, so its records never reach the root handlers.
         path = kpflog.setup_batch_logging(str(tmp_path), "masters")
         logging.getLogger("scripts.processing.masters").info("driver narration")
         logging.getLogger("thirdparty.io").info("library chatter")
         logging.getLogger("thirdparty.io").warning("library warning")
 
         out = capsys.readouterr().out
-        assert "driver narration" in out  # scripts.* INFO echoed
-        assert "library chatter" not in out  # library INFO trimmed from terminal
-        assert "library warning" in out  # WARNING always echoed
+        assert "driver narration" in out
+        assert "library chatter" not in out
+        assert "library warning" in out
         text = _read(path)
         assert {"driver narration", "library chatter", "library warning"} <= {
             line.split(": ", 1)[-1].strip() for line in text.splitlines()
-        }  # ...but the file is unfiltered
+        }
 
 
 class TestBatchConsoleFilter:
-    """The batch stdout echo trims sub-WARNING records to the driver's own
-    ``scripts.*``/``__main__`` sources; WARNING and above always pass."""
+    """Sub-WARNING records pass only from ``scripts.*``/``__main__``; WARNING and
+    above always pass."""
 
     _flt = kpflog._BatchConsoleFilter()
 
@@ -247,7 +243,7 @@ class TestTeardown:
 
 
 class TestIOChokepoints:
-    """Every FITS write/read emits one INFO record (DRP-RUN-08)."""
+    """Every FITS write/read emits one INFO record."""
 
     def test_to_fits_and_from_fits_log_records(self, tmp_path, caplog):
         from kpfpipe.data_models.level4 import KPF4
@@ -317,13 +313,13 @@ class TestWarningsBridge:
         text = _read(path)
         assert "WARNING  py.warnings:" in text
         assert "bridged boom" in text
-        assert "test_logger.py" in text  # file:lineno source identification
+        assert "test_logger.py" in text
 
     @pytest.mark.filterwarnings("always")
     def test_pytest_warns_coexistence(self, tmp_path):
-        # Inside pytest.warns the recorder wins: the assertion passes and the
-        # record does NOT reach the log (captureWarnings only swaps
-        # showwarning; pytest.warns uses catch_warnings(record=True)).
+        # Inside pytest.warns the recorder wins and the record never reaches the
+        # log: captureWarnings only swaps showwarning, while pytest.warns uses
+        # catch_warnings(record=True).
         path = kpflog.setup_logging(str(tmp_path), "science", "t", console=False)
         with pytest.warns(UserWarning, match="recorded boom"):
             warnings.warn("recorded boom", stacklevel=2)

--- a/tests/regression/test_logger.py
+++ b/tests/regression/test_logger.py
@@ -252,7 +252,7 @@ class TestIOChokepoints:
     def test_to_fits_and_from_fits_log_records(self, tmp_path, caplog):
         from kpfpipe.data_models.level4 import KPF4
 
-        path = str(tmp_path / "rt_l4.fits")
+        path = str(tmp_path / "kpf_SL4_20240101T000000.fits")
         with caplog.at_level(logging.INFO, logger="kpfpipe"):
             KPF4().to_fits(path)
             KPF4.from_fits(path)

--- a/tests/regression/test_logger.py
+++ b/tests/regression/test_logger.py
@@ -57,10 +57,12 @@ class TestBuildLogPath:
 
 
 class TestSetupLogging:
-    def test_creates_file_and_returns_path(self, tmp_path):
+    def test_creates_file_and_returns_path(self, tmp_path, monkeypatch):
+        # Freeze the clock: recomputing the datecode after the call races UT
+        # midnight, a once-a-day flake in a CI-scheduled suite.
+        monkeypatch.setattr(kpflog.time, "gmtime", lambda *a: _UT_FROZEN)
         path = kpflog.setup_logging(str(tmp_path), "science", "KP.1.2.3")
-        datecode = time.strftime("%Y%m%d", time.gmtime())
-        assert path.startswith(str(tmp_path / datecode))
+        assert path.startswith(str(tmp_path / "20260702"))
         assert re.search(r"kpf_science_KP\.1\.2\.3_\d{8}T\d{6}\.log$", path)
         assert _read(path) == ""  # created, empty until a record arrives
 
@@ -96,6 +98,16 @@ class TestSetupLogging:
         first = kpflog.setup_logging(str(tmp_path), "science", "t", console=False)
         second = kpflog.setup_logging(str(tmp_path), "science", "t", console=False)
         assert second == f"{first}.1"
+
+    def test_collision_retries_are_exhausted_loudly(self, tmp_path, monkeypatch):
+        # The retry loop must terminate: turning it into `while True` would hang
+        # a run forever instead of failing it.
+        monkeypatch.setattr(kpflog.time, "gmtime", lambda *a: _UT_FROZEN)
+        monkeypatch.setattr(kpflog, "_MAX_COLLISION_RETRIES", 1)
+        kpflog.setup_logging(str(tmp_path), "science", "t", console=False)
+        kpflog.setup_logging(str(tmp_path), "science", "t", console=False)
+        with pytest.raises(FileExistsError, match="unique log file"):
+            kpflog.setup_logging(str(tmp_path), "science", "t", console=False)
 
     def test_repeated_setup_no_duplicate_handlers(self, tmp_path):
         root = logging.getLogger()
@@ -136,10 +148,11 @@ class TestSetupBatchLogging:
     """A per-invocation ``_batch_`` log echoed to stdout so an operator can watch
     fan-out progress live."""
 
-    def test_creates_batch_file_and_returns_path(self, tmp_path):
+    def test_creates_batch_file_and_returns_path(self, tmp_path, monkeypatch):
+        # Frozen for the same UT-midnight reason as TestSetupLogging's twin.
+        monkeypatch.setattr(kpflog.time, "gmtime", lambda *a: _UT_FROZEN)
         path = kpflog.setup_batch_logging(str(tmp_path), "masters")
-        datecode = time.strftime("%Y%m%d", time.gmtime())
-        assert path.startswith(str(tmp_path / datecode))
+        assert path.startswith(str(tmp_path / "20260702"))
         assert re.search(r"kpf_masters_batch_\d{8}T\d{6}\.log$", path)
         assert _read(path) == ""  # created, empty until a record arrives
 
@@ -262,6 +275,9 @@ def _config(tmp_path, body):
     return path
 
 
+# resolve_logging lives in scripts/processing/reduce.py, so this class belongs to
+# the scripts/CLI layer -- without the mark `make test-cli` collects none of it.
+@pytest.mark.cli
 class TestResolveLogging:
     _LOGGER_TOML = '[LOGGER]\nlog_dir = "/logs/"\nlog_level = "DEBUG"\n'
 

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -1,12 +1,9 @@
-"""Unit tests for the shared master-frame engine.
+"""Unit tests for the shared master-frame engine, `BaseMasterModule`.
 
-`BaseMasterModule` (modules/masters/base.py) implements the stacking, calibration
-resolution/application, frame loading, array cleaning, and L1 assembly shared by
-every master type. It is abstract, so these tests drive it through the simplest
-concrete vehicles: `Bias` (applies no calibrations) for the pure L1
-output/dtype/save path, and `Dark` (bias-subtracted) for the calibration
-orchestration path. Behavior specific to a concrete module lives in
-test_master_<type>.py.
+The base is abstract, so these drive it through the simplest concrete vehicles:
+`Bias` (no calibrations) for the L1 output/dtype/save path, and `Dark`
+(bias-subtracted) for the calibration orchestration path. Behavior specific to a
+concrete module lives in test_master_<type>.py.
 """
 
 import logging
@@ -39,10 +36,8 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 class TestMasterBaseErrors:
-    """Error/guard paths shared by all master modules (BaseMasterModule)."""
-
     def test_unsorted_l0_list_raises(self):
-        # The base requires a sorted L0 list so stacking order is deterministic.
+        # The L0 list must be sorted so stacking order is deterministic.
         with pytest.raises(ValueError, match="sorted in ascending order"):
             Dark(["KP.20240101.00002.00.fits", "KP.20240101.00001.00.fits"])
 
@@ -53,7 +48,6 @@ class TestMasterBaseErrors:
             Dark(FILE_LIST, config="not-a-config")
 
     def test_load_frame_missing_file_warns_and_skips(self, caplog):
-        # A missing/unreadable L0 frame warns and returns None, not a crash.
         fn = "/nonexistent/KP.20240101.00001.00.fits"
         m = Dark([fn])
         with caplog.at_level(logging.WARNING):
@@ -62,8 +56,8 @@ class TestMasterBaseErrors:
         assert l1_obj is None
 
     def test_load_frame_qc_failure_warns_and_skips(self, caplog, monkeypatch):
-        # A frame failing a required QCL0 flag (here the EXPTIME/ELAPSED
-        # consistency flag EXPTIMOK) is warned and dropped before assembly.
+        # EXPTIMOK is the EXPTIME/ELAPSED consistency flag; failing a required
+        # QCL0 flag drops the frame before assembly instead of raising.
         m = Dark(FILE_LIST)
         fn = FILE_LIST[0]
         qc_result = {kw: (kw != "EXPTIMOK", "") for kw in Dark._REQUIRED_L0_QC_FLAGS}
@@ -80,8 +74,7 @@ class TestMasterBaseErrors:
         assert l1_obj is None
 
     def test_load_frame_qc_pass_returns_assembled(self, monkeypatch):
-        # All required QCL0 flags pass -> the frame is assembled and returned
-        # (the gate's pass-through branch, otherwise only exercised in slow tests).
+        # The gate's pass-through branch, otherwise only exercised in slow tests.
         m = Dark(FILE_LIST)
         fn = FILE_LIST[0]
         qc_result = {kw: (True, "") for kw in Dark._REQUIRED_L0_QC_FLAGS}
@@ -107,7 +100,7 @@ class TestMasterBaseErrors:
 
 class TestProcessFrame:
     """Dark subtracts the master bias by reusing the standard science modules
-    through the shared `_process_frame` hook, not by hand-rolling the math."""
+    through `_process_frame`, not by hand-rolling the math."""
 
     def test_process_frame_runs_ca_then_ip(self):
         dark = Dark(FILE_LIST, config={"KPF_MASTERS_OUTPUT": "/masters"})
@@ -131,14 +124,12 @@ class TestProcessFrame:
 
             result = dark._process_frame(frame_in)
 
-        # Associate only the bias master, reading it from the masters root.
         mock_ca.assert_called_once_with(frame_in, {"KPF_MASTERS_OUTPUT": "/masters"})
         mock_ca.return_value.perform.assert_called_once_with(["bias"])
 
-        # The bias master is loaded (and cached) from the associated frame...
         mock_load.assert_any_call(associated, "bias")
 
-        # ...then the loaded bias (and only the bias) is subtracted.
+        # Only the bias is subtracted.
         mock_ip.assert_called_once_with(associated)
         mock_ip.return_value.perform.assert_called_once_with(
             bias=loaded_bias, dark=False, flat=False
@@ -170,8 +161,8 @@ class TestProcessFrame:
         assert result is processed
 
     def test_mixed_true_and_explicit_associates_only_true(self):
-        # True calibrations are associated; explicit paths skip association but
-        # are still loaded by the module before ImageProcessing runs.
+        # True calibrations are associated; explicit paths skip association but are
+        # still loaded before ImageProcessing runs.
         dark = Dark(FILE_LIST, config={"KPF_MASTERS_OUTPUT": "/masters"})
         dark._active_calibrations = {
             "bias": True,
@@ -200,7 +191,6 @@ class TestProcessFrame:
             mock_ip.calibration_applied.return_value = False  # frame not yet calibrated
             result = dark._process_frame(frame_in)
 
-        # Only the True (bias) calibration is associated; the explicit dark is not.
         mock_ca.return_value.perform.assert_called_once_with(["bias"])
         mock_ip.assert_called_once_with(associated)
         mock_ip.return_value.perform.assert_called_once_with(
@@ -209,9 +199,8 @@ class TestProcessFrame:
         assert result is processed
 
     def test_skips_frame_already_calibrated(self):
-        # A frame whose active calibrations are already flagged applied (e.g. a
-        # cached frame revisited by the streaming pass) is returned untouched,
-        # so calibrations are never subtracted twice.
+        # The streaming pass revisits cached frames, so an already-calibrated frame
+        # must pass through untouched rather than be subtracted twice.
         dark = Dark(FILE_LIST, config={"KPF_MASTERS_OUTPUT": "/masters"})
         frame_in = MagicMock(name="l1_in")
 
@@ -227,8 +216,8 @@ class TestProcessFrame:
         assert result is frame_in
 
     def test_forwards_configured_search_window(self):
-        # A configured search window must reach CalibrationAssociation rather
-        # than silently falling back to the module default.
+        # A configured window must reach CalibrationAssociation rather than
+        # silently falling back to the module default.
         dark = Dark(
             FILE_LIST,
             config={
@@ -250,7 +239,7 @@ class TestProcessFrame:
         assert ca_config["masters_search_window_days"] == [-3, 1]
 
     def test_omits_search_window_when_unset(self):
-        # Without a configured window, the key is left out so CalibrationAssociation
+        # With no configured window the key is omitted, so CalibrationAssociation
         # applies its own default.
         dark = Dark(FILE_LIST, config={"KPF_MASTERS_OUTPUT": "/masters"})
         frame_in = MagicMock(name="l1_in")
@@ -274,13 +263,12 @@ class TestProcessFrame:
 
 class TestLoadMaster:
     """A master shared across a stack is read from disk once; a different
-    associated master replaces the cached one (reload-and-replace)."""
+    associated master replaces the cached one."""
 
     @staticmethod
     def _frame(biasfile="master_bias.fits", biasdir="/m"):
         frame = MagicMock(name="l1")
-        # BIASFILE holds the master's full path (no separate BIASDIR) and now
-        # lives on the RECEIPT extension (its registry home).
+        # BIASFILE holds the master's full path and lives on RECEIPT.
         frame.headers = {"RECEIPT": {"BIASFILE": os.path.join(biasdir, biasfile)}}
         return frame
 
@@ -365,8 +353,8 @@ class TestLoadMaster:
 def _stack_frame(exptime, ccd_val, var_val, shape=(2, 2)):
     """A synthetic assembled frame with uniform CCD/VAR and a given EXPTIME."""
     frame = MagicMock()
-    # Stacking reads the EPRV-standard PRIMARY EXPTIME (actual elapsed time,
-    # mapped from native WMKO ELAPSED).
+    # Stacking reads PRIMARY EXPTIME, the actual elapsed time (mapped from the
+    # native WMKO ELAPSED), not the requested exposure.
     frame.headers = {"PRIMARY": {"EXPTIME": exptime}, "INSTRUMENT_HEADER": {}}
     frame.data = {
         "GREEN_CCD": np.full(shape, ccd_val, dtype=np.float32),
@@ -376,9 +364,9 @@ def _stack_frame(exptime, ccd_val, var_val, shape=(2, 2)):
 
 
 class TestRateEstimator:
-    """The master IMG is the exposure-weighted rate (total counts / total
-    exposure time), correct even when the stack mixes exposure times. Outlier
-    rejection is disabled (large sigma) so the arithmetic is exact."""
+    """The master IMG is the exposure-weighted rate (total counts / total exposure
+    time), correct even when the stack mixes exposure times. Outlier rejection is
+    disabled here (large sigma) so the arithmetic is exact."""
 
     @staticmethod
     def _stacked_img(frames, *, nstream=6):
@@ -387,8 +375,8 @@ class TestRateEstimator:
         dark.chips = ["GREEN"]
         dark.ccd = {"nrow": 2, "ncol": 2}
         dark.stack_sigma = 1e6  # effectively no clipping
-        # Keyed by filename: the streaming path re-reads its first frames for
-        # the approximate (clip-bound) pass, so a frame may be loaded twice.
+        # Keyed by filename because the streaming path re-reads its first frames
+        # for the approximate (clip-bound) pass, loading a frame twice.
         by_fn = dict(zip(file_list, frames, strict=True))
         with (
             patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
@@ -397,8 +385,8 @@ class TestRateEstimator:
             return dark.stack_frames(nstream=nstream)["GREEN_IMG"]
 
     def test_mixed_exptime_is_exposure_weighted(self):
-        # rates per frame are 10 and 3.33; an equal-weight mean would give
-        # ~6.67, but the correct estimate is (100+100)/(10+30) = 5.0 e-/sec.
+        # Per-frame rates are 10 and 3.33; an equal-weight mean would give ~6.67,
+        # but the correct estimate is (100+100)/(10+30) = 5.0 e-/sec.
         frames = [_stack_frame(10.0, 100.0, 10.0), _stack_frame(30.0, 100.0, 10.0)]
         np.testing.assert_allclose(self._stacked_img(frames), 5.0, rtol=1e-5)
 
@@ -408,14 +396,14 @@ class TestRateEstimator:
         np.testing.assert_allclose(self._stacked_img(frames), 6.0, rtol=1e-5)
 
     def test_zero_exptime_is_mean_counts(self):
-        # Zero-exptime (bias-like) branch: T = 1, so the estimate is the mean
-        # in electrons: (100 + 140) / 2.
+        # Zero-exptime (bias-like) branch: T = 1, so the estimate is the mean in
+        # electrons, (100 + 140) / 2.
         frames = [_stack_frame(0.0, 100.0, 10.0), _stack_frame(0.0, 140.0, 10.0)]
         np.testing.assert_allclose(self._stacked_img(frames), 120.0, rtol=1e-5)
 
     def test_streaming_path_matches(self):
-        # Force the streaming path (nframe >= nstream) with mixed
-        # exposures: (4*100) / (10+30+10+30) = 5.0 e-/sec.
+        # Streaming path (nframe >= nstream), mixed exposures:
+        # (4*100) / (10+30+10+30) = 5.0 e-/sec.
         frames = [
             _stack_frame(10.0, 100.0, 10.0),
             _stack_frame(30.0, 100.0, 10.0),
@@ -432,22 +420,21 @@ class TestRateEstimator:
 
 
 class TestPerPixelRejection:
-    """Counts and exposure time are summed over the SAME per-pixel survivor set,
-    so a pixel with fewer good frames yields the same rate as a fully-sampled
-    pixel -- only its SNR drops (photon statistics)."""
+    """Counts and exposure time are summed over the SAME per-pixel survivor set, so
+    a pixel with fewer good frames yields the same rate as a fully-sampled pixel --
+    only its SNR drops (photon statistics)."""
 
     def test_datacube_partial_rejection_preserves_rate(self, monkeypatch):
-        # 5 identical frames (100 e- over 10 s -> 10 e-/sec). flag_outliers is
-        # stubbed to reject frame 4 at pixel (0, 0) only; all other pixels keep
-        # all 5 frames.
+        # 5 identical frames (100 e- over 10 s -> 10 e-/sec), with flag_outliers
+        # stubbed to reject frame 4 at pixel (0, 0) only.
         n, nrow, ncol = 5, 2, 2
         frames = [
             _stack_frame(10.0, 100.0, 100.0, shape=(nrow, ncol)) for _ in range(n)
         ]
         outlier = np.zeros((n, nrow, ncol), dtype=bool)
         outlier[4, 0, 0] = True
-        # Reject frame 4 at (0, 0) during stacking (3D cube input); return no
-        # outliers for the 2D bad-pixel pass in _clean_l1_arrays.
+        # 3D input is the stacking pass; 2D is the bad-pixel pass in
+        # _clean_l1_arrays, which must stay clean here.
         monkeypatch.setattr(
             "kpfpipe.modules.masters.base.flag_outliers",
             lambda arr, sigma, axis=0, **kwargs: (
@@ -466,18 +453,17 @@ class TestPerPixelRejection:
             arrays = dark.stack_frames()
 
         img, snr = arrays["GREEN_IMG"], arrays["GREEN_SNR"]
-        # Rate is the same at the 4/5 pixel (400/40) as at the 5/5 pixels
-        # (500/50): both 10 e-/sec. A bug summing exptime over all frames would
-        # give 400/50 = 8 at (0, 0).
+        # The 4/5 pixel (400/40) and the 5/5 pixels (500/50) both give 10 e-/sec.
+        # A bug summing exptime over all frames would give 400/50 = 8 at (0, 0).
         np.testing.assert_allclose(img, 10.0, rtol=1e-5)
-        # SNR drops at the rejected pixel by sqrt(4/5) (one fewer frame's
-        # photons): 400/sqrt(400) vs 500/sqrt(500).
+        # One fewer frame's photons drops SNR by sqrt(4/5): 400/sqrt(400) vs
+        # 500/sqrt(500).
         assert snr[0, 0] < snr[1, 1]
         np.testing.assert_allclose(snr[0, 0] / snr[1, 1], np.sqrt(4 / 5), rtol=1e-4)
 
     def test_streaming_rejection_keeps_rate_consistent(self, monkeypatch):
-        # Force the streaming path; a clear outlier frame must drop out of BOTH
-        # the counts sum and the exposure-time sum, leaving the rate correct.
+        # On the streaming path a clear outlier must drop out of BOTH the counts
+        # sum and the exposure-time sum, leaving the rate correct.
         n = 4
         counts = [95.0, 105.0, 100.0, 1e5]  # last frame is a gross outlier
         frames = [_stack_frame(10.0, c, 100.0) for c in counts]
@@ -499,7 +485,7 @@ class TestPerPixelRejection:
             # nstream = 3 -> ndirect = 2 -> approx from frames 0, 1
             img = dark.stack_frames(nstream=3)["GREEN_IMG"]
 
-        # (95 + 105 + 100) / (3 * 10) = 10 e-/sec; the outlier is excluded from
+        # (95 + 105 + 100) / (3 * 10) = 10 e-/sec, the outlier excluded from
         # numerator and denominator alike. A mismatch would give 300/40 = 7.5.
         np.testing.assert_allclose(img, 10.0, rtol=1e-5)
 
@@ -510,14 +496,12 @@ class TestPerPixelRejection:
 
 
 class TestDatacubeClipping:
-    """The datacube path runs the real flag_outliers rejection (unlike
-    TestRateEstimator, which disables clipping, and TestPerPixelRejection, which
-    stubs flag_outliers). A gross outlier frame is dropped from both the counts
-    and exposure-time sums, leaving the surviving rate correct."""
+    """The datacube path runs the real flag_outliers rejection, unlike
+    TestRateEstimator (clipping disabled) and TestPerPixelRejection (stubbed)."""
 
     def test_outlier_frame_is_rejected(self):
         # Five identical frames (100 e- over 10 s -> 10 e-/sec) plus one gross
-        # outlier frame; nstream is set high to stay on the datacube path.
+        # outlier; nstream is set high to stay on the datacube path.
         nrow, ncol = 3, 3
         good = [_stack_frame(10.0, 100.0, 100.0, shape=(nrow, ncol)) for _ in range(5)]
         outlier = _stack_frame(10.0, 1e5, 100.0, shape=(nrow, ncol))
@@ -541,8 +525,8 @@ class TestDatacubeClipping:
         assert np.all(arrays["GREEN_MASK"])
 
     def test_var_outlier_frame_is_not_rejected(self):
-        # Rejection is CCD-only: a frame with a gross VAR outlier but normal CCD
-        # counts is NOT dropped (VAR = |CCD| + RN carries no independent info).
+        # Rejection is CCD-only: VAR = |CCD| + RN carries no independent
+        # information, so a gross VAR outlier alone must not drop a frame.
         nrow, ncol = 3, 3
         good = [_stack_frame(10.0, 100.0, 100.0, shape=(nrow, ncol)) for _ in range(5)]
         var_outlier = _stack_frame(10.0, 100.0, 1e5, shape=(nrow, ncol))
@@ -560,8 +544,8 @@ class TestDatacubeClipping:
             arrays = dark.stack_frames(nstream=10)  # > nframe, so datacube path
 
         # CCD normal -> IMG unaffected at 10 e-/sec, and the VAR outlier stays in
-        # the variance sum: SNR = |6*100| / sqrt(5*100 + 1e5) ~= 1.89. Had it been
-        # rejected (old CCD|VAR criterion) SNR would be ~22.4.
+        # the variance sum: SNR = 6*100 / sqrt(5*100 + 1e5) ~= 1.89. Had the frame
+        # been rejected, SNR would be ~22.4.
         np.testing.assert_allclose(arrays["GREEN_IMG"], 10.0, rtol=1e-5)
         np.testing.assert_allclose(
             arrays["GREEN_SNR"], 600.0 / np.sqrt(100500.0), rtol=1e-5
@@ -575,9 +559,8 @@ class TestDatacubeClipping:
 
 class TestCleanL1Arrays:
     """_clean_l1_arrays interpolates masked-bad pixels for the final IMG/SNR, but
-    the recomputed mask is the union of all rejections (across-stack, bad
-    SNR/IMG, FFI outliers): a repaired pixel keeps its filled value yet stays
-    flagged, preserving provenance."""
+    the recomputed mask unions all rejections (across-stack, bad SNR/IMG, FFI
+    outliers): a repaired pixel keeps its filled value yet stays flagged."""
 
     @staticmethod
     def _dark():
@@ -590,10 +573,9 @@ class TestCleanL1Arrays:
         return {"GREEN_IMG": img, "GREEN_SNR": snr, "GREEN_MASK": mask}
 
     def test_rejected_pixel_is_interpolated_but_stays_masked(self):
-        # A pixel rejected by stacking (IMG/SNR = 0, mask False) is filled from
-        # its neighbors rather than left at zero, but it stays flagged: the
-        # across-stack rejection is one of the three checks the final mask
-        # unions, so a repair does not restore it to good.
+        # A pixel rejected by stacking is filled from its neighbors rather than
+        # left at zero, but the across-stack rejection is one of the checks the
+        # final mask unions, so the repair does not restore it to good.
         img = np.full((5, 5), 10.0, dtype=np.float32)
         snr = np.full((5, 5), 20.0, dtype=np.float32)
         mask = np.ones((5, 5), dtype=bool)
@@ -606,8 +588,8 @@ class TestCleanL1Arrays:
         assert bool(out["GREEN_MASK"][2, 2]) is False
 
     def test_final_image_outlier_is_flagged(self):
-        # A pixel consistent across frames (so it survives stacking, mask True)
-        # but extreme in the combined image is caught by the final outlier pass.
+        # A pixel consistent across frames survives stacking, so only the final
+        # outlier pass can catch it being extreme in the combined image.
         img = np.full((5, 5), 10.0, dtype=np.float32)
         snr = np.full((5, 5), 20.0, dtype=np.float32)
         mask = np.ones((5, 5), dtype=bool)
@@ -619,8 +601,8 @@ class TestCleanL1Arrays:
         assert bool(out["GREEN_MASK"][0, 0]) is True
 
     def test_zero_value_pixel_is_flagged(self):
-        # A good-masked zero pixel is not interpolated (only masked-bad pixels
-        # are) and is flagged by the IMG == 0 rule in the mask recompute.
+        # Only masked-bad pixels are interpolated, so this one is left at zero and
+        # flagged by the IMG == 0 rule in the mask recompute.
         img = np.full((5, 5), 10.0, dtype=np.float32)
         snr = np.full((5, 5), 20.0, dtype=np.float32)
         mask = np.ones((5, 5), dtype=bool)
@@ -632,8 +614,7 @@ class TestCleanL1Arrays:
 
 
 # ---------------------------------------------------------------------------
-# Stacking input validation (the ValueErrors raised by stack_frames /
-# _compute_stats_from_datacube on malformed stacks)
+# Stacking input validation (stack_frames / _compute_stats_from_datacube)
 # ---------------------------------------------------------------------------
 
 
@@ -681,8 +662,8 @@ class TestStackingValidation:
                 dark.stack_frames()
 
     def test_ccd_var_frame_count_mismatch_raises(self):
-        # CCD and VAR normally share a survivor mask; a mismatch signals a bug
-        # and must not be averaged into a master.
+        # CCD and VAR share a survivor mask, so a mismatch signals a bug and must
+        # not be averaged into a master.
         dark = self._dark(3)
         ones = np.ones((2, 2), dtype=np.float32)
         stats = {
@@ -704,16 +685,16 @@ class TestStackingValidation:
 
 
 # ---------------------------------------------------------------------------
-# _resolve_calibrations: standard ∩ resolved(bias/dark/flat) clamp
+# _resolve_calibrations: standard intersected with resolved(bias/dark/flat)
 # ---------------------------------------------------------------------------
 
 
 class TestResolveCalibrations:
-    """Effective calibrations = the per-master standard intersected with the
+    """Effective calibrations are the per-master standard intersected with the
     resolved flags; flags can only turn standard calibrations off."""
 
     def test_default_is_bias_only(self):
-        # Dark's standard is ("bias",); the enabled defaults are (bias, dark).
+        # Dark's standard is ("bias",), but the enabled defaults are bias and dark.
         dark = Dark(FILE_LIST)
         assert dark._resolve_calibrations() == {
             "bias": True,
@@ -726,7 +707,7 @@ class TestResolveCalibrations:
         assert dark._resolve_calibrations(bias=False)["bias"] is False
 
     def test_illogical_enable_is_clamped(self):
-        # dark/flat are outside a dark master's standard -> stay off.
+        # dark/flat are outside a dark master's standard, so they stay off.
         dark = Dark(FILE_LIST)
         assert dark._resolve_calibrations(dark=True, flat=True) == {
             "bias": True,
@@ -752,7 +733,7 @@ class TestResolveCalibrations:
         assert dark._resolve_calibrations(bias=sentinel)["bias"] is sentinel
 
     def test_str_override_outside_standard_is_clamped(self):
-        # flat is not in a dark master's standard -> ignored even as a path.
+        # flat is outside a dark master's standard, so even a path is ignored.
         dark = Dark(FILE_LIST)
         assert dark._resolve_calibrations(flat="/p/master_flat.fits")["flat"] is False
 
@@ -805,8 +786,7 @@ class TestDtypeProvenance:
 
 
 class TestSaveMaster:
-    """save_master / make_master_l1(master_path=...) is shared base behavior,
-    exercised here through Bias (the simplest master)."""
+    """The shared write path, exercised through Bias (the simplest master)."""
 
     def test_master_path_writes_fits(self, tmp_path):
         synthetic = make_l1_arrays()

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -780,13 +780,21 @@ class TestDtypeProvenance:
             assert_dtype(master.data[ext], MASK_MEM, ext)
 
     def test_roundtrip_img_float32_mask_uint8(self, master, tmp_path):
-        assert_roundtrip_dtype(KPFMasterL1, master, "GREEN_IMG", L1_IMAGE, tmp_path)
+        assert_roundtrip_dtype(
+            KPFMasterL1,
+            master,
+            "GREEN_IMG",
+            L1_IMAGE,
+            tmp_path,
+            name="KP.20240113.23249.10_master_bias_L1.fits",
+        )
         assert_roundtrip_dtype(
             KPFMasterL1,
             master,
             "GREEN_MASK",
             MASK_MEM,
             tmp_path,
+            name="KP.20240113.23249.10_master_bias_L1.fits",
             expected_disk=MASK_DISK,
         )
 
@@ -803,7 +811,7 @@ class TestSaveMaster:
     def test_master_path_writes_fits(self, tmp_path):
         synthetic = make_l1_arrays()
         bias = Bias(FILE_LIST)
-        master_path = tmp_path / "master_bias.fits"
+        master_path = tmp_path / "KP.20240113.23249.10_master_bias_L1.fits"
         with patch.object(bias, "stack_frames", return_value=synthetic):
             bias.make_master_l1(master_path=str(master_path))
         assert master_path.exists()
@@ -811,7 +819,9 @@ class TestSaveMaster:
     def test_master_path_creates_parent_dir(self, tmp_path):
         synthetic = make_l1_arrays()
         bias = Bias(FILE_LIST)
-        master_path = tmp_path / "nested" / "subdir" / "master_bias.fits"
+        master_path = (
+            tmp_path / "nested" / "subdir" / "KP.20240113.23249.10_master_bias_L1.fits"
+        )
         with patch.object(bias, "stack_frames", return_value=synthetic):
             bias.make_master_l1(master_path=str(master_path))
         assert master_path.exists()
@@ -819,7 +829,7 @@ class TestSaveMaster:
     def test_master_path_overwrites_existing(self, tmp_path):
         synthetic = make_l1_arrays()
         bias = Bias(FILE_LIST)
-        master_path = tmp_path / "master_bias.fits"
+        master_path = tmp_path / "KP.20240113.23249.10_master_bias_L1.fits"
         master_path.touch()
         with patch.object(bias, "stack_frames", return_value=synthetic):
             bias.make_master_l1(master_path=str(master_path))
@@ -833,7 +843,7 @@ class TestSaveMaster:
     def test_save_master_refuses_overwrite_by_default(self, tmp_path):
         synthetic = make_l1_arrays()
         bias = Bias(FILE_LIST)
-        master_path = tmp_path / "master_bias.fits"
+        master_path = tmp_path / "KP.20240113.23249.10_master_bias_L1.fits"
         master_path.touch()
         with patch.object(bias, "stack_frames", return_value=synthetic):
             bias.make_master_l1()  # populates ml1_obj

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -25,10 +25,12 @@ from ._dtype_policy import (
     assert_dtype,
     assert_roundtrip_dtype,
 )
-from ._masters import make_l1_arrays
-
-FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
-
+from ._masters import (
+    FILE_LIST,
+    MASTER_NAME,
+    make_mocked_master,
+    mocked_stack,
+)
 
 # ---------------------------------------------------------------------------
 # Base-class fail-loudly paths (construction + frame loading)
@@ -748,9 +750,7 @@ class TestDtypeProvenance:
 
     @pytest.fixture(scope="class")
     def master(self):
-        bias = Bias(FILE_LIST)
-        with patch.object(bias, "stack_frames", return_value=make_l1_arrays()):
-            return bias.make_master_l1()
+        return make_mocked_master(Bias)
 
     def test_img_snr_float32(self, master):
         for ext in ("GREEN_IMG", "RED_IMG", "GREEN_SNR", "RED_SNR"):
@@ -767,7 +767,7 @@ class TestDtypeProvenance:
             "GREEN_IMG",
             L1_IMAGE,
             tmp_path,
-            name="KP.20240113.23249.10_master_bias_L1.fits",
+            name=MASTER_NAME,
         )
         assert_roundtrip_dtype(
             KPFMasterL1,
@@ -775,7 +775,7 @@ class TestDtypeProvenance:
             "GREEN_MASK",
             MASK_MEM,
             tmp_path,
-            name="KP.20240113.23249.10_master_bias_L1.fits",
+            name=MASTER_NAME,
             expected_disk=MASK_DISK,
         )
 
@@ -789,43 +789,31 @@ class TestSaveMaster:
     """The shared write path, exercised through Bias (the simplest master)."""
 
     def test_master_path_writes_fits(self, tmp_path):
-        synthetic = make_l1_arrays()
-        bias = Bias(FILE_LIST)
-        master_path = tmp_path / "KP.20240113.23249.10_master_bias_L1.fits"
-        with patch.object(bias, "stack_frames", return_value=synthetic):
-            bias.make_master_l1(master_path=str(master_path))
+        master_path = tmp_path / MASTER_NAME
+        make_mocked_master(Bias, master_path=str(master_path))
         assert master_path.exists()
 
     def test_master_path_creates_parent_dir(self, tmp_path):
-        synthetic = make_l1_arrays()
-        bias = Bias(FILE_LIST)
-        master_path = (
-            tmp_path / "nested" / "subdir" / "KP.20240113.23249.10_master_bias_L1.fits"
-        )
-        with patch.object(bias, "stack_frames", return_value=synthetic):
-            bias.make_master_l1(master_path=str(master_path))
+        master_path = tmp_path / "nested" / "subdir" / MASTER_NAME
+        make_mocked_master(Bias, master_path=str(master_path))
         assert master_path.exists()
 
     def test_master_path_overwrites_existing(self, tmp_path):
-        synthetic = make_l1_arrays()
-        bias = Bias(FILE_LIST)
-        master_path = tmp_path / "KP.20240113.23249.10_master_bias_L1.fits"
+        master_path = tmp_path / MASTER_NAME
         master_path.touch()
-        with patch.object(bias, "stack_frames", return_value=synthetic):
-            bias.make_master_l1(master_path=str(master_path))
+        make_mocked_master(Bias, master_path=str(master_path))
         assert master_path.read_bytes()[:6] == b"SIMPLE"
 
-    def test_save_master_before_make_raises(self):
+    def test_save_master_before_make_raises(self, tmp_path):
         bias = Bias(FILE_LIST)
         with pytest.raises(RuntimeError, match="run make_master_l1"):
-            bias.save_master("L1", "/tmp/should_not_be_created.fits")
+            bias.save_master("L1", str(tmp_path / "should_not_be_created.fits"))
 
     def test_save_master_refuses_overwrite_by_default(self, tmp_path):
-        synthetic = make_l1_arrays()
         bias = Bias(FILE_LIST)
-        master_path = tmp_path / "KP.20240113.23249.10_master_bias_L1.fits"
+        master_path = tmp_path / MASTER_NAME
         master_path.touch()
-        with patch.object(bias, "stack_frames", return_value=synthetic):
+        with mocked_stack(bias):
             bias.make_master_l1()  # populates ml1_obj
         with pytest.raises(FileExistsError, match="overwrite=True"):
             bias.save_master("L1", str(master_path))

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -14,9 +14,13 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
+import kpfpipe.modules.masters.base as masters_base
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.bias import Bias
 from kpfpipe.modules.masters.dark import Dark
+from kpfpipe.modules.masters.flat import Flat
+from kpfpipe.modules.masters.wls import WLS
+from kpfpipe.utils.config import ConfigHandler
 
 from ._dtype_policy import (
     L1_IMAGE,
@@ -30,6 +34,11 @@ from ._masters import (
     MASTER_NAME,
     make_mocked_master,
     mocked_stack,
+)
+
+MASTERS_CONFIG_PATH = (
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    + "/configs/kpf_drp_masters.toml"
 )
 
 # ---------------------------------------------------------------------------
@@ -81,18 +90,29 @@ class TestMasterBaseErrors:
         fn = FILE_LIST[0]
         qc_result = {kw: (True, "") for kw in Dark._REQUIRED_L0_QC_FLAGS}
         assembled = object()
+        raw_l0 = object()
+        seen = {}
         monkeypatch.setattr(
-            "kpfpipe.modules.masters.base.KPF0.from_fits", lambda fn: object()
+            "kpfpipe.modules.masters.base.KPF0.from_fits", lambda fn: raw_l0
         )
-        monkeypatch.setattr(
-            "kpfpipe.modules.masters.base.QCL0",
-            lambda l0: MagicMock(run=lambda: qc_result),
-        )
-        monkeypatch.setattr(
-            "kpfpipe.modules.masters.base.ImageAssembly",
-            lambda l0: MagicMock(perform=lambda: assembled),
-        )
+
+        def _qc(l0):
+            seen["qc"] = l0
+            return MagicMock(run=lambda: qc_result)
+
+        def _assembly(l0):
+            seen["assembly"] = l0
+            return MagicMock(perform=lambda: assembled)
+
+        monkeypatch.setattr("kpfpipe.modules.masters.base.QCL0", _qc)
+        monkeypatch.setattr("kpfpipe.modules.masters.base.ImageAssembly", _assembly)
+
         assert m._load_frame(fn, cache=False) is assembled
+        # Both stages must see the frame that was read, not some other object:
+        # assembling the pre-QC frame, or QC-ing the wrong one, still returns
+        # `assembled` if only the return value is checked.
+        assert seen["qc"] is raw_l0
+        assert seen["assembly"] is raw_l0
 
 
 # ---------------------------------------------------------------------------
@@ -415,6 +435,38 @@ class TestRateEstimator:
         img = self._stacked_img(frames, nstream=3)
         np.testing.assert_allclose(img, 5.0, rtol=1e-5)
 
+    def test_flat_is_total_electrons_not_a_rate(self):
+        # A master flat is the total electrons summed over the stack, not a
+        # rate: two frames of 100 e- over 10 s give 200, not 10. Deleting that
+        # branch rescales every master flat by 1/exptime_sum while leaving
+        # BUNIT ("electrons") and every other assertion in the suite true.
+        # The final cleaning pass is bypassed so the arithmetic is exact; the
+        # flat-mode cleaner is covered by TestCleanL1Arrays and by the real
+        # master flat in test_master_flat.py.
+        frames = [_stack_frame(10.0, 100.0, 10.0), _stack_frame(10.0, 100.0, 10.0)]
+        file_list = sorted(f"f{i}.fits" for i in range(len(frames)))
+        dark = Dark(file_list)
+        dark.chips = ["GREEN"]
+        dark.ccd = {"nrow": 2, "ncol": 2}
+        dark.stack_sigma = 1e6
+        by_fn = dict(zip(file_list, frames, strict=True))
+        with (
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
+            patch.object(dark, "_process_frame", lambda l1: l1),
+            patch.object(dark, "_clean_l1_arrays", lambda arrays, *a, **k: arrays),
+        ):
+            arrays = dark.stack_frames(cal_type="flat")
+        np.testing.assert_allclose(arrays["GREEN_IMG"], 200.0, rtol=1e-5)
+
+        # Same frames without the flat token take the rate branch: 200/20 = 10.
+        with (
+            patch.object(dark, "_load_frame", lambda fn, **k: by_fn[fn]),
+            patch.object(dark, "_process_frame", lambda l1: l1),
+            patch.object(dark, "_clean_l1_arrays", lambda arrays, *a, **k: arrays),
+        ):
+            arrays = dark.stack_frames()
+        np.testing.assert_allclose(arrays["GREEN_IMG"], 10.0, rtol=1e-5)
+
 
 # ---------------------------------------------------------------------------
 # Per-pixel-per-frame rejection in the final normalization
@@ -555,6 +607,75 @@ class TestDatacubeClipping:
 
 
 # ---------------------------------------------------------------------------
+# Per-pixel inclusion gates in the final normalization
+# ---------------------------------------------------------------------------
+
+
+class TestSurvivorGate:
+    """The last gate before a pixel enters a master: it must have survived in a
+    majority of the requested frames, and carry non-zero variance and exposure.
+    Otherwise it is zeroed and flagged rather than reconstructed from a
+    minority of the stack and published as if fully sampled."""
+
+    @staticmethod
+    def _stats(nframe_ccd, var_sum, exptime_sum):
+        counts = np.full((2, 2), 300.0, dtype=np.float32)
+        return {
+            "GREEN_CCD": {
+                "counts_sum": counts,
+                "exptime_sum": np.asarray(exptime_sum, dtype=np.float32),
+                "nframe": np.asarray(nframe_ccd, dtype=np.int32),
+            },
+            "GREEN_VAR": {
+                "counts_sum": np.asarray(var_sum, dtype=np.float32),
+                "nframe": np.asarray(nframe_ccd, dtype=np.int32),
+            },
+        }
+
+    def _stack(self, stats, nrequested=4):
+        dark = Dark(sorted(f"f{i}.fits" for i in range(nrequested)))
+        dark.chips = ["GREEN"]
+        dark.ccd = {"nrow": 2, "ncol": 2}
+        # The gate is what is under test, so the later cleaning pass -- which
+        # would interpolate the zeroed pixels back in -- is bypassed.
+        with (
+            patch.object(
+                dark, "_compute_stats_from_datacube", return_value=(stats, False)
+            ),
+            patch.object(dark, "_clean_l1_arrays", lambda arrays, *a, **k: arrays),
+        ):
+            return dark.stack_frames()
+
+    def test_pixel_surviving_a_minority_of_frames_is_dropped(self):
+        # Four frames requested, so the threshold is > 2.0: three survivors pass,
+        # two do not. Weakening this to >= would admit the half-sampled pixel.
+        stats = self._stats(
+            nframe_ccd=[[2, 3], [4, 4]],
+            var_sum=[[9.0, 9.0], [9.0, 9.0]],
+            exptime_sum=[[3.0, 3.0], [3.0, 3.0]],
+        )
+        arrays = self._stack(stats)
+        assert bool(arrays["GREEN_MASK"][0, 0]) is False
+        assert arrays["GREEN_IMG"][0, 0] == 0.0
+        assert bool(arrays["GREEN_MASK"][0, 1]) is True
+        assert arrays["GREEN_IMG"][0, 1] > 0.0
+
+    def test_zero_variance_or_zero_exposure_pixels_are_dropped(self):
+        # Both guards sit beside the majority test and are otherwise unexercised:
+        # a pixel with no variance has no SNR, and one with no exposure has no
+        # rate, so neither may be published as good.
+        stats = self._stats(
+            nframe_ccd=[[4, 4], [4, 4]],
+            var_sum=[[0.0, 9.0], [9.0, 9.0]],
+            exptime_sum=[[3.0, 0.0], [3.0, 3.0]],
+        )
+        arrays = self._stack(stats)
+        assert bool(arrays["GREEN_MASK"][0, 0]) is False  # var_sum == 0
+        assert bool(arrays["GREEN_MASK"][0, 1]) is False  # exptime_sum == 0
+        assert bool(arrays["GREEN_MASK"][1, 1]) is True
+
+
+# ---------------------------------------------------------------------------
 # _clean_l1_arrays: bad-pixel interpolation and mask recompute
 # ---------------------------------------------------------------------------
 
@@ -613,6 +734,50 @@ class TestCleanL1Arrays:
         out = self._dark()._clean_l1_arrays(self._arrays(img, snr, mask), sigma=5.0)
 
         assert bool(out["GREEN_MASK"][4, 4]) is False
+
+    @pytest.mark.parametrize(
+        "cal_type,expected",
+        [
+            # The detector is illuminated only for flats, so each master type
+            # judges a pixel against a different reference: a bias against its
+            # own cross-dispersion column (axis=0), a flat against the smooth
+            # illumination trend along dispersion (axis=1, windowed), a dark
+            # against the global median. Collapsing this dispatch to one mode
+            # over-flags bias column structure and the flat's blaze while
+            # leaving mean(mask) > 0.9 true.
+            (None, {"method": "median"}),
+            ("dark", {"method": "median"}),
+            ("bias", {"axis": 0, "method": "median"}),
+            ("flat", {"axis": 1, "kernel_size": 32, "method": "trend"}),
+        ],
+    )
+    def test_cal_type_selects_the_flagging_mode(self, cal_type, expected, monkeypatch):
+        seen = {}
+
+        def _spy(data, sigma, **kwargs):
+            seen.update(kwargs)
+            return np.zeros(data.shape, dtype=bool)
+
+        monkeypatch.setattr(masters_base, "flag_outliers", _spy)
+        img = np.full((5, 5), 10.0, dtype=np.float32)
+        snr = np.full((5, 5), 20.0, dtype=np.float32)
+        mask = np.ones((5, 5), dtype=bool)
+
+        self._dark()._clean_l1_arrays(
+            self._arrays(img, snr, mask), sigma=5.0, cal_type=cal_type
+        )
+
+        assert seen == expected
+
+    def test_unknown_cal_type_raises(self):
+        # Fail loud rather than silently falling back to the dark mode.
+        img = np.full((5, 5), 10.0, dtype=np.float32)
+        snr = np.full((5, 5), 20.0, dtype=np.float32)
+        mask = np.ones((5, 5), dtype=bool)
+        with pytest.raises(ValueError, match="unknown cal_type"):
+            self._dark()._clean_l1_arrays(
+                self._arrays(img, snr, mask), sigma=5.0, cal_type="wls"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -778,6 +943,10 @@ class TestDtypeProvenance:
             name=MASTER_NAME,
             expected_disk=MASK_DISK,
         )
+        # to_fits casts the masks to uint8 and restores them in a finally:.
+        # Losing that restore would turn boolean masking into fancy integer
+        # indexing for every in-process consumer of this object.
+        assert_dtype(master.data["GREEN_MASK"], MASK_MEM, "GREEN_MASK after to_fits")
 
 
 # ---------------------------------------------------------------------------
@@ -817,3 +986,70 @@ class TestSaveMaster:
             bias.make_master_l1()  # populates ml1_obj
         with pytest.raises(FileExistsError, match="overwrite=True"):
             bias.save_master("L1", str(master_path))
+
+
+# ---------------------------------------------------------------------------
+# Config plumbing: each module reads the sections it names, and only those
+# ---------------------------------------------------------------------------
+
+
+class TestConfigSectionPlumbing:
+    """Every masters subclass names the config sections it reads. Dropping one
+    from that list is a silent fallback to _DEFAULTS -- a stack_sigma of 5.0
+    instead of the configured rejection threshold, or a search window reset --
+    with the master still building and only the numbers changing."""
+
+    # One config carrying a different stack_sigma in every section, so a module
+    # reading the wrong section is caught by the value, not merely by its absence.
+    SIGMAS = {"BIAS": 1.5, "DARK": 7.5, "FLAT": 3.25, "WLS": 9.0}
+
+    @classmethod
+    def _config(cls, **extra):
+        overrides = {section: {"stack_sigma": v} for section, v in cls.SIGMAS.items()}
+        for section, values in extra.items():
+            overrides.setdefault(section, {}).update(values)
+        return ConfigHandler(MASTERS_CONFIG_PATH, overrides=overrides)
+
+    @pytest.mark.parametrize(
+        "cls,section",
+        [(Bias, "BIAS"), (Dark, "DARK"), (Flat, "FLAT"), (WLS, "WLS")],
+    )
+    def test_stack_sigma_comes_from_the_modules_own_section(self, cls, section):
+        module = cls(FILE_LIST, self._config())
+        assert module.stack_sigma == self.SIGMAS[section]
+
+    @pytest.mark.parametrize("cls", [Bias, Dark, Flat, WLS])
+    def test_masters_output_comes_from_data_dirs(self, cls, tmp_path):
+        config = self._config(DATA_DIRS={"KPF_MASTERS_OUTPUT": str(tmp_path)})
+        assert cls(FILE_LIST, config)._masters_output == str(tmp_path)
+
+    @pytest.mark.parametrize("cls", [Dark, Flat, WLS])
+    def test_search_window_comes_from_the_calibration_association_section(self, cls):
+        # Bias takes no calibrations, so only the three that associate masters
+        # need this section; a reset to the default window would silently change
+        # which master calibrates which frame.
+        config = self._config(
+            MODULE_CALIBRATION_ASSOCIATION={"masters_search_window_days": [-3, 1]}
+        )
+        assert cls(FILE_LIST, config)._masters_search_window_days == [-3, 1]
+
+
+# ---------------------------------------------------------------------------
+# INPUT_FILES provenance
+# ---------------------------------------------------------------------------
+
+
+class TestInputFilesProvenance:
+    def test_records_the_input_list_and_master_type(self):
+        # INPUT_FILES and MASTYPE are the master's provenance anchor, and
+        # MASTYPE is what generate_standard_filename() needs to build a
+        # DRP-RUN-05 name after a round trip.
+        #
+        # NOTE: production records the *requested* L0 list, not the frames that
+        # survived stacking -- _build_ml1_obj passes l0_file_list straight to
+        # set_input_files, while _load_frame may drop QC failures within the
+        # tolerated budget. No frame is dropped here, so this assertion holds
+        # under either semantic; it is deliberately silent on which is intended.
+        ml1 = make_mocked_master(Bias)
+        assert ml1.data["INPUT_FILES"]["FILENAME"].tolist() == FILE_LIST
+        assert ml1.headers["PRIMARY"]["MASTYPE"] == "bias"

--- a/tests/regression/test_master_bias.py
+++ b/tests/regression/test_master_bias.py
@@ -1,8 +1,8 @@
 """Unit and regression tests for the master bias module (`Bias`).
 
-Unit tests mock stack_frames (no real data). TestMasterBiasRegression stacks the
-bundled L0 bias frames. The shared stacking engine and L1 output contract these
-exercise (`BaseMasterModule`) are unit-tested in test_master_base.py.
+Unit tests mock stack_frames (no real data); the regression tests stack the
+bundled L0 bias frames. The shared engine (`BaseMasterModule`) these exercise is
+unit-tested in test_master_base.py.
 """
 
 import os
@@ -30,8 +30,7 @@ TESTDATA_BIAS_FILES = sorted(
 )
 
 CHIPS = ["GREEN", "RED"]
-NROW, NCOL = 10, 10  # small arrays for unit tests
-# make_l1_arrays() -- shared synthetic stack_frames builder -- lives in _masters.py
+NROW, NCOL = 10, 10  # must match the shape make_l1_arrays() builds
 
 FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
@@ -42,8 +41,6 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 class TestMasterBiasUnit:
-    """Unit tests using a mocked stack_frames -- no real data needed."""
-
     @pytest.fixture(scope="class")
     def master_bias(self):
         synthetic = make_l1_arrays()
@@ -86,8 +83,6 @@ class TestMasterBiasUnit:
 
 
 class TestMasterBiasInfo:
-    """Smoke tests for Bias.info() in both pre- and post-perform states."""
-
     def test_info_before_make_master_l1(self, capsys):
         bias = Bias(FILE_LIST)
         bias.info()
@@ -114,8 +109,6 @@ class TestMasterBiasInfo:
 
 
 class TestMasterBiasRoundTrip:
-    """Test that master bias output survives a FITS write/read cycle."""
-
     def test_roundtrip_arrays(self):
         synthetic = make_l1_arrays()
         bias = Bias(FILE_LIST)
@@ -182,8 +175,6 @@ class TestMasterBiasSignature:
 
 @pytest.mark.slow
 class TestMasterBiasRegression:
-    """Regression tests against a real stack of L0 bias frames."""
-
     @pytest.fixture(scope="class")
     def master_bias(self):
         return Bias(TESTDATA_BIAS_FILES).make_master_l1()

--- a/tests/regression/test_master_bias.py
+++ b/tests/regression/test_master_bias.py
@@ -5,10 +5,7 @@ bundled L0 bias frames. The shared engine (`BaseMasterModule`) these exercise is
 unit-tested in test_master_base.py.
 """
 
-import os
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -16,7 +13,16 @@ import pytest
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.bias import Bias
 
-from ._masters import make_l1_arrays
+from ._dtype_policy import L1_IMAGE, assert_dtype
+from ._masters import (
+    CHIPS,
+    FILE_LIST,
+    MASTER_NAME,
+    NCOL,
+    NROW,
+    make_mocked_master,
+    mocked_stack,
+)
 
 TESTDATA_L0_DIR = Path(__file__).parent.parent / "testdata" / "L0" / "20240405"
 TESTDATA_BIAS_FILES = sorted(
@@ -29,11 +35,6 @@ TESTDATA_BIAS_FILES = sorted(
     ]
 )
 
-CHIPS = ["GREEN", "RED"]
-NROW, NCOL = 10, 10  # must match the shape make_l1_arrays() builds
-
-FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
-
 
 # ---------------------------------------------------------------------------
 # Unit tests (mocked stack_frames)
@@ -43,10 +44,7 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 class TestMasterBiasUnit:
     @pytest.fixture(scope="class")
     def master_bias(self):
-        synthetic = make_l1_arrays()
-        bias = Bias(FILE_LIST)
-        with patch.object(bias, "stack_frames", return_value=synthetic):
-            return bias.make_master_l1()
+        return make_mocked_master(Bias)
 
     def test_returns_kpf_master_l1(self, master_bias):
         assert isinstance(master_bias, KPFMasterL1)
@@ -57,10 +55,6 @@ class TestMasterBiasUnit:
     )
     def test_extension_shape(self, master_bias, ext):
         assert master_bias.data[ext].shape == (NROW, NCOL)
-
-    def test_mask_is_boolean(self, master_bias):
-        assert master_bias.data["GREEN_MASK"].dtype == bool
-        assert master_bias.data["RED_MASK"].dtype == bool
 
     def test_snr_non_negative(self, master_bias):
         assert np.all(master_bias.data["GREEN_SNR"] >= 0)
@@ -91,9 +85,8 @@ class TestMasterBiasInfo:
         assert "make_master_l1() has not been called" in out
 
     def test_info_after_make_master_l1(self, capsys):
-        synthetic = make_l1_arrays()
         bias = Bias(FILE_LIST)
-        with patch.object(bias, "stack_frames", return_value=synthetic):
+        with mocked_stack(bias):
             bias.make_master_l1()
         bias.info()
         out = capsys.readouterr().out
@@ -109,51 +102,26 @@ class TestMasterBiasInfo:
 
 
 class TestMasterBiasRoundTrip:
-    def test_roundtrip_arrays(self):
-        synthetic = make_l1_arrays()
-        bias = Bias(FILE_LIST)
-        with patch.object(bias, "stack_frames", return_value=synthetic):
-            ml1 = bias.make_master_l1()
+    """The mask/BITPIX dtype round-trip lives in test_master_base.py, which
+    exercises the same shared write path and also checks the on-disk BITPIX."""
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "KP.20240113.23249.10_master_bias_L1.fits")
-            ml1.to_fits(fn)
-            ml1_read = KPFMasterL1.from_fits(fn)
+    @pytest.fixture
+    def reread(self, tmp_path):
+        ml1 = make_mocked_master(Bias)
+        fn = str(tmp_path / MASTER_NAME)
+        ml1.to_fits(fn)
+        return ml1, KPFMasterL1.from_fits(fn)
 
-        np.testing.assert_array_almost_equal(
-            ml1_read.data["GREEN_IMG"], ml1.data["GREEN_IMG"], decimal=4
-        )
-        np.testing.assert_array_almost_equal(
-            ml1_read.data["RED_IMG"], ml1.data["RED_IMG"], decimal=4
-        )
+    def test_roundtrip_arrays(self, reread):
+        ml1, ml1_read = reread
+        for chip in CHIPS:
+            np.testing.assert_array_almost_equal(
+                ml1_read.data[f"{chip}_IMG"], ml1.data[f"{chip}_IMG"], decimal=4
+            )
 
-    def test_roundtrip_datalvl(self):
-        synthetic = make_l1_arrays()
-        bias = Bias(FILE_LIST)
-        with patch.object(bias, "stack_frames", return_value=synthetic):
-            ml1 = bias.make_master_l1()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "KP.20240113.23249.10_master_bias_L1.fits")
-            ml1.to_fits(fn)
-            ml1_read = KPFMasterL1.from_fits(fn)
-
-        val = ml1_read.headers["PRIMARY"].get("DATALVL")
-        assert val == "ML1"
-
-    def test_roundtrip_mask_dtype(self):
-        synthetic = make_l1_arrays()
-        bias = Bias(FILE_LIST)
-        with patch.object(bias, "stack_frames", return_value=synthetic):
-            ml1 = bias.make_master_l1()
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "KP.20240113.23249.10_master_bias_L1.fits")
-            ml1.to_fits(fn)
-            ml1_read = KPFMasterL1.from_fits(fn)
-
-        assert ml1_read.data["GREEN_MASK"].dtype == bool
-        assert ml1_read.data["RED_MASK"].dtype == bool
+    def test_roundtrip_datalvl(self, reread):
+        _, ml1_read = reread
+        assert ml1_read.headers["PRIMARY"].get("DATALVL") == "ML1"
 
 
 # ---------------------------------------------------------------------------
@@ -174,6 +142,7 @@ class TestMasterBiasSignature:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestMasterBiasRegression:
     @pytest.fixture(scope="class")
     def master_bias(self):
@@ -201,9 +170,10 @@ class TestMasterBiasRegression:
         assert np.sum(master_bias.data["RED_MASK"]) > 0
 
     def test_img_snr_dtype_is_float32(self, master_bias):
-        for chip in ("GREEN", "RED"):
-            assert master_bias.data[f"{chip}_IMG"].dtype == np.float32
-            assert master_bias.data[f"{chip}_SNR"].dtype == np.float32
+        for chip in CHIPS:
+            for suffix in ("IMG", "SNR"):
+                ext = f"{chip}_{suffix}"
+                assert_dtype(master_bias.data[ext], L1_IMAGE, ext)
 
     def test_receipt_chain(self, master_bias):
         assert "master_bias" in master_bias.receipt["FUNCTION"].values

--- a/tests/regression/test_master_bias.py
+++ b/tests/regression/test_master_bias.py
@@ -123,7 +123,7 @@ class TestMasterBiasRoundTrip:
             ml1 = bias.make_master_l1()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "master_bias.fits")
+            fn = os.path.join(tmpdir, "KP.20240113.23249.10_master_bias_L1.fits")
             ml1.to_fits(fn)
             ml1_read = KPFMasterL1.from_fits(fn)
 
@@ -141,7 +141,7 @@ class TestMasterBiasRoundTrip:
             ml1 = bias.make_master_l1()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "master_bias.fits")
+            fn = os.path.join(tmpdir, "KP.20240113.23249.10_master_bias_L1.fits")
             ml1.to_fits(fn)
             ml1_read = KPFMasterL1.from_fits(fn)
 
@@ -155,7 +155,7 @@ class TestMasterBiasRoundTrip:
             ml1 = bias.make_master_l1()
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            fn = os.path.join(tmpdir, "master_bias.fits")
+            fn = os.path.join(tmpdir, "KP.20240113.23249.10_master_bias_L1.fits")
             ml1.to_fits(fn)
             ml1_read = KPFMasterL1.from_fits(fn)
 

--- a/tests/regression/test_master_bias.py
+++ b/tests/regression/test_master_bias.py
@@ -12,6 +12,8 @@ import pytest
 
 from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.bias import Bias
+from kpfpipe.utils.io import kpf_filepath
+from kpfpipe.utils.kpf import get_obs_id
 
 from ._dtype_policy import L1_IMAGE, assert_dtype
 from ._masters import (
@@ -55,10 +57,6 @@ class TestMasterBiasUnit:
     )
     def test_extension_shape(self, master_bias, ext):
         assert master_bias.data[ext].shape == (NROW, NCOL)
-
-    def test_snr_non_negative(self, master_bias):
-        assert np.all(master_bias.data["GREEN_SNR"] >= 0)
-        assert np.all(master_bias.data["RED_SNR"] >= 0)
 
     def test_receipt_entry(self, master_bias):
         assert "master_bias" in master_bias.receipt["FUNCTION"].values
@@ -132,8 +130,9 @@ class TestMasterBiasRoundTrip:
 class TestMasterBiasSignature:
     @pytest.mark.parametrize("kwarg", ["bias", "dark", "flat"])
     def test_calibration_kwargs_rejected(self, kwarg):
-        with pytest.raises(TypeError):
-            Bias(FILE_LIST).make_master_l1(**{kwarg: True})
+        module = Bias(FILE_LIST)
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            module.make_master_l1(**{kwarg: True})
 
 
 # ---------------------------------------------------------------------------
@@ -177,3 +176,52 @@ class TestMasterBiasRegression:
 
     def test_receipt_chain(self, master_bias):
         assert "master_bias" in master_bias.receipt["FUNCTION"].values
+
+    # ------------------------------------------------------------------
+    # The persisted product: written through kpf_filepath, as the masters
+    # recipe writes it, then read back. These assertions arrived from a
+    # recipe test that re-stacked this same five-frame bias to reach them.
+    # ------------------------------------------------------------------
+
+    @pytest.fixture(scope="class")
+    def master_bias_on_disk(self, master_bias, tmp_path_factory):
+        out_path = kpf_filepath(
+            get_obs_id(TESTDATA_BIAS_FILES[0]),
+            "L1",
+            data_root=str(tmp_path_factory.mktemp("master_bias_out")),
+            master="bias",
+        )
+        Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+        master_bias.to_fits(out_path)
+        return out_path, KPFMasterL1.from_fits(out_path)
+
+    def test_written_to_the_convention_path(self, master_bias_on_disk):
+        out_path, _ = master_bias_on_disk
+        assert Path(out_path).is_file()
+        assert Path(out_path).name.endswith("_master_bias_L1.fits")
+
+    def test_round_trip_preserves_chip_images(self, master_bias, master_bias_on_disk):
+        _, read_back = master_bias_on_disk
+        for chip in CHIPS:
+            np.testing.assert_array_equal(
+                read_back.data[f"{chip}_IMG"], master_bias.data[f"{chip}_IMG"]
+            )
+
+    def test_input_files_extension_present(self, master_bias_on_disk):
+        _, read_back = master_bias_on_disk
+        assert "INPUT_FILES" in read_back.extensions
+
+    def test_input_files_records_the_stacked_frames(self, master_bias_on_disk):
+        # NOTE: production records the *requested* file list, not the frames that
+        # survived stacking -- masters/base.py passes l0_file_list into
+        # set_input_files unchanged, while _load_frame may drop QC failures within
+        # the tolerated budget. All five frames here pass, so the count is the
+        # same under either semantic; when that provenance defect is fixed, this
+        # is the assertion that will need revisiting.
+        _, read_back = master_bias_on_disk
+        assert len(read_back.data["INPUT_FILES"]) == len(TESTDATA_BIAS_FILES)
+
+    def test_input_files_all_fits(self, master_bias_on_disk):
+        _, read_back = master_bias_on_disk
+        filenames = read_back.data["INPUT_FILES"]["FILENAME"].tolist()
+        assert all(name.endswith(".fits") for name in filenames)

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -8,7 +8,6 @@ unit-tested in test_master_base.py.
 """
 
 from pathlib import Path
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -17,13 +16,10 @@ from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.dark import Dark
 from kpfpipe.utils.io import FileHandler
 
-from ._masters import make_l1_arrays
-
-CHIPS = ["GREEN", "RED"]
+from ._dtype_policy import MASK_MEM, assert_dtype
+from ._masters import CHIPS, FILE_LIST, make_mocked_master
 
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
-
-FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 # ---------------------------------------------------------------------------
@@ -34,10 +30,7 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 class TestMasterDarkUnit:
     @pytest.fixture(scope="class")
     def master_dark(self):
-        synthetic = make_l1_arrays()
-        dark = Dark(FILE_LIST)
-        with patch.object(dark, "stack_frames", return_value=synthetic):
-            return dark.make_master_l1()
+        return make_mocked_master(Dark)
 
     def test_receipt_entry(self, master_dark):
         assert "master_dark" in master_dark.receipt["FUNCTION"].values
@@ -60,11 +53,7 @@ class TestMasterDarkSignature:
             Dark(FILE_LIST).make_master_l1(**{kwarg: True})
 
     def test_bias_kwarg_accepted(self):
-        synthetic = make_l1_arrays()
-        dark = Dark(FILE_LIST)
-        with patch.object(dark, "stack_frames", return_value=synthetic):
-            ml1 = dark.make_master_l1(bias=False)
-        assert isinstance(ml1, KPFMasterL1)
+        assert isinstance(make_mocked_master(Dark, bias=False), KPFMasterL1)
 
 
 # ---------------------------------------------------------------------------
@@ -74,6 +63,7 @@ class TestMasterDarkSignature:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestMasterDarkRegression:
     @pytest.fixture(scope="class")
     def master_dark(self):
@@ -110,7 +100,7 @@ class TestMasterDarkRegression:
         # A clean detector stack keeps the large majority of pixels.
         for chip in CHIPS:
             mask = master_dark.data[f"{chip}_MASK"]
-            assert mask.dtype == bool
+            assert_dtype(mask, MASK_MEM, f"{chip}_MASK")
             assert np.mean(mask) > 0.9
 
     def test_bias_subtracted_via_receipt(self, master_dark):

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -1,11 +1,10 @@
 """Unit and regression tests for the master dark module (`Dark`).
 
-Unit tests mock stack_frames (no real data). TestMasterDarkRegression builds a
-real master dark from the bundled L0 darks: the five frames span two default-gap
-clusters and HST midnight, so it groups them with groupby='obs_night' (the whole
-loaded night in one stack) before bias-subtracting each frame. The shared
-stacking engine these exercise (`BaseMasterModule`) is unit-tested in
-test_master_base.py.
+Unit tests mock stack_frames; the regression class builds a real master dark from
+the five bundled L0 darks, which span two default-gap clusters and HST midnight and
+so are grouped with groupby='obs_night' (the whole night in one stack), as the
+masters recipe does for darks. The shared stacking engine (`BaseMasterModule`) is
+unit-tested in test_master_base.py.
 """
 
 from pathlib import Path
@@ -21,7 +20,6 @@ from kpfpipe.utils.io import FileHandler
 from ._masters import make_l1_arrays
 
 CHIPS = ["GREEN", "RED"]
-# make_l1_arrays() -- shared synthetic stack_frames builder -- lives in _masters.py
 
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 
@@ -34,8 +32,6 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 class TestMasterDarkUnit:
-    """Unit tests using a mocked stack_frames -- no real data needed."""
-
     @pytest.fixture(scope="class")
     def master_dark(self):
         synthetic = make_l1_arrays()
@@ -79,11 +75,6 @@ class TestMasterDarkSignature:
 
 @pytest.mark.slow
 class TestMasterDarkRegression:
-    """End-to-end master dark from real L0 frames. The five bundled darks span
-    two default-gap clusters *and* HST midnight, so they are grouped with
-    groupby='obs_night' (the whole night in one stack, as the masters recipe does
-    for darks); each frame is bias-subtracted against the bundled master bias."""
-
     @pytest.fixture(scope="class")
     def master_dark(self):
         file_handler = FileHandler({"KPF_DATA_INPUT": str(TESTDATA_DIR)})
@@ -116,7 +107,7 @@ class TestMasterDarkRegression:
             assert np.all(master_dark.data[f"{chip}_SNR"] >= 0)
 
     def test_mask_mostly_good(self, master_dark):
-        # A clean detector stack should keep the large majority of pixels.
+        # A clean detector stack keeps the large majority of pixels.
         for chip in CHIPS:
             mask = master_dark.data[f"{chip}_MASK"]
             assert mask.dtype == bool

--- a/tests/regression/test_master_dark.py
+++ b/tests/regression/test_master_dark.py
@@ -49,8 +49,9 @@ class TestMasterDarkUnit:
 class TestMasterDarkSignature:
     @pytest.mark.parametrize("kwarg", ["dark", "flat"])
     def test_dark_flat_kwargs_rejected(self, kwarg):
-        with pytest.raises(TypeError):
-            Dark(FILE_LIST).make_master_l1(**{kwarg: True})
+        module = Dark(FILE_LIST)
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            module.make_master_l1(**{kwarg: True})
 
     def test_bias_kwarg_accepted(self):
         assert isinstance(make_mocked_master(Dark, bias=False), KPFMasterL1)
@@ -102,6 +103,3 @@ class TestMasterDarkRegression:
             mask = master_dark.data[f"{chip}_MASK"]
             assert_dtype(mask, MASK_MEM, f"{chip}_MASK")
             assert np.mean(mask) > 0.9
-
-    def test_bias_subtracted_via_receipt(self, master_dark):
-        assert "master_dark" in master_dark.receipt["FUNCTION"].values

--- a/tests/regression/test_master_flat.py
+++ b/tests/regression/test_master_flat.py
@@ -7,7 +7,6 @@ stacking engine (`BaseMasterModule`) is unit-tested in test_master_base.py.
 """
 
 from pathlib import Path
-from unittest.mock import patch
 
 import numpy as np
 import pytest
@@ -16,13 +15,10 @@ from kpfpipe.data_models.masters import KPFMasterL1
 from kpfpipe.modules.masters.flat import Flat
 from kpfpipe.utils.io import FileHandler
 
-from ._masters import make_l1_arrays
-
-CHIPS = ["GREEN", "RED"]
+from ._dtype_policy import MASK_MEM, assert_dtype
+from ._masters import CHIPS, FILE_LIST, make_mocked_master
 
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
-
-FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 # ---------------------------------------------------------------------------
@@ -33,10 +29,7 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 class TestMasterFlatUnit:
     @pytest.fixture(scope="class")
     def master_flat(self):
-        synthetic = make_l1_arrays()
-        flat = Flat(FILE_LIST)
-        with patch.object(flat, "stack_frames", return_value=synthetic):
-            return flat.make_master_l1()
+        return make_mocked_master(Flat)
 
     def test_receipt_entry(self, master_flat):
         assert "master_flat" in master_flat.receipt["FUNCTION"].values
@@ -60,10 +53,7 @@ class TestMasterFlatSignature:
 
     @pytest.mark.parametrize("kwarg", ["bias", "dark"])
     def test_bias_dark_kwargs_accepted(self, kwarg):
-        synthetic = make_l1_arrays()
-        flat = Flat(FILE_LIST)
-        with patch.object(flat, "stack_frames", return_value=synthetic):
-            ml1 = flat.make_master_l1(**{kwarg: False})
+        ml1 = make_mocked_master(Flat, **{kwarg: False})
         assert isinstance(ml1, KPFMasterL1)
 
 
@@ -74,6 +64,7 @@ class TestMasterFlatSignature:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestMasterFlatRegression:
     @pytest.fixture(scope="class")
     def master_flat(self):
@@ -111,7 +102,7 @@ class TestMasterFlatRegression:
         # bright orders are not over-flagged against the dark inter-order floor.
         for chip in CHIPS:
             mask = master_flat.data[f"{chip}_MASK"]
-            assert mask.dtype == bool
+            assert_dtype(mask, MASK_MEM, f"{chip}_MASK")
             assert np.mean(mask) > 0.9
 
     def test_calibrated_via_receipt(self, master_flat):

--- a/tests/regression/test_master_flat.py
+++ b/tests/regression/test_master_flat.py
@@ -1,11 +1,9 @@
 """Unit and regression tests for the master flat module (`Flat`).
 
-Unit tests mock stack_frames (no real data). TestMasterFlatRegression builds a
-real master flat from the bundled L0 flats: the five frames fall within one
-time-of-day cluster, so it groups them with groupby='time_of_day' (as the masters
-recipe does for flats) before bias- and dark-subtracting each frame. The shared
-stacking engine these exercise (`BaseMasterModule`) is unit-tested in
-test_master_base.py.
+Unit tests mock stack_frames; the regression class builds a real master flat from
+the five bundled L0 flats, which fall in one time-of-day cluster and so are grouped
+with groupby='time_of_day', as the masters recipe does for flats. The shared
+stacking engine (`BaseMasterModule`) is unit-tested in test_master_base.py.
 """
 
 from pathlib import Path
@@ -21,7 +19,6 @@ from kpfpipe.utils.io import FileHandler
 from ._masters import make_l1_arrays
 
 CHIPS = ["GREEN", "RED"]
-# make_l1_arrays() -- shared synthetic stack_frames builder -- lives in _masters.py
 
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 
@@ -34,8 +31,6 @@ FILE_LIST = [f"KP.20240101.{i:05d}.00.fits" for i in range(8)]
 
 
 class TestMasterFlatUnit:
-    """Unit tests using a mocked stack_frames -- no real data needed."""
-
     @pytest.fixture(scope="class")
     def master_flat(self):
         synthetic = make_l1_arrays()
@@ -80,11 +75,6 @@ class TestMasterFlatSignature:
 
 @pytest.mark.slow
 class TestMasterFlatRegression:
-    """End-to-end master flat from real L0 frames. The five bundled flats fall
-    within a single time-of-day cluster, so they are grouped with
-    groupby='time_of_day' (as the masters recipe does for flats); each frame is
-    bias- and dark-subtracted against the bundled master bias and dark."""
-
     @pytest.fixture(scope="class")
     def master_flat(self):
         file_handler = FileHandler({"KPF_DATA_INPUT": str(TESTDATA_DIR)})
@@ -102,8 +92,7 @@ class TestMasterFlatRegression:
         assert isinstance(master_flat, KPFMasterL1)
 
     def test_flat_is_illuminated(self, master_flat):
-        # A flat is an illuminated exposure, so the stacked image has real
-        # positive signal.
+        # A flat is an illuminated exposure, so the stack carries positive signal.
         for chip in CHIPS:
             median = np.nanmedian(master_flat.data[f"{chip}_IMG"])
             assert median > 0
@@ -117,10 +106,9 @@ class TestMasterFlatRegression:
             assert np.all(master_flat.data[f"{chip}_SNR"] >= 0)
 
     def test_mask_mostly_good(self, master_flat):
-        # A clean detector stack keeps the large majority of pixels. The final
-        # trend outlier pass scales its threshold by a local (not global) noise
-        # scale, so the flat's bright orders are not over-flagged against the
-        # dark inter-order floor.
+        # A clean detector stack keeps the large majority of pixels: the final trend
+        # outlier pass scales its threshold by a local (not global) noise scale, so
+        # bright orders are not over-flagged against the dark inter-order floor.
         for chip in CHIPS:
             mask = master_flat.data[f"{chip}_MASK"]
             assert mask.dtype == bool

--- a/tests/regression/test_master_flat.py
+++ b/tests/regression/test_master_flat.py
@@ -48,8 +48,9 @@ class TestMasterFlatUnit:
 
 class TestMasterFlatSignature:
     def test_flat_kwarg_rejected(self):
-        with pytest.raises(TypeError):
-            Flat(FILE_LIST).make_master_l1(flat=True)
+        module = Flat(FILE_LIST)
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            module.make_master_l1(flat=True)
 
     @pytest.mark.parametrize("kwarg", ["bias", "dark"])
     def test_bias_dark_kwargs_accepted(self, kwarg):
@@ -104,6 +105,3 @@ class TestMasterFlatRegression:
             mask = master_flat.data[f"{chip}_MASK"]
             assert_dtype(mask, MASK_MEM, f"{chip}_MASK")
             assert np.mean(mask) > 0.9
-
-    def test_calibrated_via_receipt(self, master_flat):
-        assert "master_flat" in master_flat.receipt["FUNCTION"].values

--- a/tests/regression/test_master_order_trace.py
+++ b/tests/regression/test_master_order_trace.py
@@ -809,9 +809,13 @@ class TestCSVWriting:
 
         tracer.save_master(output, overwrite=False)
         assert output.is_file()
-        with pytest.raises(FileExistsError):
+        with pytest.raises(FileExistsError, match="pass overwrite=True"):
             tracer.save_master(output, overwrite=False)
+
+        output.write_text("")  # the rewrite must replace this, not skip it
         tracer.save_master(output, overwrite=True)
+        assert tracer.output_path == output
+        assert pd.read_csv(output)["Fiber"].tolist() == ["SKY"]
 
     def test_refuses_to_save_before_make_master(self, tmp_path, master_path):
         tracer = OrderTrace(master_path)
@@ -850,6 +854,30 @@ def _assert_apertures_disjoint(table, ncol):
     upper = centers + measured["TopEdge"].to_numpy(dtype=float)[:, None]
     lower = centers - measured["BottomEdge"].to_numpy(dtype=float)[:, None]
     assert np.all(lower[1:] > upper[:-1])
+
+
+def _edge_reaching_tracer(tmp_path, monkeypatch):
+    """A detected, identified tracer whose first cluster runs off a row edge.
+
+    Extends that cluster to row 0 over every column past the midpoint, so the
+    trace can no longer be centered there. Returns ``(tracer, image, half)``;
+    ``half`` is the first column the cluster reaches the edge at.
+    """
+    image, _ = _synthetic_flat()
+    tracer = _tracer(tmp_path, image, monkeypatch)
+    tracer.detect_traces("GREEN")
+    tracer.assign_trace_identities("GREEN")
+
+    cluster = tracer._clusters["GREEN"][
+        int(tracer._metadata["GREEN"]["cluster"].iloc[0])
+    ]
+    half = image.shape[1] // 2
+    reaching = cluster["col_indices"][cluster["col_indices"] >= half]
+    cluster["row_indices"] = np.concatenate(
+        [cluster["row_indices"], np.zeros(reaching.size, dtype=int)]
+    )
+    cluster["col_indices"] = np.concatenate([cluster["col_indices"], reaching])
+    return tracer, image, half
 
 
 def _fitted_tracer(tmp_path, monkeypatch, **kwargs):
@@ -947,21 +975,10 @@ class TestApertureConstraint:
         # A column where the cluster reaches a detector edge cannot yield a
         # center, so an order running off the detector is judged on its own
         # span rather than on the whole dispersion.
-        image, _ = _synthetic_flat()
-        tracer = _tracer(tmp_path, image, monkeypatch)
-        tracer.detect_traces("GREEN")
-        tracer.assign_trace_identities("GREEN")
+        tracer, _, half = _edge_reaching_tracer(tmp_path, monkeypatch)
+        # Sampled columns depend on the column alone, so the cluster edit above
+        # does not affect them.
         columns = tracer._sample_profiles("GREEN")["columns"]
-
-        cluster = tracer._clusters["GREEN"][
-            int(tracer._metadata["GREEN"]["cluster"].iloc[0])
-        ]
-        half = image.shape[1] // 2
-        reaching = cluster["col_indices"][cluster["col_indices"] >= half]
-        cluster["row_indices"] = np.concatenate(
-            [cluster["row_indices"], np.zeros(reaching.size, dtype=int)]
-        )
-        cluster["col_indices"] = np.concatenate([cluster["col_indices"], reaching])
 
         offered = []
         fit_polynomial = order_trace_module.robust_polyfit
@@ -981,20 +998,7 @@ class TestApertureConstraint:
     ):
         # A cubic extrapolated beyond its fitted span can curl back over the
         # detector and read as carried, so X1-X2 must stay inside that span.
-        image, _ = _synthetic_flat()
-        tracer = _tracer(tmp_path, image, monkeypatch)
-        tracer.detect_traces("GREEN")
-        tracer.assign_trace_identities("GREEN")
-
-        cluster = tracer._clusters["GREEN"][
-            int(tracer._metadata["GREEN"]["cluster"].iloc[0])
-        ]
-        half = image.shape[1] // 2
-        reaching = cluster["col_indices"][cluster["col_indices"] >= half]
-        cluster["row_indices"] = np.concatenate(
-            [cluster["row_indices"], np.zeros(reaching.size, dtype=int)]
-        )
-        cluster["col_indices"] = np.concatenate([cluster["col_indices"], reaching])
+        tracer, image, half = _edge_reaching_tracer(tmp_path, monkeypatch)
 
         fitted = tracer.fit_trace_polynomials("GREEN")
         assert fitted[["X1", "X2"]].iloc[0].tolist() == [0.0, half - 1.0]
@@ -1011,20 +1015,7 @@ class TestApertureConstraint:
         # Over the columns a partial trace was not fitted at, a cubic is free
         # to turn back and carry the aperture off the detector and onto it
         # again, so such a fit is redone as a parabola.
-        image, _ = _synthetic_flat()
-        tracer = _tracer(tmp_path, image, monkeypatch)
-        tracer.detect_traces("GREEN")
-        tracer.assign_trace_identities("GREEN")
-
-        cluster = tracer._clusters["GREEN"][
-            int(tracer._metadata["GREEN"]["cluster"].iloc[0])
-        ]
-        half = image.shape[1] // 2
-        reaching = cluster["col_indices"][cluster["col_indices"] >= half]
-        cluster["row_indices"] = np.concatenate(
-            [cluster["row_indices"], np.zeros(reaching.size, dtype=int)]
-        )
-        cluster["col_indices"] = np.concatenate([cluster["col_indices"], reaching])
+        tracer, image, half = _edge_reaching_tracer(tmp_path, monkeypatch)
 
         degrees = []
         fit_polynomial = order_trace_module.robust_polyfit

--- a/tests/regression/test_master_order_trace.py
+++ b/tests/regression/test_master_order_trace.py
@@ -1,9 +1,9 @@
 """Tests for spectral order tracing from one vNext L1 master flat.
 
-Numerical tests use synthetic master images and require no real data. The
-synthetic flat reproduces the morphology the algorithm depends on: science and
-sky orderlets are wide and flat-topped, and the CAL orderlet is narrow, which
-is the difference identity rests on. The real master-flat test uses gitignored
+Numerical tests use synthetic master images and need no real data. The synthetic
+flat reproduces the morphology the algorithm depends on: science and sky
+orderlets are wide and flat-topped while the CAL orderlet is narrow, which is the
+difference identity rests on. The real master-flat test uses gitignored
 ``tests/testdata`` and is skipped when the vNext product is unavailable.
 """
 
@@ -72,7 +72,6 @@ def _stub_master_class(master_flat):
 
 
 def _orderlet_profile(offsets, fiber):
-    """Return the cross-dispersion profile of one orderlet."""
     if fiber == "CAL":
         return 1500.0 * np.exp(-0.5 * (offsets / 1.8) ** 2)
     return 500.0 * np.exp(-0.5 * (offsets / 5.5) ** 6)
@@ -189,9 +188,8 @@ def _band_cluster(rows, columns):
 def _curated_clusters(tracer):
     """Run detection and curation exactly as the module's own chain does.
 
-    The clusters are cached where the later steps read them from, as
-    detect_traces does, so identity can be exercised on cluster counts
-    detection itself would refuse.
+    The clusters are cached where the later steps read them from, as detect_traces
+    does, so identity can be exercised on cluster counts detection would refuse.
     """
     clusters = tracer._detect_clusters(tracer._detect_illuminated_pixels("GREEN"))
     clusters = tracer._reject_small_clusters(clusters)
@@ -822,7 +820,7 @@ class TestCSVWriting:
 
 
 # ---------------------------------------------------------------------------
-# Aperture non-overlap constraint
+# Trace fitting, apertures, and validation
 # ---------------------------------------------------------------------------
 
 
@@ -1211,12 +1209,10 @@ class TestRealData:
     @pytest.mark.slow
     @pytest.mark.requires_testdata
     def test_real_20240405_master_flat(self, tmp_path):
-        """Trace a real vNext master flat and check it reproduces the reference.
-
-        The comparison is against the vetted reference extraction would pin to
-        this frame -- the latest trace measured before it within its instrument
-        era -- so it holds the module's output to the shipped artifact rather
-        than standing as independent truth."""
+        # The comparison is against the vetted reference extraction would pin to
+        # this frame -- the latest trace measured before it within its instrument
+        # era -- so it holds the module's output to the shipped artifact rather
+        # than standing as independent truth.
         testdata = Path(__file__).parent.parent / "testdata"
         masters = sorted(testdata.glob("**/KP.20240405.*_master_flat_L1.fits"))
         if not masters:

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -17,13 +17,13 @@ from kpfpipe.data_models.masters import KPFMasterL2
 from kpfpipe.modules.masters.wls import WLS
 from kpfpipe.utils.kpf import get_obs_id
 
-from ._dtype_policy import WAVE, assert_dtype, assert_roundtrip_dtype
+from ._dtype_policy import MASK_MEM, WAVE, assert_dtype, assert_roundtrip_dtype
+from ._masters import FILE_LIST
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
 NORDER_RED = DETECTOR["norder"]["RED"]
 NCOL_TEST = 16
 
-FILE_LIST = sorted([f"KP.20240101.{i:05d}.00.fits" for i in range(8)])
 DATECODE = "20240101"  # shared by FILE_LIST and the master obs_ids below
 
 
@@ -94,6 +94,21 @@ def mock_pipeline(monkeypatch):
 # ---------------------------------------------------------------------------
 # TestInit
 # ---------------------------------------------------------------------------
+
+
+def _stub_frame_pipeline(monkeypatch, l1=None, extract=None):
+    """Short-circuit load -> process -> extract so a test drives only the fit.
+
+    ``_load_frame`` threads each source filename through as the opaque L1 token
+    unless ``l1`` overrides it, so the extracted L2 stub carries that frame's
+    obs_id (which drives per-frame naming). The fit/combine stubs stay per-test:
+    their survivor and rejection structure IS what each test asserts.
+    """
+    load = (lambda self, fn, cache=False, **kw: fn) if l1 is None else l1
+    extract = extract or (lambda self, l1_obj, **kw: MockL2(get_obs_id(l1_obj)))
+    monkeypatch.setattr(WLS, "_load_frame", load)
+    monkeypatch.setattr(WLS, "_process_frame", lambda self, l1_obj, **kw: l1_obj)
+    monkeypatch.setattr(WLS, "_extract_frame", extract)
 
 
 class TestInit:
@@ -207,13 +222,7 @@ def mock_make_master_l2(monkeypatch):
     so the default min_stack_size=5 gate passes); the combine stub returns
     synthetic W and coefficient arrays with chip-correct shapes.
     """
-    # Thread each source filename through as the opaque L1 token so the
-    # extracted L2 stub carries that frame's obs_id (drives per-frame naming).
-    monkeypatch.setattr(WLS, "_load_frame", lambda self, fn, cache=False, **kwargs: fn)
-    monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kwargs: l1)
-    monkeypatch.setattr(
-        WLS, "_extract_frame", lambda self, l1, **kwargs: MockL2(get_obs_id(l1))
-    )
+    _stub_frame_pipeline(monkeypatch)
 
     def mock_fit_and_qc(
         self,
@@ -293,11 +302,11 @@ class TestMakeMasterL2:
         # W's planes are ordered by fiber_positions (SKY=0..CAL=4), so the write
         # loop must sort by that, not trust self.fibers' config-overridable
         # order -- else SKY's solution lands on CAL and vice versa.
-        monkeypatch.setattr(
-            WLS, "_load_frame", lambda self, fn, cache=False, **kw: MockL1()
+        _stub_frame_pipeline(
+            monkeypatch,
+            l1=lambda self, fn, cache=False, **kw: MockL1(),
+            extract=lambda self, l1_obj, **kw: MockL2(),
         )
-        monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kw: l1)
-        monkeypatch.setattr(WLS, "_extract_frame", lambda self, l1, **kw: MockL2())
 
         def mock_fit_and_qc(self, chip, fibers, **kwargs):
             coeffs = np.zeros((self.poly_degree_x + 1, self.poly_degree_m + 1, 1))
@@ -451,10 +460,12 @@ class TestMakeMasterL2:
             assert chip in wls._frame_diagnostics
             assert len(wls._frame_diagnostics[chip]) == len(FILE_LIST)
 
-    def test_save_diagnostics_before_make_raises(self):
+    def test_save_diagnostics_before_make_raises(self, tmp_path):
         wls = WLS(FILE_LIST)
         with pytest.raises(RuntimeError, match="run make_master_l2"):
-            wls.save_diagnostics("/tmp/KP.20240101.00000.00_master_thar_L2.fits")
+            wls.save_diagnostics(
+                str(tmp_path / "KP.20240101.00000.00_master_thar_L2.fits")
+            )
 
     def test_save_diagnostics_with_empty_stash_raises(self, tmp_path):
         # An empty (not None) stash means the chip loop aborted before any chip
@@ -581,7 +592,7 @@ class TestMakeMasterL2:
                     assert np.issubdtype(lines["pix"].dtype, np.floating)
                     assert np.issubdtype(lines["index"].dtype, np.integer)
                     assert np.issubdtype(lines["echelle"].dtype, np.integer)
-                    assert lines["isgood"].dtype == bool
+                    assert_dtype(lines["isgood"], MASK_MEM, "isgood")
                     assert h5py.check_string_dtype(lines["chip"].dtype) is not None
                     assert h5py.check_string_dtype(lines["fiber"].dtype) is not None
                     for key in ["wav", "pix", "std", "amp"]:
@@ -947,11 +958,7 @@ class TestMinStackSizeGate:
         # n_survivors is an int (same for every chip) or a {chip: count} dict, so
         # a test can make GREEN and RED pass/fail the gate independently.
         files = sorted(f"KP.20240101.{i:05d}.00.fits" for i in range(n_frames))
-        monkeypatch.setattr(WLS, "_load_frame", lambda self, fn, cache=False, **kw: fn)
-        monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kw: l1)
-        monkeypatch.setattr(
-            WLS, "_extract_frame", lambda self, l1, **kw: MockL2(get_obs_id(l1))
-        )
+        _stub_frame_pipeline(monkeypatch)
 
         def mock_fit(self, chip, fibers, **kwargs):
             n = n_survivors[chip] if isinstance(n_survivors, dict) else n_survivors
@@ -1079,7 +1086,7 @@ class TestFitLinePositions:
         )
         assert len(result["wav"]) == 1
         for key in ["wav", "pix", "std", "amp"]:
-            assert result[key].dtype == np.float64
+            assert_dtype(result[key], WAVE, f"_fit_line_positions_1d {key}")
 
     def test_all_nan_fiber_emits_fiber_level_warning(self, caplog):
         wls = WLS(FILE_LIST)

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -20,6 +20,9 @@ from kpfpipe.utils.kpf import get_obs_id
 from ._dtype_policy import MASK_MEM, WAVE, assert_dtype, assert_roundtrip_dtype
 from ._masters import FILE_LIST
 
+# Captured before the memoizing fixture below patches the method.
+_REAL_LOAD_ROUGH_WLS = WLS._load_rough_wls
+
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]
 NORDER_RED = DETECTOR["norder"]["RED"]
 NCOL_TEST = 16
@@ -30,6 +33,38 @@ DATECODE = "20240101"  # shared by FILE_LIST and the master obs_ids below
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def cached_rough_wls():
+    """The rough-WLS grid, built once for the whole module."""
+    return WLS(FILE_LIST).rough_wls
+
+
+@pytest.fixture(autouse=True)
+def _memoize_rough_wls(cached_rough_wls, monkeypatch):
+    """Serve every ``WLS(...)`` in this file the grid built once above.
+
+    ``WLS.__init__`` rebuilds the rough-WLS grid unconditionally -- measured at
+    0.15 s a call, and this file constructs roughly sixty. The grid depends only
+    on class defaults (the CSV, ncol, chips, fibers, echelle orders), so each
+    instance gets a fresh dict wrapping the shared arrays; the three tests that
+    override a channel rebind the key rather than writing through it.
+
+    A caller passing an explicit ``rough_wls_file`` still reaches the real
+    loader, so the missing-file path is unaffected, and
+    ``test_cached_grid_matches_the_real_loader`` drives the real loader once per
+    run to keep this cache honest.
+    """
+
+    def _cached(self, rough_wls_file=None):
+        if rough_wls_file is not None and rough_wls_file != self.rough_wls_file:
+            return _REAL_LOAD_ROUGH_WLS(self, rough_wls_file)
+        if not hasattr(self, "rough_wls"):
+            self.rough_wls = dict(cached_rough_wls)
+        return self.rough_wls
+
+    monkeypatch.setattr(WLS, "_load_rough_wls", _cached)
 
 
 class MockL1:
@@ -128,7 +163,9 @@ class TestInit:
         assert wls._masters_output is None
 
     def test_invalid_config_raises(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(
+            TypeError, match="config must be None, dict, or ConfigHandler"
+        ):
             WLS(FILE_LIST, config=42)
 
 
@@ -289,15 +326,6 @@ class TestMakeMasterL2:
         result = wls.make_master_l2()
         assert isinstance(result, KPFMasterL2)
 
-    def test_wave_extensions_populated(self, mock_make_master_l2):
-        wls = WLS(FILE_LIST)
-        ml2 = wls.make_master_l2()
-        for chip in wls.chips:
-            for fiber in wls.fibers:
-                wave = ml2.data[f"{chip}_{fiber}_WAVE"]
-                assert np.size(wave) > 0
-                assert np.all(wave == 5500.0)
-
     def test_wave_routing_uses_physical_position_not_fiber_order(self, monkeypatch):
         # W's planes are ordered by fiber_positions (SKY=0..CAL=4), so the write
         # loop must sort by that, not trust self.fibers' config-overridable
@@ -402,13 +430,22 @@ class TestMakeMasterL2:
 
     def test_to_fits_round_trip(self, mock_make_master_l2, tmp_path):
         # Regression: rvdata builds non-PRIMARY headers via fits.Header(dict),
-        # which rejects (value, comment) tuple values. Make sure every header
-        # we set survives the round-trip.
+        # which rejects (value, comment) tuple values. Every header this module
+        # sets must come back off disk, not merely survive the write.
         wls = WLS(FILE_LIST)
         ml2 = wls.make_master_l2()
         out_path = tmp_path / "KP.20240113.23249.10_master_thar_L2.fits"
         ml2.to_fits(str(out_path))
-        assert out_path.exists()
+
+        read_back = KPFMasterL2.from_fits(str(out_path))
+        primary = read_back.headers["PRIMARY"]
+        assert primary["MASTYPE"] == "thar"
+        assert primary["ROUGHWLS"] == wls.rough_wls_file
+        assert primary["LINELIST"] == wls.linelist
+        assert primary["LINEPROF"] == wls.lineprofile
+        assert primary["POLYDEGX"] == wls.poly_degree_x
+        assert primary["POLYDEGM"] == wls.poly_degree_m
+        assert primary["POLYDEGF"] == wls.poly_degree_f
 
     def test_ml2_datalvl_and_minimal_primary(self, mock_make_master_l2, tmp_path):
         # Regression: ML2 must not inherit RV2's EPRV science PRIMARY skeleton, and
@@ -573,7 +610,7 @@ class TestMakeMasterL2:
                     assert grp.attrs["rejected"] == np.False_
 
                     assert grp["coeffs"].shape == expected_coeffs_shape
-                    assert np.issubdtype(grp["coeffs"].dtype, np.floating)
+                    assert_dtype(grp["coeffs"][...], WAVE, "h5 coeffs")
 
                     lines = grp["lines"]
                     for key in [
@@ -588,8 +625,8 @@ class TestMakeMasterL2:
                         "isgood",
                     ]:
                         assert key in lines
-                    assert np.issubdtype(lines["wav"].dtype, np.floating)
-                    assert np.issubdtype(lines["pix"].dtype, np.floating)
+                    assert_dtype(lines["wav"][...], WAVE, "h5 lines/wav")
+                    assert_dtype(lines["pix"][...], WAVE, "h5 lines/pix")
                     assert np.issubdtype(lines["index"].dtype, np.integer)
                     assert np.issubdtype(lines["echelle"].dtype, np.integer)
                     assert_dtype(lines["isgood"], MASK_MEM, "isgood")
@@ -639,36 +676,6 @@ class TestMakeMasterL2:
             assert rej.attrs["rejected"] == np.True_
             assert "coeffs" not in rej
             assert "lines" in rej  # rejected frame's line diagnostics still written
-
-    def test_nan_orderlet_emits_warning_and_does_not_crash(self, caplog):
-        # A NaN-filled orderlet (extraction failure) is skipped rather than
-        # crashing scipy's least_squares.
-        wls = WLS(FILE_LIST)
-        ncol = wls.ccd["ncol"]
-        norder = wls.norder["RED"]
-
-        flux = np.ones((norder, ncol))
-        flux[0, :] = np.nan
-
-        class StubL2:
-            data = {"RED_SCI1_FLUX": flux}
-
-        wls.rough_wls["RED_SCI1_WAVE"] = np.tile(
-            np.linspace(6500.0, 6510.0, ncol), (norder, 1)
-        )
-        wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
-
-        with caplog.at_level(logging.DEBUG):
-            result = wls._fit_line_positions_ffi(
-                StubL2(),
-                "RED",
-                ["SCI1"],
-            )
-        assert "RED SCI1 order 102: orderlet skipped" in caplog.text
-
-        # The NaN order (bluest RED, echelle 102) contributed no lines; rest did.
-        assert 102 not in result["echelle"]
-        assert len(result["wav"]) > 0
 
     def test_linelist_override(self, mock_make_master_l2, tmp_path, monkeypatch):
         override = tmp_path / "alt_linelist.csv"
@@ -1041,6 +1048,36 @@ class TestMinStackSizeGate:
 
 
 class TestFitLinePositions:
+    def test_nan_orderlet_emits_warning_and_does_not_crash(self, caplog):
+        # A NaN-filled orderlet (extraction failure) is skipped rather than
+        # crashing scipy's least_squares.
+        wls = WLS(FILE_LIST)
+        ncol = wls.ccd["ncol"]
+        norder = wls.norder["RED"]
+
+        flux = np.ones((norder, ncol))
+        flux[0, :] = np.nan
+
+        class StubL2:
+            data = {"RED_SCI1_FLUX": flux}
+
+        wls.rough_wls["RED_SCI1_WAVE"] = np.tile(
+            np.linspace(6500.0, 6510.0, ncol), (norder, 1)
+        )
+        wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
+
+        with caplog.at_level(logging.DEBUG):
+            result = wls._fit_line_positions_ffi(
+                StubL2(),
+                "RED",
+                ["SCI1"],
+            )
+        assert "RED SCI1 order 102: orderlet skipped" in caplog.text
+
+        # The NaN order (bluest RED, echelle 102) contributed no lines; rest did.
+        assert 102 not in result["echelle"]
+        assert len(result["wav"]) > 0
+
     def test_no_lines_returns_empty(self):
         wls = WLS(FILE_LIST)
         flux = np.ones(100)
@@ -1114,27 +1151,6 @@ class TestFitLinePositions:
         assert "RED SCI1: no good lines retained" in caplog.text
         assert len(result["wav"]) == 0
 
-    def test_nan_orderlet_emits_skip_warning(self, caplog):
-        wls = WLS(FILE_LIST)
-        ncol = wls.ccd["ncol"]
-        norder = wls.norder["RED"]
-
-        flux = np.ones((norder, ncol))
-        flux[0, :] = np.nan
-
-        class StubL2:
-            data = {"RED_SCI1_FLUX": flux}
-
-        wls.rough_wls["RED_SCI1_WAVE"] = np.tile(
-            np.linspace(6500.0, 6510.0, ncol), (norder, 1)
-        )
-        wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0, 6508.0])
-
-        with caplog.at_level(logging.DEBUG):
-            wls._fit_line_positions_ffi(StubL2(), "RED", ["SCI1"])
-
-        assert "orderlet skipped" in caplog.text
-
 
 # ---------------------------------------------------------------------------
 # TestRoughWlsLoading
@@ -1144,5 +1160,15 @@ class TestFitLinePositions:
 class TestRoughWlsLoading:
     def test_missing_rough_wls_file_raises(self):
         wls = WLS(FILE_LIST)
-        with pytest.raises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError, match="/nonexistent/path.csv"):
             wls._load_rough_wls(rough_wls_file="/nonexistent/path.csv")
+
+    def test_cached_grid_matches_the_real_loader(self, cached_rough_wls):
+        # The one test that runs the real Legendre evaluation, so the module's
+        # memoized grid cannot drift from what production would have built.
+        wls = WLS(FILE_LIST)
+        del wls.rough_wls
+        _REAL_LOAD_ROUGH_WLS(wls)
+        assert set(wls.rough_wls) == set(cached_rough_wls)
+        for channel_ext, grid in wls.rough_wls.items():
+            np.testing.assert_array_equal(grid, cached_rough_wls[channel_ext])

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -351,7 +351,14 @@ class TestMakeMasterL2:
         ml2 = wls.make_master_l2()
         assert_dtype(ml2.data["TRACE3_WAVE"], WAVE, "master TRACE3_WAVE")
         ml2.headers["PRIMARY"]["DATE-OBS"] = "2024-01-13T10:26:56"
-        assert_roundtrip_dtype(KPFMasterL2, ml2, "TRACE3_WAVE", WAVE, tmp_path)
+        assert_roundtrip_dtype(
+            KPFMasterL2,
+            ml2,
+            "TRACE3_WAVE",
+            WAVE,
+            tmp_path,
+            name="KP.20240113.23249.10_master_thar_L2.fits",
+        )
 
     def test_coeffs_extensions_populated(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)
@@ -396,7 +403,7 @@ class TestMakeMasterL2:
         # we set survives the round-trip.
         wls = WLS(FILE_LIST)
         ml2 = wls.make_master_l2()
-        out_path = tmp_path / "round_trip_master.fits"
+        out_path = tmp_path / "KP.20240113.23249.10_master_thar_L2.fits"
         ml2.to_fits(str(out_path))
         assert out_path.exists()
 
@@ -412,7 +419,7 @@ class TestMakeMasterL2:
         seeded = set(ml2.keyword_registry.eprv_primary_seed)
         assert not (seeded & set(ml2.headers["PRIMARY"])) - {"DATALVL"}
 
-        out_path = tmp_path / "ml2_datalvl.fits"
+        out_path = tmp_path / "KP.20240113.23249.10_master_thar_L2.fits"
         ml2.to_fits(str(out_path))
         read_back = KPFMasterL2.from_fits(str(out_path))
         assert read_back.headers["PRIMARY"].get("DATALVL") == "ML2"
@@ -487,7 +494,9 @@ class TestMakeMasterL2:
         wls = WLS(FILE_LIST)
         wls.make_master_l2()
         with pytest.raises(ValueError, match="level"):
-            wls.save_master("L4", str(tmp_path / "master.fits"))
+            wls.save_master(
+                "L4", str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
+            )
 
     def test_master_path_writes_fits(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST, config={"KPF_MASTERS_OUTPUT": str(tmp_path)})
@@ -498,7 +507,7 @@ class TestMakeMasterL2:
     def test_save_master_post_hoc(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
         wls.make_master_l2()  # no master_path; ml2_obj stashed on self
-        master_path = tmp_path / "master.fits"
+        master_path = tmp_path / "KP.20240113.23249.10_master_thar_L2.fits"
         wls.save_master("L2", str(master_path))
         assert master_path.exists()
 
@@ -521,7 +530,9 @@ class TestMakeMasterL2:
     def test_save_reduced_frames_before_make_raises(self, tmp_path):
         wls = WLS(FILE_LIST)
         with pytest.raises(RuntimeError, match="run make_master_l2"):
-            wls.save_reduced_frames(str(tmp_path / "master.fits"))
+            wls.save_reduced_frames(
+                str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
+            )
 
     def test_save_reduced_frames_refuses_overwrite(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST, config={"KPF_MASTERS_OUTPUT": str(tmp_path)})
@@ -534,7 +545,7 @@ class TestMakeMasterL2:
     def test_save_master_overwrite_true_replaces(self, mock_make_master_l2, tmp_path):
         wls = WLS(FILE_LIST)
         wls.make_master_l2()
-        master_path = tmp_path / "master.fits"
+        master_path = tmp_path / "KP.20240113.23249.10_master_thar_L2.fits"
         master_path.write_bytes(b"stale")
         wls.save_master("L2", str(master_path), overwrite=True)
         assert master_path.read_bytes()[:6] == b"SIMPLE"

--- a/tests/regression/test_master_wls.py
+++ b/tests/regression/test_master_wls.py
@@ -24,7 +24,7 @@ NORDER_RED = DETECTOR["norder"]["RED"]
 NCOL_TEST = 16
 
 FILE_LIST = sorted([f"KP.20240101.{i:05d}.00.fits" for i in range(8)])
-DATECODE = "20240101"  # datecode shared by FILE_LIST and the master obs_ids below
+DATECODE = "20240101"  # shared by FILE_LIST and the master obs_ids below
 
 
 # ---------------------------------------------------------------------------
@@ -54,19 +54,18 @@ def _linelist_df(chip, norder, waves):
 
 
 def _master_and_stack(masters_output, obs_id="KP.20240101.00000.00"):
-    """The (master_path, stack_dir) pair in the canonical masters tree under
-    `masters_output` for a ThAr master keyed on `obs_id`. The stack subdir is
-    where WLS writes its per-frame L2s/diagnostics (via kpf_directory), beside
-    the master itself."""
+    """The (master_path, stack_dir) pair for a ThAr master keyed on `obs_id`.
+
+    The stack subdir, beside the master, is where WLS writes its per-frame L2s
+    and diagnostics.
+    """
     night = masters_output / "masters" / DATECODE
     return night / f"{obs_id}_master_thar_L2.fits", night / "thar_L2"
 
 
 @pytest.fixture
 def mock_pipeline(monkeypatch):
-    """Patch CalibrationAssociation, ImageProcessing, and SpectralExtraction so
-    that _process_frame and _extract_frame run without touching disk or real
-    data.
+    """Run _process_frame and _extract_frame without touching disk or real data.
 
     Returns the MockL2 instance that SpectralExtraction.perform() will return.
     """
@@ -77,7 +76,7 @@ def mock_pipeline(monkeypatch):
 
     mock_ip = MagicMock()
     mock_ip.return_value.perform.return_value = MockL1()
-    mock_ip.calibration_applied.return_value = False  # frame not yet calibrated
+    mock_ip.calibration_applied.return_value = False
 
     mock_se = MagicMock()
     mock_se.return_value.perform.return_value = l2
@@ -103,14 +102,13 @@ class TestInit:
         assert wls._masters_output is None
 
     def test_reads_masters_output_from_config(self):
-        # WLS associates the master bias from KPF_MASTERS_OUTPUT -- where the
-        # masters recipe writes it and where CalibrationAssociation reads it.
+        # WLS associates the master bias from KPF_MASTERS_OUTPUT, where the
+        # masters recipe writes it.
         wls = WLS(FILE_LIST, config={"KPF_MASTERS_OUTPUT": "/masters"})
         assert wls._masters_output == "/masters"
 
     def test_ignores_data_input_for_masters_output(self):
-        # The raw input root is not where masters live; only KPF_MASTERS_OUTPUT
-        # drives the masters search.
+        # The raw input root is not where masters live.
         wls = WLS(FILE_LIST, config={"KPF_DATA_INPUT": "/in"})
         assert wls._masters_output is None
 
@@ -131,13 +129,12 @@ class TestExtractFrame:
         assert result is mock_pipeline
 
     def test_passes_masters_output_to_calibration_association(self, monkeypatch):
-        # _process_frame (run before _extract_frame) associates the bias from
-        # KPF_MASTERS_OUTPUT; _extract_frame itself no longer does calibration.
+        # _process_frame, not _extract_frame, is what associates the bias.
         mock_ca = MagicMock()
         mock_ca.return_value.perform.return_value = MockL1()
         mock_ip = MagicMock()
         mock_ip.return_value.perform.return_value = MockL1()
-        mock_ip.calibration_applied.return_value = False  # frame not yet calibrated
+        mock_ip.calibration_applied.return_value = False
         mock_se = MagicMock()
         mock_se.return_value.perform.return_value = MockL2()
 
@@ -204,10 +201,10 @@ class TestProcessIndividualFrames:
 
 @pytest.fixture
 def mock_make_master_l2(monkeypatch):
-    """Patch frame loading, _fit_and_qc_lines_stack, and _combine_coeffs_stack so
-    make_master_l2 runs without touching disk or real spectra. The fitting
-    stub reports one non-rejected frame per input (FILE_LIST has 8 frames, so
-    the default min_stack_size=5 gate passes), and the combine stub returns
+    """Run make_master_l2 without touching disk or real spectra.
+
+    The fitting stub reports one non-rejected frame per input (FILE_LIST has 8,
+    so the default min_stack_size=5 gate passes); the combine stub returns
     synthetic W and coefficient arrays with chip-correct shapes.
     """
     # Thread each source filename through as the opaque L1 token so the
@@ -293,12 +290,9 @@ class TestMakeMasterL2:
                 assert np.all(wave == 5500.0)
 
     def test_wave_routing_uses_physical_position_not_fiber_order(self, monkeypatch):
-        """Each W plane routes to its fiber by physical slicer position, even
-        when self.fibers is reordered. W's planes are ordered by fiber_positions
-        (SKY=0..CAL=4), so the write loop must sort by that, not trust
-        self.fibers' (config-overridable) order -- else SKY's solution lands on
-        CAL and vice versa.
-        """
+        # W's planes are ordered by fiber_positions (SKY=0..CAL=4), so the write
+        # loop must sort by that, not trust self.fibers' config-overridable
+        # order -- else SKY's solution lands on CAL and vice versa.
         monkeypatch.setattr(
             WLS, "_load_frame", lambda self, fn, cache=False, **kw: MockL1()
         )
@@ -330,7 +324,7 @@ class TestMakeMasterL2:
         monkeypatch.setattr(WLS, "_combine_coeffs_stack", mock_combine)
 
         wls = WLS(FILE_LIST)
-        # Reorder away from physical-slicer order (here: TRACE order).
+        # Reorder away from physical-slicer order.
         wls.fibers = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]
         ml2 = wls.make_master_l2()
 
@@ -390,7 +384,7 @@ class TestMakeMasterL2:
 
     def test_primary_header_keyword_comments_from_registry(self, mock_make_master_l2):
         # WLS metadata routes through set_keyword, so the FITS comments come from
-        # ML2-wls-headers.csv (registry), not code-local strings.
+        # the keyword registry, not code-local strings.
         wls = WLS(FILE_LIST)
         ml2 = wls.make_master_l2()
         primary = ml2.headers["PRIMARY"]
@@ -409,13 +403,12 @@ class TestMakeMasterL2:
 
     def test_ml2_datalvl_and_minimal_primary(self, mock_make_master_l2, tmp_path):
         # Regression: ML2 must not inherit RV2's EPRV science PRIMARY skeleton, and
-        # DATALVL must be "ML2" (not the RV2 placeholder "UNKNOWN") in-memory and on
-        # disk -- rvdata's to_fits never re-stamps DATALVL.
+        # DATALVL must be "ML2" both in memory and on disk -- rvdata's to_fits
+        # never re-stamps DATALVL.
         from kpfpipe.data_models.masters.level2 import KPFMasterL2
 
         ml2 = WLS(FILE_LIST).make_master_l2()
         assert ml2.headers["PRIMARY"].get("DATALVL") == "ML2"
-        # None of the EPRV-required science PRIMARY keywords should be seeded.
         seeded = set(ml2.keyword_registry.eprv_primary_seed)
         assert not (seeded & set(ml2.headers["PRIMARY"])) - {"DATALVL"}
 
@@ -426,12 +419,11 @@ class TestMakeMasterL2:
 
     def test_poly_degree_override_stamped(self, mock_make_master_l2):
         wls = WLS(FILE_LIST)
-        override_x = wls.poly_degree_x + 4  # ensure different from default
+        override_x = wls.poly_degree_x + 4
         ml2 = wls.make_master_l2(poly_degree_x=override_x)
         assert ml2.headers["PRIMARY"].get("POLYDEGX") == override_x
         for chip in wls.chips:
-            # POLYDEG* live on PRIMARY only now; verify the override actually
-            # propagated into the fit (coeffs array shape), not just the header.
+            # Verify the override propagated into the fit, not just the header.
             coeffs = ml2.data[f"{chip}_WLS_COEFFS"]
             assert coeffs.shape[0] == override_x + 1
 
@@ -465,9 +457,8 @@ class TestMakeMasterL2:
             wls.save_diagnostics("/tmp/KP.20240101.00000.00_master_thar_L2.fits")
 
     def test_save_diagnostics_with_empty_stash_raises(self, tmp_path):
-        # make_master_l2 initialises _frame_diagnostics to {} before populating
-        # it. If the chip loop raises before any chip is added, it stays empty --
-        # save_diagnostics must refuse rather than write an empty HDF5.
+        # An empty (not None) stash means the chip loop aborted before any chip
+        # was added; save_diagnostics must refuse rather than write empty HDF5.
         wls = WLS(FILE_LIST)
         wls._frame_diagnostics = {}
         master_path = tmp_path / "KP.20240101.00000.00_master_thar_L2.fits"
@@ -538,7 +529,7 @@ class TestMakeMasterL2:
         wls = WLS(FILE_LIST, config={"KPF_MASTERS_OUTPUT": str(tmp_path)})
         wls.make_master_l2()  # populates _l2_obj_cache, writes nothing
         master_path = str(_master_and_stack(tmp_path)[0])
-        wls.save_reduced_frames(master_path)  # first write; overwrite defaults False
+        wls.save_reduced_frames(master_path)  # first write
         with pytest.raises(FileExistsError, match="overwrite=True"):
             wls.save_reduced_frames(master_path)
 
@@ -639,16 +630,14 @@ class TestMakeMasterL2:
             assert "lines" in rej  # rejected frame's line diagnostics still written
 
     def test_nan_orderlet_emits_warning_and_does_not_crash(self, caplog):
-        """
-        A NaN-filled orderlet (extraction failure) should be skipped (logged at
-        DEBUG) rather than crashing scipy's least_squares.
-        """
+        # A NaN-filled orderlet (extraction failure) is skipped rather than
+        # crashing scipy's least_squares.
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
         norder = wls.norder["RED"]
 
         flux = np.ones((norder, ncol))
-        flux[0, :] = np.nan  # simulate failed-extraction orderlet
+        flux[0, :] = np.nan
 
         class StubL2:
             data = {"RED_SCI1_FLUX": flux}
@@ -671,7 +660,6 @@ class TestMakeMasterL2:
         assert len(result["wav"]) > 0
 
     def test_linelist_override(self, mock_make_master_l2, tmp_path, monkeypatch):
-        """Override file is loaded into the cache and stamped to the header."""
         override = tmp_path / "alt_linelist.csv"
         override.write_text(
             "CHIP,INDEX,ECHELLE,WAVE\n"
@@ -693,8 +681,7 @@ class TestMakeMasterL2:
         assert ml2.headers["PRIMARY"].get("LINELIST") == str(override)
 
     def test_single_frame_stack(self, mock_make_master_l2):
-        """A 1-frame stack still produces a valid master L2 when the survivor
-        gate allows it (min_stack_size=1)."""
+        # A 1-frame stack is valid only once the survivor gate is lowered to 1.
         wls = WLS(FILE_LIST[:1])
         wls.min_stack_size = 1
         ml2 = wls.make_master_l2()
@@ -710,19 +697,16 @@ class TestMakeMasterL2:
             wls.make_master_l2()
 
     def test_single_chip_config(self, mock_make_master_l2):
-        """A WLS configured for one chip only should not populate the other."""
         wls = WLS(FILE_LIST, config={"chips": ["GREEN"]})
         ml2 = wls.make_master_l2()
         for fiber in wls.fibers:
-            # GREEN populated by the mock (5500.0); RED left at the schema-
-            # default zeros since RED was not in self.chips.
+            # RED stays at the schema-default zeros: it is not in self.chips.
             assert np.all(ml2.data[f"GREEN_{fiber}_WAVE"] == 5500.0)
             assert np.all(ml2.data[f"RED_{fiber}_WAVE"] == 0.0)
         assert "GREEN_WLS_COEFFS" in ml2.extensions
         assert "RED_WLS_COEFFS" not in ml2.extensions
 
     def test_info_before_make_master_l2(self, capsys):
-        """info() before perform should print config and the not-called message."""
         wls = WLS(FILE_LIST)
         wls.info()
         out = capsys.readouterr().out
@@ -730,10 +714,9 @@ class TestMakeMasterL2:
         assert "make_master_l2() has not been called" in out
 
     def test_info_after_make_master_l2(self, mock_make_master_l2, capsys):
-        """info() after perform should print the per-chip line yield table."""
         wls = WLS(FILE_LIST)
         wls.make_master_l2()
-        capsys.readouterr()  # discard any output from make_master_l2 itself
+        capsys.readouterr()  # discard make_master_l2's own output
         wls.info()
         out = capsys.readouterr().out
         assert "WLS" in out
@@ -765,14 +748,14 @@ class TestCalculateWlsCoeffs:
         }
 
     def test_underconstrained_single_fiber_raises(self):
-        # default poly_degree is (6, 3, 2) → 7*4 = 28 free params single-fiber
+        # default poly_degree is (6, 6, 2): 7*7 = 49 free params single-fiber
         wls = WLS(FILE_LIST)
         lines = self._make_lines(5, fibers=("SCI1",))
         with pytest.raises(ValueError, match=r"underconstrained"):
             wls._calculate_wls_coeffs(lines, wls._echelle_orders["GREEN"])
 
     def test_underconstrained_multi_fiber_raises(self):
-        # 5-fiber → 7*4*3 = 84 free params; 10 lines per fiber * 5 = 50 < 84
+        # 5-fiber: 7*7*3 = 147 free params; 10 lines per fiber * 5 = 50 < 147
         wls = WLS(FILE_LIST)
         lines = self._make_lines(10, fibers=("SKY", "SCI1", "SCI2", "SCI3", "CAL"))
         with pytest.raises(ValueError, match=r"underconstrained"):
@@ -785,13 +768,12 @@ class TestCalculateWlsCoeffs:
         assert coeffs.shape == (wls.poly_degree_x + 1, wls.poly_degree_m + 1)
 
     def test_mlambda_roundtrip_recovers_wavelength(self):
-        """A surface exactly representable as m*lambda is recovered by the fit."""
         wls = WLS(FILE_LIST)
         orders = wls._echelle_orders["GREEN"]
         ncol = wls.ccd["ncol"]
 
-        # true m*lambda is a known low-degree Legendre surface -> divide out the
-        # order to get a wavelength surface the fit must recover exactly.
+        # The fit models m*lambda as a Legendre surface, so a surface built from
+        # known low-degree coefficients must be recovered exactly.
         coeffs_true = np.zeros((wls.poly_degree_x + 1, wls.poly_degree_m + 1))
         coeffs_true[0, 0], coeffs_true[1, 0] = 8.0e5, 300.0  # mean, pixel slope
         coeffs_true[0, 1], coeffs_true[1, 1] = 5.0e4, 5.0  # order slope, cross term
@@ -813,19 +795,19 @@ class TestCalculateWlsCoeffs:
 
 
 # ---------------------------------------------------------------------------
-# TestComputeWlsFrameRejection
+# Stack QC: line-fit QC, coefficient combination, min_stack_size gate
 # ---------------------------------------------------------------------------
 
 
 class TestFitAndQcStack:
-    """Frame-level QC in _fit_and_qc_lines_stack: a frame whose line-fit failure
-    fraction exceeds max_bad_frac, or whose per-frame WLS fit fails, is warned
-    and dropped (rejected=True, coeffs=None) -- never raised. Every frame is
-    reported so the diagnostics stay fully populated."""
+    """A frame failing line-fit QC is warned and dropped, never raised.
+
+    Dropped frames are still reported (rejected=True, coeffs=None) so the
+    diagnostics stay fully populated.
+    """
 
     def _setup(self, monkeypatch, bad_fracs, nlines=100):
-        """Build a WLS whose stack yields one fake `lines` dict per entry in
-        `bad_fracs`, each with the requested fraction of bad line fits."""
+        """Build a WLS whose stack yields one fake `lines` dict per bad_fracs entry."""
         wls = WLS(FILE_LIST)
         wls._l2_obj_cache = [MockL2() for _ in bad_fracs]
 
@@ -847,7 +829,6 @@ class TestFitAndQcStack:
     def test_all_clean_frames_kept(self, monkeypatch):
         wls = self._setup(monkeypatch, [0.01, 0.02, 0.0, 0.03, 0.01])
         frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
-        # every input frame is reported; none rejected, all carry coeffs
         assert len(frames) == 5
         assert [fr["rejected"] for fr in frames] == [False] * 5
         assert all(fr["coeffs"] is not None for fr in frames)
@@ -857,15 +838,13 @@ class TestFitAndQcStack:
         with caplog.at_level(logging.WARNING):
             frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
         assert "line fits failed QC" in caplog.text
-        # the 22%-bad frame (index 1) is flagged rejected with no coeffs, but
-        # still reported alongside the four kept frames
+        # The 22%-bad frame is rejected but still reported alongside the rest.
         assert len(frames) == 5
         assert [fr["rejected"] for fr in frames] == [False, True, False, False, False]
         assert frames[1]["coeffs"] is None
 
     def test_many_bad_frames_all_dropped_no_raise(self, caplog, monkeypatch):
-        # more than one over-threshold frame no longer aborts: each is warned
-        # and rejected, and every frame is still reported
+        # More than one over-threshold frame does not abort the build.
         wls = self._setup(monkeypatch, [0.22, 0.01, 0.34, 0.01, 0.01])
         with caplog.at_level(logging.WARNING):
             frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
@@ -874,14 +853,13 @@ class TestFitAndQcStack:
         assert sum(not fr["rejected"] for fr in frames) == 3
 
     def test_threshold_is_inclusive_at_max_bad_frac(self, monkeypatch):
-        # exactly 5% bad is not > 5%, so the frame is kept
+        # Exactly max_bad_frac (5%) is not > 5%, so the frame is kept.
         wls = self._setup(monkeypatch, [0.05, 0.01], nlines=100)
         frames = wls._fit_and_qc_lines_stack("GREEN", ["SCI1"])
         assert [fr["rejected"] for fr in frames] == [False, False]
 
     def test_nonfinite_coeffs_frame_rejected_not_raised(self, caplog, monkeypatch):
-        # a per-frame fit yielding a NaN coefficient rejects (warns) that frame
-        # rather than aborting the whole build
+        # A NaN coefficient rejects that frame, not the whole build.
         wls = WLS(FILE_LIST)
         wls._l2_obj_cache = [MockL2() for _ in range(3)]
         lines = {"wav": np.zeros(100), "isgood": np.ones(100, dtype=bool)}
@@ -899,8 +877,7 @@ class TestFitAndQcStack:
         assert frames[1]["coeffs"] is None
 
     def test_underconstrained_frame_rejected_not_raised(self, caplog, monkeypatch):
-        # a per-frame fit that raises (e.g. underconstrained) rejects (warns)
-        # that frame instead of aborting
+        # A per-frame fit that raises rejects that frame, not the whole build.
         wls = WLS(FILE_LIST)
         wls._l2_obj_cache = [MockL2() for _ in range(3)]
         lines = {"wav": np.zeros(100), "isgood": np.ones(100, dtype=bool)}
@@ -922,8 +899,7 @@ class TestFitAndQcStack:
 
 
 class TestCombineCoeffs:
-    """_combine_coeffs_stack averages the surviving per-frame coeffs; it raises only on
-    the cross-frame degeneracy where every frame is an outlier for a coefficient."""
+    """_combine_coeffs_stack averages the surviving per-frame coeffs."""
 
     def _frames(self, coeffs_list):
         return [{"coeffs": c, "rejected": False} for c in coeffs_list]
@@ -951,11 +927,9 @@ class TestCombineCoeffs:
         np.testing.assert_allclose(coeffs_mean, 5.0)
 
     def test_all_outliers_raises(self):
-        # The cross-frame degeneracy: with qc_sigma tight enough that no frame
-        # survives for some coefficient (here every frame differs from the median),
-        # denom hits 0 and the stack is uncombinable, so it raises rather than
-        # producing a spurious master. (At the default qc_sigma the MAD keeps at
-        # least half the frames within threshold, so this guard needs qc_sigma=0.)
+        # With no frame surviving for some coefficient the stack is uncombinable,
+        # so it raises rather than producing a spurious master. The default
+        # qc_sigma keeps at least half the frames, hence qc_sigma=0 here.
         wls = WLS(FILE_LIST)
         frames = self._frames([np.full((2, 2), 0.0), np.full((2, 2), 10.0)])
         with pytest.raises(ValueError, match=r"all frames rejected as outliers"):
@@ -963,13 +937,15 @@ class TestCombineCoeffs:
 
 
 class TestMinStackSizeGate:
-    """make_master_l2 gates the master on min_stack_size survivors per chip:
-    below the threshold it raises, but the per-frame diagnostics/L2s are still
-    written; at or above it, the master is produced."""
+    """make_master_l2 gates the master on min_stack_size survivors per chip.
+
+    Below the threshold it raises, but the per-frame diagnostics and L2s are
+    still written.
+    """
 
     def _mock(self, monkeypatch, n_survivors, n_frames=8, masters_output=None):
-        # n_survivors is an int (same count for every chip) or a {chip: count}
-        # dict, so a test can make GREEN and RED pass/fail the gate independently.
+        # n_survivors is an int (same for every chip) or a {chip: count} dict, so
+        # a test can make GREEN and RED pass/fail the gate independently.
         files = sorted(f"KP.20240101.{i:05d}.00.fits" for i in range(n_frames))
         monkeypatch.setattr(WLS, "_load_frame", lambda self, fn, cache=False, **kw: fn)
         monkeypatch.setattr(WLS, "_process_frame", lambda self, l1, **kw: l1)
@@ -1040,9 +1016,9 @@ class TestMinStackSizeGate:
         assert master_path.exists()
 
     def test_gate_is_per_chip(self, monkeypatch, tmp_path):
-        # GREEN clears the gate (5 survivors) but RED does not (2): the build
-        # raises naming the failing chip and withholds the master even though the
-        # other chip passed. The diagnostics still persist (saved before the gate).
+        # GREEN clears the gate but RED does not: the master is withheld even
+        # though one chip passed. Diagnostics are saved before the gate, so they
+        # still persist.
         wls = self._mock(monkeypatch, {"GREEN": 5, "RED": 2}, masters_output=tmp_path)
         wls.min_stack_size = 5
         master_path, thar_dir = _master_and_stack(tmp_path)
@@ -1059,7 +1035,6 @@ class TestMinStackSizeGate:
 
 class TestFitLinePositions:
     def test_no_lines_returns_empty(self):
-        """No reference lines for the order yields empty arrays."""
         wls = WLS(FILE_LIST)
         flux = np.ones(100)
         wave = np.linspace(5000.0, 5100.0, 100)
@@ -1069,8 +1044,8 @@ class TestFitLinePositions:
             assert len(result[key]) == 0
 
     def test_line_outside_rough_wls_range_raises(self):
-        """A reference line outside the order's rough WLS span is a CHIP/ORDER
-        labeling inconsistency and must fail loudly."""
+        # A line outside the order's rough WLS span means the CHIP/ORDER labels
+        # are inconsistent, which must fail loudly rather than fit garbage.
         wls = WLS(FILE_LIST)
         flux = np.ones(100)
         wave = np.linspace(5000.0, 5100.0, 100)
@@ -1078,8 +1053,8 @@ class TestFitLinePositions:
             wls._fit_line_positions_1d(flux, wave, np.array([6000.0]))
 
     def test_line_fit_qc_flags_centroid_outside_window(self):
-        """A fitted centroid more than `window` pixels from its window center
-        is flagged bad, even when amplitude and width are in range."""
+        # Centroid distance from the window center is an independent QC axis:
+        # amplitude and width are in range for all three lines here.
         wls = WLS(FILE_LIST)
         lines = {
             "amp": np.array([1.0, 1.0, 1.0]),
@@ -1091,7 +1066,7 @@ class TestFitLinePositions:
         assert list(isgood) == [True, True, False]
 
     def test_fit_returns_float64_from_float32_inputs(self):
-        """float32 flux/wave inputs must not drag the line fit into float32."""
+        # float32 inputs must not drag the line fit down to float32.
         wls = WLS(FILE_LIST)
         ncol = 100
         x = np.arange(ncol)
@@ -1107,12 +1082,11 @@ class TestFitLinePositions:
             assert result[key].dtype == np.float64
 
     def test_all_nan_fiber_emits_fiber_level_warning(self, caplog):
-        """A fiber whose every order is NaN should emit a fiber-level warning."""
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
         norder = wls.norder["RED"]
 
-        flux = np.full((norder, ncol), np.nan)  # entire fiber NaN
+        flux = np.full((norder, ncol), np.nan)
 
         class StubL2:
             data = {"RED_SCI1_FLUX": flux}
@@ -1122,8 +1096,8 @@ class TestFitLinePositions:
         )
         wls._linelist_df = _linelist_df("RED", norder, [6502.0, 6505.0])
 
-        # The all-NaN fiber logs a per-order skip at DEBUG plus a fiber-level
-        # WARNING; capture at WARNING and assert the fiber-level one.
+        # Capture at WARNING to isolate the fiber-level message from the
+        # per-order skips, which log at DEBUG.
         with caplog.at_level(logging.WARNING):
             result = wls._fit_line_positions_ffi(
                 StubL2(),
@@ -1134,13 +1108,12 @@ class TestFitLinePositions:
         assert len(result["wav"]) == 0
 
     def test_nan_orderlet_emits_skip_warning(self, caplog):
-        """A single NaN-filled orderlet logs the per-orderlet skip at DEBUG."""
         wls = WLS(FILE_LIST)
         ncol = wls.ccd["ncol"]
         norder = wls.norder["RED"]
 
         flux = np.ones((norder, ncol))
-        flux[0, :] = np.nan  # one orderlet NaN-filled
+        flux[0, :] = np.nan
 
         class StubL2:
             data = {"RED_SCI1_FLUX": flux}

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -1,8 +1,7 @@
-"""Tests for the kpf_drp_masters recipe: end-to-end master production and error
-paths.
+"""Tests for the kpf_drp_masters recipe: master production and error paths.
 
 Integration tests use real L0 data from tests/testdata/L0/20240405/. The
-FileHandler and path builders these exercise are unit-tested in test_io.py.
+FileHandler and path builders they exercise are unit-tested in test_io.py.
 """
 
 import importlib.util
@@ -39,7 +38,7 @@ def _load_masters_recipe():
 
 @pytest.mark.slow
 class TestMastersRecipe:
-    """End-to-end recipe test: FileHandler → Bias.make_master_l1 → to_fits."""
+    """End-to-end: FileHandler -> Bias.make_master_l1 -> to_fits."""
 
     @pytest.fixture(scope="class")
     def recipe_output(self, tmp_path_factory):
@@ -107,9 +106,9 @@ class TestMastersRecipe:
 class TestMastersRecipeOrderTraceStage:
     """The recipe traces every master flat it just stacked.
 
-    The stacking modules are stubbed out: what is under test is the wiring --
-    which flat the tracer is handed, where its CSV is written, and that the
-    trace reaches the run summary. OrderTrace's own geometry is covered by
+    The stacking modules are stubbed out; what is under test is the wiring --
+    which flat the tracer is handed, where its CSV is written, and that the trace
+    reaches the run summary. OrderTrace's geometry is covered by
     test_master_order_trace.py.
     """
 
@@ -128,8 +127,7 @@ class TestMastersRecipeOrderTraceStage:
                 pass
 
             def build_calibration_stacks(self, cal_type, **kwargs):
-                # Only the flats matter here; the other stages have nothing to
-                # stack and fall through.
+                # Only the flats matter here; the other stages fall through.
                 return [["/l0/KP.20240405.00020.86.fits"]] if cal_type == "flat" else []
 
         class StubFlat:
@@ -223,8 +221,8 @@ class TestMastersRecipeErrors:
 
     @pytest.mark.slow
     def test_missing_min_stack_size_key_raises(self, tmp_path):
-        """min_stack_size is a required quality gate: a [BIAS] section present but
-        lacking the key must fail loud, not silently stack with no size gate."""
+        # min_stack_size is a required quality gate: a [BIAS] section lacking it
+        # must fail loud, not silently stack with no size gate.
         import argparse
 
         cfg = tmp_path / "no_min_stack.toml"
@@ -240,7 +238,7 @@ class TestMastersRecipeErrors:
 
 
 class TestMastersSummary:
-    """Unit tests for the masters_run_summary() run-verdict formatter."""
+    """Unit tests for the masters_run_summary() formatter."""
 
     def test_built_masters_listed(self):
         text = masters_run_summary(

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -1,18 +1,23 @@
-"""Tests for the kpf_drp_masters recipe: master production and error paths.
+"""Tests for the kpf_drp_masters recipe: stage wiring and error paths.
 
-Integration tests use real L0 data from tests/testdata/L0/20240405/. The
-FileHandler and path builders they exercise are unit-tested in test_io.py.
+The recipe's real ``main()`` is called with every stage it resolves replaced by a
+recorder, so what is under test is the wiring -- stage order, which stack each
+stage is handed, where each master is written, and which config section supplied
+each stage's stacking limits. The masters themselves are built from real L0 data
+in test_master_{bias,dark,flat}.py; the FileHandler and path builders are
+unit-tested in test_io.py.
 """
 
+import argparse
 import importlib.util
 import os
 from pathlib import Path
 
 import pytest
 
-from kpfpipe.data_models.masters.level1 import KPFMasterL1
 from kpfpipe.utils.config import ConfigHandler
-from kpfpipe.utils.io import FileHandler, kpf_directory, kpf_filepath
+from kpfpipe.utils.io import kpf_directory, kpf_filepath
+from kpfpipe.utils.kpf import get_obs_id
 from recipes._logging import masters_run_summary
 
 TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
@@ -32,158 +37,246 @@ def _load_masters_recipe():
 
 
 # ---------------------------------------------------------------------------
-# Masters recipe integration (real L0 data from tests/testdata/)
+# Stage wiring: the real main() runs with every collaborator replaced.
+#
+# This is the canonical recipe-wiring harness; test_science_recipe.py mirrors it.
+# The rules it encodes: load the recipe and call its real main() rather than
+# re-implementing the loop; monkeypatch collaborators on the *loaded module*, so
+# what is asserted is the recipe's own wiring; record every stage into one list
+# whose order is itself the assertion; and model "nothing to stack" the way
+# production does -- by raising, never by returning an empty list.
 # ---------------------------------------------------------------------------
 
+# Three frames per stack: above no gate, below every max, and enough that a
+# dropped stack is visible in the run summary's frame counts.
+STACK_FILES = {
+    "bias": [
+        "/l0/20240405/KP.20240405.03637.74.fits",
+        "/l0/20240405/KP.20240405.03687.64.fits",
+        "/l0/20240405/KP.20240405.03737.52.fits",
+    ],
+    "dark": [
+        "/l0/20240405/KP.20240405.04184.73.fits",
+        "/l0/20240405/KP.20240405.04484.61.fits",
+        "/l0/20240405/KP.20240405.04784.49.fits",
+    ],
+    "flat": [
+        "/l0/20240405/KP.20240405.00020.86.fits",
+        "/l0/20240405/KP.20240405.00120.74.fits",
+        "/l0/20240405/KP.20240405.00220.62.fits",
+    ],
+    "thar": [
+        "/l0/20240405/KP.20240405.63499.95.fits",
+        "/l0/20240405/KP.20240405.63599.83.fits",
+        "/l0/20240405/KP.20240405.63699.71.fits",
+    ],
+}
 
-@pytest.mark.slow
-@pytest.mark.requires_testdata
-class TestMastersRecipe:
-    """End-to-end: FileHandler -> Bias.make_master_l1 -> to_fits."""
+# (groupby, min_stack_size, max_stack_size) each stage must read from its OWN
+# section of configs/kpf_drp_masters.toml. Reading [BIAS]'s limits for the flats,
+# or grouping darks by time_of_day, changes which frames are combined into a
+# master -- the RV-stability surface -- so the section-to-stage mapping is
+# asserted, not the numbers alone.
+STACK_LIMITS = {
+    "bias": ("time_of_day", 5, 20),
+    "dark": ("obs_night", 3, 20),
+    "flat": ("time_of_day", 5, 20),
+    "thar": ("time_of_day", 5, 20),
+}
 
-    @pytest.fixture(scope="class")
-    def recipe_output(self, tmp_path_factory):
-        from kpfpipe.modules.masters.bias import Bias
-        from kpfpipe.utils.kpf import get_obs_id
-
-        tmp_path = tmp_path_factory.mktemp("recipe_out")
-        data_root_out = str(tmp_path)
-
-        file_handler = FileHandler({"KPF_DATA_INPUT": str(TESTDATA_DIR)})
-        file_handler.build_mini_database("20240405")
-        output_paths = []
-        for files in file_handler.build_calibration_stacks("bias"):
-            bias_handler = Bias(files)
-            bias_l1 = bias_handler.make_master_l1()
-            out_path = kpf_filepath(
-                get_obs_id(files[0]), "L1", data_root=data_root_out, master="bias"
-            )
-            os.makedirs(os.path.dirname(out_path), exist_ok=True)
-            bias_l1.to_fits(out_path)
-            output_paths.append(out_path)
-
-        return output_paths
-
-    def test_at_least_one_master_produced(self, recipe_output):
-        assert len(recipe_output) >= 1
-
-    def test_output_files_exist(self, recipe_output):
-        for path in recipe_output:
-            assert os.path.isfile(path), f"Expected output not found: {path}"
-
-    def test_output_filename_format(self, recipe_output):
-        for path in recipe_output:
-            fname = os.path.basename(path)
-            assert "_master_bias_L1.fits" in fname
-
-    def test_output_is_valid_fits(self, recipe_output):
-        for path in recipe_output:
-            ml1 = KPFMasterL1.from_fits(path)
-            assert ml1.data["GREEN_IMG"] is not None
-            assert ml1.data["RED_IMG"] is not None
-
-    def test_input_files_extension_present(self, recipe_output):
-        for path in recipe_output:
-            ml1 = KPFMasterL1.from_fits(path)
-            assert "INPUT_FILES" in ml1.extensions
-
-    def test_input_files_extension_has_correct_count(self, recipe_output):
-        for path in recipe_output:
-            ml1 = KPFMasterL1.from_fits(path)
-            assert len(ml1.data["INPUT_FILES"]) == 5
-
-    def test_input_files_all_fits(self, recipe_output):
-        for path in recipe_output:
-            ml1 = KPFMasterL1.from_fits(path)
-            filenames = ml1.data["INPUT_FILES"]["FILENAME"].tolist()
-            assert all(f.endswith(".fits") for f in filenames)
+# Output level per stage, i.e. which kpf_filepath level token the recipe must use.
+STACK_LEVELS = {"bias": "L1", "dark": "L1", "flat": "L1", "thar": "L2"}
 
 
-# ---------------------------------------------------------------------------
-# Masters recipe order-trace stage (stacking stubbed -- wiring only)
-# ---------------------------------------------------------------------------
+def _wire_recipe(tmp_path, monkeypatch, stacks):
+    """Load the recipe, replace every stage on it, and return it ready to run.
 
+    ``stacks`` maps a cal type to the list of stacks ``build_calibration_stacks``
+    returns for it, or to an exception instance to raise instead -- the two
+    outcomes production has (``kpfpipe/utils/io.py`` raises when no cluster meets
+    ``min_stack_size``).
 
-@pytest.mark.requires_testdata
-class TestMastersRecipeOrderTraceStage:
-    """The recipe traces every master flat it just stacked.
-
-    The stacking modules are stubbed out; what is under test is the wiring --
-    which flat the tracer is handed, where its CSV is written, and that the trace
-    reaches the run summary. OrderTrace's geometry is covered by
-    test_master_order_trace.py.
+    Returns ``(recipe, config, args, record)``. ``record["calls"]`` holds one
+    ``(stage, files, master_path, stack_kwargs)`` tuple per stage in call order;
+    ``stack_kwargs`` are the keywords the stage's stack source was called with.
     """
+    recipe = _load_masters_recipe()
+    record = {"calls": [], "built": []}
+    stack_kwargs = {}
 
-    @pytest.fixture
-    def traced(self, tmp_path, monkeypatch):
-        import argparse
+    (tmp_path / "L0" / "20240405").mkdir(parents=True, exist_ok=True)
 
-        recipe = _load_masters_recipe()
-        calls = {}
+    class StubFileHandler:
+        def __init__(self, data_dirs):
+            pass
 
-        class StubFileHandler:
-            def __init__(self, data_dirs):
-                pass
+        def build_mini_database(self, datecode, cache=None):
+            pass
 
-            def build_mini_database(self, datecode, cache=None):
-                pass
+        def build_calibration_stacks(self, cal_type, **kwargs):
+            stack_kwargs[cal_type] = kwargs
+            outcome = stacks[cal_type]
+            if isinstance(outcome, Exception):
+                raise outcome
+            return outcome
 
-            def build_calibration_stacks(self, cal_type, **kwargs):
-                # Only the flats matter here; the other stages fall through.
-                return [["/l0/KP.20240405.00020.86.fits"]] if cal_type == "flat" else []
-
-        class StubFlat:
+    def _stage(name):
+        class StubStage:
             def __init__(self, files, config):
-                pass
+                self._files = files
+
+            def _record(self, master_path):
+                record["calls"].append(
+                    (name, tuple(self._files), master_path, stack_kwargs[name])
+                )
 
             def make_master_l1(self, master_path=None):
-                calls["flat_path"] = master_path
+                self._record(master_path)
 
-        class StubOrderTrace:
-            def __init__(self, flat_path, config):
-                calls["traced_flat"] = flat_path
-                self.output_path = str(tmp_path / "kpf_20240405_order_trace.csv")
+            def make_master_l2(self, master_path=None):
+                self._record(master_path)
 
-            def make_master(self, output_dir=None):
-                calls["output_dir"] = output_dir
+        return StubStage
 
-        monkeypatch.setattr(recipe, "FileHandler", StubFileHandler)
-        monkeypatch.setattr(recipe, "Flat", StubFlat)
-        monkeypatch.setattr(recipe, "OrderTrace", StubOrderTrace)
+    class StubOrderTrace:
+        def __init__(self, flat_path, config):
+            self._flat_path = flat_path
+            self.output_path = None
 
-        def capture_summary(datecode, built, elapsed):
-            calls["built"] = built
-            return ""
+        def make_master(self, output_dir=None):
+            self.output_path = os.path.join(
+                str(output_dir), "KP.20240405.00020.86_master_order_trace.csv"
+            )
+            record["calls"].append(
+                ("order_trace", (self._flat_path,), self.output_path, {})
+            )
+            record["trace_output_dir"] = output_dir
 
-        monkeypatch.setattr(recipe, "masters_run_summary", capture_summary)
+    monkeypatch.setattr(recipe, "FileHandler", StubFileHandler)
+    monkeypatch.setattr(recipe, "Bias", _stage("bias"))
+    monkeypatch.setattr(recipe, "Dark", _stage("dark"))
+    monkeypatch.setattr(recipe, "Flat", _stage("flat"))
+    monkeypatch.setattr(recipe, "WLS", _stage("thar"))
+    monkeypatch.setattr(recipe, "OrderTrace", StubOrderTrace)
 
-        config = ConfigHandler(
-            str(MASTERS_CONFIG_PATH),
-            overrides={
-                "DATA_DIRS": {
-                    "KPF_DATA_INPUT": str(TESTDATA_DIR),
-                    "KPF_MASTERS_OUTPUT": str(tmp_path),
-                }
-            },
+    def capture_summary(datecode, built, elapsed):
+        record["built"] = built
+        return ""
+
+    monkeypatch.setattr(recipe, "masters_run_summary", capture_summary)
+
+    config = ConfigHandler(
+        str(MASTERS_CONFIG_PATH),
+        overrides={
+            "DATA_DIRS": {
+                "KPF_DATA_INPUT": str(tmp_path),
+                "KPF_MASTERS_OUTPUT": str(tmp_path),
+            }
+        },
+    )
+    args = argparse.Namespace(datecode="20240405", obs_id=None)
+    return recipe, config, args, record
+
+
+class TestMastersRecipeStages:
+    """Every stage the recipe drives, in order, with the paths and limits it uses."""
+
+    @pytest.fixture
+    def run(self, tmp_path, monkeypatch):
+        recipe, config, args, record = _wire_recipe(
+            tmp_path,
+            monkeypatch,
+            {cal_type: [files] for cal_type, files in STACK_FILES.items()},
         )
-        recipe.main(config, argparse.Namespace(datecode="20240405", obs_id=None))
-        return calls
+        recipe.main(config, args)
+        return record
 
-    def test_traces_the_master_flat_it_just_stacked(self, traced):
-        assert traced["traced_flat"] == traced["flat_path"]
+    def test_stages_run_in_dependency_order(self, run):
+        # Bias before dark and flat so CalibrationAssociation finds the bias this
+        # run just wrote; flat before the trace, whose only input is that flat.
+        assert [call[0] for call in run["calls"]] == [
+            "bias",
+            "dark",
+            "flat",
+            "order_trace",
+            "thar",
+        ]
 
-    def test_writes_the_trace_into_the_masters_directory(self, traced, tmp_path):
+    def test_each_stage_stacks_the_files_the_handler_returned(self, run):
+        stacked = {call[0]: call[1] for call in run["calls"]}
+        for cal_type, files in STACK_FILES.items():
+            assert stacked[cal_type] == tuple(files)
+
+    def test_each_master_is_written_to_its_convention_path(self, run, tmp_path):
+        written = {call[0]: call[2] for call in run["calls"]}
+        for cal_type, level in STACK_LEVELS.items():
+            assert written[cal_type] == kpf_filepath(
+                get_obs_id(STACK_FILES[cal_type][0]),
+                level,
+                data_root=str(tmp_path),
+                master=cal_type,
+            )
+
+    def test_each_stage_reads_its_own_config_section(self, run):
+        limits = {call[0]: call[3] for call in run["calls"]}
+        for cal_type, (groupby, min_size, max_size) in STACK_LIMITS.items():
+            assert limits[cal_type] == {
+                "min_stack_size": min_size,
+                "max_stack_size": max_size,
+                "groupby": groupby,
+            }
+
+    def test_traces_the_master_flat_it_just_stacked(self, run):
+        traced = [call for call in run["calls"] if call[0] == "order_trace"][0]
+        flat = [call for call in run["calls"] if call[0] == "flat"][0]
+        assert traced[1] == (flat[2],)
+
+    def test_writes_the_trace_into_the_masters_directory(self, run, tmp_path):
         expected = kpf_directory(
             kind="masters", data_root=str(tmp_path), datecode="20240405"
         )
-        assert str(traced["output_dir"]) == str(expected)
+        assert str(run["trace_output_dir"]) == str(expected)
 
-    def test_reports_the_trace_in_the_run_summary(self, traced):
-        traces = [entry for entry in traced["built"] if entry[0] == "order_trace"]
-        assert len(traces) == 1
-        _, path, n_frames = traces[0]
-        assert path.endswith("_order_trace.csv")
-        assert n_frames == 1
+    def test_run_summary_lists_every_master_built(self, run):
+        assert [entry[0] for entry in run["built"]] == [
+            "bias",
+            "dark",
+            "flat",
+            "order_trace",
+            "thar",
+        ]
+        frames = {entry[0]: entry[2] for entry in run["built"]}
+        assert frames["order_trace"] == 1
+        assert all(frames[cal_type] == 3 for cal_type in STACK_FILES)
+
+
+class TestMastersRecipeStackFailure:
+    """A night with nothing to stack for one cal type.
+
+    ``build_calibration_stacks`` raises when no cluster meets ``min_stack_size``
+    (``kpfpipe/utils/io.py``); it never returns an empty list. The recipe has no
+    try/except, so the run aborts mid-way -- after the earlier masters are
+    already on disk. That partial-night behaviour is pinned here so neither a
+    fail-soft ``try/except`` nor a ``min_stack_size`` change alters it silently.
+    """
+
+    @pytest.fixture
+    def wired(self, tmp_path, monkeypatch):
+        stacks = {cal_type: [files] for cal_type, files in STACK_FILES.items()}
+        stacks["dark"] = ValueError("no dark cluster meets min_stack_size for 20240405")
+        return _wire_recipe(tmp_path, monkeypatch, stacks)
+
+    def test_propagates_the_stack_failure(self, wired):
+        recipe, config, args, _ = wired
+        with pytest.raises(ValueError, match="min_stack_size"):
+            recipe.main(config, args)
+
+    def test_aborts_after_the_stage_that_already_ran(self, wired):
+        recipe, config, args, record = wired
+        with pytest.raises(ValueError):
+            recipe.main(config, args)
+        # The bias masters are on disk; flat, order trace and WLS never happen.
+        assert [call[0] for call in record["calls"]] == ["bias"]
 
 
 # ---------------------------------------------------------------------------
@@ -204,8 +297,6 @@ class TestMastersRecipeErrors:
         )
 
     def test_nonexistent_l0_dir_raises(self, tmp_path):
-        import argparse
-
         config = self._make_config(tmp_path, tmp_path)
         args = argparse.Namespace(datecode="20240405", obs_id=None)
         recipe = _load_masters_recipe()
@@ -213,8 +304,6 @@ class TestMastersRecipeErrors:
             recipe.main(config, args)
 
     def test_missing_datecode_raises(self, tmp_path):
-        import argparse
-
         config = self._make_config(tmp_path, tmp_path)
         args = argparse.Namespace(datecode=None, obs_id=None)
         recipe = _load_masters_recipe()
@@ -226,8 +315,6 @@ class TestMastersRecipeErrors:
     def test_missing_min_stack_size_key_raises(self, tmp_path):
         # min_stack_size is a required quality gate: a [BIAS] section lacking it
         # must fail loud, not silently stack with no size gate.
-        import argparse
-
         cfg = tmp_path / "no_min_stack.toml"
         cfg.write_text(
             f'[DATA_DIRS]\nKPF_DATA_INPUT = "{TESTDATA_DIR}"\n'

--- a/tests/regression/test_masters_recipe.py
+++ b/tests/regression/test_masters_recipe.py
@@ -37,6 +37,7 @@ def _load_masters_recipe():
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestMastersRecipe:
     """End-to-end: FileHandler -> Bias.make_master_l1 -> to_fits."""
 
@@ -103,6 +104,7 @@ class TestMastersRecipe:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.requires_testdata
 class TestMastersRecipeOrderTraceStage:
     """The recipe traces every master flat it just stacked.
 
@@ -220,6 +222,7 @@ class TestMastersRecipeErrors:
             recipe.main(config, args)
 
     @pytest.mark.slow
+    @pytest.mark.requires_testdata
     def test_missing_min_stack_size_key_raises(self, tmp_path):
         # min_stack_size is a required quality gate: a [BIAS] section lacking it
         # must fail loud, not silently stack with no size gate.

--- a/tests/regression/test_masters_script.py
+++ b/tests/regression/test_masters_script.py
@@ -1,10 +1,10 @@
 """Tests for scripts/processing/masters.py: the nightly-masters build driver.
 
-Cover the driver's own surface: arg parsing and the two input forms, the
+Covers the driver's own surface: arg parsing and the two input forms, the
 ``_cli_task`` argv it fans out, datecode resolution, and the ``main`` exit-code
-contract (nonzero iff at least one night failed). The shared fan-out engine
-(``run_stage``, job sizing) lives in ``_dispatch`` and the ``datecode_dirs_in_range``
-helper in ``kpfpipe.utils.io``; they are tested in test_dispatch_script.py / test_io.py.
+contract (nonzero iff at least one night failed). The shared fan-out engine and
+the ``datecode_dirs_in_range`` helper are tested in test_dispatch_script.py and
+test_io.py.
 
 Unit tests use synthetic dir trees in tmp_path -- no real testdata needed.
 """
@@ -33,12 +33,11 @@ class _NoLogDirConfig(_FakeConfig):
     """A config with a resolvable data input but no configured log_dir."""
 
     def get_params(self, keys):
-        return {"KPF_DATA_INPUT": "/in"}  # no log_dir
+        return {"KPF_DATA_INPUT": "/in"}
 
 
 @pytest.fixture(scope="module")
 def m():
-    """The masters driver module (a normal package import)."""
     return _masters
 
 
@@ -219,10 +218,10 @@ class TestResolveDatecodes:
 
 class TestMainExitCode:
     def _patch(self, m, monkeypatch, failed, calls=None):
-        # Skip the runtime setup and the real dir/config resolution + subprocess
-        # fan-out; assert only the exit-code contract from run_stage's failure set.
-        # setup_batch_logging is stubbed so main() writes no real batch log file.
-        # `calls`, if given, records run_stage's kwargs for wiring assertions.
+        # Stub out runtime setup, dir/config resolution and the subprocess fan-out
+        # (setup_batch_logging included, so main() writes no real batch log), and
+        # assert only what run_stage's failure set does. `calls`, if given, records
+        # run_stage's kwargs for wiring assertions.
         monkeypatch.setattr(m, "configure_runtime", lambda: None)
         monkeypatch.setattr(m, "ConfigHandler", _FakeConfig)
         monkeypatch.setattr(m, "setup_batch_logging", lambda *a, **k: "/l/x.log")
@@ -247,8 +246,8 @@ class TestMainExitCode:
         assert exc.value.code == 1
 
     def test_fan_out_is_staggered(self, m, monkeypatch):
-        # Masters must pass its stagger interval to run_stage so the lockstep
-        # disk-read wave is desynchronized (see _LAUNCH_INTERVAL).
+        # Masters passes its stagger interval to run_stage so the lockstep
+        # disk-read wave is desynchronized.
         calls = []
         self._patch(m, monkeypatch, failed=[], calls=calls)
         m.main(["--dates", "20240405"])
@@ -256,8 +255,7 @@ class TestMainExitCode:
         assert m._LAUNCH_INTERVAL > 0
 
     def test_prescans_before_fan_out(self, m, monkeypatch):
-        # The mini-db caches are warmed up front (parallel per-datecode) before the
-        # reduces fan out, with the resolved datecodes and the pool size.
+        # The mini-db caches are warmed up front, before the reduces fan out.
         order = []
         warm_args = {}
 
@@ -274,14 +272,14 @@ class TestMainExitCode:
             m, "run_stage", lambda *a, **k: order.append("run_stage") or set()
         )
         m.main(["--dates", "20240405"])
-        assert order == ["warm", "run_stage"]  # pre-scan precedes fan-out
+        assert order == ["warm", "run_stage"]
         assert warm_args["data_input"] == "/in"  # resolved L0 input root
         assert warm_args["datecodes"] == ["20240405"]
         assert warm_args["jobs"] == m._default_masters_jobs()
         assert warm_args["cache"] == "rw"  # masters default: warm up front
 
     def test_errors_when_log_dir_unset(self, m, monkeypatch):
-        # A missing log_dir is fatal before any fan-out (DRP-RUN-07).
+        # A missing log_dir is fatal before any fan-out.
         monkeypatch.setattr(m, "configure_runtime", lambda: None)
         monkeypatch.setattr(m, "ConfigHandler", _NoLogDirConfig)
         with pytest.raises(SystemExit) as exc:

--- a/tests/regression/test_masters_script.py
+++ b/tests/regression/test_masters_script.py
@@ -85,18 +85,25 @@ class TestParseArgs:
             )
 
     @pytest.mark.parametrize(
-        "argv",
+        "argv,expected",
         [
-            ["--dates", "2024"],  # malformed datecode (list form)
-            ["--date_range", "2024", "20240131"],  # malformed datecode (range form)
-            ["--date_range", "20240201", "20240101"],  # start > end
-            ["--dates", "20240405", "--jobs", "0"],  # jobs below 1
-            ["--dates", "20240405", "--job_timeout", "0"],  # timeout below 1
+            (["--dates", "2024"], "2024"),  # malformed datecode (list form)
+            (
+                ["--date_range", "2024", "20240131"],  # malformed datecode (range form)
+                "2024",
+            ),
+            (["--date_range", "20240201", "20240101"], "20240201"),  # start > end
+            (["--dates", "20240405", "--jobs", "0"], "jobs"),  # jobs below 1
+            (
+                ["--dates", "20240405", "--job_timeout", "0"],  # timeout below 1
+                "job_timeout",
+            ),
         ],
     )
-    def test_invalid_args_exit(self, m, argv):
+    def test_invalid_args_exit(self, m, argv, expected, capsys):
         with pytest.raises(SystemExit):
             m.parse_args(argv)
+        assert expected in capsys.readouterr().err
 
     def test_config_defaults_to_none(self, m):
         assert m.parse_args(["--dates", "20240405"]).config is None
@@ -186,13 +193,13 @@ class TestResolveDatecodes:
 
     def test_range_missing_l0_root_exits(self, m, tmp_path):
         args = m.parse_args(["--date_range", "20240101", "20240131"])
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit, match="L0 input directory not found"):
             m.resolve_datecodes(args, str(tmp_path))  # no L0/ dir
 
     def test_range_no_nights_in_range_exits(self, m, tmp_path):
         (tmp_path / "L0" / "20250101").mkdir(parents=True)
         args = m.parse_args(["--date_range", "20240101", "20240131"])
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit, match="no datecode dirs"):
             m.resolve_datecodes(args, str(tmp_path))
 
 
@@ -215,7 +222,7 @@ class TestMainExitCode:
 
         def _fake_run_stage(*a, **k):
             if calls is not None:
-                calls.append(k)
+                calls.append({"args": a, **k})
             return set(failed)
 
         monkeypatch.setattr(m, "run_stage", _fake_run_stage)
@@ -262,6 +269,31 @@ class TestMainExitCode:
         assert warm_args["datecodes"] == ["20240405"]
         assert warm_args["jobs"] == m._default_masters_jobs()
         assert warm_args["cache"] == "rw"  # masters default: warm up front
+
+    def test_forwards_dir_and_log_overrides_to_each_child(self, m, monkeypatch):
+        calls = []
+        self._patch(m, monkeypatch, failed=[], calls=calls)
+        m.main(
+            [
+                "--dates",
+                "20240405",
+                "--input_dir",
+                "/in",
+                "--output_dir",
+                "/out",
+                "--log_level",
+                "DEBUG",
+            ]
+        )
+        tasks = calls[0]["args"][1]
+        assert len(tasks) == 1
+        _, argv = tasks[0]
+        assert argv[-8:] == [
+            "--kpf_data_input", "/in",
+            "--kpf_masters_output", "/out",
+            "--log_dir", "/out/logs",
+            "--log_level", "DEBUG",
+        ]  # fmt: skip
 
     def test_errors_when_log_dir_unset(self, m, monkeypatch):
         # A missing log_dir is fatal before any fan-out.

--- a/tests/regression/test_masters_script.py
+++ b/tests/regression/test_masters_script.py
@@ -15,25 +15,10 @@ import pytest
 
 from scripts.processing import masters as _masters
 
+from ._scripts import _FakeConfig, _NoLogDirConfig
+
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
 pytestmark = pytest.mark.cli
-
-
-class _FakeConfig:
-    """Stand-in for ConfigHandler in the exit-code tests (no real file read)."""
-
-    def __init__(self, path):
-        pass
-
-    def get_params(self, keys):
-        return {"KPF_DATA_INPUT": "/in", "log_dir": "/l"}
-
-
-class _NoLogDirConfig(_FakeConfig):
-    """A config with a resolvable data input but no configured log_dir."""
-
-    def get_params(self, keys):
-        return {"KPF_DATA_INPUT": "/in"}
 
 
 @pytest.fixture(scope="module")

--- a/tests/regression/test_network.py
+++ b/tests/regression/test_network.py
@@ -1,8 +1,7 @@
 """Tests for the network retry helper in kpfpipe.utils.network.
 
-The network is never touched: every test drives ``retry_request`` with a MagicMock
-callable and patches ``time.sleep`` so the backoff schedule is inspected rather than
-waited out.
+The network is never touched: every test drives ``retry_request`` with a mock
+callable and patches ``time.sleep``, so the backoff is inspected, not waited out.
 """
 
 import logging
@@ -15,7 +14,7 @@ from kpfpipe.utils.network import _RETRY_WAITS, retry_request
 
 
 def _patch_sleep():
-    """Patch the helper's time.sleep; the mock's call args are the backoff waits."""
+    """Patch the helper's time.sleep; its call args are the backoff waits."""
     return patch("kpfpipe.utils.network.time.sleep")
 
 
@@ -25,8 +24,6 @@ def _slept(sleep_mock):
 
 
 class TestRetryRequest:
-    """Backoff schedule, transient/non-transient classification, and logging."""
-
     def test_success_returns_immediately(self):
         func = MagicMock(return_value="ok")
         with _patch_sleep() as sleep:
@@ -58,8 +55,8 @@ class TestRetryRequest:
         "exc", [ValueError("bad input"), DALQueryError("malformed ADQL")]
     )
     def test_non_transient_exception_is_not_retried(self, exc):
-        # A bad query or bad input will never succeed on a second try, so it must
-        # fail at once rather than burn the full backoff.
+        # A bad query or bad input never succeeds on a retry, so it must fail at
+        # once rather than burn the full backoff.
         func = MagicMock(side_effect=exc)
         with _patch_sleep() as sleep, pytest.raises(type(exc)):
             retry_request(func, "Service")

--- a/tests/regression/test_plot_timeseries_script.py
+++ b/tests/regression/test_plot_timeseries_script.py
@@ -86,7 +86,7 @@ class TestParseArgs:
     @pytest.mark.parametrize(
         "drop", ["--target", "--date_range", "--data_dir", "--plot_dir"]
     )
-    def test_required_flags(self, pt, drop):
+    def test_required_flags(self, pt, capsys, drop):
         # Removing any one required flag (and its value) is a parse error.
         argv, skip = [], 0
         for tok in _BASE_ARGS:
@@ -96,23 +96,35 @@ class TestParseArgs:
                 skip -= 1
                 continue
             argv.append(tok)
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc:
             pt.parse_args(argv)
+        assert exc.value.code == 2
+        assert drop in capsys.readouterr().err
 
-    @pytest.mark.parametrize(
-        "rng",
-        [["2024", "20240131"], ["20240201", "20240101"]],  # malformed / start>end
-    )
-    def test_date_range_validated(self, pt, rng):
+    @pytest.mark.parametrize("rng", [["2024", "20240131"], ["20240101", "2024"]])
+    def test_date_range_validated(self, pt, capsys, rng):
         argv = ["--target", "x", "--date_range", *rng, "--data_dir", "/d",
                 "--plot_dir", "/p"]  # fmt: skip
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc:
             pt.parse_args(argv)
+        assert exc.value.code == 2
+        # Distinguishes the two validators: a malformed datecode vs start > end.
+        assert "--date_range value is not a valid datecode" in capsys.readouterr().err
 
-    def test_group_bursts_flag_removed(self, pt):
-        # Grouping is always on, so the flag was dropped.
-        with pytest.raises(SystemExit):
-            pt.parse_args(_BASE_ARGS + ["--group_bursts"])
+    def test_date_range_start_after_end(self, pt, capsys):
+        argv = ["--target", "x", "--date_range", "20240201", "20240101",
+                "--data_dir", "/d", "--plot_dir", "/p"]  # fmt: skip
+        with pytest.raises(SystemExit) as exc:
+            pt.parse_args(argv)
+        assert exc.value.code == 2
+        assert "--date_range START must be <= END" in capsys.readouterr().err
+
+    def test_removed_flag_has_no_dest(self, pt):
+        # Grouping is always on, so --group_bursts was dropped. Asserting the
+        # *dest* is gone is the real contract; argparse rejects any unknown
+        # string for free, so a bare "it exits" would pass on --nonsense too --
+        # and would keep passing if the flag came back as a no-op alias.
+        assert "group_bursts" not in vars(pt.parse_args(_BASE_ARGS))
 
     def test_obs_ids_source_valid(self, pt):
         ns = pt.parse_args(
@@ -129,16 +141,24 @@ class TestParseArgs:
         )
         assert ns.obs_ids == [_OID] and ns.date_range is None
 
-    def test_date_range_and_obs_ids_mutually_exclusive(self, pt):
-        with pytest.raises(SystemExit):
+    def test_date_range_and_obs_ids_mutually_exclusive(self, pt, capsys):
+        with pytest.raises(SystemExit) as exc:
             pt.parse_args(_BASE_ARGS + ["--obs_ids", _OID])
+        assert exc.value.code == 2
+        assert "--obs_ids: not allowed with argument --date_range" in (
+            capsys.readouterr().err
+        )
 
-    def test_neither_source_errors(self, pt):
-        with pytest.raises(SystemExit):
+    def test_neither_source_errors(self, pt, capsys):
+        with pytest.raises(SystemExit) as exc:
             pt.parse_args(["--target", "x", "--data_dir", "/d", "--plot_dir", "/p"])
+        assert exc.value.code == 2
+        assert "one of the arguments --date_range --obs_ids is required" in (
+            capsys.readouterr().err
+        )
 
-    def test_invalid_obs_id_errors(self, pt):
-        with pytest.raises(SystemExit):
+    def test_invalid_obs_id_errors(self, pt, capsys):
+        with pytest.raises(SystemExit) as exc:
             pt.parse_args(
                 [
                     "--target",
@@ -151,6 +171,8 @@ class TestParseArgs:
                     "/p",
                 ]  # fmt: skip
             )
+        assert exc.value.code == 2
+        assert "--obs_ids value is not a valid obs_id" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------
@@ -191,11 +213,13 @@ class TestDiscoverL4Files:
 
     def test_no_matches_exits(self, pt, tmp_path):
         _write_l4(str(tmp_path), "20240101", 100, "99999", 2.4e6, 1.0, 0.5)
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit, match="no L4 products for target '10700'"):
             pt.discover_l4_files(str(tmp_path), "10700", "20240101", "20240131", 4)
 
     def test_missing_l4_root_exits(self, pt, tmp_path):
-        with pytest.raises(SystemExit):
+        # A distinct diagnostic from "no matches": without the match= the tmp
+        # tree has no matches either way and this test duplicates its neighbour.
+        with pytest.raises(SystemExit, match="L4 output directory not found"):
             pt.discover_l4_files(str(tmp_path), "10700", "20240101", "20240131", 4)
 
 
@@ -230,7 +254,7 @@ class TestL4PathsForObsIds:
         assert "not target '10700'" in out and "plotting anyway" in out
 
     def test_exits_when_none_present(self, pt, tmp_path):
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit, match="none of the 1 supplied obs_id"):
             pt.l4_paths_for_obs_ids(str(tmp_path), ["KP.20240101.03600.00"], "10700")
 
 
@@ -423,6 +447,49 @@ class TestDeltaRvReference:
         assert ref == pytest.approx(np.median(g_rvs))
 
 
+class TestDeltaRvStats:
+    """``RV_RMS`` is the number an observer reads off the plot to judge RV
+    stability, and nothing checked it -- the plot tests assert only that a PNG
+    exists. Its sibling ``_delta_rv_reference`` is value-tested above; the
+    asymmetry was unintentional.
+
+    These are arithmetic checks on inputs the test supplies. They pin no
+    pipeline RV.
+    """
+
+    def test_scaling_and_rms(self, pt):
+        # km/s -> m/s on both the offsets and the error bars: rvs 2 mm/s either
+        # side of ref give drv [-2, 0, 2] m/s, whose std is sqrt(8/3).
+        rvs = np.array([1.000, 1.002, 1.004])
+        errs = np.array([0.001, 0.002, 0.003])
+        outlier = np.zeros(3, dtype=bool)
+        drv, derr, rms, med_err = pt._delta_rv_stats(rvs, errs, 1.002, outlier)
+        assert drv == pytest.approx([-2.0, 0.0, 2.0])
+        assert derr == pytest.approx([1.0, 2.0, 3.0])
+        assert rms == pytest.approx(np.sqrt(8.0 / 3.0))
+        assert med_err == pytest.approx(2.0)
+
+    def test_flagged_outlier_does_not_inflate_rms(self, pt):
+        # A flagged point 1 km/s off would dominate the std if it leaked back in;
+        # the retained three must give the same answer as if it were absent.
+        rvs = np.array([1.000, 1.002, 1.004, 2.000])
+        errs = np.full(4, 0.002)
+        outlier = np.array([False, False, False, True])
+        _, _, rms, _ = pt._delta_rv_stats(rvs, errs, 1.002, outlier)
+        assert rms == pytest.approx(np.sqrt(8.0 / 3.0))
+        # Guard the direction: including the outlier gives a vastly larger number.
+        assert rms < np.std((rvs - 1.002) * 1e3) / 100
+
+    def test_all_outliers_falls_back_to_every_point(self, pt):
+        # With nothing retained there is no meaningful subset, so the std is taken
+        # over everything rather than over an empty slice (which would be nan).
+        rvs = np.array([1.000, 1.002, 1.004])
+        errs = np.full(3, 0.002)
+        outlier = np.ones(3, dtype=bool)
+        _, _, rms, _ = pt._delta_rv_stats(rvs, errs, 1.002, outlier)
+        assert rms == pytest.approx(np.sqrt(8.0 / 3.0))
+
+
 # ---------------------------------------------------------------------------
 # plot outputs
 # ---------------------------------------------------------------------------
@@ -435,6 +502,22 @@ class TestPlot:
             _write_l4(data_dir, dc, sec, "10700", bjd, 1.0 + 0.001 * i, 0.3)
             for i, (dc, sec, bjd) in enumerate(spec)
         ]
+
+    def test_no_finite_rv_points_exits(self, pt, tmp_path):
+        # Without this guard the plotter runs on empty arrays and emits a blank
+        # PNG that looks like a successful run; the wrapper only reads the exit
+        # code, so the difference is "loud" vs "green run, no data".
+        # The one frame is dropped by _read_l4_rv for a missing RVERR (the
+        # builder idiom from TestReadL4Rv), leaving nothing to plot.
+        l4_dir = tmp_path / "L4" / "20240101"
+        l4_dir.mkdir(parents=True)
+        path = l4_dir / "kpf_SL4_20240101T000100.fits"
+        fits.PrimaryHDU(
+            header=fits.Header({"OBJECT": "10700", "BJDTDB": 2.4e6, "RV": 1.0})
+        ).writeto(path)
+
+        with pytest.raises(SystemExit, match="no finite RV"):
+            pt.plot_rv_timeseries("10700", [str(path)], str(tmp_path / "plots"))
 
     def test_timeseries_png_written(self, pt, tmp_path):
         # Single-observation nights get no nightly panel.

--- a/tests/regression/test_plot_timeseries_script.py
+++ b/tests/regression/test_plot_timeseries_script.py
@@ -1,10 +1,10 @@
 """Tests for scripts/plots/plot_timeseries.py: the standalone RV-timeseries plotter.
 
-plot_timeseries reads a target's L4 products off disk (over a datecode range) and
-renders the RV-vs-date plot; bursts are always grouped, and per-night panels are
-written only for nights with multiple observations. These cover what the script
-owns: arg parsing, the threaded L4 discovery, the RV-header read, the burst
-grouping, the main() wiring, and that the plot files actually get written.
+plot_timeseries reads a target's L4 products off disk and renders the RV-vs-date
+plot; bursts are always grouped, and per-night panels are written only for nights
+with multiple observations. These cover what the script owns: arg parsing, the
+threaded L4 discovery, the RV-header read, the burst grouping, the main() wiring,
+and that the plot files actually get written.
 
 Unit tests use synthetic bare-PRIMARY L4 frames in temp trees -- no real testdata.
 """
@@ -40,8 +40,8 @@ def pt():
 def _write_l4(data_dir, datecode, seconds, obj, bjd, rv, rverr, notjunk=None):
     """Write one L4 frame under {data_dir}/L4/{datecode}; return path.
 
-    Bare PRIMARY by default; pass `notjunk` (0/1) to add a QUALITY_CONTROL extension
-    carrying that NOTJUNK card (the junk QC flag the plotter reads).
+    Bare PRIMARY by default; pass `notjunk` (0/1) to add a QUALITY_CONTROL
+    extension carrying that NOTJUNK card, the junk QC flag the plotter reads.
     """
     from pathlib import Path
 
@@ -110,7 +110,7 @@ class TestParseArgs:
             pt.parse_args(argv)
 
     def test_group_bursts_flag_removed(self, pt):
-        # --group_bursts no longer exists (grouping is always on).
+        # Grouping is always on, so the flag was dropped.
         with pytest.raises(SystemExit):
             pt.parse_args(_BASE_ARGS + ["--group_bursts"])
 
@@ -134,7 +134,6 @@ class TestParseArgs:
             pt.parse_args(_BASE_ARGS + ["--obs_ids", _OID])
 
     def test_neither_source_errors(self, pt):
-        # Exactly one of --date_range / --obs_ids is required.
         with pytest.raises(SystemExit):
             pt.parse_args(["--target", "x", "--data_dir", "/d", "--plot_dir", "/p"])
 
@@ -216,7 +215,7 @@ class TestL4PathsForObsIds:
 
     def test_skips_missing_l4(self, pt, tmp_path, capsys):
         a = _write_l4_for(str(tmp_path), "KP.20240101.03600.00", "10700")
-        # The second obs_id has no L4 on disk -> warned and skipped, not fatal.
+        # The second obs_id has no L4 on disk: warn and skip, not fatal.
         got = pt.l4_paths_for_obs_ids(
             str(tmp_path), ["KP.20240101.03600.00", "KP.20240101.07200.00"], "10700"
         )
@@ -224,7 +223,6 @@ class TestL4PathsForObsIds:
         assert "no L4 product for KP.20240101.07200.00" in capsys.readouterr().out
 
     def test_mismatched_object_warns_but_kept(self, pt, tmp_path, capsys):
-        # A frame whose L4 OBJECT != target is plotted anyway, with a warning.
         a = _write_l4_for(str(tmp_path), "KP.20240101.03600.00", "99999")
         got = pt.l4_paths_for_obs_ids(str(tmp_path), ["KP.20240101.03600.00"], "10700")
         assert got == [a]
@@ -266,13 +264,13 @@ class TestReadL4Rv:
         assert times.size == 0
 
     def test_skips_string_valued_card_without_crashing(self, pt, tmp_path):
-        # A present-but-non-numeric card (e.g. a stringified 'nan' -- these bare
-        # keywords aren't registry-validated) must skip the one frame, not raise
-        # from np.isfinite(str) and abort the whole plot. The good frame survives.
+        # These bare keywords aren't registry-validated, so a non-numeric card
+        # (a stringified 'nan') must skip its frame rather than raise from
+        # np.isfinite(str) and abort the whole plot.
         good = _write_l4(str(tmp_path), "20240101", 100, "10700", 2.4e6, 1.5, 0.5)
         bad = tmp_path / "L4" / "20240101" / "kpf_SL4_str.fits"
-        # All three cards present so the None-guard passes; RV is a string, which
-        # is exactly what would reach (and crash) np.isfinite before the fix.
+        # All three cards present so the None-guard passes and the string RV is
+        # what reaches np.isfinite.
         fits.PrimaryHDU(
             header=fits.Header(
                 {"OBJECT": "10700", "BJDTDB": 2.4e6, "RV": "nan", "RVERR": 0.5}
@@ -317,7 +315,6 @@ class TestJunkExclusion:
 
 class TestGroupBursts:
     def test_single_burst_weighted_mean(self, pt):
-        # Three frames within a burst collapse to one 1/err^2-weighted point.
         day = 1.0 / 1440.0  # one minute in days
         times = np.array([0.0, day, 2 * day])
         rvs = np.array([10.0, 20.0, 30.0])
@@ -353,7 +350,7 @@ class TestClassifyObservingMode:
         ]
 
     def test_uniform_many_frames_is_high_cadence(self, pt):
-        # 40 frames at a steady ~1-min cadence: ratio ~ 1, well over the floor.
+        # 40 frames at a steady ~1-min cadence: ratio ~1, above the frame floor.
         assert self._mode(pt, np.arange(40) * self._MIN) == pt._MODE_HIGH_CADENCE
 
     def test_three_frame_cluster_is_burst(self, pt):
@@ -368,7 +365,7 @@ class TestClassifyObservingMode:
         assert self._mode(pt, [0.0]) == pt._MODE_STANDARD
 
     def test_multi_burst_night_is_burst_not_high_cadence(self, pt):
-        # Many frames but in two clusters hours apart: ratio >> 3 -> burst, not hicad.
+        # Many frames, but in two clusters hours apart: ratio >> 3 -> burst.
         first = np.arange(6) * self._MIN
         second = 0.2 + np.arange(6) * self._MIN  # ~4.8 h later
         assert self._mode(pt, np.concatenate([first, second])) == pt._MODE_BURST
@@ -395,9 +392,8 @@ class TestClassifyObservingMode:
 
 class TestDeltaRvReference:
     def test_zero_point_excludes_outlier(self, pt):
-        # 12 points at RV=1.0 plus one gross outlier at 1000. The zero-point must be
-        # the median of the retained points (1.0), NOT the all-points median that
-        # the outlier would tug upward, and the outlier must be flagged.
+        # The zero-point must be the median of the retained points (1.0), not the
+        # all-points median that the 1000 outlier would tug upward.
         g_times = np.arange(13, dtype=float)
         g_rvs = np.full(13, 1.0)
         g_rvs[6] = 1000.0
@@ -406,8 +402,8 @@ class TestDeltaRvReference:
         assert outlier[6] and outlier.sum() == 1
 
     def test_reference_is_order_independent(self, pt):
-        # The mask is found on the time-ordered series, so a shuffled input yields
-        # the same reference and the same flagged point (by identity, not index).
+        # The mask is found on the time-ordered series, so a shuffled input gives
+        # the same reference and flags the same point (by identity, not index).
         g_times = np.arange(13, dtype=float)
         g_rvs = np.full(13, 5.0)
         g_rvs[3] = -900.0
@@ -418,8 +414,8 @@ class TestDeltaRvReference:
         assert g_times[out_a][0] == g_times[perm][out_b][0] == 3.0
 
     def test_below_gate_flags_nothing(self, pt):
-        # Fewer than 10 points: no trend, nothing flagged, zero-point is the plain
-        # median over all points (an outlier is not rejected here by design).
+        # Below the 10-point gate: no trend fit, so nothing is flagged and the
+        # zero-point is the plain median over all points.
         g_times = np.arange(5, dtype=float)
         g_rvs = np.array([1.0, 1.0, 1.0, 1.0, 50.0])
         ref, outlier = pt._delta_rv_reference(g_times, g_rvs)
@@ -428,7 +424,7 @@ class TestDeltaRvReference:
 
 
 # ---------------------------------------------------------------------------
-# plot outputs (establishes the repo's first Agg/PNG test)
+# plot outputs
 # ---------------------------------------------------------------------------
 
 
@@ -441,7 +437,7 @@ class TestPlot:
         ]
 
     def test_timeseries_png_written(self, pt, tmp_path):
-        # Two single-observation nights: the main plot is written, no nightly panel.
+        # Single-observation nights get no nightly panel.
         paths = self._paths(
             str(tmp_path), [("20240101", 100, 2.4e6), ("20240102", 100, 2.4e6 + 1)]
         )
@@ -451,7 +447,7 @@ class TestPlot:
         assert not (plot_dir / "10700_rv_nightly.png").exists()
 
     def test_nightly_png_only_for_multiobs_nights(self, pt, tmp_path):
-        # One night with two frames (a burst) -> the nightly panel is written too.
+        # One night with two frames (a burst) also gets the nightly panel.
         day = 1.0 / 1440.0
         paths = self._paths(
             str(tmp_path),
@@ -463,9 +459,8 @@ class TestPlot:
         assert (plot_dir / "10700_rv_nightly.png").exists()
 
     def test_high_cadence_night_gets_own_plot_and_is_held_out(self, pt, tmp_path):
-        # A 12-frame uniform night (high cadence) plus two ordinary single-obs
-        # nights: the high-cadence night gets its own PNG and is excluded from the
-        # main plot, which is still written from the two remaining nights.
+        # The high-cadence night gets its own PNG and is excluded from the main
+        # plot, which is still written from the two remaining nights.
         minute = 1.0 / 1440.0
         spec = [("20240926", 100 + i, 2.4e6 + i * minute) for i in range(12)]
         spec += [("20240101", 100, 2.45e6), ("20240102", 100, 2.45e6 + 1)]
@@ -479,7 +474,7 @@ class TestPlot:
         assert not (plot_dir / "10700_rv_nightly.png").exists()
 
     def test_all_high_cadence_writes_only_per_night_plots(self, pt, tmp_path):
-        # Every night high-cadence: only the per-night plots exist, no main plot.
+        # Every night high-cadence, so there is nothing left for a main plot.
         minute = 1.0 / 1440.0
         spec = [("20240926", 100 + i, 2.4e6 + i * minute) for i in range(12)]
         spec += [("20240927", 200 + i, 2.41e6 + i * minute) for i in range(12)]

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -1,15 +1,7 @@
 """Tests for the KPF QC framework (quality_control/qc_flags).
 
-Covers:
-  - QC base class runner (TestQCBase)
-  - QCL0 checks (TestQCL0)
-  - QCL1 checks (TestQCL1)
-  - QCL1 full run on an all-good synthetic L1 (TestQCL1Run)
-  - QCL2 checks (TestQCL2)
-  - QCL4 checks (TestQCL4)
-
-All tests use synthetic in-memory data -- no real KPF files required.
-The qc.py CLI smoke tests live in test_qc_script.py.
+All tests use synthetic in-memory data -- no real KPF files required. The qc.py
+CLI smoke tests live in test_qc_script.py.
 """
 
 import logging
@@ -54,11 +46,10 @@ def _make_kpf0(
 ):
     """Minimal 4-amp KPF0 object with required headers.
 
-    ``dates`` optionally seeds raw DATE-BEG/MID/END/ELAPSED cards on PRIMARY for
-    the DATTIMOK timing check. ``expmeter`` optionally maps an EXPMETER_SCI/SKY
-    extension name to its table, for the EMTIMEOK/EMFLUXOK checks; without it the
-    frame has no EM data at all, like a calibration. ``imtype`` sets the PRIMARY
-    IMTYPE ('Object' is a science frame; anything else is a calibration).
+    ``dates`` seeds raw DATE-BEG/MID/END/ELAPSED cards on PRIMARY. ``expmeter``
+    maps an EXPMETER_SCI/SKY extension name to its table; without it the frame has
+    no EM data at all, like a calibration. ``imtype`` sets PRIMARY IMTYPE
+    ('Object' is a science frame, anything else a calibration).
     """
     fn = str(tmp_path / f"{obs_id}.fits")
     primary = fits.PrimaryHDU()
@@ -100,9 +91,10 @@ _EM_CLEAN_FLUX = np.full((4, 25), 1000.0)
 
 
 def _seed_required_primary(kpf, qc_cls):
-    """Seed every PRIMARY keyword ``qc_cls`` requires present, skipping any already
-    set. The KWRDPR* check is presence-only, so placeholder sentinel values are
-    fine; reusing the production ``_required_primary_keywords`` avoids drift.
+    """Seed every PRIMARY keyword ``qc_cls`` requires, skipping ones already set.
+
+    KWRDPR* is presence-only, so sentinel values suffice; reusing the production
+    ``_required_primary_keywords`` avoids drift.
     """
     for kw in qc_cls(kpf)._required_primary_keywords():
         if kw not in kpf.headers["PRIMARY"]:
@@ -125,10 +117,10 @@ def _make_kpf1(
 ):
     """Minimal KPF1 with all L1 QC-relevant headers.
 
-    QC-relevant keywords now live on their registry-home extensions rather than
-    PRIMARY: the applied-step flags (OSCANSUB/BIASSUB/DARKSUB/FLATDIV) on
-    RECEIPT, and the read-noise and master-age keywords on QUALITY_CONTROL.
-    They are seeded on the loaded object after ``from_fits`` returns.
+    QC-relevant keywords live on their registry-home extensions, not PRIMARY: the
+    applied-step flags (OSCANSUB/BIASSUB/DARKSUB/FLATDIV) on RECEIPT, and the
+    read-noise and master-age keywords on QUALITY_CONTROL. They are seeded on the
+    loaded object after ``from_fits`` returns.
     """
     fn = str(tmp_path / "kpf_L1_20240405T010037.fits")
     primary = fits.PrimaryHDU()
@@ -165,10 +157,8 @@ def _make_kpf1(
             qc[f"RNNGGR{i}"] = (1.0, "RNNG")
             qc[f"RNNGRD{i}"] = (1.0, "RNNG")
 
-    # Seed the full required-PRIMARY set so KWRDPRL1 (presence of all required
-    # keywords) passes. KPF1.__init__ seeds the EPRV skeleton, but KPF1._read
-    # replaces PRIMARY with the file's (sparse) header, so a synthetic from_fits L1
-    # is otherwise missing them.
+    # KPF1.__init__ seeds the EPRV skeleton, but KPF1._read replaces PRIMARY with
+    # the file's sparse header, so a synthetic from_fits L1 would fail KWRDPRL1.
     _seed_required_primary(l1, QCL1)
     return l1
 
@@ -176,12 +166,10 @@ def _make_kpf1(
 def _make_kpf2_with_flux(*, nan_frac=0.0, zero_frac=0.1, missing_ext=None):
     """Minimal KPF2 with all 10 {CHIP}_{FIBER}_FLUX extensions populated.
 
-    Uses per-chip shapes matching NORDER_GREEN (35) and NORDER_RED (32)
-    because KPF2's chip-prefix __setitem__ requires the correct row count.
-
-    nan_frac: fraction of total pixels that are NaN (injected via NANSCI* headers).
-    zero_frac: value written to ZEROFRAC header.
-    missing_ext: optional chip_fiber key to leave empty (e.g. "GREEN_SKY_FLUX").
+    Per-chip row counts must match NORDER_GREEN/NORDER_RED because KPF2's
+    chip-prefix __setitem__ rejects any other shape. ``nan_frac`` is the fraction
+    of total pixels reported NaN via the NANSCI* headers, ``zero_frac`` the value
+    written to ZEROFRAC, and ``missing_ext`` a chip_fiber key to leave empty.
     """
     chips = ["GREEN", "RED"]
     fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
@@ -219,7 +207,7 @@ def _set_kpf2_var(kpf2, fill=1.0):
 
 
 # ---------------------------------------------------------------------------
-# Task 2: QC base class runner
+# QC base class runner
 # ---------------------------------------------------------------------------
 
 
@@ -229,13 +217,10 @@ class TestQCBase:
     def _make_obj(self):
         """Minimal object with a headers dict and a set_keyword router.
 
-        QC.run() writes each result via ``set_keyword`` and aggregates ISGOOD; it
-        does NOT validate headers (that moved to the checkpoints layer). It reads
-        each check's comment off ``keyword_registry.routing`` (the synthetic keys
-        are registered here with blank comments) and derives ISGOOD as the AND over
-        ``keyword_registry.qc_flag_keywords`` present on QUALITY_CONTROL, so the
-        stub declares the synthetic check keys as the QC-flag set. This fake stores
-        every keyword on QUALITY_CONTROL (value only).
+        QC.run() reads each check's comment off ``keyword_registry.routing`` and
+        derives ISGOOD as the AND over the ``keyword_registry.qc_flag_keywords``
+        present on QUALITY_CONTROL, so the stub declares the synthetic check keys
+        as the QC-flag set and stores every keyword on QUALITY_CONTROL.
         """
         qc_keys = frozenset({"CHECKA", "CHECKB", "CHKOK", "CHKFAIL", "FLAG", "ISGOOD"})
 
@@ -302,8 +287,7 @@ class TestQCBase:
 
             check_boom._qc_key = "BOOM"
 
-        # Fail-fast: the original exception propagates unchanged (no RuntimeError
-        # wrap), and run() logs the offending check at ERROR.
+        # Fail-fast: the exception propagates unwrapped, logged at ERROR.
         with caplog.at_level(logging.ERROR):
             with pytest.raises(ValueError, match="boom!"):
                 MyQC(obj).run()
@@ -320,12 +304,8 @@ class TestQCBase:
         assert obj.headers["QUALITY_CONTROL"]["ISGOOD"] == 1
 
     def test_repeated_run_resets_results(self):
-        """Calling run() twice on the same instance should not accumulate state.
-
-        First run with one failing check → ISGOOD=0. Mutate underlying state to make
-        the check pass, run again → ISGOOD=1. Without the reset, the failed result
-        from the first run would still be in self.results and ISGOOD would stay 0.
-        """
+        # Without the per-run reset, the first run's failed result would linger in
+        # self.results and ISGOOD would stay 0 once the check starts passing.
         obj = self._make_obj()
         obj.flag = False
 
@@ -348,7 +328,6 @@ class TestQCBase:
         assert qc.results["FLAG"][0] is True
 
     def test_run_logs_pass_debug_fail_warning(self, caplog):
-        """Each flag is logged as written: a pass at DEBUG, a failure at WARNING."""
         obj = self._make_obj()
 
         class MyQC(QC):
@@ -374,22 +353,21 @@ class TestQCBase:
         assert not any("CHKOK" in r.getMessage() for r in warnings)
 
     def test_hdr_float_absent_empty_none_corrupt_raises(self):
-        # Absent and valueless cards degrade to None (checks skip/FAIL gracefully);
-        # a present-but-non-numeric card is malformed, so it raises rather than
-        # being silently swallowed.
+        # Absent and valueless cards degrade to None so checks can skip or fail
+        # gracefully; a present-but-non-numeric card is malformed and raises.
         hdr = fits.Header()
         hdr["NUM"] = 3.5
-        hdr["EMPTY"] = None  # present-but-empty (valueless) card
+        hdr["EMPTY"] = None  # a valueless card
         hdr["STR"] = "not-a-number"
         assert QC._hdr_float(hdr, "NUM") == 3.5
-        assert QC._hdr_float(hdr, "MISSING") is None  # absent
-        assert QC._hdr_float(hdr, "EMPTY") is None  # valueless
+        assert QC._hdr_float(hdr, "MISSING") is None
+        assert QC._hdr_float(hdr, "EMPTY") is None
         with pytest.raises(ValueError):
-            QC._hdr_float(hdr, "STR")  # corrupt -> surfaces
+            QC._hdr_float(hdr, "STR")
 
 
 # ---------------------------------------------------------------------------
-# Task 3: QCL0 checks
+# QCL0 checks
 # ---------------------------------------------------------------------------
 
 
@@ -403,7 +381,6 @@ class TestQCL0:
         assert QCL0(l0).data_l0_red_green() is False
 
     def test_data_l0_red_green_fail_empty(self, tmp_path):
-        """An extension present with data=None (stored as array(None)) should fail."""
         fn = str(tmp_path / "KP.20240405.00002.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
@@ -419,8 +396,7 @@ class TestQCL0:
         assert QCL0(l0).data_l0_red_green() is False
 
     def test_data_l0_red_green_pass_two_amp(self, tmp_path):
-        """2-amp readout (only AMP1/AMP2 per chip; AMP3/4 absent) -- the truth-frame
-        layout -- has data present and must pass."""
+        # 2-amp readout (AMP1/AMP2 only) is the truth-frame layout and must pass.
         fn = str(tmp_path / "KP.20240405.00003.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
@@ -436,8 +412,6 @@ class TestQCL0:
         assert QCL0(l0).data_l0_red_green() is True
 
     def test_data_l0_red_green_fail_partial_amp(self, tmp_path):
-        """A partial/invalid amp set (3 present) is not a supported readout mode
-        (2 or 4), so the inferred count is rejected."""
         fn = str(tmp_path / "KP.20240405.00004.00.fits")
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
@@ -457,7 +431,6 @@ class TestQCL0:
         assert QCL0(l0).header_keywords_present() is True
 
     def test_header_keywords_present_fail(self, tmp_path):
-        """Remove OFNAME from PRIMARY so check fails."""
         l0 = _make_kpf0(tmp_path)
         del l0.headers["PRIMARY"]["OFNAME"]
         assert QCL0(l0).header_keywords_present() is False
@@ -471,8 +444,7 @@ class TestQCL0:
         assert QCL0(_make_kpf0(tmp_path, dates=bad)).times_consistent() is False
 
     def test_times_ignores_elapsed(self, tmp_path):
-        # DATTIMOK checks only DATE ordering now; a mismatched ELAPSED (validated by
-        # EXPTIMOK instead) no longer affects it.
+        # DATTIMOK checks only DATE ordering; ELAPSED is EXPTIMOK's business.
         bad = dict(_GOOD_DATES, ELAPSED=99.0)  # END-BEG != ELAPSED
         assert QCL0(_make_kpf0(tmp_path, dates=bad)).times_consistent() is True
 
@@ -488,7 +460,7 @@ class TestQCL0:
         assert QCL0(l0).exptime_sane() is True
 
     def test_exptime_sane_pass_zero(self, tmp_path):
-        """Bias frames legitimately have EXPTIME=0; should pass."""
+        # Bias frames legitimately have EXPTIME=0.
         l0 = _make_kpf0(tmp_path, exptime=0.0)
         assert QCL0(l0).exptime_sane() is True
 
@@ -522,13 +494,11 @@ class TestQCL0:
         l0 = _make_kpf0(tmp_path, exptime=300.0, dates={"ELAPSED": 301.0})
         assert QCL0(l0).exptime_sane() is False
 
-    # not_junk delegates all file I/O to io.load_junk_obs_ids, so these tests
-    # monkeypatch that helper (no junk file is ever written to a data tree) and
-    # verify only not_junk's own logic: the dirname -> data_input recovery, the
-    # obs_id membership test, and the two short-circuits. load_junk_obs_ids's
-    # CSV parsing is covered separately in test_masters_recipe.py.
+    # not_junk delegates all file I/O to load_junk_obs_ids, so these tests
+    # monkeypatch it (no junk file is ever written to a data tree) and cover only
+    # not_junk's own logic. The CSV parsing is covered in test_masters_recipe.py.
     def test_not_junk_pass_empty_list(self, tmp_path, monkeypatch):
-        """No junk (empty set, e.g. no list on disk) → not junk."""
+        # An empty set is what an absent junk list on disk yields.
         import kpfpipe.quality_control.qc_flags.level0 as mod
 
         monkeypatch.setattr(mod, "load_junk_obs_ids", lambda data_input: set())
@@ -556,7 +526,7 @@ class TestQCL0:
         assert QCL0(l0).not_junk() is False
 
     def test_not_junk_recovers_data_input_from_dirname(self, tmp_path, monkeypatch):
-        """data_input is the L0 dir's grandparent ({root}/L0/{datecode} → {root})."""
+        # data_input is the L0 dir's grandparent: {root}/L0/{datecode} -> {root}.
         import kpfpipe.quality_control.qc_flags.level0 as mod
 
         seen = {}
@@ -572,8 +542,7 @@ class TestQCL0:
         assert seen["data_input"] == str(tmp_path)
 
     def test_not_junk_pass_none_obs_id(self, tmp_path, monkeypatch):
-        """obs_id=None is not in any junk list → passes (documented residual: an
-        unresolved obs_id is not caught here)."""
+        # obs_id=None is on no junk list, so an unresolved obs_id passes here.
         import kpfpipe.quality_control.qc_flags.level0 as mod
 
         monkeypatch.setattr(
@@ -585,9 +554,8 @@ class TestQCL0:
         assert QCL0(l0).not_junk() is True
 
     def test_not_junk_raises_on_unknown_dirname(self, tmp_path):
-        """dirname is set on every L0 read; an absent one is a broken upstream
-        invariant and fails loud (os.path.dirname(None) → TypeError) rather than
-        silently passing."""
+        # dirname is set on every L0 read, so an absent one is a broken upstream
+        # invariant and must fail loud rather than silently pass.
         l0 = _make_kpf0(tmp_path)
         l0.dirname = None
         with pytest.raises(TypeError):
@@ -638,13 +606,12 @@ class TestQCL0:
 
     @pytest.mark.parametrize("imtype", ["Bias", "Dark", "Flatlamp", "Arclamp"])
     def test_radec_calibration_frames_pass(self, tmp_path, imtype):
-        """Pointing is a science-frame check: a calibration frame has no target,
-        so its blank TARGOFF must not fail RADECOK."""
+        # A calibration frame has no target, so its blank TARGOFF must not fail.
         l0 = _make_kpf0(tmp_path, imtype=imtype)
         assert QCL0(l0).radec_consistent() is True
 
     def test_radec_calibration_ignores_offsets(self, tmp_path):
-        """Even a badly-off offset on a calibration frame is not a pointing fault."""
+        # Even a badly-off offset on a calibration frame is not a pointing fault.
         l0 = _make_kpf0(tmp_path, imtype="Bias")
         for k, v in (("TARGOFF", 1.5), ("OBJOFF", 6.0), ("GAIAOFF", 91004.96)):
             l0.set_keyword(k, v)
@@ -654,11 +621,13 @@ class TestQCL0:
         assert QCL0.__dict__["radec_consistent"]._qc_key == "RADECOK"
 
     # --- catalog_astrometry_sane (ASTROMOK): physical range of the canonical
-    # CATALOG_RECORD astrometry, the v2.12 TARG* checks moved onto the merged row.
+    # CATALOG_RECORD astrometry.
 
     def _make_kpf0_with_canonical(self, tmp_path, **overrides):
-        """KPF0 whose CATALOG_RECORD holds a merged 'kpf-drp' row; overrides patch
-        individual fields of a physically-sane base."""
+        """KPF0 whose CATALOG_RECORD holds a merged 'kpf-drp' row.
+
+        Overrides patch individual fields of a physically-sane base.
+        """
         from kpfpipe.modules.astro_query import AstroQuery
 
         l0 = _make_kpf0(tmp_path)
@@ -685,15 +654,15 @@ class TestQCL0:
         assert QCL0(l0).catalog_astrometry_sane() is True
 
     def test_catalog_astrometry_sane_no_record_passes(self, tmp_path):
-        # Calibration/fresh L0: CATALOG_RECORD empty (AstroQuery never ran). Value
-        # sanity is N/A -> passes (presence is enforced elsewhere, not here).
+        # CATALOG_RECORD is empty when AstroQuery never ran; value sanity is then
+        # N/A and presence is enforced elsewhere.
         l0 = _make_kpf0(tmp_path)
         assert not l0.data["CATALOG_RECORD"].colnames
         assert QCL0(l0).catalog_astrometry_sane() is True
 
     def test_catalog_astrometry_sane_fail_epoch_zero(self, tmp_path):
-        # A WMKO TARGEPOC=0.0 placeholder passes the merge's is-not-None gate, so the
-        # range check is what catches it.
+        # A WMKO TARGEPOC=0.0 placeholder clears the merge's is-not-None gate, so
+        # only the range check catches it.
         l0 = self._make_kpf0_with_canonical(tmp_path, epoch=0.0)
         assert QCL0(l0).catalog_astrometry_sane() is False
 
@@ -735,8 +704,7 @@ class TestQCL0:
         assert QCL0(l0).catalog_astrometry_sane() is True
 
     def test_catalog_astrometry_sane_fail_parallax_negative(self, tmp_path):
-        # A negative Gaia parallax (routine for faint sources) is nonphysical; the
-        # legacy check bounded only the upper end.
+        # A negative Gaia parallax is routine for faint sources but nonphysical.
         l0 = self._make_kpf0_with_canonical(tmp_path, parallax=-0.3)
         assert QCL0(l0).catalog_astrometry_sane() is False
 
@@ -745,7 +713,7 @@ class TestQCL0:
         assert QCL0(l0).catalog_astrometry_sane() is False
 
     def test_catalog_astrometry_sane_fail_parallax_too_large(self, tmp_path):
-        # >= 1000 mas (< 1 pc) is unphysically close -- the legacy upper bound.
+        # >= 1000 mas is nearer than 1 pc, which nothing observable is.
         l0 = self._make_kpf0_with_canonical(tmp_path, parallax=1000.0)
         assert QCL0(l0).catalog_astrometry_sane() is False
 
@@ -766,8 +734,9 @@ class TestQCL0:
     def test_astromok_key_present(self):
         assert QCL0.__dict__["catalog_astrometry_sane"]._qc_key == "ASTROMOK"
 
-    # --- catalog_color_sane (COLOROK): the canonical color is present, labeled, and
-    # on the dwarf sequence, so CrossCorrelation can turn it into a line-mask Teff.
+    # --- catalog_color_sane (COLOROK): the canonical color must be present,
+    # labeled, and on the dwarf sequence for CrossCorrelation to turn it into a
+    # line-mask Teff.
 
     @pytest.mark.parametrize(
         ("color", "color_name"),
@@ -821,12 +790,11 @@ class TestQCL0:
     def test_dataprl0_key_and_comment(self):
         fn = QCL0.__dict__["data_l0_red_green"]
         assert fn._qc_key == "DATAPRL0"
-        # The comment now lives in the registry Description (not on the method).
+        # The comment lives in the registry Description, not on the method.
         assert "GREEN" in KPF0.keyword_registry.routing["DATAPRL0"][1]
 
-    # --- expmeter_times_consistent (EMTIMEOK) and expmeter_flux_sane (EMFLUXOK):
-    # the exposure-meter checks ported from v2.12 L0_datetime / EM_not_saturated /
-    # EM_flux_not_negative. Four readings tile the _GOOD_DATES shutter window.
+    # --- expmeter_times_consistent (EMTIMEOK) and expmeter_flux_sane (EMFLUXOK).
+    # Four readings tile the _GOOD_DATES shutter window.
 
     _EM_BEGS = [
         "2024-09-23T09:12:09.484",
@@ -851,9 +819,12 @@ class TestQCL0:
         sky_flux=None,
         corrected=False,
     ):
-        """KPF0 carrying an EXPMETER_SCI table (plus EXPMETER_SKY when ``sky_flux``
-        is given), built from per-reading timestamps and an (nreading, nchannel)
-        flux array with numeric (wavelength) column labels."""
+        """KPF0 carrying an EXPMETER_SCI table, plus EXPMETER_SKY when ``sky_flux``
+        is given.
+
+        Built from per-reading timestamps and an (nreading, nchannel) flux array
+        whose column labels are wavelengths.
+        """
         suffix = "-Corr" if corrected else ""
 
         def table(values):
@@ -897,7 +868,7 @@ class TestQCL0:
         assert QCL0(l0).expmeter_times_consistent() is False
 
     def test_expmeter_times_prefers_corrected_columns(self, tmp_path):
-        # Corrected columns bracket the window; only reading them passes.
+        # Only the -Corr columns bracket the window, so plain ones would fail.
         l0 = self._make_kpf0_with_expmeter(tmp_path, corrected=True)
         assert "Date-Beg-Corr" in l0.data["EXPMETER_SCI"].colnames
         assert QCL0(l0).expmeter_times_consistent() is True
@@ -960,7 +931,7 @@ class TestQCL0:
 
 
 # ---------------------------------------------------------------------------
-# Task 4: QCL1 checks
+# QCL1 checks
 # ---------------------------------------------------------------------------
 
 
@@ -1097,7 +1068,6 @@ class TestQCL1:
 
     def test_ffi_finite_fail_missing(self, tmp_path):
         l1 = _make_kpf1(tmp_path)
-        # Remove GREEN_CCD from data
         l1.data["GREEN_CCD"] = None
         assert QCL1(l1).ffi_finite() is False
 
@@ -1120,7 +1090,7 @@ class TestQCL1:
 
 
 # ---------------------------------------------------------------------------
-# Task 4 integration: full QCL1 run on all-good synthetic L1
+# Full QCL1 run on an all-good synthetic L1
 # ---------------------------------------------------------------------------
 
 
@@ -1132,11 +1102,9 @@ class TestQCL1Run:
         isgood = l1.headers["QUALITY_CONTROL"].get("ISGOOD")
         assert isgood == 1
 
-        # Every L1 QC flag lands on QUALITY_CONTROL. The per-calibration OK flags
-        # (BIASOK/DARKOK/FLATOK) read the RECEIPT *SUB flags and DiagL1 *AGE
-        # values but are themselves QUALITY_CONTROL keywords. The applied-step
-        # flags (OSCANSUB/BIASSUB/DARKSUB/FLATDIV) stay RECEIPT-only provenance
-        # and are not QC checks.
+        # BIASOK/DARKOK/FLATOK read the RECEIPT *SUB flags and DiagL1 *AGE values
+        # but are themselves QUALITY_CONTROL keywords; the applied-step flags
+        # (OSCANSUB/BIASSUB/DARKSUB/FLATDIV) stay RECEIPT-only provenance.
         qc_keys = [
             "DATAPRL1",
             "KWRDPRL1",
@@ -1158,25 +1126,21 @@ class TestQCL1Run:
         isgood = l1.headers["QUALITY_CONTROL"].get("ISGOOD")
         assert isgood == 0
 
-        # Bias not subtracted -> BIASOK fails (a QUALITY_CONTROL flag); the
-        # RECEIPT BIASSUB provenance keyword is untouched by QC.
+        # QC writes the BIASOK flag and never touches RECEIPT's BIASSUB.
         assert l1.headers["QUALITY_CONTROL"].get("BIASOK") == 0
 
     def test_isgood_aggregates_propagated_flag(self, tmp_path):
-        """ISGOOD is the running aggregate over EVERY QC flag on QUALITY_CONTROL,
-        including ones propagated from a lower level -- not just this level's
-        checks. Seed a failed L0 flag; all L1 checks still pass, yet ISGOOD=0."""
+        # ISGOOD aggregates every QC flag on QUALITY_CONTROL, including ones
+        # propagated from a lower level, not just this level's checks.
         l1 = _make_kpf1(tmp_path)
         l1.headers["QUALITY_CONTROL"]["DATAPRL0"] = (0, "L0 data present (propagated)")
         QCL1(l1).run()
-        # This level's own checks all pass...
         assert l1.headers["QUALITY_CONTROL"].get("DATAPRL1") == 1
-        # ...but the propagated L0 failure drags the aggregate down.
         assert l1.headers["QUALITY_CONTROL"].get("ISGOOD") == 0
 
 
 # ---------------------------------------------------------------------------
-# Task 5: QCL2 checks
+# QCL2 checks
 # ---------------------------------------------------------------------------
 
 
@@ -1186,8 +1150,8 @@ class TestQCL2:
         assert QCL2(kpf2).extraction_present() is True
 
     def test_required_keywords_present_pass(self):
-        # Fresh KPF2 is rvdata-seeded with the EPRV-required PRIMARY keywords; seed
-        # the KPF provenance cards too so all required keywords are present.
+        # A fresh KPF2 carries only the rvdata-seeded EPRV keywords, not the KPF
+        # provenance cards.
         kpf2 = _make_kpf2_with_flux()
         _seed_required_primary(kpf2, QCL2)
         assert QCL2(kpf2).required_keywords_present() is True
@@ -1199,7 +1163,6 @@ class TestQCL2:
         assert QCL2(kpf2).required_keywords_present() is False
 
     def test_extraction_present_fail_empty_kpf2(self):
-        """A freshly constructed KPF2 with no flux data → all chip-prefix sizes=0."""
         kpf2 = KPF2()
         for k in ["NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL"]:
             kpf2.headers["QUALITY_CONTROL"][k] = (0, k)
@@ -1207,35 +1170,31 @@ class TestQCL2:
         assert QCL2(kpf2).extraction_present() is False
 
     def test_extraction_present_fail_one_trace_cleared(self):
-        """Clearing a trace array (set to empty array) should fail the check."""
         kpf2 = _make_kpf2_with_flux()
-        # Resolve alias SKY_FLUX → TRACE1_FLUX and set to empty so chip views
-        # are size=0.
+        # The SKY_FLUX alias resolves to TRACE1_FLUX; emptying it zeroes the size
+        # of every chip view over it.
         kpf2.data["SKY_FLUX"] = np.array([], dtype=np.float32)
         assert QCL2(kpf2).extraction_present() is False
 
     def test_flux_finite_fraction_pass(self):
-        """0 NaN entries → passes."""
         kpf2 = _make_kpf2_with_flux(nan_frac=0.0)
         assert QCL2(kpf2).flux_finite_fraction() is True
 
     def test_flux_finite_fraction_fail_too_many_nans(self):
-        """Force nan_total/total_pixels > 1%."""
         kpf2 = _make_kpf2_with_flux()
-        # total_pixels = (35+32) * 5 fibers * _NCOLS (10) = 3350
-        # Set each NAN key to 200 → sum = 1000 → ~30% > 1%
+        # total_pixels = (35 + 32) * 5 fibers * _NCOLS = 3350, so 5 x 200 NaN is
+        # ~30%, well over the 1% limit.
         for k in ["NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL"]:
             kpf2.headers["QUALITY_CONTROL"][k] = (200, k)
         assert QCL2(kpf2).flux_finite_fraction() is False
 
     def test_flux_finite_fraction_fail_missing_header(self):
-        """Missing one NAN key → False."""
         kpf2 = _make_kpf2_with_flux(nan_frac=0.0)
         del kpf2.headers["QUALITY_CONTROL"]["NANSCI1"]
         assert QCL2(kpf2).flux_finite_fraction() is False
 
     def test_flux_finite_fraction_fail_no_extensions(self):
-        """Empty KPF2 (no flux arrays) → False (zero total pixels)."""
+        # No flux arrays means zero total pixels, so no fraction can be formed.
         kpf2 = KPF2()
         for k in ["NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL"]:
             kpf2.headers["QUALITY_CONTROL"][k] = (0, k)
@@ -1255,7 +1214,7 @@ class TestQCL2:
         assert QCL2(kpf2).nonzero_flux() is False
 
     def test_nonzero_flux_exactly_half(self):
-        """ZEROFRAC == 0.5 should fail (check is strictly < 0.5)."""
+        # The check is strictly < 0.5.
         kpf2 = _make_kpf2_with_flux(zero_frac=0.5)
         assert QCL2(kpf2).nonzero_flux() is False
 
@@ -1280,9 +1239,8 @@ class TestQCL2:
         assert QCL2(kpf2).variance_positive() is False
 
     def test_variance_positive_raises_on_shape_mismatch(self):
-        # FLUX populated but VAR left at its default empty (0,) shape is a
-        # malformed product: the shape-mismatched comparison raises rather than
-        # silently skipping the fiber.
+        # FLUX populated with VAR left at its default empty (0,) shape is a
+        # malformed product, so the shape mismatch raises rather than skipping.
         kpf2 = _make_kpf2_with_flux()  # no VAR populated
         with pytest.raises(ValueError):
             QCL2(kpf2).variance_positive()
@@ -1322,18 +1280,17 @@ class TestQCL2:
 
 
 # ---------------------------------------------------------------------------
-# QCL4 -- CCF/RV presence and BERV percent-change (ported from v2.12)
-# (timing consistency moved to QCL0 / DATTIMOK)
+# QCL4 -- CCF/RV presence and per-order BERV/BJD dispersion
 # ---------------------------------------------------------------------------
 
 
 def _make_l4(*, sci=True, rv_filled=True, bervrng=None, bjdrng=None, sci_obj=None):
     """KPF4 with science CCF/RV and optional per-order BERV/BJD range metrics.
 
-    ``rv_filled=False`` seeds the RV table with NaN RVs (a CrossCorrelation-only
-    L4, before RadialVelocity), so DATAPRL4 must fail. ``sci_obj`` sets the SCI2
-    illumination (INSTRUMENT_HEADER SCI-OBJ); the BERV/BJD tolerance checks only
-    apply when it is 'target'.
+    ``rv_filled=False`` seeds the RV table with NaN RVs, as a CrossCorrelation-only
+    L4 has before RadialVelocity runs. ``sci_obj`` sets the SCI2 illumination
+    (INSTRUMENT_HEADER SCI-OBJ), which the BERV/BJD tolerance checks apply only
+    when it is 'target'.
     """
     l4 = KPF4()
     if sci:
@@ -1371,13 +1328,13 @@ class TestQCL4:
         assert QCL4(_make_l4(sci=False)).ccf_rv_present() is False
 
     def test_ccf_rv_present_fail_when_rvs_unfilled(self):
-        # CCF present but RV column all-NaN (CrossCorrelation ran, RadialVelocity
-        # did not) -> the RVs are the L4 product, so DATAPRL4 must fail.
+        # The RVs are the L4 product, so an all-NaN RV column fails even with the
+        # CCFs in place.
         assert QCL4(_make_l4(rv_filled=False)).ccf_rv_present() is False
 
     def test_ccf_rv_present_fail_when_columns_missing(self):
-        # RV filled but the per-order BJD_TDB/BERV/WEIGHT columns the DiagL4
-        # dispersion metrics consume are absent -> DATAPRL4 must fail.
+        # The per-order BJD_TDB/BERV/WEIGHT columns the DiagL4 dispersion metrics
+        # consume are absent, so the product is incomplete.
         l4 = KPF4()
         for fiber in ("SCI1", "SCI2", "SCI3"):
             l4.set_data(f"{fiber}_CCF", np.ones((_NORDER_TOTAL, 5)))
@@ -1401,20 +1358,19 @@ class TestQCL4:
         assert QCL4(l4).berv_within_tolerance() is False
 
     def test_berv_within_tolerance_non_target_passes(self):
-        # SCI2 not star-illuminated (e.g. thar/etalon) -> not applicable, passes
-        # even with an out-of-tolerance BERVRNG present.
+        # SCI2 is not star-illuminated, so the check is N/A however bad BERVRNG is.
         l4 = _make_l4(sci_obj="etalon", bervrng=0.5)
         assert QCL4(l4).berv_within_tolerance() is True
 
     def test_berv_within_tolerance_raises_when_sci_obj_absent(self):
-        # A frame with no SCI-OBJ is malformed (CrossCorrelation requires it
-        # upstream) -> raise, not silently pass as a non-target source.
+        # CrossCorrelation requires SCI-OBJ upstream, so a frame without one is
+        # malformed and must not pass as a non-target source.
         with pytest.raises(ValueError, match="SCI-OBJ not in INSTRUMENT_HEADER"):
             QCL4(_make_l4(bervrng=0.05)).berv_within_tolerance()
 
     def test_berv_within_tolerance_target_absent_fails(self):
-        # Target frame but DiagL4 skipped the metric (degenerate weights / NaN
-        # barycorr) -> malformed, must fail rather than pass vacuously.
+        # DiagL4 skips the metric on degenerate weights or a NaN barycorr; on a
+        # target frame that is malformed, not a vacuous pass.
         assert QCL4(_make_l4(sci_obj="target")).berv_within_tolerance() is False
 
     def test_bjd_within_tolerance_pass(self):

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -337,7 +337,7 @@ class TestQCBase:
         assert QC._hdr_float(hdr, "NUM") == 3.5
         assert QC._hdr_float(hdr, "MISSING") is None
         assert QC._hdr_float(hdr, "EMPTY") is None
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="could not convert string to float"):
             QC._hdr_float(hdr, "STR")
 
 
@@ -533,7 +533,7 @@ class TestQCL0:
         # invariant and must fail loud rather than silently pass.
         l0 = _make_kpf0(tmp_path)
         l0.dirname = None
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="NoneType"):
             QCL0(l0).not_junk()
 
     def test_not_junk_key_present(self):
@@ -944,6 +944,22 @@ class TestQCL1:
         l1.headers["QUALITY_CONTROL"]["RNGREEN1"] = (99.0, "bad RN")
         assert QCL1(l1).read_noise_ok() is False
 
+    def test_read_noise_ok_fail_too_low(self, tmp_path):
+        # The realistic failure signature: a broken or short-circuited RN
+        # estimator returns ~0, not 99. Only the upper bound was ever crossed,
+        # so rewriting the predicate as `v <= hi` left the whole suite green.
+        l1 = _make_kpf1(tmp_path, with_rn=True)
+        l1.headers["QUALITY_CONTROL"]["RNGREEN1"] = (0.5, "collapsed RN")
+        assert QCL1(l1).read_noise_ok() is False
+
+    def test_read_noise_ok_boundaries_pass(self, tmp_path):
+        # The range is inclusive at both ends.
+        l1 = _make_kpf1(tmp_path, with_rn=True)
+        qc = l1.headers["QUALITY_CONTROL"]
+        qc["RNGREEN1"] = (2.0, "lower bound")
+        qc["RNRED1"] = (6.0, "upper bound")
+        assert QCL1(l1).read_noise_ok() is True
+
     def test_read_noise_ok_fail_missing(self, tmp_path):
         l1 = _make_kpf1(tmp_path, with_rn=False)
         assert QCL1(l1).read_noise_ok() is False
@@ -965,6 +981,11 @@ class TestQCL1:
         l1.headers["QUALITY_CONTROL"]["RNNGGR1"] = (9.9, "bad RNNG")
         assert QCL1(l1).read_noise_nongauss_ok() is False
 
+    def test_read_noise_nongauss_ok_fail_too_low(self, tmp_path):
+        l1 = _make_kpf1(tmp_path, with_rn=True)
+        l1.headers["QUALITY_CONTROL"]["RNNGGR1"] = (0.1, "collapsed RNNG")
+        assert QCL1(l1).read_noise_nongauss_ok() is False
+
     def test_read_noise_nongauss_ok_fail_missing(self, tmp_path):
         l1 = _make_kpf1(tmp_path, with_rn=False)
         assert QCL1(l1).read_noise_nongauss_ok() is False
@@ -980,6 +1001,19 @@ class TestQCL1:
     def test_bias_ok_pass(self, tmp_path):
         l1 = _make_kpf1(tmp_path, biassub=True, agebias=3.0)
         assert QCL1(l1).bias_ok() is True
+
+    def test_bias_ok_pass_future_dated_master(self, tmp_path):
+        # DiagL1 writes a SIGNED age (master_dt - obs_dt), and the check uses
+        # abs(), so a master processed after the science frame -- routine in the
+        # masters pipeline -- is still in range. Dropping the abs() would start
+        # failing BIASOK on every same-night master.
+        l1 = _make_kpf1(tmp_path, biassub=True, agebias=-3.0)
+        assert QCL1(l1).bias_ok() is True
+
+    def test_bias_ok_boundary(self, tmp_path):
+        # 7 days exactly is inside the gate; just past it is not.
+        assert QCL1(_make_kpf1(tmp_path, agebias=7.0)).bias_ok() is True
+        assert QCL1(_make_kpf1(tmp_path, agebias=7.5)).bias_ok() is False
 
     def test_bias_ok_fail_not_subtracted(self, tmp_path):
         l1 = _make_kpf1(tmp_path, biassub=False, agebias=3.0)
@@ -1217,7 +1251,7 @@ class TestQCL2:
         # FLUX populated with VAR left at its default empty (0,) shape is a
         # malformed product, so the shape mismatch raises rather than skipping.
         kpf2 = _make_kpf2_nan_headers()  # no VAR populated
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="could not be broadcast"):
             QCL2(kpf2).variance_positive()
 
     # --- science_snr (L2SNROK) ---
@@ -1357,8 +1391,46 @@ class TestQCL4:
         l4 = make_l4(sci=False, sci_obj="target", bervrng=0.5, bjdrng=2.0)
         for kw in QCL4(l4)._required_primary_keywords():
             l4.headers["PRIMARY"][kw] = 1.0
-        l4.headers["QUALITY_CONTROL"]  # ensure present
         QCL4(l4).run()
         qc = l4.headers["QUALITY_CONTROL"]
         assert qc["DATAPRL4"] == 0 and qc["BERVOK"] == 0 and qc["BJDOK"] == 0
         assert qc["ISGOOD"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Every check's _qc_key must be a registered keyword
+# ---------------------------------------------------------------------------
+
+
+class TestQCKeyRegistration:
+    """Each ``_qc_key`` tag resolves in the keyword registry.
+
+    The per-class ``test_qc_keys_correct`` tests above compare each tag against a
+    literal dict in this file, which restates the tag rather than checking it is
+    registered. ``QC.run`` looks the tag up in ``keyword_registry.routing`` to
+    fetch its comment, so an unregistered key is a ``KeyError`` at run time --
+    and QCL0/QCL2 have no in-process ``run()`` test to surface it.
+    """
+
+    _CLASSES = {"L0": QCL0, "L1": QCL1, "L2": QCL2, "L4": QCL4}
+
+    @pytest.mark.parametrize("level", sorted(_CLASSES))
+    def test_qc_keys_are_registered(self, level):
+        qc_cls = self._CLASSES[level]
+        registry = KPF0().keyword_registry
+        tagged = {
+            attr._qc_key
+            for cls in qc_cls.__mro__
+            for attr in cls.__dict__.values()
+            if getattr(attr, "_qc_key", None) is not None
+        }
+        assert tagged, f"{qc_cls.__name__} exposes no tagged checks"
+        for key in sorted(tagged):
+            assert key in registry.routing, (
+                f"{qc_cls.__name__} writes {key}, which no config/L*-headers.csv "
+                "row registers"
+            )
+            assert key in registry.qc_flag_keywords_by_level[level], (
+                f"{key} is not tagged as a {level} QC flag in the registry, so "
+                "Checkpoint.qc_flags would never scan it"
+            )

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -50,13 +50,15 @@ def _make_kpf0(
     obs_id="KP.20240405.00001.00",
     dates=None,
     expmeter=None,
+    imtype="Object",
 ):
     """Minimal 4-amp KPF0 object with required headers.
 
     ``dates`` optionally seeds raw DATE-BEG/MID/END/ELAPSED cards on PRIMARY for
     the DATTIMOK timing check. ``expmeter`` optionally maps an EXPMETER_SCI/SKY
     extension name to its table, for the EMTIMEOK/EMFLUXOK checks; without it the
-    frame has no EM data at all, like a calibration.
+    frame has no EM data at all, like a calibration. ``imtype`` sets the PRIMARY
+    IMTYPE ('Object' is a science frame; anything else is a calibration).
     """
     fn = str(tmp_path / f"{obs_id}.fits")
     primary = fits.PrimaryHDU()
@@ -65,7 +67,7 @@ def _make_kpf0(
     primary.header["EXPTIME"] = exptime
     primary.header["OBJECT"] = "synthetic"
     primary.header["OFNAME"] = f"{obs_id}.fits"
-    primary.header["IMTYPE"] = "Object"
+    primary.header["IMTYPE"] = imtype
     for k, v in (dates or {}).items():
         primary.header[k] = v
 
@@ -628,6 +630,20 @@ class TestQCL0:
         l0.set_keyword("TARGOFF", 0.02)
         l0.set_keyword("GAIAOFF", None)
         l0.set_keyword("OBJOFF", None)
+        assert QCL0(l0).radec_consistent() is True
+
+    @pytest.mark.parametrize("imtype", ["Bias", "Dark", "Flatlamp", "Arclamp"])
+    def test_radec_calibration_frames_pass(self, tmp_path, imtype):
+        """Pointing is a science-frame check: a calibration frame has no target,
+        so its blank TARGOFF must not fail RADECOK."""
+        l0 = _make_kpf0(tmp_path, imtype=imtype)
+        assert QCL0(l0).radec_consistent() is True
+
+    def test_radec_calibration_ignores_offsets(self, tmp_path):
+        """Even a badly-off offset on a calibration frame is not a pointing fault."""
+        l0 = _make_kpf0(tmp_path, imtype="Bias")
+        for k, v in (("TARGOFF", 1.5), ("OBJOFF", 6.0), ("GAIAOFF", 91004.96)):
+            l0.set_keyword(k, v)
         assert QCL0(l0).radec_consistent() is True
 
     def test_radecok_key_present(self):

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -67,6 +67,7 @@ def _make_kpf0(
     primary.header["EXPTIME"] = exptime
     primary.header["OBJECT"] = "synthetic"
     primary.header["OFNAME"] = f"{obs_id}.fits"
+    primary.header["PROGNAME"] = "K123"
     primary.header["IMTYPE"] = imtype
     for k, v in (dates or {}).items():
         primary.header[k] = v
@@ -407,6 +408,7 @@ class TestQCL0:
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
         primary.header["OFNAME"] = os.path.basename(fn)
+        primary.header["PROGNAME"] = "K123"
         hdus = [primary]
         for chip in ["GREEN", "RED"]:
             for amp in range(1, 5):
@@ -423,6 +425,7 @@ class TestQCL0:
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
         primary.header["OFNAME"] = os.path.basename(fn)
+        primary.header["PROGNAME"] = "K123"
         hdus = [primary]
         for chip in ["GREEN", "RED"]:
             for amp in (1, 2):
@@ -439,6 +442,7 @@ class TestQCL0:
         primary = fits.PrimaryHDU()
         primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
         primary.header["OFNAME"] = os.path.basename(fn)
+        primary.header["PROGNAME"] = "K123"
         hdus = [primary]
         for chip in ["GREEN", "RED"]:
             for amp in (1, 2, 3):  # 3 amps -> not a valid 2/4-amp readout

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -13,7 +13,6 @@ import pytest
 from astropy.io import fits
 from astropy.table import Table
 
-from kpfpipe import DETECTOR
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
 from kpfpipe.data_models.level2 import KPF2
@@ -24,8 +23,16 @@ from kpfpipe.quality_control.qc_flags.level1 import QCL1
 from kpfpipe.quality_control.qc_flags.level2 import QCL2
 from kpfpipe.quality_control.qc_flags.level4 import QCL4
 
-_NORDER = {"GREEN": DETECTOR["norder"]["GREEN"], "RED": DETECTOR["norder"]["RED"]}
-_NORDER_TOTAL = _NORDER["GREEN"] + _NORDER["RED"]
+from ._data_models import (
+    GOOD_DATES,
+    NORDER,
+    NORDER_TOTAL,
+    make_l4,
+    seed_required_primary,
+    set_fiber_arrays,
+    write_amp_l0,
+)
+
 _NCOLS = 10  # small column count for fast tests
 
 
@@ -51,54 +58,27 @@ def _make_kpf0(
     no EM data at all, like a calibration. ``imtype`` sets PRIMARY IMTYPE
     ('Object' is a science frame, anything else a calibration).
     """
-    fn = str(tmp_path / f"{obs_id}.fits")
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
-    primary.header["EXPTIME"] = exptime
-    primary.header["OBJECT"] = "synthetic"
-    primary.header["OFNAME"] = f"{obs_id}.fits"
-    primary.header["PROGNAME"] = "K123"
-    primary.header["IMTYPE"] = imtype
-    for k, v in (dates or {}).items():
-        primary.header[k] = v
-
-    hdus = [primary]
-    if with_amps:
-        for chip in ["GREEN", "RED"]:
-            for amp in range(1, 5):
-                data = np.ones((10, 10), dtype=np.float32)
-                hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
-    for name, table in (expmeter or {}).items():
-        hdus.append(fits.BinTableHDU(table, name=name))
-
-    fits.HDUList(hdus).writeto(fn, overwrite=True)
+    fn = write_amp_l0(
+        tmp_path / f"{obs_id}.fits",
+        namps=4 if with_amps else 0,
+        shape=(10, 10),
+        primary_cards={
+            "DATE-OBS": "2024-04-05T01:00:37",
+            "EXPTIME": exptime,
+            "IMTYPE": imtype,
+            **(dates or {}),
+        },
+        extra_hdus=[
+            fits.BinTableHDU(table, name=name)
+            for name, table in (expmeter or {}).items()
+        ],
+    )
     return KPF0.from_fits(fn)
-
-
-# Self-consistent raw timing cards (END - BEG == ELAPSED), for the DATTIMOK check.
-_GOOD_DATES = {
-    "DATE-BEG": "2024-09-23T09:12:09.484",
-    "DATE-MID": "2024-09-23T09:12:15.519",
-    "DATE-END": "2024-09-23T09:12:21.554",
-    "ELAPSED": 12.07,
-}
 
 
 # Clean exposure-meter flux for the EMFLUXOK tests: 4 readings x 25 wavelength
 # channels (more than the 20-channel negative run the check looks for).
 _EM_CLEAN_FLUX = np.full((4, 25), 1000.0)
-
-
-def _seed_required_primary(kpf, qc_cls):
-    """Seed every PRIMARY keyword ``qc_cls`` requires, skipping ones already set.
-
-    KWRDPR* is presence-only, so sentinel values suffice; reusing the production
-    ``_required_primary_keywords`` avoids drift.
-    """
-    for kw in qc_cls(kpf)._required_primary_keywords():
-        if kw not in kpf.headers["PRIMARY"]:
-            kpf.headers["PRIMARY"][kw] = ("UNKNOWN", "seeded for test")
 
 
 def _make_kpf1(
@@ -159,12 +139,17 @@ def _make_kpf1(
 
     # KPF1.__init__ seeds the EPRV skeleton, but KPF1._read replaces PRIMARY with
     # the file's sparse header, so a synthetic from_fits L1 would fail KWRDPRL1.
-    _seed_required_primary(l1, QCL1)
+    seed_required_primary(l1, QCL1)
     return l1
 
 
-def _make_kpf2_with_flux(*, nan_frac=0.0, zero_frac=0.1, missing_ext=None):
+def _make_kpf2_nan_headers(*, nan_frac=0.0, zero_frac=0.1, missing_ext=None):
     """Minimal KPF2 with all 10 {CHIP}_{FIBER}_FLUX extensions populated.
+
+    The arrays stay clean; the NaN counts and zero fraction are written as HEADERS,
+    because QCL2 reads them from the header rather than measuring pixels. Not the
+    same as test_diagnostics.py's ``_make_kpf2_nan_pixels``, which injects real
+    NaN/zero PIXELS for DiagL2 to measure. Do not merge them.
 
     Per-chip row counts must match NORDER_GREEN/NORDER_RED because KPF2's
     chip-prefix __setitem__ rejects any other shape. ``nan_frac`` is the fraction
@@ -179,7 +164,7 @@ def _make_kpf2_with_flux(*, nan_frac=0.0, zero_frac=0.1, missing_ext=None):
 
     total_pixels = 0
     for chip in chips:
-        nrows = _NORDER[chip]
+        nrows = NORDER[chip]
         for fiber in fibers:
             ext = f"{chip}_{fiber}_FLUX"
             if ext == missing_ext:
@@ -194,16 +179,6 @@ def _make_kpf2_with_flux(*, nan_frac=0.0, zero_frac=0.1, missing_ext=None):
     kpf2.headers["QUALITY_CONTROL"]["ZEROFRAC"] = (zero_frac, "Zero-flux fraction")
 
     return kpf2
-
-
-def _set_kpf2_var(kpf2, fill=1.0):
-    """Populate all {CHIP}_{FIBER}_VAR extensions with a constant fill."""
-    for chip in ["GREEN", "RED"]:
-        nrows = _NORDER[chip]
-        for fiber in ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]:
-            kpf2.set_data(
-                f"{chip}_{fiber}_VAR", np.full((nrows, _NCOLS), fill, dtype=np.float32)
-            )
 
 
 # ---------------------------------------------------------------------------
@@ -436,16 +411,16 @@ class TestQCL0:
         assert QCL0(l0).header_keywords_present() is False
 
     def test_times_consistent_pass(self, tmp_path):
-        l0 = _make_kpf0(tmp_path, dates=_GOOD_DATES)
+        l0 = _make_kpf0(tmp_path, dates=GOOD_DATES)
         assert QCL0(l0).times_consistent() is True
 
     def test_times_out_of_order_fails(self, tmp_path):
-        bad = dict(_GOOD_DATES, **{"DATE-MID": "2024-09-23T09:12:25.000"})  # mid > end
+        bad = dict(GOOD_DATES, **{"DATE-MID": "2024-09-23T09:12:25.000"})  # mid > end
         assert QCL0(_make_kpf0(tmp_path, dates=bad)).times_consistent() is False
 
     def test_times_ignores_elapsed(self, tmp_path):
         # DATTIMOK checks only DATE ordering; ELAPSED is EXPTIMOK's business.
-        bad = dict(_GOOD_DATES, ELAPSED=99.0)  # END-BEG != ELAPSED
+        bad = dict(GOOD_DATES, ELAPSED=99.0)  # END-BEG != ELAPSED
         assert QCL0(_make_kpf0(tmp_path, dates=bad)).times_consistent() is True
 
     def test_times_missing_keys_fail(self, tmp_path):
@@ -794,7 +769,7 @@ class TestQCL0:
         assert "GREEN" in KPF0.keyword_registry.routing["DATAPRL0"][1]
 
     # --- expmeter_times_consistent (EMTIMEOK) and expmeter_flux_sane (EMFLUXOK).
-    # Four readings tile the _GOOD_DATES shutter window.
+    # Four readings tile the GOOD_DATES shutter window.
 
     _EM_BEGS = [
         "2024-09-23T09:12:09.484",
@@ -839,7 +814,7 @@ class TestQCL0:
         extensions = {"EXPMETER_SCI": table(_EM_CLEAN_FLUX if flux is None else flux)}
         if sky_flux is not None:
             extensions["EXPMETER_SKY"] = table(sky_flux)
-        return _make_kpf0(tmp_path, dates=_GOOD_DATES, expmeter=extensions)
+        return _make_kpf0(tmp_path, dates=GOOD_DATES, expmeter=extensions)
 
     def test_expmeter_times_consistent_pass(self, tmp_path):
         l0 = self._make_kpf0_with_expmeter(tmp_path)
@@ -847,7 +822,7 @@ class TestQCL0:
 
     def test_expmeter_times_no_em_data_passes(self, tmp_path):
         # Calibration frames carry no EM extension; there is nothing to check.
-        l0 = _make_kpf0(tmp_path, dates=_GOOD_DATES)
+        l0 = _make_kpf0(tmp_path, dates=GOOD_DATES)
         assert l0.data.get("EXPMETER_SCI") is None
         assert QCL0(l0).expmeter_times_consistent() is True
 
@@ -887,7 +862,7 @@ class TestQCL0:
         assert QCL0(l0).expmeter_flux_sane() is True
 
     def test_expmeter_flux_no_em_data_passes(self, tmp_path):
-        l0 = _make_kpf0(tmp_path, dates=_GOOD_DATES)
+        l0 = _make_kpf0(tmp_path, dates=GOOD_DATES)
         assert QCL0(l0).expmeter_flux_sane() is True
 
     def test_expmeter_flux_saturated_fails(self, tmp_path):
@@ -1146,19 +1121,19 @@ class TestQCL1Run:
 
 class TestQCL2:
     def test_extraction_present_pass(self):
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_headers()
         assert QCL2(kpf2).extraction_present() is True
 
     def test_required_keywords_present_pass(self):
         # A fresh KPF2 carries only the rvdata-seeded EPRV keywords, not the KPF
         # provenance cards.
-        kpf2 = _make_kpf2_with_flux()
-        _seed_required_primary(kpf2, QCL2)
+        kpf2 = _make_kpf2_nan_headers()
+        seed_required_primary(kpf2, QCL2)
         assert QCL2(kpf2).required_keywords_present() is True
 
     def test_required_keywords_present_fail_missing(self):
-        kpf2 = _make_kpf2_with_flux()
-        _seed_required_primary(kpf2, QCL2)
+        kpf2 = _make_kpf2_nan_headers()
+        seed_required_primary(kpf2, QCL2)
         del kpf2.headers["PRIMARY"]["INSTRUME"]
         assert QCL2(kpf2).required_keywords_present() is False
 
@@ -1170,18 +1145,18 @@ class TestQCL2:
         assert QCL2(kpf2).extraction_present() is False
 
     def test_extraction_present_fail_one_trace_cleared(self):
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_headers()
         # The SKY_FLUX alias resolves to TRACE1_FLUX; emptying it zeroes the size
         # of every chip view over it.
         kpf2.data["SKY_FLUX"] = np.array([], dtype=np.float32)
         assert QCL2(kpf2).extraction_present() is False
 
     def test_flux_finite_fraction_pass(self):
-        kpf2 = _make_kpf2_with_flux(nan_frac=0.0)
+        kpf2 = _make_kpf2_nan_headers(nan_frac=0.0)
         assert QCL2(kpf2).flux_finite_fraction() is True
 
     def test_flux_finite_fraction_fail_too_many_nans(self):
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_headers()
         # total_pixels = (35 + 32) * 5 fibers * _NCOLS = 3350, so 5 x 200 NaN is
         # ~30%, well over the 1% limit.
         for k in ["NANSCI1", "NANSCI2", "NANSCI3", "NANSKY", "NANCAL"]:
@@ -1189,7 +1164,7 @@ class TestQCL2:
         assert QCL2(kpf2).flux_finite_fraction() is False
 
     def test_flux_finite_fraction_fail_missing_header(self):
-        kpf2 = _make_kpf2_with_flux(nan_frac=0.0)
+        kpf2 = _make_kpf2_nan_headers(nan_frac=0.0)
         del kpf2.headers["QUALITY_CONTROL"]["NANSCI1"]
         assert QCL2(kpf2).flux_finite_fraction() is False
 
@@ -1201,39 +1176,39 @@ class TestQCL2:
         assert QCL2(kpf2).flux_finite_fraction() is False
 
     def test_nonzero_flux_pass(self):
-        kpf2 = _make_kpf2_with_flux(zero_frac=0.1)
+        kpf2 = _make_kpf2_nan_headers(zero_frac=0.1)
         assert QCL2(kpf2).nonzero_flux() is True
 
     def test_nonzero_flux_fail_high_frac(self):
-        kpf2 = _make_kpf2_with_flux(zero_frac=0.75)
+        kpf2 = _make_kpf2_nan_headers(zero_frac=0.75)
         assert QCL2(kpf2).nonzero_flux() is False
 
     def test_nonzero_flux_fail_missing(self):
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_headers()
         del kpf2.headers["QUALITY_CONTROL"]["ZEROFRAC"]
         assert QCL2(kpf2).nonzero_flux() is False
 
     def test_nonzero_flux_exactly_half(self):
         # The check is strictly < 0.5.
-        kpf2 = _make_kpf2_with_flux(zero_frac=0.5)
+        kpf2 = _make_kpf2_nan_headers(zero_frac=0.5)
         assert QCL2(kpf2).nonzero_flux() is False
 
     # --- variance_positive (L2VAROK) ---
 
     def test_variance_positive_pass(self):
-        kpf2 = _make_kpf2_with_flux()
-        _set_kpf2_var(kpf2, 1.0)
+        kpf2 = _make_kpf2_nan_headers()
+        set_fiber_arrays(kpf2, "VAR", 1.0, ncol=_NCOLS)
         assert QCL2(kpf2).variance_positive() is True
 
     def test_variance_positive_tolerates_zero(self):
-        kpf2 = _make_kpf2_with_flux()
-        _set_kpf2_var(kpf2, 0.0)  # zero variance is allowed
+        kpf2 = _make_kpf2_nan_headers()
+        set_fiber_arrays(kpf2, "VAR", 0.0, ncol=_NCOLS)  # zero variance is allowed
         assert QCL2(kpf2).variance_positive() is True
 
     def test_variance_positive_fail_negative(self):
-        kpf2 = _make_kpf2_with_flux()
-        _set_kpf2_var(kpf2, 1.0)
-        var = np.full((_NORDER["GREEN"], _NCOLS), 1.0, dtype=np.float32)
+        kpf2 = _make_kpf2_nan_headers()
+        set_fiber_arrays(kpf2, "VAR", 1.0, ncol=_NCOLS)
+        var = np.full((NORDER["GREEN"], _NCOLS), 1.0, dtype=np.float32)
         var[0, 0] = -1.0  # negative variance where flux is finite
         kpf2.set_data("GREEN_SCI1_VAR", var)
         assert QCL2(kpf2).variance_positive() is False
@@ -1241,24 +1216,24 @@ class TestQCL2:
     def test_variance_positive_raises_on_shape_mismatch(self):
         # FLUX populated with VAR left at its default empty (0,) shape is a
         # malformed product, so the shape mismatch raises rather than skipping.
-        kpf2 = _make_kpf2_with_flux()  # no VAR populated
+        kpf2 = _make_kpf2_nan_headers()  # no VAR populated
         with pytest.raises(ValueError):
             QCL2(kpf2).variance_positive()
 
     # --- science_snr (L2SNROK) ---
 
     def test_science_snr_pass(self):
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_headers()
         kpf2.headers["QUALITY_CONTROL"]["GSNRSCI"] = (20.0, "g snr")
         kpf2.headers["QUALITY_CONTROL"]["RSNRSCI"] = (18.0, "r snr")
         assert QCL2(kpf2).science_snr() is True
 
     def test_science_snr_fail_missing(self):
-        kpf2 = _make_kpf2_with_flux()  # no GSNRSCI/RSNRSCI headers
+        kpf2 = _make_kpf2_nan_headers()  # no GSNRSCI/RSNRSCI headers
         assert QCL2(kpf2).science_snr() is False
 
     def test_science_snr_fail_below_floor(self):
-        kpf2 = _make_kpf2_with_flux()
+        kpf2 = _make_kpf2_nan_headers()
         kpf2.headers["QUALITY_CONTROL"]["GSNRSCI"] = (0.5, "g snr")  # below floor
         kpf2.headers["QUALITY_CONTROL"]["RSNRSCI"] = (18.0, "r snr")
         assert QCL2(kpf2).science_snr() is False
@@ -1284,117 +1259,81 @@ class TestQCL2:
 # ---------------------------------------------------------------------------
 
 
-def _make_l4(*, sci=True, rv_filled=True, bervrng=None, bjdrng=None, sci_obj=None):
-    """KPF4 with science CCF/RV and optional per-order BERV/BJD range metrics.
-
-    ``rv_filled=False`` seeds the RV table with NaN RVs, as a CrossCorrelation-only
-    L4 has before RadialVelocity runs. ``sci_obj`` sets the SCI2 illumination
-    (INSTRUMENT_HEADER SCI-OBJ), which the BERV/BJD tolerance checks apply only
-    when it is 'target'.
-    """
-    l4 = KPF4()
-    if sci:
-        rv_col = (
-            np.zeros(_NORDER_TOTAL) if rv_filled else np.full(_NORDER_TOTAL, np.nan)
-        )
-        for fiber in ("SCI1", "SCI2", "SCI3"):
-            l4.set_data(f"{fiber}_CCF", np.ones((_NORDER_TOTAL, 5)))
-            l4.set_data(
-                f"{fiber}_RV",
-                Table(
-                    {
-                        "ORDER_INDEX": np.arange(_NORDER_TOTAL),
-                        "RV": rv_col,
-                        "BJD_TDB": np.full(_NORDER_TOTAL, 2460000.0),
-                        "BERV": np.zeros(_NORDER_TOTAL),
-                        "WEIGHT": np.ones(_NORDER_TOTAL),
-                    }
-                ),
-            )
-    if bervrng is not None:
-        l4.headers["QUALITY_CONTROL"]["BERVRNG"] = bervrng
-    if bjdrng is not None:
-        l4.headers["QUALITY_CONTROL"]["BJDRNG"] = bjdrng
-    if sci_obj is not None:
-        l4.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = sci_obj
-    return l4
-
-
 class TestQCL4:
     def test_ccf_rv_present_pass(self):
-        assert QCL4(_make_l4()).ccf_rv_present() is True
+        assert QCL4(make_l4()).ccf_rv_present() is True
 
     def test_ccf_rv_present_fail_when_missing(self):
-        assert QCL4(_make_l4(sci=False)).ccf_rv_present() is False
+        assert QCL4(make_l4(sci=False)).ccf_rv_present() is False
 
     def test_ccf_rv_present_fail_when_rvs_unfilled(self):
         # The RVs are the L4 product, so an all-NaN RV column fails even with the
         # CCFs in place.
-        assert QCL4(_make_l4(rv_filled=False)).ccf_rv_present() is False
+        assert QCL4(make_l4(rv_filled=False)).ccf_rv_present() is False
 
     def test_ccf_rv_present_fail_when_columns_missing(self):
         # The per-order BJD_TDB/BERV/WEIGHT columns the DiagL4 dispersion metrics
         # consume are absent, so the product is incomplete.
         l4 = KPF4()
         for fiber in ("SCI1", "SCI2", "SCI3"):
-            l4.set_data(f"{fiber}_CCF", np.ones((_NORDER_TOTAL, 5)))
+            l4.set_data(f"{fiber}_CCF", np.ones((NORDER_TOTAL, 5)))
             l4.set_data(
                 f"{fiber}_RV",
                 Table(
                     {
-                        "ORDER_INDEX": np.arange(_NORDER_TOTAL),
-                        "RV": np.zeros(_NORDER_TOTAL),
+                        "ORDER_INDEX": np.arange(NORDER_TOTAL),
+                        "RV": np.zeros(NORDER_TOTAL),
                     }
                 ),
             )
         assert QCL4(l4).ccf_rv_present() is False
 
     def test_berv_within_tolerance_pass(self):
-        l4 = _make_l4(sci_obj="target", bervrng=0.05)
+        l4 = make_l4(sci_obj="target", bervrng=0.05)
         assert QCL4(l4).berv_within_tolerance() is True
 
     def test_berv_within_tolerance_fail(self):
-        l4 = _make_l4(sci_obj="target", bervrng=0.5)
+        l4 = make_l4(sci_obj="target", bervrng=0.5)
         assert QCL4(l4).berv_within_tolerance() is False
 
     def test_berv_within_tolerance_non_target_passes(self):
         # SCI2 is not star-illuminated, so the check is N/A however bad BERVRNG is.
-        l4 = _make_l4(sci_obj="etalon", bervrng=0.5)
+        l4 = make_l4(sci_obj="etalon", bervrng=0.5)
         assert QCL4(l4).berv_within_tolerance() is True
 
     def test_berv_within_tolerance_raises_when_sci_obj_absent(self):
         # CrossCorrelation requires SCI-OBJ upstream, so a frame without one is
         # malformed and must not pass as a non-target source.
         with pytest.raises(ValueError, match="SCI-OBJ not in INSTRUMENT_HEADER"):
-            QCL4(_make_l4(bervrng=0.05)).berv_within_tolerance()
+            QCL4(make_l4(bervrng=0.05)).berv_within_tolerance()
 
     def test_berv_within_tolerance_target_absent_fails(self):
         # DiagL4 skips the metric on degenerate weights or a NaN barycorr; on a
         # target frame that is malformed, not a vacuous pass.
-        assert QCL4(_make_l4(sci_obj="target")).berv_within_tolerance() is False
+        assert QCL4(make_l4(sci_obj="target")).berv_within_tolerance() is False
 
     def test_bjd_within_tolerance_pass(self):
-        l4 = _make_l4(sci_obj="target", bjdrng=0.5)
+        l4 = make_l4(sci_obj="target", bjdrng=0.5)
         assert QCL4(l4).bjd_within_tolerance() is True
 
     def test_bjd_within_tolerance_fail(self):
-        l4 = _make_l4(sci_obj="target", bjdrng=2.0)
+        l4 = make_l4(sci_obj="target", bjdrng=2.0)
         assert QCL4(l4).bjd_within_tolerance() is False
 
     def test_bjd_within_tolerance_non_target_passes(self):
         assert (
-            QCL4(_make_l4(sci_obj="etalon", bjdrng=2.0)).bjd_within_tolerance() is True
+            QCL4(make_l4(sci_obj="etalon", bjdrng=2.0)).bjd_within_tolerance() is True
         )
 
     def test_bjd_within_tolerance_raises_when_sci_obj_absent(self):
         with pytest.raises(ValueError, match="SCI-OBJ not in INSTRUMENT_HEADER"):
-            QCL4(_make_l4(bjdrng=0.5)).bjd_within_tolerance()
+            QCL4(make_l4(bjdrng=0.5)).bjd_within_tolerance()
 
     def test_bjd_within_tolerance_target_absent_fails(self):
-        assert QCL4(_make_l4(sci_obj="target")).bjd_within_tolerance() is False
+        assert QCL4(make_l4(sci_obj="target")).bjd_within_tolerance() is False
 
     def test_required_keywords_present(self):
-        l4 = _make_l4()
+        l4 = make_l4()
         req = QCL4(l4)._required_primary_keywords()
         for kw in req:
             l4.headers["PRIMARY"][kw] = 1.0
@@ -1404,7 +1343,7 @@ class TestQCL4:
             assert QCL4(l4).required_keywords_present() is False
 
     def test_run_all_good_isgood(self):
-        l4 = _make_l4(sci_obj="target", bervrng=0.05, bjdrng=0.5)
+        l4 = make_l4(sci_obj="target", bervrng=0.05, bjdrng=0.5)
         for kw in QCL4(l4)._required_primary_keywords():
             l4.headers["PRIMARY"][kw] = 1.0
         results = QCL4(l4).run()
@@ -1415,7 +1354,7 @@ class TestQCL4:
 
     def test_run_flags_failure_in_isgood(self):
         # no CCF/RV, and out-of-tolerance BERV/BJD ranges on a target frame
-        l4 = _make_l4(sci=False, sci_obj="target", bervrng=0.5, bjdrng=2.0)
+        l4 = make_l4(sci=False, sci_obj="target", bervrng=0.5, bjdrng=2.0)
         for kw in QCL4(l4)._required_primary_keywords():
             l4.headers["PRIMARY"][kw] = 1.0
         l4.headers["QUALITY_CONTROL"]  # ensure present

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -1,14 +1,24 @@
 """Tests for scripts/quality_control/qc.py: the standalone QC runner.
 
-Subprocess smoke tests driving the CLI on synthetic L0 fixtures -- exit codes and
-the ISGOOD summary -- plus a fail-loud check that a config missing a required
-DATA_DIRS key errors instead of substituting a default.
+Two tests keep the subprocess boundary, and only two, because only one property
+needs a real process: that the script is invocable *as a program* -- the
+``__main__`` guard reached through a plain interpreter with PYTHONPATH and cwd
+set by ``_scripts.run_script``. One spawn witnesses a real exit 0, the other a
+real nonzero exit; between them the 0/1/2 contract a scheduler branches on has a
+process-level witness at both ends.
+
+Everything else drives ``main()`` in-process, where a bare integer becomes an
+exit code *and* the stderr message that explains it.
 """
 
+import sys
 import tomllib
 from pathlib import Path
 
 import pytest
+
+from kpfpipe.data_models.level0 import KPF0
+from scripts.quality_control import qc
 
 from ._data_models import GOOD_DATES, write_amp_l0
 from ._scripts import CHILD_WARNINGS, REPO_ROOT, run_script, write_config
@@ -79,13 +89,25 @@ def _run_qc_script(fixture_path, level="L0", extra_args=None):
     )
 
 
+def _main(monkeypatch, *args):
+    """Drive qc.main() in-process with ``args`` as argv."""
+    monkeypatch.setattr(sys, "argv", [_SCRIPT, *map(str, args)])
+    qc.main()
+
+
+def _main_qc(monkeypatch, fixture_path, level="L0", extra_args=None):
+    _main(monkeypatch, "--input", fixture_path, "--level", level, *(extra_args or ()))
+
+
 class TestQCScript:
     def test_all_passing_exit_0_isgood_pass(self, tmp_path):
         fixture = tmp_path / "KP.20240405.00001.00.fits"
         _write_l0_fixture(str(fixture), passing=True)
         cfg = _write_astro_config(tmp_path / "astro.toml")
 
-        result = _run_qc_script(fixture, level="L0", extra_args=["--config", str(cfg)])
+        result = _run_qc_script(
+            fixture, level="L0", extra_args=["--config", str(cfg), "--write"]
+        )
 
         assert result.returncode == 0, (
             f"Expected exit 0, got {result.returncode}\n"
@@ -94,71 +116,112 @@ class TestQCScript:
         assert "ISGOOD: PASS" in result.stdout, (
             f"Expected 'ISGOOD: PASS' in stdout:\n{result.stdout}"
         )
+        # --write persists the QC keywords back to the source file. Archive
+        # consumers read them from there, so the round trip is the contract --
+        # not the summary the CLI printed.
+        assert KPF0.from_fits(str(fixture)).headers["QUALITY_CONTROL"]["ISGOOD"] == 1
 
-    def test_failure_injected_exit_1_isgood_fail(self, tmp_path):
+    def test_failure_injected_exit_1_isgood_fail(self, tmp_path, monkeypatch, capsys):
         fixture = tmp_path / "KP.20240405.00002.00.fits"
         _write_l0_fixture(str(fixture), passing=False)
         cfg = _write_astro_config(tmp_path / "astro.toml")
 
-        result = _run_qc_script(fixture, level="L0", extra_args=["--config", str(cfg)])
+        with pytest.raises(SystemExit) as exc:
+            _main_qc(monkeypatch, fixture, extra_args=["--config", str(cfg)])
 
-        assert result.returncode == 1, (
-            f"Expected exit 1, got {result.returncode}\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
-        )
-        assert "ISGOOD: FAIL" in result.stdout, (
-            f"Expected 'ISGOOD: FAIL' in stdout:\n{result.stdout}"
-        )
+        # 1 is "checks ran and one failed" -- distinct from 2, "never got that far".
+        assert exc.value.code == 1
+        assert "ISGOOD: FAIL" in capsys.readouterr().out
 
-    def test_calibration_frame_skips_astroquery_no_exit_2(self, tmp_path):
+    def test_calibration_frame_skips_astroquery_no_exit_2(
+        self, tmp_path, monkeypatch, capsys
+    ):
         # A cal frame stays inspectable: qc.py skips AstroQuery rather than erroring.
         fixture = tmp_path / "KP.20240405.00005.00.fits"
         _write_l0_fixture(str(fixture), passing=True, imtype="Bias")
         cfg = _write_astro_config(tmp_path / "astro.toml")
 
-        result = _run_qc_script(fixture, level="L0", extra_args=["--config", str(cfg)])
+        with pytest.raises(SystemExit) as exc:
+            _main_qc(monkeypatch, fixture, extra_args=["--config", str(cfg)])
 
-        assert result.returncode != 2, (
-            f"Calibration L0 should not exit 2\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
-        )
-        assert "Skipping AstroQuery" in result.stdout, (
-            f"Expected AstroQuery-skip note in stdout:\n{result.stdout}"
-        )
+        assert exc.value.code != 2
+        assert "Skipping AstroQuery" in capsys.readouterr().out
 
     def test_missing_file_exit_2(self, tmp_path):
+        # Deliberately still a subprocess. It is the only test that witnesses a
+        # real nonzero process exit; without it every surviving spawn asserts 0
+        # and nothing proves the CLI fails a scheduler the way it claims to.
         missing = tmp_path / "does_not_exist.fits"
         result = _run_qc_script(missing, level="L0")
         assert result.returncode == 2
+        assert "file not found" in result.stderr
 
-    def test_no_args_exit_nonzero(self):
-        result = run_script(_SCRIPT)
-        assert result.returncode != 0
+    def test_no_args_exit_nonzero(self, monkeypatch, capsys):
+        with pytest.raises(SystemExit) as exc:
+            _main(monkeypatch)
+        assert exc.value.code == 2
+        assert "--level" in capsys.readouterr().err
+
+    def test_unreadable_input_exit_2(self, tmp_path, monkeypatch, capsys):
+        # qc.py's exit codes mean different things: 2 is structural ("could not
+        # get as far as running the checks"), 1 is "the checks ran and failed".
+        # A file that exists but is not readable as FITS is the structural case
+        # the missing-file test cannot reach.
+        broken = tmp_path / "KP.20240405.00006.00.fits"
+        broken.write_text("this is not a FITS file")
+
+        with pytest.raises(SystemExit) as exc:
+            _main_qc(monkeypatch, broken)
+
+        assert exc.value.code == 2
+        assert "Error loading" in capsys.readouterr().err
+
+    def test_fatal_qc_flag_exit_2(self, tmp_path, monkeypatch, capsys):
+        # A single-amp readout fails DATAPRL0, which CheckpointL0 lists in
+        # RAISE_FLAGS, so run() raises and the runner reports it as structural
+        # (2) rather than as an ordinary failed check (1).
+        fixture = tmp_path / "KP.20240405.00007.00.fits"
+        write_amp_l0(
+            str(fixture),
+            namps=1,
+            shape=(10, 10),
+            primary_cards={
+                "DATE-OBS": "2024-04-05T01:00:37",
+                "MJD-OBS": 60405.04,
+                "EXPTIME": 12.0,
+                "OBJECT": "synthetic",
+                "IMTYPE": "Bias",
+                "PROGNAME": None,
+                **GOOD_DATES,
+            },
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            _main_qc(monkeypatch, fixture)
+
+        assert exc.value.code == 2
+        assert "QC/checkpoint failed" in capsys.readouterr().err
 
 
 class TestQCScriptConfig:
     """The config-driven input path fails loud on a missing DATA_DIRS key."""
 
-    def test_missing_data_input_key_fails_loud(self, tmp_path):
+    def test_missing_data_input_key_fails_loud(self, tmp_path, monkeypatch):
         # The runner reads KPF_DATA_INPUT with no default, so an absent key must
         # surface as an error rather than silently using a hardcoded path.
         cfg = tmp_path / "cfg.toml"
         write_config(cfg, {"KPF_SCIENCE_OUTPUT": str(tmp_path)})  # no KPF_DATA_INPUT
 
-        result = run_script(
-            _SCRIPT,
-            "--obs_id",
-            "KP.20240405.00001.00",
-            "--level",
-            "L0",
-            "--config",
-            cfg,
-        )
-
-        assert result.returncode != 0
-        assert "KPF_DATA_INPUT" in result.stderr, (
-            f"Expected 'KPF_DATA_INPUT' in stderr:\n{result.stderr}"
-        )
+        with pytest.raises(KeyError, match="KPF_DATA_INPUT"):
+            _main(
+                monkeypatch,
+                "--obs_id",
+                "KP.20240405.00001.00",
+                "--level",
+                "L0",
+                "--config",
+                cfg,
+            )
 
 
 class TestChildWarningParity:

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -1,9 +1,8 @@
 """Tests for scripts/quality_control/qc.py: the standalone QC runner.
 
-Subprocess smoke tests that drive the CLI end-to-end on synthetic L0 fixtures --
-exit codes and the ISGOOD summary (TestQCScript) -- plus a fail-loud check that a
-config missing a required DATA_DIRS key errors instead of substituting a default
-(TestQCScriptConfig).
+Subprocess smoke tests driving the CLI on synthetic L0 fixtures -- exit codes and
+the ISGOOD summary -- plus a fail-loud check that a config missing a required
+DATA_DIRS key errors instead of substituting a default.
 """
 
 import os
@@ -21,12 +20,10 @@ _REPO_ROOT = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 
-# pytest's filterwarnings does not reach a child process, so the CLI would run with
-# default filters and any warning it raised would be invisible. Mirror the pyproject
-# rules into the child, where a warning becomes a non-zero exit the tests already check.
-# PYTHONWARNINGS splits entries on commas and resolves categories at interpreter
-# startup, before astropy is importable, so the astropy rule is carried by its
-# message prefix alone.
+# pytest's filterwarnings does not reach a child process, so mirror the pyproject
+# rules in, where a warning becomes the non-zero exit the tests already check.
+# PYTHONWARNINGS resolves categories at interpreter startup, before astropy is
+# importable, so the astropy rule is carried by its message prefix alone.
 _CHILD_WARNINGS = ",".join(
     (
         "error",
@@ -35,10 +32,9 @@ _CHILD_WARNINGS = ",".join(
     )
 )
 
-# qc.py reaches the network (Gaia/SIMBAD via AstroQuery, and astropy's IERS
-# auto-download), and neither bounds a connection that opens and never answers, so a
-# child can block forever. Cap every run: a hang becomes a loud TimeoutExpired instead
-# of a stalled suite. Generous enough that a slow-but-working run still passes.
+# qc.py reaches the network (AstroQuery, astropy's IERS auto-download) and neither
+# bounds a stalled connection, so a child can block forever. Cap every run so a hang
+# becomes a loud TimeoutExpired; generous enough for a slow-but-working run.
 _CHILD_TIMEOUT = 120
 
 # Self-consistent raw exposure times so DATTIMOK passes (END-BEG == ELAPSED).
@@ -53,17 +49,13 @@ _GOOD_DATES = {
 def _write_l0_fixture(path, *, passing=True, imtype="Object"):
     """Write a minimal L0 FITS fixture at path.
 
-    passing=True  → all QCL0 checks pass (valid header keywords, EXPTIME finite
-                    and consistent with ELAPSED, amps present).
-    passing=False → inject a failure (negative EXPTIME so EXPTIMOK fails).
-    imtype        → PRIMARY IMTYPE; a non-'Object' (calibration) frame carries no
-                    pointing/DCS target block, so qc.py skips AstroQuery for it.
+    passing=False injects a negative EXPTIME so EXPTIMOK fails. A non-'Object'
+    imtype carries no pointing/DCS target block, so qc.py skips AstroQuery for it.
     """
     primary = fits.PrimaryHDU()
     primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
     primary.header["MJD-OBS"] = 60405.04
-    # Requested EXPTIME within tolerance of the elapsed time (_GOOD_DATES
-    # ELAPSED = 12.07) so EXPTIMOK's ELAPSED-consistency check passes.
+    # Within tolerance of _GOOD_DATES ELAPSED (12.07) so EXPTIMOK passes.
     primary.header["EXPTIME"] = 12.0 if passing else -1.0
     primary.header["OBJECT"] = "synthetic"
     primary.header["OFNAME"] = os.path.basename(path)
@@ -72,9 +64,8 @@ def _write_l0_fixture(path, *, passing=True, imtype="Object"):
         primary.header[k] = v
 
     if imtype == "Object":
-        # Pointing + DCS target (identical -> TARGOFF ~ 0) so AstroQuery resolves the
-        # wmko record and DiagL0's required TARGOFF is available offline; the external
-        # Gaia/SIMBAD lookups are disabled via config (see _write_astro_config).
+        # Pointing + DCS target (identical -> TARGOFF ~ 0) so the header-native wmko
+        # record supplies DiagL0's required TARGOFF with Gaia/SIMBAD disabled.
         primary.header["RA"] = "12:00:00.00"
         primary.header["DEC"] = "+40:00:00.0"
         primary.header["TARGRA"] = "12:00:00.00"
@@ -99,7 +90,7 @@ def _write_l0_fixture(path, *, passing=True, imtype="Object"):
 
 
 def _write_config(path, data_dirs):
-    """Write a TOML config with a [DATA_DIRS] section from ``data_dirs``."""
+    """Write a TOML config with a [DATA_DIRS] section."""
     lines = ["[DATA_DIRS]"]
     lines += [f'{key} = "{value}"' for key, value in data_dirs.items()]
     path.write_text("\n".join(lines) + "\n")
@@ -108,9 +99,10 @@ def _write_config(path, data_dirs):
 def _write_astro_config(path):
     """A minimal config that disables AstroQuery's network lookups.
 
-    qc.py runs AstroQuery for L0; disabling Gaia/SIMBAD keeps these smoke tests
-    offline, so wmko -- the header-native row, the only one left -- must also be
-    the permitted astrometric base for the merge to succeed and TARGOFF to exist."""
+    Disabling Gaia/SIMBAD keeps these smoke tests offline, so wmko -- the
+    header-native row, the only one left -- must also be the permitted astrometric
+    base for the merge to succeed and TARGOFF to exist.
+    """
     path.write_text(
         "[DATA_DIRS]\n[TRACES]\n"
         "[MODULE_ASTRO_QUERY]\ndo_gaia_query = false\ndo_simbad_query = false\n"
@@ -120,7 +112,6 @@ def _write_astro_config(path):
 
 
 def _run_qc_script(fixture_path, level="L0", extra_args=None):
-    """Run scripts/quality_control/qc.py via subprocess, return the CompletedProcess."""
     cmd = [
         sys.executable,
         "scripts/quality_control/qc.py",
@@ -143,10 +134,7 @@ def _run_qc_script(fixture_path, level="L0", extra_args=None):
 
 
 class TestQCScript:
-    """Smoke tests for scripts/quality_control/qc.py via subprocess."""
-
     def test_all_passing_exit_0_isgood_pass(self, tmp_path):
-        """All-good L0 → exit code 0, stdout contains 'ISGOOD: PASS'."""
         fixture = tmp_path / "KP.20240405.00001.00.fits"
         _write_l0_fixture(str(fixture), passing=True)
         cfg = _write_astro_config(tmp_path / "astro.toml")
@@ -162,7 +150,6 @@ class TestQCScript:
         )
 
     def test_failure_injected_exit_1_isgood_fail(self, tmp_path):
-        """L0 with negative EXPTIME → exit code 1, stdout contains 'ISGOOD: FAIL'."""
         fixture = tmp_path / "KP.20240405.00002.00.fits"
         _write_l0_fixture(str(fixture), passing=False)
         cfg = _write_astro_config(tmp_path / "astro.toml")
@@ -178,8 +165,7 @@ class TestQCScript:
         )
 
     def test_calibration_frame_skips_astroquery_no_exit_2(self, tmp_path):
-        """A calibration L0 (IMTYPE != 'Object') stays inspectable: qc.py skips
-        AstroQuery rather than erroring, so it never exits 2 on a cal frame."""
+        # A cal frame stays inspectable: qc.py skips AstroQuery rather than erroring.
         fixture = tmp_path / "KP.20240405.00005.00.fits"
         _write_l0_fixture(str(fixture), passing=True, imtype="Bias")
         cfg = _write_astro_config(tmp_path / "astro.toml")
@@ -195,13 +181,11 @@ class TestQCScript:
         )
 
     def test_missing_file_exit_2(self, tmp_path):
-        """Non-existent file → exit code 2."""
         missing = tmp_path / "does_not_exist.fits"
         result = _run_qc_script(missing, level="L0")
         assert result.returncode == 2
 
     def test_no_args_exit_nonzero(self):
-        """No args → argparse error → non-zero exit."""
         env = {
             **os.environ,
             "PYTHONPATH": _REPO_ROOT,
@@ -222,11 +206,8 @@ class TestQCScriptConfig:
     """The config-driven input path fails loud on a missing DATA_DIRS key."""
 
     def test_missing_data_input_key_fails_loud(self, tmp_path):
-        """--obs_id + a config without KPF_DATA_INPUT → nonzero exit naming the key.
-
-        The runner reads params["KPF_DATA_INPUT"] directly (no default), so an
-        absent key surfaces as an error rather than silently using a hardcoded path.
-        """
+        # The runner reads KPF_DATA_INPUT with no default, so an absent key must
+        # surface as an error rather than silently using a hardcoded path.
         cfg = tmp_path / "cfg.toml"
         _write_config(cfg, {"KPF_SCIENCE_OUTPUT": str(tmp_path)})  # no KPF_DATA_INPUT
         env = {

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -5,44 +5,35 @@ the ISGOOD summary -- plus a fail-loud check that a config missing a required
 DATA_DIRS key errors instead of substituting a default.
 """
 
-import os
-import subprocess
-import sys
+import tomllib
+from pathlib import Path
 
-import numpy as np
 import pytest
-from astropy.io import fits
+
+from ._data_models import GOOD_DATES, write_amp_l0
+from ._scripts import CHILD_WARNINGS, REPO_ROOT, run_script, write_config
 
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
 pytestmark = pytest.mark.cli
 
-_REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-)
+_SCRIPT = "scripts/quality_control/qc.py"
 
-# pytest's filterwarnings does not reach a child process, so mirror the pyproject
-# rules in, where a warning becomes the non-zero exit the tests already check.
-# PYTHONWARNINGS resolves categories at interpreter startup, before astropy is
-# importable, so the astropy rule is carried by its message prefix alone.
-_CHILD_WARNINGS = ",".join(
-    (
-        "error",
-        "ignore:Card is too long",
-        "default::ResourceWarning",
-    )
-)
-
-# qc.py reaches the network (AstroQuery, astropy's IERS auto-download) and neither
-# bounds a stalled connection, so a child can block forever. Cap every run so a hang
-# becomes a loud TimeoutExpired; generous enough for a slow-but-working run.
-_CHILD_TIMEOUT = 120
-
-# Self-consistent raw exposure times so DATTIMOK passes (END-BEG == ELAPSED).
-_GOOD_DATES = {
-    "DATE-BEG": "2024-09-23T09:12:09.484",
-    "DATE-MID": "2024-09-23T09:12:15.519",
-    "DATE-END": "2024-09-23T09:12:21.554",
-    "ELAPSED": 12.07,
+# Pointing + DCS target (identical -> TARGOFF ~ 0) so the header-native wmko
+# record supplies DiagL0's required TARGOFF with Gaia/SIMBAD disabled.
+_TARGET_CARDS = {
+    "RA": "12:00:00.00",
+    "DEC": "+40:00:00.0",
+    "TARGRA": "12:00:00.00",
+    "TARGDEC": "+40:00:00.0",
+    "TARGFRAM": "FK5",
+    "TARGEQUI": 2000.0,
+    "TARGPMRA": 0.0,
+    "TARGPMDC": 0.0,
+    "TARGPLAX": 100.0,
+    "TARGEPOC": 2000.0,
+    # The wmko record's colour is G-J, so COLOROK needs both magnitudes.
+    "GAIAMAG": 6.0,
+    "2MASSMAG": 5.0,
 }
 
 
@@ -52,48 +43,19 @@ def _write_l0_fixture(path, *, passing=True, imtype="Object"):
     passing=False injects a negative EXPTIME so EXPTIMOK fails. A non-'Object'
     imtype carries no pointing/DCS target block, so qc.py skips AstroQuery for it.
     """
-    primary = fits.PrimaryHDU()
-    primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
-    primary.header["MJD-OBS"] = 60405.04
-    # Within tolerance of _GOOD_DATES ELAPSED (12.07) so EXPTIMOK passes.
-    primary.header["EXPTIME"] = 12.0 if passing else -1.0
-    primary.header["OBJECT"] = "synthetic"
-    primary.header["OFNAME"] = os.path.basename(path)
-    primary.header["IMTYPE"] = imtype
-    for k, v in _GOOD_DATES.items():
-        primary.header[k] = v
-
+    cards = {
+        "DATE-OBS": "2024-04-05T01:00:37",
+        "MJD-OBS": 60405.04,
+        # Within tolerance of GOOD_DATES ELAPSED (12.07) so EXPTIMOK passes.
+        "EXPTIME": 12.0 if passing else -1.0,
+        "OBJECT": "synthetic",
+        "IMTYPE": imtype,
+        "PROGNAME": None,  # not a QC input here
+        **GOOD_DATES,
+    }
     if imtype == "Object":
-        # Pointing + DCS target (identical -> TARGOFF ~ 0) so the header-native wmko
-        # record supplies DiagL0's required TARGOFF with Gaia/SIMBAD disabled.
-        primary.header["RA"] = "12:00:00.00"
-        primary.header["DEC"] = "+40:00:00.0"
-        primary.header["TARGRA"] = "12:00:00.00"
-        primary.header["TARGDEC"] = "+40:00:00.0"
-        primary.header["TARGFRAM"] = "FK5"
-        primary.header["TARGEQUI"] = 2000.0
-        primary.header["TARGPMRA"] = 0.0
-        primary.header["TARGPMDC"] = 0.0
-        primary.header["TARGPLAX"] = 100.0
-        primary.header["TARGEPOC"] = 2000.0
-        # The wmko record's colour is G-J, so COLOROK needs both magnitudes.
-        primary.header["GAIAMAG"] = 6.0
-        primary.header["2MASSMAG"] = 5.0
-
-    hdus = [primary]
-    for chip in ["GREEN", "RED"]:
-        for amp in range(1, 5):
-            data = np.ones((10, 10), dtype=np.float32)
-            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
-
-    fits.HDUList(hdus).writeto(path, overwrite=True)
-
-
-def _write_config(path, data_dirs):
-    """Write a TOML config with a [DATA_DIRS] section."""
-    lines = ["[DATA_DIRS]"]
-    lines += [f'{key} = "{value}"' for key, value in data_dirs.items()]
-    path.write_text("\n".join(lines) + "\n")
+        cards.update(_TARGET_CARDS)
+    write_amp_l0(path, namps=4, shape=(10, 10), primary_cards=cards)
 
 
 def _write_astro_config(path):
@@ -112,24 +74,8 @@ def _write_astro_config(path):
 
 
 def _run_qc_script(fixture_path, level="L0", extra_args=None):
-    cmd = [
-        sys.executable,
-        "scripts/quality_control/qc.py",
-        "--input",
-        str(fixture_path),
-        "--level",
-        level,
-    ]
-    if extra_args:
-        cmd.extend(extra_args)
-    env = {**os.environ, "PYTHONPATH": _REPO_ROOT, "PYTHONWARNINGS": _CHILD_WARNINGS}
-    return subprocess.run(
-        cmd,
-        cwd=_REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=_CHILD_TIMEOUT,
+    return run_script(
+        _SCRIPT, "--input", fixture_path, "--level", level, *(extra_args or ())
     )
 
 
@@ -186,19 +132,7 @@ class TestQCScript:
         assert result.returncode == 2
 
     def test_no_args_exit_nonzero(self):
-        env = {
-            **os.environ,
-            "PYTHONPATH": _REPO_ROOT,
-            "PYTHONWARNINGS": _CHILD_WARNINGS,
-        }
-        result = subprocess.run(
-            [sys.executable, "scripts/quality_control/qc.py"],
-            cwd=_REPO_ROOT,
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=_CHILD_TIMEOUT,
-        )
+        result = run_script(_SCRIPT)
         assert result.returncode != 0
 
 
@@ -209,30 +143,49 @@ class TestQCScriptConfig:
         # The runner reads KPF_DATA_INPUT with no default, so an absent key must
         # surface as an error rather than silently using a hardcoded path.
         cfg = tmp_path / "cfg.toml"
-        _write_config(cfg, {"KPF_SCIENCE_OUTPUT": str(tmp_path)})  # no KPF_DATA_INPUT
-        env = {
-            **os.environ,
-            "PYTHONPATH": _REPO_ROOT,
-            "PYTHONWARNINGS": _CHILD_WARNINGS,
-        }
-        result = subprocess.run(
-            [
-                sys.executable,
-                "scripts/quality_control/qc.py",
-                "--obs_id",
-                "KP.20240405.00001.00",
-                "--level",
-                "L0",
-                "--config",
-                str(cfg),
-            ],
-            cwd=_REPO_ROOT,
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=_CHILD_TIMEOUT,
+        write_config(cfg, {"KPF_SCIENCE_OUTPUT": str(tmp_path)})  # no KPF_DATA_INPUT
+
+        result = run_script(
+            _SCRIPT,
+            "--obs_id",
+            "KP.20240405.00001.00",
+            "--level",
+            "L0",
+            "--config",
+            cfg,
         )
+
         assert result.returncode != 0
         assert "KPF_DATA_INPUT" in result.stderr, (
             f"Expected 'KPF_DATA_INPUT' in stderr:\n{result.stderr}"
         )
+
+
+class TestChildWarningParity:
+    """``_scripts.CHILD_WARNINGS`` mirrors pyproject's filterwarnings.
+
+    pytest's filterwarnings never crosses a subprocess boundary, so a rule added
+    to pyproject.toml silently stops applying to every CLI test unless it is
+    hand-mirrored into PYTHONWARNINGS. Nothing else asserts the mirror is complete.
+    """
+
+    @staticmethod
+    def _parent_rules():
+        pyproject = Path(REPO_ROOT) / "pyproject.toml"
+        config = tomllib.loads(pyproject.read_text())
+        return config["tool"]["pytest"]["ini_options"]["filterwarnings"]
+
+    def test_pyproject_rules_are_all_mirrored(self):
+        child = CHILD_WARNINGS.split(",")
+        for rule in self._parent_rules():
+            action, _, rest = rule.partition(":")
+            message = rest.split(":")[0]
+            # PYTHONWARNINGS resolves categories at interpreter startup, before
+            # astropy is importable, so a mirrored rule may truncate the message
+            # and drop the category. Require only that some child rule shares the
+            # action and carries a message prefix of the parent's.
+            assert any(
+                c.partition(":")[0] == action
+                and message.startswith(c.partition(":")[2].split(":")[0])
+                for c in child
+            ), f"pyproject filterwarnings rule {rule!r} is not in CHILD_WARNINGS"

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -21,6 +21,17 @@ _REPO_ROOT = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 )
 
+# pytest's filterwarnings does not reach a child process, so the CLI would run with
+# default filters and any warning it raised would be invisible. Mirror the pyproject
+# rule into the child, where a warning becomes a non-zero exit the tests already check.
+_CHILD_WARNINGS = "error"
+
+# qc.py reaches the network (Gaia/SIMBAD via AstroQuery, and astropy's IERS
+# auto-download), and neither bounds a connection that opens and never answers, so a
+# child can block forever. Cap every run: a hang becomes a loud TimeoutExpired instead
+# of a stalled suite. Generous enough that a slow-but-working run still passes.
+_CHILD_TIMEOUT = 120
+
 # Self-consistent raw exposure times so DATTIMOK passes (END-BEG == ELAPSED).
 _GOOD_DATES = {
     "DATE-BEG": "2024-09-23T09:12:09.484",
@@ -111,8 +122,15 @@ def _run_qc_script(fixture_path, level="L0", extra_args=None):
     ]
     if extra_args:
         cmd.extend(extra_args)
-    env = {**os.environ, "PYTHONPATH": _REPO_ROOT}
-    return subprocess.run(cmd, cwd=_REPO_ROOT, env=env, capture_output=True, text=True)
+    env = {**os.environ, "PYTHONPATH": _REPO_ROOT, "PYTHONWARNINGS": _CHILD_WARNINGS}
+    return subprocess.run(
+        cmd,
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_CHILD_TIMEOUT,
+    )
 
 
 class TestQCScript:
@@ -175,13 +193,18 @@ class TestQCScript:
 
     def test_no_args_exit_nonzero(self):
         """No args → argparse error → non-zero exit."""
-        env = {**os.environ, "PYTHONPATH": _REPO_ROOT}
+        env = {
+            **os.environ,
+            "PYTHONPATH": _REPO_ROOT,
+            "PYTHONWARNINGS": _CHILD_WARNINGS,
+        }
         result = subprocess.run(
             [sys.executable, "scripts/quality_control/qc.py"],
             cwd=_REPO_ROOT,
             env=env,
             capture_output=True,
             text=True,
+            timeout=_CHILD_TIMEOUT,
         )
         assert result.returncode != 0
 
@@ -197,7 +220,11 @@ class TestQCScriptConfig:
         """
         cfg = tmp_path / "cfg.toml"
         _write_config(cfg, {"KPF_SCIENCE_OUTPUT": str(tmp_path)})  # no KPF_DATA_INPUT
-        env = {**os.environ, "PYTHONPATH": _REPO_ROOT}
+        env = {
+            **os.environ,
+            "PYTHONPATH": _REPO_ROOT,
+            "PYTHONWARNINGS": _CHILD_WARNINGS,
+        }
         result = subprocess.run(
             [
                 sys.executable,
@@ -213,6 +240,7 @@ class TestQCScriptConfig:
             env=env,
             capture_output=True,
             text=True,
+            timeout=_CHILD_TIMEOUT,
         )
         assert result.returncode != 0
         assert "KPF_DATA_INPUT" in result.stderr, (

--- a/tests/regression/test_qc_script.py
+++ b/tests/regression/test_qc_script.py
@@ -23,8 +23,17 @@ _REPO_ROOT = os.path.dirname(
 
 # pytest's filterwarnings does not reach a child process, so the CLI would run with
 # default filters and any warning it raised would be invisible. Mirror the pyproject
-# rule into the child, where a warning becomes a non-zero exit the tests already check.
-_CHILD_WARNINGS = "error"
+# rules into the child, where a warning becomes a non-zero exit the tests already check.
+# PYTHONWARNINGS splits entries on commas and resolves categories at interpreter
+# startup, before astropy is importable, so the astropy rule is carried by its
+# message prefix alone.
+_CHILD_WARNINGS = ",".join(
+    (
+        "error",
+        "ignore:Card is too long",
+        "default::ResourceWarning",
+    )
+)
 
 # qc.py reaches the network (Gaia/SIMBAD via AstroQuery, and astropy's IERS
 # auto-download), and neither bounds a connection that opens and never answers, so a

--- a/tests/regression/test_qlp_script.py
+++ b/tests/regression/test_qlp_script.py
@@ -1,10 +1,6 @@
-"""Tests for scripts/quality_control/qlp.py: the standalone quicklook-plot generator.
+"""Subprocess tests for scripts/quality_control/qlp.py, the quicklook-plot generator.
 
-Subprocess smoke tests that drive the CLI end-to-end on a synthetic, plottable L0
-fixture: direct-path plotting (--input/--output_dir), the config-driven output
-tree (--config → {KPF_SCIENCE_OUTPUT}/QLP/...), and the usual missing-file /
-no-args guards. A fail-loud check confirms a config missing KPF_SCIENCE_OUTPUT
-errors rather than substituting a default output root.
+Each test drives the CLI end-to-end on a synthetic, plottable L0 fixture.
 """
 
 import os
@@ -27,12 +23,10 @@ _REPO_ROOT = os.path.dirname(
 # A valid obs_id (and matching datecode) the quicklook filenames/paths key off.
 _OBS_ID = "KP.20240405.00004.00"
 
-# pytest's filterwarnings does not reach a child process, so the CLI would run with
-# default filters and any warning it raised would be invisible. Mirror the pyproject
-# rules into the child, where a warning becomes a non-zero exit the tests already check.
-# PYTHONWARNINGS splits entries on commas and resolves categories at interpreter
-# startup, before astropy is importable, so the astropy rule is carried by its
-# message prefix alone.
+# pytest's filterwarnings does not reach a child process, so mirror the pyproject
+# rules in: a child warning then becomes the non-zero exit the tests check for.
+# PYTHONWARNINGS resolves categories at interpreter startup, before astropy is
+# importable, so the astropy rule is carried by its message prefix alone.
 _CHILD_WARNINGS = ",".join(
     (
         "error",
@@ -41,18 +35,13 @@ _CHILD_WARNINGS = ",".join(
     )
 )
 
-# A child that reaches the network (astropy's IERS auto-download) can block forever --
-# nothing bounds a connection that opens and never answers. Cap every run: a hang
-# becomes a loud TimeoutExpired instead of a stalled suite.
+# A child that reaches the network (astropy's IERS auto-download) can block forever,
+# so cap every run: a hang becomes a loud TimeoutExpired instead of a stalled suite.
 _CHILD_TIMEOUT = 120
 
 
 def _write_l0_image_fixture(path):
-    """Write a small, plottable two-amp L0 FITS fixture (green + red).
-
-    Two amps per chip at 32x24 is enough for PlotL0 to stitch and render both
-    CCDs; the pixel values are arbitrary noise.
-    """
+    """Write an L0 FITS fixture with the two amps per chip PlotL0 needs to stitch."""
     rng = np.random.default_rng(123)
     primary = fits.PrimaryHDU()
     primary.header["INSTRUME"] = "KPF"
@@ -71,14 +60,12 @@ def _write_l0_image_fixture(path):
 
 
 def _write_config(path, data_dirs):
-    """Write a TOML config with a [DATA_DIRS] section from ``data_dirs``."""
     lines = ["[DATA_DIRS]"]
     lines += [f'{key} = "{value}"' for key, value in data_dirs.items()]
     path.write_text("\n".join(lines) + "\n")
 
 
 def _run_qlp_script(*args):
-    """Run scripts/quality_control/qlp.py via subprocess; return the result."""
     env = {**os.environ, "PYTHONPATH": _REPO_ROOT, "PYTHONWARNINGS": _CHILD_WARNINGS}
     cmd = [sys.executable, "scripts/quality_control/qlp.py", *map(str, args)]
     return subprocess.run(
@@ -99,10 +86,7 @@ def _png_names(obs_id):
 
 
 class TestQLPScript:
-    """Smoke tests for scripts/quality_control/qlp.py via subprocess."""
-
     def test_generates_plots_exit_0(self, tmp_path):
-        """--input + --output_dir → exit 0, both CCD PNGs written."""
         fixture = tmp_path / f"{_OBS_ID}.fits"
         _write_l0_image_fixture(str(fixture))
         out_dir = tmp_path / "out"
@@ -119,12 +103,7 @@ class TestQLPScript:
             assert (out_dir / name).is_file(), f"missing plot {name} in {out_dir}"
 
     def test_config_output_resolution(self, tmp_path):
-        """--config (no --output_dir) → plots under {KPF_SCIENCE_OUTPUT}/QLP/...
-
-        Exercises the fix that reads KPF_SCIENCE_OUTPUT (the science output root)
-        rather than the never-defined KPF_DATA_OUTPUT. --input supplies the frame,
-        so only the output tree comes from the config.
-        """
+        # --input supplies the frame, so only the output tree comes from the config.
         fixture = tmp_path / f"{_OBS_ID}.fits"
         _write_l0_image_fixture(str(fixture))
         science_out = tmp_path / "science-root"
@@ -149,11 +128,8 @@ class TestQLPScript:
             )
 
     def test_missing_science_output_key_fails_loud(self, tmp_path):
-        """--config without KPF_SCIENCE_OUTPUT → nonzero exit naming the key.
-
-        The output path reads params["KPF_SCIENCE_OUTPUT"] directly (no default),
-        so an absent key surfaces as an error rather than a silent fallback root.
-        """
+        # The output path reads params["KPF_SCIENCE_OUTPUT"] with no default, so an
+        # absent key must error rather than silently fall back to some other root.
         fixture = tmp_path / f"{_OBS_ID}.fits"
         _write_l0_image_fixture(str(fixture))
         cfg = tmp_path / "cfg.toml"
@@ -167,7 +143,6 @@ class TestQLPScript:
         )
 
     def test_missing_file_exit_1(self, tmp_path):
-        """Non-existent input file → exit code 1."""
         missing = tmp_path / "does_not_exist.fits"
         result = _run_qlp_script(
             "--input", missing, "--level", "L0", "--output_dir", tmp_path
@@ -175,6 +150,6 @@ class TestQLPScript:
         assert result.returncode == 1
 
     def test_no_args_exit_nonzero(self):
-        """No args → argparse error (--level required) → non-zero exit."""
+        # --level is required, so bare argv is an argparse error.
         result = _run_qlp_script()
         assert result.returncode != 0

--- a/tests/regression/test_qlp_script.py
+++ b/tests/regression/test_qlp_script.py
@@ -27,6 +27,16 @@ _REPO_ROOT = os.path.dirname(
 # A valid obs_id (and matching datecode) the quicklook filenames/paths key off.
 _OBS_ID = "KP.20240405.00004.00"
 
+# pytest's filterwarnings does not reach a child process, so the CLI would run with
+# default filters and any warning it raised would be invisible. Mirror the pyproject
+# rule into the child, where a warning becomes a non-zero exit the tests already check.
+_CHILD_WARNINGS = "error"
+
+# A child that reaches the network (astropy's IERS auto-download) can block forever --
+# nothing bounds a connection that opens and never answers. Cap every run: a hang
+# becomes a loud TimeoutExpired instead of a stalled suite.
+_CHILD_TIMEOUT = 120
+
 
 def _write_l0_image_fixture(path):
     """Write a small, plottable two-amp L0 FITS fixture (green + red).
@@ -60,9 +70,16 @@ def _write_config(path, data_dirs):
 
 def _run_qlp_script(*args):
     """Run scripts/quality_control/qlp.py via subprocess; return the result."""
-    env = {**os.environ, "PYTHONPATH": _REPO_ROOT}
+    env = {**os.environ, "PYTHONPATH": _REPO_ROOT, "PYTHONWARNINGS": _CHILD_WARNINGS}
     cmd = [sys.executable, "scripts/quality_control/qlp.py", *map(str, args)]
-    return subprocess.run(cmd, cwd=_REPO_ROOT, env=env, capture_output=True, text=True)
+    return subprocess.run(
+        cmd,
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=_CHILD_TIMEOUT,
+    )
 
 
 def _png_names(obs_id):

--- a/tests/regression/test_qlp_script.py
+++ b/tests/regression/test_qlp_script.py
@@ -29,8 +29,17 @@ _OBS_ID = "KP.20240405.00004.00"
 
 # pytest's filterwarnings does not reach a child process, so the CLI would run with
 # default filters and any warning it raised would be invisible. Mirror the pyproject
-# rule into the child, where a warning becomes a non-zero exit the tests already check.
-_CHILD_WARNINGS = "error"
+# rules into the child, where a warning becomes a non-zero exit the tests already check.
+# PYTHONWARNINGS splits entries on commas and resolves categories at interpreter
+# startup, before astropy is importable, so the astropy rule is carried by its
+# message prefix alone.
+_CHILD_WARNINGS = ",".join(
+    (
+        "error",
+        "ignore:Card is too long",
+        "default::ResourceWarning",
+    )
+)
 
 # A child that reaches the network (astropy's IERS auto-download) can block forever --
 # nothing bounds a connection that opens and never answers. Cap every run: a hang

--- a/tests/regression/test_qlp_script.py
+++ b/tests/regression/test_qlp_script.py
@@ -1,13 +1,17 @@
-"""Subprocess tests for scripts/quality_control/qlp.py, the quicklook-plot generator.
+"""Tests for scripts/quality_control/qlp.py, the quicklook-plot generator.
 
-Each test drives the CLI end-to-end on a synthetic, plottable L0 fixture.
+One subprocess test proves the script is invocable as a program; the rest drive
+``main()`` in-process, which costs milliseconds instead of an interpreter start
+and lets each case assert the message as well as the exit code.
 """
 
 import os
+import sys
 
 import pytest
 
 from kpfpipe.utils.io import kpf_directory
+from scripts.quality_control import qlp
 
 from ._data_models import write_amp_l0
 from ._scripts import run_script, write_config
@@ -41,6 +45,12 @@ def _run_qlp_script(*args):
     return run_script(_SCRIPT, *args)
 
 
+def _main(monkeypatch, *args):
+    """Drive qlp.main() in-process with ``args`` as argv."""
+    monkeypatch.setattr(sys, "argv", [_SCRIPT, *map(str, args)])
+    qlp.main()
+
+
 def _png_names(obs_id):
     """The two stitched-image PNG basenames PlotL0 writes for a frame."""
     return [
@@ -65,7 +75,7 @@ class TestQLPScript:
         for name in _png_names(_OBS_ID):
             assert (out_dir / name).is_file(), f"missing plot {name} in {out_dir}"
 
-    def test_config_output_resolution(self, tmp_path):
+    def test_config_output_resolution(self, tmp_path, monkeypatch):
         # --input supplies the frame, so only the output tree comes from the config.
         fixture = tmp_path / f"{_OBS_ID}.fits"
         _write_l0_image_fixture(str(fixture))
@@ -76,12 +86,8 @@ class TestQLPScript:
             {"KPF_DATA_INPUT": str(tmp_path), "KPF_SCIENCE_OUTPUT": str(science_out)},
         )
 
-        result = _run_qlp_script("--input", fixture, "--level", "L0", "--config", cfg)
+        _main(monkeypatch, "--input", fixture, "--level", "L0", "--config", cfg)
 
-        assert result.returncode == 0, (
-            f"Expected exit 0, got {result.returncode}\n"
-            f"stdout: {result.stdout}\nstderr: {result.stderr}"
-        )
         expected_dir = kpf_directory(
             kind="QLP", data_root=str(science_out), level="L0", obs_id=_OBS_ID
         )
@@ -90,7 +96,7 @@ class TestQLPScript:
                 f"missing plot {name} in {expected_dir}"
             )
 
-    def test_missing_science_output_key_fails_loud(self, tmp_path):
+    def test_missing_science_output_key_fails_loud(self, tmp_path, monkeypatch):
         # The output path reads params["KPF_SCIENCE_OUTPUT"] with no default, so an
         # absent key must error rather than silently fall back to some other root.
         fixture = tmp_path / f"{_OBS_ID}.fits"
@@ -98,21 +104,27 @@ class TestQLPScript:
         cfg = tmp_path / "cfg.toml"
         write_config(cfg, {"KPF_DATA_INPUT": str(tmp_path)})  # no KPF_SCIENCE_OUTPUT
 
-        result = _run_qlp_script("--input", fixture, "--level", "L0", "--config", cfg)
+        with pytest.raises(KeyError, match="KPF_SCIENCE_OUTPUT"):
+            _main(monkeypatch, "--input", fixture, "--level", "L0", "--config", cfg)
 
-        assert result.returncode != 0
-        assert "KPF_SCIENCE_OUTPUT" in result.stderr, (
-            f"Expected 'KPF_SCIENCE_OUTPUT' in stderr:\n{result.stderr}"
-        )
-
-    def test_missing_file_exit_1(self, tmp_path):
+    def test_missing_file_exit_1(self, tmp_path, monkeypatch, capsys):
         missing = tmp_path / "does_not_exist.fits"
-        result = _run_qlp_script(
-            "--input", missing, "--level", "L0", "--output_dir", tmp_path
-        )
-        assert result.returncode == 1
+        with pytest.raises(SystemExit) as exc:
+            _main(
+                monkeypatch,
+                "--input",
+                missing,
+                "--level",
+                "L0",
+                "--output_dir",
+                tmp_path,
+            )
+        assert exc.value.code == 1
+        assert "file not found" in capsys.readouterr().err
 
-    def test_no_args_exit_nonzero(self):
+    def test_no_args_exit_nonzero(self, monkeypatch, capsys):
         # --level is required, so bare argv is an argparse error.
-        result = _run_qlp_script()
-        assert result.returncode != 0
+        with pytest.raises(SystemExit) as exc:
+            _main(monkeypatch)
+        assert exc.value.code == 2
+        assert "--level" in capsys.readouterr().err

--- a/tests/regression/test_qlp_script.py
+++ b/tests/regression/test_qlp_script.py
@@ -4,78 +4,41 @@ Each test drives the CLI end-to-end on a synthetic, plottable L0 fixture.
 """
 
 import os
-import subprocess
-import sys
 
-import numpy as np
 import pytest
-from astropy.io import fits
 
 from kpfpipe.utils.io import kpf_directory
+
+from ._data_models import write_amp_l0
+from ._scripts import run_script, write_config
 
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
 pytestmark = pytest.mark.cli
 
-_REPO_ROOT = os.path.dirname(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-)
+_SCRIPT = "scripts/quality_control/qlp.py"
 
 # A valid obs_id (and matching datecode) the quicklook filenames/paths key off.
 _OBS_ID = "KP.20240405.00004.00"
 
-# pytest's filterwarnings does not reach a child process, so mirror the pyproject
-# rules in: a child warning then becomes the non-zero exit the tests check for.
-# PYTHONWARNINGS resolves categories at interpreter startup, before astropy is
-# importable, so the astropy rule is carried by its message prefix alone.
-_CHILD_WARNINGS = ",".join(
-    (
-        "error",
-        "ignore:Card is too long",
-        "default::ResourceWarning",
-    )
-)
-
-# A child that reaches the network (astropy's IERS auto-download) can block forever,
-# so cap every run: a hang becomes a loud TimeoutExpired instead of a stalled suite.
-_CHILD_TIMEOUT = 120
-
 
 def _write_l0_image_fixture(path):
     """Write an L0 FITS fixture with the two amps per chip PlotL0 needs to stitch."""
-    rng = np.random.default_rng(123)
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["OBJECT"] = "small-2amp"
-    primary.header["IMTYPE"] = "Bias"
-    primary.header["DATE-OBS"] = "2024-04-05T01:00:39"
-    primary.header["OFNAME"] = os.path.basename(path)
-
-    hdus = [primary]
-    for chip in ["GREEN", "RED"]:
-        for amp in range(1, 3):
-            data = rng.normal(1000.0, 3.0, (32, 24)).astype(np.float32)
-            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
-
-    fits.HDUList(hdus).writeto(path, overwrite=True)
-
-
-def _write_config(path, data_dirs):
-    lines = ["[DATA_DIRS]"]
-    lines += [f'{key} = "{value}"' for key, value in data_dirs.items()]
-    path.write_text("\n".join(lines) + "\n")
+    write_amp_l0(
+        path,
+        namps=2,
+        shape=(32, 24),
+        bias_level=1000.0,
+        seed=123,
+        primary_cards={
+            "OBJECT": "small-2amp",
+            "DATE-OBS": "2024-04-05T01:00:39",
+            "PROGNAME": None,
+        },
+    )
 
 
 def _run_qlp_script(*args):
-    env = {**os.environ, "PYTHONPATH": _REPO_ROOT, "PYTHONWARNINGS": _CHILD_WARNINGS}
-    cmd = [sys.executable, "scripts/quality_control/qlp.py", *map(str, args)]
-    return subprocess.run(
-        cmd,
-        cwd=_REPO_ROOT,
-        env=env,
-        capture_output=True,
-        text=True,
-        timeout=_CHILD_TIMEOUT,
-    )
+    return run_script(_SCRIPT, *args)
 
 
 def _png_names(obs_id):
@@ -108,7 +71,7 @@ class TestQLPScript:
         _write_l0_image_fixture(str(fixture))
         science_out = tmp_path / "science-root"
         cfg = tmp_path / "cfg.toml"
-        _write_config(
+        write_config(
             cfg,
             {"KPF_DATA_INPUT": str(tmp_path), "KPF_SCIENCE_OUTPUT": str(science_out)},
         )
@@ -133,7 +96,7 @@ class TestQLPScript:
         fixture = tmp_path / f"{_OBS_ID}.fits"
         _write_l0_image_fixture(str(fixture))
         cfg = tmp_path / "cfg.toml"
-        _write_config(cfg, {"KPF_DATA_INPUT": str(tmp_path)})  # no KPF_SCIENCE_OUTPUT
+        write_config(cfg, {"KPF_DATA_INPUT": str(tmp_path)})  # no KPF_SCIENCE_OUTPUT
 
         result = _run_qlp_script("--input", fixture, "--level", "L0", "--config", cfg)
 

--- a/tests/regression/test_quicklook_l0.py
+++ b/tests/regression/test_quicklook_l0.py
@@ -46,6 +46,7 @@ def synthetic_4amp_l0(tmp_path):
     primary.header["IMTYPE"] = "Bias"
     primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
     primary.header["OFNAME"] = os.path.basename(fn)
+    primary.header["PROGNAME"] = "K123"
 
     hdus = [primary]
     for chip in ["GREEN", "RED"]:
@@ -74,6 +75,7 @@ def synthetic_2amp_l0(tmp_path):
     primary.header["IMTYPE"] = "Bias"
     primary.header["DATE-OBS"] = "2024-04-05T01:00:38"
     primary.header["OFNAME"] = os.path.basename(fn)
+    primary.header["PROGNAME"] = "K123"
 
     hdus = [primary]
     for chip in ["GREEN", "RED"]:
@@ -101,6 +103,7 @@ def small_2amp_l0(tmp_path):
     primary.header["IMTYPE"] = "Bias"
     primary.header["DATE-OBS"] = "2024-04-05T01:00:39"
     primary.header["OFNAME"] = os.path.basename(fn)
+    primary.header["PROGNAME"] = "K123"
 
     hdus = [primary]
     for chip in ["GREEN", "RED"]:
@@ -221,6 +224,7 @@ class TestStitchedImage2To16:
         primary = fits.PrimaryHDU()
         primary.header["OBJECT"] = "high-value"
         primary.header["OFNAME"] = os.path.basename(fn)
+        primary.header["PROGNAME"] = "K123"
         hdus = [primary]
         for chip in ["GREEN", "RED"]:
             for amp in range(1, 5):
@@ -343,6 +347,7 @@ class TestPlotL0Run:
         primary = fits.PrimaryHDU()
         primary.header["OBJECT"] = "green-only"
         primary.header["OFNAME"] = os.path.basename(fn)
+        primary.header["PROGNAME"] = "K123"
         hdus = [primary]
         for amp in range(1, 5):
             data = rng.normal(1000, 3, (100, 100)).astype(np.float32)

--- a/tests/regression/test_quicklook_l0.py
+++ b/tests/regression/test_quicklook_l0.py
@@ -25,7 +25,46 @@ pytestmark = pytest.mark.quicklook
 
 @pytest.fixture
 def synthetic_4amp_l0(tmp_path):
-    # 4-amp readout geometry, at full detector size so the stitch is realistic.
+    # 4-amp readout geometry. Deliberately tiny: every consumer asserts titles,
+    # axis counts, run() keys or PNG names, none of which depend on detector
+    # size. Only test_image_shape_4amp needs real geometry -- it takes
+    # fullres_4amp_l0 instead.
+    fn = write_amp_l0(
+        tmp_path / "KP.20240405.00001.00.fits",
+        namps=4,
+        shape=(32, 24),
+        bias_level=1000.0,
+        seed=42,
+        primary_cards={
+            "OBJECT": "synthetic-4amp",
+            "DATE-OBS": "2024-04-05T01:00:37",
+        },
+    )
+    return KPF0.from_fits(fn)
+
+
+@pytest.fixture
+def synthetic_2amp_l0(tmp_path):
+    # Tiny for the same reason as synthetic_4amp_l0; test_image_shape_2amp takes
+    # fullres_2amp_l0.
+    fn = write_amp_l0(
+        tmp_path / "KP.20240405.00002.00.fits",
+        namps=2,
+        shape=(32, 24),
+        bias_level=1000.0,
+        seed=99,
+        primary_cards={
+            "OBJECT": "synthetic-2amp",
+            "DATE-OBS": "2024-04-05T01:00:38",
+        },
+    )
+    return KPF0.from_fits(fn)
+
+
+@pytest.fixture
+def fullres_4amp_l0(tmp_path):
+    """Real detector geometry: the stitched-shape assertion is the only thing
+    that needs it, and it costs ~1.5 s to build and render."""
     fn = write_amp_l0(
         tmp_path / "KP.20240405.00001.00.fits",
         namps=4,
@@ -41,7 +80,8 @@ def synthetic_4amp_l0(tmp_path):
 
 
 @pytest.fixture
-def synthetic_2amp_l0(tmp_path):
+def fullres_2amp_l0(tmp_path):
+    """Real detector geometry for the 2-amp stitched-shape assertion."""
     fn = write_amp_l0(
         tmp_path / "KP.20240405.00002.00.fits",
         namps=2,
@@ -131,10 +171,10 @@ class TestStitchedImage4Amp:
         assert len(fig.axes) == 2
         plt.close(fig)
 
-    def test_image_shape_4amp(self, synthetic_4amp_l0):
+    def test_image_shape_4amp(self, fullres_4amp_l0):
         from kpfpipe.quality_control.quicklook.level0 import PlotL0
 
-        qlp = PlotL0(synthetic_4amp_l0)
+        qlp = PlotL0(fullres_4amp_l0)
         fig = qlp.stitched_image("green")
         ax = fig.axes[0]
         images = ax.get_images()
@@ -150,10 +190,10 @@ class TestStitchedImage4Amp:
 
 
 class TestStitchedImage2Amp:
-    def test_image_shape_2amp(self, synthetic_2amp_l0):
+    def test_image_shape_2amp(self, fullres_2amp_l0):
         from kpfpipe.quality_control.quicklook.level0 import PlotL0
 
-        qlp = PlotL0(synthetic_2amp_l0)
+        qlp = PlotL0(fullres_2amp_l0)
         fig = qlp.stitched_image("red")
         ax = fig.axes[0]
         images = ax.get_images()

--- a/tests/regression/test_quicklook_l0.py
+++ b/tests/regression/test_quicklook_l0.py
@@ -2,28 +2,20 @@
 
 import os
 
-import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from astropy.io import fits
 from PIL import Image
 
-matplotlib.use("Agg")
-
-import matplotlib.pyplot as plt
-
 from kpfpipe.data_models.level0 import KPF0
+
+from ._data_models import write_amp_l0
 
 # Quicklook/QLP render suite: slow PNG rendering, so excluded from
 # `make test-fast`. Run in the full suite or `make test-qlp`.
+# The Agg pin and the close-figures teardown come from tests/regression/conftest.py.
 pytestmark = pytest.mark.quicklook
-
-
-@pytest.fixture(autouse=True)
-def _close_figures():
-    """Close any figures a test left open (the output_dir=None path returns them)."""
-    yield
-    plt.close("all")
 
 
 # ---------------------------------------------------------------------------
@@ -33,85 +25,51 @@ def _close_figures():
 
 @pytest.fixture
 def synthetic_4amp_l0(tmp_path):
-    fn = str(tmp_path / "KP.20240405.00001.00.fits")
-    rng = np.random.default_rng(42)
-
-    nrow, ncol = 2070, 2094
-    bias_level = 1000.0
-
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["OBJECT"] = "synthetic-4amp"
-    primary.header["IMTYPE"] = "Bias"
-    primary.header["DATE-OBS"] = "2024-04-05T01:00:37"
-    primary.header["OFNAME"] = os.path.basename(fn)
-    primary.header["PROGNAME"] = "K123"
-
-    hdus = [primary]
-    for chip in ["GREEN", "RED"]:
-        for amp in range(1, 5):
-            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
-            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
-
-    hdul = fits.HDUList(hdus)
-    hdul.writeto(fn, overwrite=True)
-    hdul.close()
+    # 4-amp readout geometry, at full detector size so the stitch is realistic.
+    fn = write_amp_l0(
+        tmp_path / "KP.20240405.00001.00.fits",
+        namps=4,
+        shape=(2070, 2094),
+        bias_level=1000.0,
+        seed=42,
+        primary_cards={
+            "OBJECT": "synthetic-4amp",
+            "DATE-OBS": "2024-04-05T01:00:37",
+        },
+    )
     return KPF0.from_fits(fn)
 
 
 @pytest.fixture
 def synthetic_2amp_l0(tmp_path):
-    fn = str(tmp_path / "KP.20240405.00002.00.fits")
-    rng = np.random.default_rng(99)
-
-    nrow, ncol = 4080, 2094
-    bias_level = 1000.0
-
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["OBJECT"] = "synthetic-2amp"
-    primary.header["IMTYPE"] = "Bias"
-    primary.header["DATE-OBS"] = "2024-04-05T01:00:38"
-    primary.header["OFNAME"] = os.path.basename(fn)
-    primary.header["PROGNAME"] = "K123"
-
-    hdus = [primary]
-    for chip in ["GREEN", "RED"]:
-        for amp in range(1, 3):
-            data = (bias_level + rng.normal(0, 3.0, (nrow, ncol))).astype(np.float32)
-            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
-
-    hdul = fits.HDUList(hdus)
-    hdul.writeto(fn, overwrite=True)
-    hdul.close()
+    fn = write_amp_l0(
+        tmp_path / "KP.20240405.00002.00.fits",
+        namps=2,
+        shape=(4080, 2094),
+        bias_level=1000.0,
+        seed=99,
+        primary_cards={
+            "OBJECT": "synthetic-2amp",
+            "DATE-OBS": "2024-04-05T01:00:38",
+        },
+    )
     return KPF0.from_fits(fn)
 
 
 @pytest.fixture
 def small_2amp_l0(tmp_path):
     """Small enough that a native-resolution PNG can be size-checked exactly."""
-    fn = str(tmp_path / "KP.20240405.00004.00.fits")
-    rng = np.random.default_rng(123)
-
-    nrow, ncol = 32, 24
-
-    primary = fits.PrimaryHDU()
-    primary.header["INSTRUME"] = "KPF"
-    primary.header["OBJECT"] = "small-2amp"
-    primary.header["IMTYPE"] = "Bias"
-    primary.header["DATE-OBS"] = "2024-04-05T01:00:39"
-    primary.header["OFNAME"] = os.path.basename(fn)
-    primary.header["PROGNAME"] = "K123"
-
-    hdus = [primary]
-    for chip in ["GREEN", "RED"]:
-        for amp in range(1, 3):
-            data = rng.normal(1000.0, 3.0, (nrow, ncol)).astype(np.float32)
-            hdus.append(fits.ImageHDU(data=data, name=f"{chip}_AMP{amp}"))
-
-    hdul = fits.HDUList(hdus)
-    hdul.writeto(fn, overwrite=True)
-    hdul.close()
+    fn = write_amp_l0(
+        tmp_path / "KP.20240405.00004.00.fits",
+        namps=2,
+        shape=(32, 24),
+        bias_level=1000.0,
+        seed=123,
+        primary_cards={
+            "OBJECT": "small-2amp",
+            "DATE-OBS": "2024-04-05T01:00:39",
+        },
+    )
     return KPF0.from_fits(fn)
 
 
@@ -336,22 +294,16 @@ class TestPlotL0Run:
             qlp.run()
 
     def test_run_skips_missing_chip(self, tmp_path):
-        fn = str(tmp_path / "KP.20240405.00004.00.fits")
-        rng = np.random.default_rng(7)
-
-        primary = fits.PrimaryHDU()
-        primary.header["OBJECT"] = "green-only"
-        primary.header["OFNAME"] = os.path.basename(fn)
-        primary.header["PROGNAME"] = "K123"
-        hdus = [primary]
-        for amp in range(1, 5):
-            data = rng.normal(1000, 3, (100, 100)).astype(np.float32)
-            hdus.append(fits.ImageHDU(data=data, name=f"GREEN_AMP{amp}"))
-
-        hdul = fits.HDUList(hdus)
-        hdul.writeto(fn, overwrite=True)
-        hdul.close()
-
+        # GREEN only: no RED_AMP* HDU at all, so run() must skip the red chip.
+        fn = write_amp_l0(
+            tmp_path / "KP.20240405.00004.00.fits",
+            namps=4,
+            chips=("GREEN",),
+            shape=(100, 100),
+            bias_level=1000.0,
+            seed=7,
+            primary_cards={"OBJECT": "green-only"},
+        )
         l0 = KPF0.from_fits(fn)
 
         from kpfpipe.quality_control.quicklook.level0 import PlotL0

--- a/tests/regression/test_quicklook_l0.py
+++ b/tests/regression/test_quicklook_l0.py
@@ -14,8 +14,8 @@ import matplotlib.pyplot as plt
 
 from kpfpipe.data_models.level0 import KPF0
 
-# Quicklook/QLP render suite: excluded from `make test-fast` (slow PNG rendering,
-# an offshoot from the production path). Run in the full suite or `make test-qlp`.
+# Quicklook/QLP render suite: slow PNG rendering, so excluded from
+# `make test-fast`. Run in the full suite or `make test-qlp`.
 pytestmark = pytest.mark.quicklook
 
 
@@ -33,7 +33,6 @@ def _close_figures():
 
 @pytest.fixture
 def synthetic_4amp_l0(tmp_path):
-    """Create a synthetic KPF0 with 4-amp green and red data."""
     fn = str(tmp_path / "KP.20240405.00001.00.fits")
     rng = np.random.default_rng(42)
 
@@ -62,7 +61,6 @@ def synthetic_4amp_l0(tmp_path):
 
 @pytest.fixture
 def synthetic_2amp_l0(tmp_path):
-    """Create a synthetic KPF0 with 2-amp green and red data."""
     fn = str(tmp_path / "KP.20240405.00002.00.fits")
     rng = np.random.default_rng(99)
 
@@ -91,7 +89,7 @@ def synthetic_2amp_l0(tmp_path):
 
 @pytest.fixture
 def small_2amp_l0(tmp_path):
-    """Create a small two-amp KPF0 for native-resolution PNG tests."""
+    """Small enough that a native-resolution PNG can be size-checked exactly."""
     fn = str(tmp_path / "KP.20240405.00004.00.fits")
     rng = np.random.default_rng(123)
 
@@ -118,7 +116,7 @@ def small_2amp_l0(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Task 1: Constructor
+# Constructor
 # ---------------------------------------------------------------------------
 
 
@@ -140,7 +138,7 @@ class TestPlotL0Constructor:
 
 
 # ---------------------------------------------------------------------------
-# Task 2: stitched_image
+# stitched_image
 # ---------------------------------------------------------------------------
 
 
@@ -171,7 +169,7 @@ class TestStitchedImage4Amp:
 
         qlp = PlotL0(synthetic_4amp_l0)
         fig = qlp.stitched_image("green")
-        # Figure should have 2 axes: image + colorbar
+        # image + colorbar
         assert len(fig.axes) == 2
         plt.close(fig)
 
@@ -189,7 +187,7 @@ class TestStitchedImage4Amp:
 
 
 # ---------------------------------------------------------------------------
-# Task 3: 2-amp mode and 2^16 scaling
+# 2-amp mode and 2^16 scaling
 # ---------------------------------------------------------------------------
 
 
@@ -217,7 +215,7 @@ class TestStitchedImage2Amp:
 
 class TestStitchedImage2To16:
     def test_scales_high_values(self, tmp_path):
-        """Data with median > 200 * 2^16 should be divided by 2^16."""
+        # A median above the 200 * 2^16 threshold triggers the 2^16 rescale.
         fn = str(tmp_path / "KP.20240405.00003.00.fits")
         high_val = 300 * 2**16
 
@@ -242,7 +240,6 @@ class TestStitchedImage2To16:
         qlp = PlotL0(l0)
         fig = qlp.stitched_image("green")
 
-        # Image data should be scaled down to ~300
         ax = fig.axes[0]
         # imshow keeps the stitched image masked, so use the mask-aware median.
         img_data = ax.get_images()[0].get_array()
@@ -251,7 +248,7 @@ class TestStitchedImage2To16:
 
 
 # ---------------------------------------------------------------------------
-# Task 4: File saving and all()
+# File saving and run()
 # ---------------------------------------------------------------------------
 
 
@@ -273,7 +270,6 @@ class TestPlotL0FileSaving:
 
         qlp = PlotL0(synthetic_4amp_l0)
         fig = qlp.stitched_image("green")
-        # No PNG should exist anywhere in tmp_path
         pngs = list(tmp_path.glob("*.png"))
         assert pngs == []
         plt.close(fig)
@@ -340,7 +336,6 @@ class TestPlotL0Run:
             qlp.run()
 
     def test_run_skips_missing_chip(self, tmp_path):
-        """L0 with only green amps should only produce green plot."""
         fn = str(tmp_path / "KP.20240405.00004.00.fits")
         rng = np.random.default_rng(7)
 

--- a/tests/regression/test_quicklook_l1.py
+++ b/tests/regression/test_quicklook_l1.py
@@ -1,26 +1,17 @@
 """Tests for L1 quicklook plots."""
 
-import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from astropy.io import fits
 from PIL import Image
 
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-
 from kpfpipe.data_models.level1 import KPF1
 
 # Quicklook/QLP render suite: slow PNG rendering, so it is excluded from
 # `make test-fast`. Run in the full suite or `make test-qlp`.
+# The Agg pin and the close-figures teardown come from tests/regression/conftest.py.
 pytestmark = pytest.mark.quicklook
-
-
-@pytest.fixture(autouse=True)
-def _close_figures():
-    """Close any figures a test left open (the output_dir=None path returns them)."""
-    yield
-    plt.close("all")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_quicklook_l1.py
+++ b/tests/regression/test_quicklook_l1.py
@@ -11,8 +11,8 @@ import matplotlib.pyplot as plt
 
 from kpfpipe.data_models.level1 import KPF1
 
-# Quicklook/QLP render suite: excluded from `make test-fast` (slow PNG rendering,
-# an offshoot from the production path). Run in the full suite or `make test-qlp`.
+# Quicklook/QLP render suite: slow PNG rendering, so it is excluded from
+# `make test-fast`. Run in the full suite or `make test-qlp`.
 pytestmark = pytest.mark.quicklook
 
 
@@ -27,8 +27,8 @@ def _close_figures():
 # Fixtures
 # ---------------------------------------------------------------------------
 
-# 300x300 is large enough to exercise the 100-pixel border stripping used by
-# image()'s percentile scaling without paying for full 4080x4080 arrays.
+# Large enough to exercise the 100-pixel border strip in image()'s percentile
+# scaling, without paying for full 4080x4080 arrays.
 _FIXTURE_SHAPE = (300, 300)
 
 
@@ -67,10 +67,9 @@ def _build_synthetic_l1(
 def _seed_read_noise(l1):
     """Seed RN*/RNNG* via set_keyword, exactly as ImageAssembly does.
 
-    set_keyword routes these to QUALITY_CONTROL (their registry home), so this
-    exercises the real read path the quicklook annotation depends on -- writing
-    them onto PRIMARY here would let the annotation test pass while production
-    (which reads QUALITY_CONTROL) silently rendered nothing.
+    set_keyword routes them to QUALITY_CONTROL, which is where the quicklook
+    annotation reads them; writing them onto PRIMARY here would let the
+    annotation test pass while production silently rendered nothing.
     """
     for i in range(1, 5):
         l1.set_keyword(f"RNGREEN{i}", 3.5 + 0.05 * i)
@@ -97,7 +96,7 @@ def synthetic_l1_no_rn(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Task 1: Constructor
+# Constructor
 # ---------------------------------------------------------------------------
 
 
@@ -143,8 +142,7 @@ class TestImage:
 
         qlp = PlotL1(synthetic_l1)
         fig = qlp.image("green")
-        # image axis + colorbar axis
-        assert len(fig.axes) == 2
+        assert len(fig.axes) == 2  # image axis + colorbar axis
         plt.close(fig)
 
     def test_image_shape(self, synthetic_l1):
@@ -162,7 +160,6 @@ class TestImage:
         qlp = PlotL1(synthetic_l1)
         fig = qlp.image("green")
         texts = [t.get_text() for t in fig.axes[0].texts]
-        # Should have a read noise annotation containing 'RN:' prefix
         assert any("RN:" in t for t in texts), f"texts found: {texts}"
         plt.close(fig)
 
@@ -250,7 +247,6 @@ class TestRun:
             qlp.run()
 
     def test_run_skips_missing_chip(self, tmp_path):
-        # KPF1 with only green CCD, no red
         rng = np.random.default_rng(42)
         fn = str(tmp_path / "KP.20240405.00003.00_L1.fits")
         primary = fits.PrimaryHDU()

--- a/tests/regression/test_quicklook_l1.py
+++ b/tests/regression/test_quicklook_l1.py
@@ -171,8 +171,10 @@ class TestFileSaving:
         qlp = PlotL1(synthetic_l1, output_dir=str(tmp_path))
         fig = qlp.image("green")
         expected = tmp_path / "KP.20240405.00001.00_L1_image_green_zoomable.png"
-        assert expected.exists()
-        assert expected.stat().st_size > 0
+        assert sorted(p.name for p in tmp_path.glob("*.png")) == [expected.name]
+        # An empty canvas would satisfy a bare exists(); check for ink.
+        with Image.open(expected) as png:
+            assert png.convert("L").getextrema() != (255, 255)
         plt.close(fig)
 
     def test_no_file_when_output_dir_none(self, synthetic_l1, tmp_path):
@@ -266,21 +268,22 @@ class TestRun:
 
 
 class TestStubs:
-    @pytest.mark.parametrize(
-        "method_name",
-        [
-            "histogram",
-            "column_cut",
-            "zoom_3x3",
-            "order_trace_overlay",
-            "bias_subtracted",
-            "dark_subtracted",
-        ],
+    _STUBS = (
+        "histogram",
+        "column_cut",
+        "zoom_3x3",
+        "order_trace_overlay",
+        "bias_subtracted",
+        "dark_subtracted",
     )
-    def test_stub_raises_not_implemented(self, synthetic_l1, method_name):
+
+    def test_stubs_raise_not_implemented(self):
+        # One behaviour, not six: each stub raises before reading any data, so a
+        # bare KPF1 is enough and the synthetic FITS fixture is not needed. The
+        # match= pins that the stub raised for its own reason.
         from kpfpipe.quality_control.quicklook.level1 import PlotL1
 
-        qlp = PlotL1(synthetic_l1)
-        method = getattr(qlp, method_name)
-        with pytest.raises(NotImplementedError):
-            method("green")
+        qlp = PlotL1(KPF1())
+        for method_name in self._STUBS:
+            with pytest.raises(NotImplementedError, match=method_name):
+                getattr(qlp, method_name)("green")

--- a/tests/regression/test_quicklook_l2.py
+++ b/tests/regression/test_quicklook_l2.py
@@ -11,14 +11,13 @@ from kpfpipe import DETECTOR
 from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.quality_control.quicklook.level2 import PlotL2
 
-# Quicklook/QLP render suite: excluded from `make test-fast` (slow PNG rendering,
-# an offshoot from the production path). Run in the full suite or `make test-qlp`.
+# Slow PNG rendering off the production path: excluded from `make test-fast`.
 pytestmark = pytest.mark.quicklook
 
 
 @pytest.fixture(autouse=True)
 def _close_figures():
-    """Close any figures a test left open (the output_dir=None path returns them)."""
+    """Close figures a test left open; the output_dir=None path returns them."""
     yield
     plt.close("all")
 
@@ -41,10 +40,7 @@ _OBS_ID = "KP.20240405.40113.57"
 
 
 def _make_l2(*, with_wave=True, object_name="Tau Ceti"):
-    """Build a KPF2 with FLUX/VAR (and optionally WAVE) for all fibers/chips.
-
-    obs_id is set on the model attribute, as the pipeline populates it.
-    """
+    """Build a KPF2 with FLUX/VAR (and optionally WAVE) for all fibers/chips."""
     l2 = KPF2()
     l2.obs_id = _OBS_ID
     l2.headers["PRIMARY"]["INSTRUME"] = "KPF"

--- a/tests/regression/test_quicklook_l2.py
+++ b/tests/regression/test_quicklook_l2.py
@@ -3,6 +3,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from PIL import Image
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.level2 import KPF2
@@ -87,12 +88,9 @@ class TestConstructor:
 
 
 class TestPlots:
-    @pytest.mark.parametrize("method", _PLOT_METHODS)
-    @pytest.mark.parametrize("chip", ["green", "red"])
-    def test_method_returns_figure(self, l2, method, chip):
-        fig = getattr(PlotL2(l2), method)(chip)
-        assert isinstance(fig, plt.Figure)
-        plt.close(fig)
+    # A parametrized "every method returns a Figure" test used to live here. It
+    # rendered the same ten figures TestRun::test_run_all_returns_all_plots_both_chips
+    # already renders, and asserted strictly less about them.
 
     def test_spectrum_single_order_explicit_order(self, l2):
         fig = PlotL2(l2).spectrum_single_order("green", order=3)
@@ -108,6 +106,9 @@ class TestPlots:
         title = fig.axes[0].get_title()
         assert _OBS_ID in title
         assert "Tau Ceti" in title
+        # Riding on the same render: the series carries one point per green
+        # order, so a chip-slice or order-index slip is visible here.
+        assert len(fig.axes[0].lines[0].get_xdata()) == NORDER_GREEN
         plt.close(fig)
 
 
@@ -168,7 +169,9 @@ class TestFileSaving:
             for c in ("green", "red")
         )
         assert pngs == expected
-        assert all((tmp_path / n).stat().st_size > 0 for n in pngs)
+        # The name set is the contract; a blank canvas would still satisfy it.
+        with Image.open(tmp_path / pngs[0]) as png:
+            assert png.convert("L").getextrema() != (255, 255)
 
     def test_no_files_when_output_dir_none(self, l2, tmp_path):
         PlotL2(l2).run("all")

--- a/tests/regression/test_quicklook_l2.py
+++ b/tests/regression/test_quicklook_l2.py
@@ -1,8 +1,5 @@
 """Tests for L2 quicklook plots (wavelength-aware extracted spectra)."""
 
-import matplotlib
-
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -12,14 +9,8 @@ from kpfpipe.data_models.level2 import KPF2
 from kpfpipe.quality_control.quicklook.level2 import PlotL2
 
 # Slow PNG rendering off the production path: excluded from `make test-fast`.
+# The Agg pin and the close-figures teardown come from tests/regression/conftest.py.
 pytestmark = pytest.mark.quicklook
-
-
-@pytest.fixture(autouse=True)
-def _close_figures():
-    """Close figures a test left open; the output_dir=None path returns them."""
-    yield
-    plt.close("all")
 
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]

--- a/tests/regression/test_quicklook_l4.py
+++ b/tests/regression/test_quicklook_l4.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 from astropy.table import Table
+from PIL import Image
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.level4 import KPF4
@@ -164,40 +165,35 @@ def _sci2_panel(fig):
 
 
 class TestCcfGridAnnotations:
-    def test_sci_panel_labels_every_order(self, l4):
-        # At least one text annotation per order (the order-index labels).
-        fig = PlotL4(l4).ccf_grid("green")
-        assert len(_sci2_panel(fig).texts) >= NORDER_GREEN
-        plt.close(fig)
+    def test_sci_panel_annotations(self, l4):
+        """Every read-only property of the SCI2 panel, on one render.
 
-    def test_sci_panel_has_delta_rv_and_weight_headers(self, l4):
-        fig = PlotL4(l4).ccf_grid("green")
-        txt = " ".join(t.get_text() for t in _sci2_panel(fig).texts)
-        assert "(this - avg)" in txt  # the delta-RV column header
-        assert "weight" in txt
-        plt.close(fig)
-
-    def test_orderlet_rv_value_annotated(self, l4):
-        # Green SCI2 combined RV is CCD1RV2 = 0.5 km/s, shown to 5 dp at the
-        # vertical RV line.
-        fig = PlotL4(l4).ccf_grid("green")
-        txt = " ".join(t.get_text() for t in _sci2_panel(fig).texts)
-        assert "0.50000" in txt and "km s" in txt
-        plt.close(fig)
-
-    def test_per_order_delta_rv_values_present(self, l4):
+        These were six tests re-rendering an identical 5-panel x 35-order figure
+        to make six read-only assertions; one render answers all of them. A
+        class-scoped figure fixture would not work here -- conftest's autouse
+        teardown closes every figure after each test.
+        """
         import re
 
         fig = PlotL4(l4).ccf_grid("green")
-        txt = " ".join(t.get_text() for t in _sci2_panel(fig).texts)
+        panel = _sci2_panel(fig)
+        txt = " ".join(t.get_text() for t in panel.texts)
+
+        # At least one text annotation per order (the order-index labels).
+        assert len(panel.texts) >= NORDER_GREEN
+        # The delta-RV and weight column headers.
+        assert "(this - avg)" in txt
+        assert "weight" in txt
+        # Green SCI2 combined RV is CCD1RV2 = 0.5 km/s, shown to 5 dp.
+        assert "0.50000" in txt and "km s" in txt
         # Per-order delta-RV is km/s to 4 decimals, e.g. "0.0020 km s^-1".
         assert re.search(r"\d\.\d{4}", txt)
+        # The three bluest green orders carry weight 0 in the CCF weight table;
+        # the panel must report them as "0.00", not a fabricated nonzero value.
+        assert "0.00" in txt
+        # Orders follow the default color cycle.
+        assert len({ln.get_color() for ln in panel.lines}) > 1
         plt.close(fig)
-
-    def test_per_order_distinct_colors(self, l4):
-        fig = PlotL4(l4).ccf_grid("green")
-        colors = {ln.get_color() for ln in _sci2_panel(fig).lines}
-        assert len(colors) > 1  # orders follow the default color cycle
 
     def test_renders_without_rv_tables(self):
         # No RV tables -> annotations are omitted but the plot still renders.
@@ -205,12 +201,16 @@ class TestCcfGridAnnotations:
         assert isinstance(fig, plt.Figure)
         plt.close(fig)
 
-    def test_zero_weight_orders_annotated_as_zero(self, l4):
-        # The three bluest green orders carry weight 0 in the CCF weight table;
-        # the panel must report them as "0.00", not a fabricated nonzero value.
-        fig = PlotL4(l4).ccf_grid("green")
-        txt = " ".join(t.get_text() for t in _sci2_panel(fig).texts)
-        assert "0.00" in txt
+    def test_unilluminated_fiber_panel_says_not_illuminated(self, l4):
+        # CAL and SKY carry no CCF on many science frames. Draw the panel
+        # directly on a bare axes: the 5-panel grid render is not needed to see
+        # which branch _draw_ccf_panel takes.
+        l4.set_data("CAL_CCF", np.zeros((NORDER, NVEL), dtype=np.float64))
+        fig, ax = plt.subplots()
+        PlotL4(l4)._draw_ccf_panel(
+            ax, "green", "CAL", norder=NORDER_GREEN, vref=np.array([-10.0, 10.0])
+        )
+        assert any("not illuminated" in t.get_text() for t in ax.texts)
         plt.close(fig)
 
     def test_missing_weight_column_raises(self):
@@ -218,6 +218,17 @@ class TestCcfGridAnnotations:
         l4 = _make_l4(with_weight=False)
         with pytest.raises(ValueError, match="WEIGHT column"):
             PlotL4(l4).ccf_grid("green")
+
+
+class TestVelocityGrid:
+    def test_missing_velstep_raises(self, l4):
+        # CrossCorrelation writes VELSTART/VELSTEP/VELNSTEP on every CCF, so
+        # their absence is a malformed product. A hdr.get(..., 0.0) here would
+        # fabricate a velocity axis instead -- the silent substitution the
+        # method's docstring forbids. No render.
+        del l4.headers[l4.data._resolve("SCI2_CCF")]["VELSTEP"]
+        with pytest.raises(KeyError):
+            PlotL4(l4)._velocity_grid("SCI2", NVEL)
 
 
 # ---------------------------------------------------------------------------
@@ -251,5 +262,11 @@ class TestRun:
 class TestOutput:
     def test_writes_png_per_chip(self, l4, tmp_path):
         PlotL4(l4, output_dir=str(tmp_path), obs_id=_OBS_ID).run("all")
-        for chip in ("green", "red"):
-            assert (tmp_path / f"{_OBS_ID}_L4_ccf_grid_{chip}_zoomable.png").is_file()
+        pngs = sorted(p.name for p in tmp_path.glob("*.png"))
+        assert pngs == sorted(
+            f"{_OBS_ID}_L4_ccf_grid_{chip}_zoomable.png" for chip in ("green", "red")
+        )
+        # The name set is the real contract, but a blank canvas would satisfy it;
+        # check one file actually has ink on it.
+        with Image.open(tmp_path / pngs[0]) as png:
+            assert png.convert("L").getextrema() != (255, 255)

--- a/tests/regression/test_quicklook_l4.py
+++ b/tests/regression/test_quicklook_l4.py
@@ -12,8 +12,8 @@ from kpfpipe import DETECTOR
 from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.quality_control.quicklook.level4 import PlotL4
 
-# Quicklook/QLP render suite: excluded from `make test-fast` (slow PNG rendering,
-# an offshoot from the production path). Run in the full suite or `make test-qlp`.
+# Quicklook/QLP render suite: slow PNG rendering, so it is excluded from
+# `make test-fast`. Run in the full suite or `make test-qlp`.
 pytestmark = pytest.mark.quicklook
 
 
@@ -39,7 +39,7 @@ _RV_SFX = {"SCI1": "1", "SCI2": "2", "SCI3": "3", "CAL": "C", "SKY": "S"}
 
 
 def _gaussian_ccf(rng, depth=0.5):
-    """A single-order CCF: a downward Gaussian dip plus noise (one per order)."""
+    """A single-order CCF: a downward Gaussian dip plus noise."""
     v = np.arange(NVEL) * _VELSTEP + _VELSTART
     dip = 1.0 - depth * np.exp(-0.5 * (v / 3.0) ** 2)
     return dip + rng.normal(0.0, 0.01, size=NVEL)
@@ -50,14 +50,12 @@ def _make_l4(
 ):
     """Build a KPF4 with CCF cubes + velocity headers + per-CCD RV keywords.
 
-    `chips` selects which detector halves carry real CCF data; a chip omitted
-    here is left as the zero-filled concatenation slice (i.e. "no CCF there").
-    `with_rv` also attaches per-order RV tables (ORDER_INDEX/RV/RV_ERR/WEIGHT) for
-    the science + sky orderlets, as RadialVelocity writes them; the first three
-    green orders carry weight 0 (excluded from the combined RV, as the real CCF
-    order-weight table does). `with_weight=False` omits the WEIGHT column to
-    exercise PlotL4's fail-loud path. obs_id is set on the model attribute, as
-    the pipeline populates it.
+    `chips` selects which detector halves carry real CCF data; an omitted chip is
+    left as the zero-filled concatenation slice ("no CCF there"). `with_rv` adds
+    per-order RV tables for the science + sky orderlets, as RadialVelocity writes
+    them, with weight 0 on the three bluest green orders as the real CCF
+    order-weight table has. `with_weight=False` omits the WEIGHT column to
+    exercise PlotL4's fail-loud path.
     """
     l4 = KPF4()
     l4.obs_id = _OBS_ID
@@ -66,8 +64,7 @@ def _make_l4(
 
     rng = np.random.default_rng(7)
     for fiber in _FIBERS:
-        # Build the full concatenated cube, writing real data only into the
-        # requested chips' order ranges (the rest stays zero).
+        # Real data goes only into the requested chips' order ranges.
         cube = np.zeros((NORDER, NVEL), dtype=np.float64)
         green_sl = slice(0, NORDER_GREEN)
         red_sl = slice(NORDER_GREEN, NORDER)
@@ -79,7 +76,7 @@ def _make_l4(
                 cube[red_sl][o] = _gaussian_ccf(rng)
         l4.set_data(f"{fiber}_CCF", cube)
 
-        # Velocity grid + mask live in the CCF extension header (resolved alias).
+        # Velocity grid + mask live in the CCF extension header.
         ext = l4.data._resolve(f"{fiber}_CCF")
         l4.headers[ext]["VELSTART"] = _VELSTART
         l4.headers[ext]["VELSTEP"] = _VELSTEP
@@ -87,8 +84,7 @@ def _make_l4(
         l4.headers[ext]["CCFMASK"] = "G2_espresso"
 
     # Per-order RV tables (green orders near CCD1RV=0.5, red near CCD2RV=0.6),
-    # plus the legacy combined-RV keyword on each fiber's own RV extension header
-    # (CCD{n}RV{sfx} -> RV#), as RadialVelocity writes them via set_keyword.
+    # plus the combined-RV keyword on each fiber's own RV extension header.
     if with_rv:
         rng2 = np.random.default_rng(11)
         base = np.where(np.arange(NORDER) < NORDER_GREEN, 0.5, 0.6)
@@ -186,13 +182,13 @@ class TestCcfGridAnnotations:
     def test_sci_panel_has_delta_rv_and_weight_headers(self, l4):
         fig = PlotL4(l4).ccf_grid("green")
         txt = " ".join(t.get_text() for t in _sci2_panel(fig).texts)
-        assert "(this - avg)" in txt  # the delta-RV column header (mathtext Delta)
+        assert "(this - avg)" in txt  # the delta-RV column header
         assert "weight" in txt
         plt.close(fig)
 
     def test_orderlet_rv_value_annotated(self, l4):
-        # Green SCI2 combined RV is CCD1RV2 = 0.5 km/s; shown (5 dp, km s^-1) at
-        # the vertical RV line.
+        # Green SCI2 combined RV is CCD1RV2 = 0.5 km/s, shown to 5 dp at the
+        # vertical RV line.
         fig = PlotL4(l4).ccf_grid("green")
         txt = " ".join(t.get_text() for t in _sci2_panel(fig).texts)
         assert "0.50000" in txt and "km s" in txt
@@ -227,8 +223,7 @@ class TestCcfGridAnnotations:
         plt.close(fig)
 
     def test_missing_weight_column_raises(self):
-        # An RV table without WEIGHT must fail loudly -- PlotL4 never substitutes
-        # weights the pipeline did not actually use (e.g. inverse-variance).
+        # PlotL4 must never substitute weights the pipeline did not actually use.
         l4 = _make_l4(with_weight=False)
         with pytest.raises(ValueError, match="WEIGHT column"):
             PlotL4(l4).ccf_grid("green")

--- a/tests/regression/test_quicklook_l4.py
+++ b/tests/regression/test_quicklook_l4.py
@@ -1,8 +1,5 @@
 """Tests for L4 quicklook plots (CCFs and radial velocities)."""
 
-import matplotlib
-
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
@@ -14,14 +11,8 @@ from kpfpipe.quality_control.quicklook.level4 import PlotL4
 
 # Quicklook/QLP render suite: slow PNG rendering, so it is excluded from
 # `make test-fast`. Run in the full suite or `make test-qlp`.
+# The Agg pin and the close-figures teardown come from tests/regression/conftest.py.
 pytestmark = pytest.mark.quicklook
-
-
-@pytest.fixture(autouse=True)
-def _close_figures():
-    """Close any figures a test left open (the output_dir=None path returns them)."""
-    yield
-    plt.close("all")
 
 
 NORDER_GREEN = DETECTOR["norder"]["GREEN"]

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -396,12 +396,30 @@ class TestComputeRVPublic:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.slow
 class TestPerform:
+    """perform() on the shared default run, plus the option and failure paths.
+
+    Not marked ``slow``: the class runs on synthetic CCFs in well under a
+    second, and it holds the only coverage of the combined-RV contract, the RV
+    header keywords and the L4 serialization -- which belong in the default
+    pre-commit loop.
+    """
+
     _ILLUMINATED = ["SCI1", "SCI2", "SCI3", "SKY"]  # CAL-OBJ='None' -> skipped
 
-    def test_fills_rv_columns_preserving_metadata(self, rv_module):
-        l4 = rv_module.perform()
+    @pytest.fixture(scope="module")
+    def performed(self, rv_l4):
+        """One default-argument perform(), shared read-only.
+
+        Seven tests inspect different facets of the same result and each was
+        recomputing it. Tests that pass explicit chips/fibers, or that mutate
+        the L4 first, keep taking the per-test ``rv_module``.
+        """
+        module = RadialVelocity(copy.deepcopy(rv_l4), config={"rv_window": RANGE_KMS})
+        return module, module.perform()
+
+    def test_fills_rv_columns_preserving_metadata(self, performed):
+        _, l4 = performed
         assert isinstance(l4, KPF4)
         for fiber in self._ILLUMINATED:
             table = l4.data[f"{fiber}_RV"]
@@ -421,30 +439,30 @@ class TestPerform:
                 "RV_ERR",
             }
 
-    def test_unilluminated_fiber_skipped(self, rv_module):
+    def test_unilluminated_fiber_skipped(self, performed):
         # CAL-OBJ='None' -> CrossCorrelation wrote no CAL CCF or RV table.
-        l4 = rv_module.perform()
+        _, l4 = performed
         assert l4.data["CAL_CCF"].size == 0
         assert len(l4.data["CAL_RV"]) == 0
 
-    def test_recovers_injected_rv_illuminated_orderlets(self, rv_module):
-        l4 = rv_module.perform()
+    def test_recovers_injected_rv_illuminated_orderlets(self, performed):
+        _, l4 = performed
         for fiber in self._ILLUMINATED:
             rv = np.asarray(l4.data[f"{fiber}_RV"]["RV"])
             np.testing.assert_allclose(rv, V_INJECT, atol=0.1)
 
-    def test_rv_headers(self, rv_module):
-        l4 = rv_module.perform()
+    def test_rv_headers(self, performed):
+        _, l4 = performed
         rv_hdr = l4.headers["SCI2_RV"]
         assert rv_hdr["RVMETHOD"] == "CCF"
         assert rv_hdr["SKYRMVD"] is False
         assert rv_hdr["TELLRMVD"] is False
         assert l4.headers["PRIMARY"]["RVMETHOD"] == "CCF"
 
-    def test_per_ccd_rv_keywords(self, rv_module):
+    def test_per_ccd_rv_keywords(self, performed):
         # Per-orderlet legacy RVs route to their RV# table header as CCD<n>RV<sfx>
         # (CCD1=GREEN, CCD2=RED; SCI2 has suffix '2' and lives on RV3).
-        l4 = rv_module.perform()
+        _, l4 = performed
         rv_hdr = l4.headers["RV3"]
         assert rv_hdr["CCD1RV2"] == pytest.approx(V_INJECT, abs=0.1)
         assert rv_hdr["CCD2RV2"] == pytest.approx(V_INJECT, abs=0.1)
@@ -452,9 +470,9 @@ class TestPerform:
         # The per-orderlet keywords do not leak onto PRIMARY.
         assert "CCD1RV2" not in l4.headers["PRIMARY"]
 
-    def test_combined_rv_populated(self, rv_module):
+    def test_combined_rv_populated(self, performed):
         # PRIMARY: EPRV RV/RVERR plus the KPF SCI-combined per-CCD CCD1RV/CCD2RV.
-        l4 = rv_module.perform()
+        _, l4 = performed
         prim = l4.headers["PRIMARY"]
         assert prim["CCD1RV"] == pytest.approx(V_INJECT, abs=0.1)
         assert prim["CCD2RV"] == pytest.approx(V_INJECT, abs=0.1)
@@ -465,13 +483,13 @@ class TestPerform:
         assert "CCD1RV" not in l4.headers["RV3"]
         assert "RV" not in l4.headers["RV3"]
 
-    def test_combined_rv_is_weighted_ccd_combine(self, rv_module):
+    def test_combined_rv_is_weighted_ccd_combine(self, performed):
         # PRIMARY RV = (CCD1RV*Wg + CCD2RV*Wr)/(Wg+Wr), Wg/Wr the summed order
         # weights; RVERR = inverse-variance combination of the per-CCD errors.
-        l4 = rv_module.perform()
+        module, l4 = performed
         prim = l4.headers["PRIMARY"]
-        wg = np.nansum(rv_module._get_order_weights("GREEN", "SCI1"))
-        wr = np.nansum(rv_module._get_order_weights("RED", "SCI1"))
+        wg = np.nansum(module._get_order_weights("GREEN", "SCI1"))
+        wr = np.nansum(module._get_order_weights("RED", "SCI1"))
         expect_rv = (prim["CCD1RV"] * wg + prim["CCD2RV"] * wr) / (wg + wr)
         expect_err = (1.0 / prim["CCD1ERV"] ** 2 + 1.0 / prim["CCD2ERV"] ** 2) ** -0.5
         assert prim["RV"] == pytest.approx(expect_rv, abs=1e-9)

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -1,11 +1,9 @@
 """Tests for the RadialVelocity module (KPF4 -> KPF4: fit per-order CCFs to RVs).
 
-RadialVelocity consumes the CCF-bearing L4 that CrossCorrelation produces and
-fills the RV/RV_ERR columns and RV headers. Static-method unit tests
-(_compute_rv_1d, _ccf_noise_corr_length, _pixel_velocity_scale) build synthetic
-CCFs with no fixtures. Integration tests build a synthetic KPF2, run
-CrossCorrelation (mask monkeypatched, narrow grid) to get an L4, then exercise
-RadialVelocity on it.
+Static-method unit tests (_compute_rv_1d, _ccf_noise_corr_length,
+_pixel_velocity_scale) build synthetic CCFs with no fixtures. Integration tests
+build a synthetic KPF2, run CrossCorrelation (mask monkeypatched, narrow grid) to
+get a CCF-bearing L4, then exercise RadialVelocity on it.
 """
 
 import copy
@@ -25,7 +23,7 @@ from ._dtype_policy import RV_FLOAT, assert_dtype
 
 NORDER = NORDER_GREEN + NORDER_RED
 SPEED_OF_LIGHT_KMS = np.float64(c.to("km/s").value)
-_FIBERS = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]  # all orderlets
+_FIBERS = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]
 
 # Narrow CCF grid for fast integration tests; wide enough for the second-pass
 # +/-3 sigma window (sigma ~ 4 km/s) to stay on-grid: +/-15 km/s at 0.25 km/s.
@@ -33,9 +31,9 @@ _RANGE_KMS = [-15.0, 15.0]
 _STEP_KMS = 0.25  # matches the module default
 _NVEL = round((_RANGE_KMS[1] - _RANGE_KMS[0]) / _STEP_KMS) + 1
 _V_INJECT = 1.5  # injected RV [km/s], on the grid
-_MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Å]
+_MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Angstrom]
 # Wide enough that the default CCF clip (clip_edge_pixels=(500, 500)) trims the
-# order edges but leaves the 5015-5035 Å mask lines well inside.
+# order edges but leaves the mask lines well inside.
 NCOL = 2000
 
 
@@ -82,9 +80,8 @@ def _make_l4(
     bjd=0.0,
     perform_fibers=None,
 ):
-    """Build a synthetic KPF2 (absorption injected at _MASK_CENTERS, shifted by
-    _V_INJECT) and run CrossCorrelation (mask stubbed, narrow grid) to a KPF4.
-    """
+    """Synthetic KPF2 (absorption at _MASK_CENTERS, shifted by _V_INJECT) run
+    through CrossCorrelation (mask stubbed, narrow grid) into a KPF4."""
     kpf2 = KPF2()
     kpf2.headers["PRIMARY"]["CCLR3"] = 0.823  # G2V -> 5770 K
     kpf2.headers["PRIMARY"]["CCLRN3"] = "Gaia BP-RP"
@@ -94,7 +91,7 @@ def _make_l4(
     kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = cal_obj
 
     wave_1d = np.linspace(5000.0, 5050.0, NCOL)
-    lam_obs = _MASK_CENTERS * (1.0 + _V_INJECT / SPEED_OF_LIGHT_KMS)  # z = 0
+    lam_obs = _MASK_CENTERS * (1.0 + _V_INJECT / SPEED_OF_LIGHT_KMS)
     flux_1d = _absorption_spectrum(wave_1d, lam_obs)
     for chip, n in [("GREEN", NORDER_GREEN), ("RED", NORDER_RED)]:
         for fiber in _FIBERS:
@@ -186,7 +183,7 @@ class TestComputeRV:
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_nonfinite_ccf_returns_nan(self):
-        # Non-finite CCF values fail loudly (NaN) rather than being masked out.
+        # Non-finite CCF values are not quietly masked out; the fit returns NaN.
         vel, ccf, ccf_var, vps = self._ccf(v0=1.0)
         ccf[10] = np.nan
         rv, rv_err = RadialVelocity._compute_rv_1d(
@@ -216,7 +213,7 @@ class TestComputeRV:
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_first_pass_fit_failure_returns_nan(self, monkeypatch):
-        # optimize_lsq raising on the first pass fails loudly as NaN, not a crash.
+        # optimize_lsq raising on the first pass degrades to NaN, not a crash.
         vel, ccf, ccf_var, vps = self._ccf(v0=0.0)
 
         def boom(*args, **kwargs):
@@ -229,7 +226,6 @@ class TestComputeRV:
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_nonfinite_fit_params_return_nan(self, monkeypatch):
-        # A fit returning a non-finite mean/sigma is rejected as NaN.
         vel, ccf, ccf_var, vps = self._ccf(v0=0.0)
 
         def bad_fit(*args, **kwargs):
@@ -242,7 +238,6 @@ class TestComputeRV:
         assert np.isnan(rv) and np.isnan(rv_err)
 
     def test_second_pass_fit_failure_keeps_first_pass_rv(self, monkeypatch):
-        # If the refinement (second) fit raises, the first-pass mean is retained.
         vel, ccf, ccf_var, vps = self._ccf(v0=0.0)
         calls = []
 
@@ -259,10 +254,9 @@ class TestComputeRV:
         assert np.isfinite(rv) and rv == pytest.approx(0.0, abs=1e-9)
 
     def test_error_scales_with_correlation_length(self):
-        # The photon error is 1/sqrt(N_scale) with N_scale = dv / corr_length,
-        # so rv_err must scale as sqrt(corr_length): widening the mask hole (via
-        # mask_width) lengthens the noise correlation and inflates the error by
-        # exactly sqrt(L2/L1). Guards the corr-length term feeding the error.
+        # The photon error is 1/sqrt(N_scale) with N_scale = dv / corr_length, so
+        # widening the mask hole lengthens the noise correlation and inflates
+        # rv_err by exactly sqrt(L2/L1).
         vel, ccf, ccf_var, vps = self._ccf(v0=0.0)
         _, err_a = RadialVelocity._compute_rv_1d(
             vel, ccf, ccf_var, vps, 0.5, [-50.0, 50.0], 11
@@ -300,8 +294,8 @@ class TestCCFNoiseCorrLength:
 
     def test_symmetric_in_the_two_widths(self):
         # L depends only on the {pixel, mask-hole} pair, not which is larger.
-        a = RadialVelocity._ccf_noise_corr_length(1.0, 0.8)  # widths {1.0, 0.8}
-        b = RadialVelocity._ccf_noise_corr_length(0.8, 1.0)  # widths {0.8, 1.0}
+        a = RadialVelocity._ccf_noise_corr_length(1.0, 0.8)
+        b = RadialVelocity._ccf_noise_corr_length(0.8, 1.0)
         assert a == pytest.approx(b)
 
 
@@ -314,10 +308,9 @@ class TestCCFNoiseCorrLength:
 def rv_l4():
     """A CCF-bearing L4 from CrossCorrelation (SCI on a star, SKY on sky, CAL dark).
 
-    Module-scoped: the CrossCorrelation.perform() build is ~1s, so it runs once and
-    is shared read-only. The stub is only needed during that build, so a self-managed
-    MonkeyPatch context replaces the function-scoped ``monkeypatch`` fixture. Tests
-    that need a mutable object wrap this via the function-scoped ``rv_module``.
+    Module-scoped: the ~1s CrossCorrelation.perform() build runs once and is shared
+    read-only. The mask stub is needed only during that build, hence a self-managed
+    MonkeyPatch context instead of the function-scoped ``monkeypatch`` fixture.
     """
     with pytest.MonkeyPatch.context() as mp:
         return _make_l4(mp)
@@ -327,9 +320,9 @@ def rv_l4():
 def rv_module(rv_l4):
     """RadialVelocity on a per-test copy of the CCF-bearing L4; caches not yet loaded.
 
-    ``perform()`` mutates the L4 in place, so each test wraps a deepcopy of the
-    shared module-scoped ``rv_l4`` (a memcpy — the ~1s cost was the CCF compute,
-    not the data). This keeps per-test isolation while building the CCFs only once.
+    ``perform()`` mutates the L4 in place, so each test deepcopies the shared
+    ``rv_l4``. The copy is a memcpy -- the ~1s cost was the CCF compute, not the
+    data -- so isolation is cheap while the CCFs are still built only once.
     """
     return RadialVelocity(copy.deepcopy(rv_l4), config={"rv_window": _RANGE_KMS})
 
@@ -357,8 +350,7 @@ class TestComputeRVPublic:
         np.testing.assert_allclose(rv, _V_INJECT, atol=0.1)
 
     def test_per_ccd_rv_recovers_injected(self, rv_loaded):
-        # The weighted-combined per-CCD RV recovers the injected velocity, with a
-        # finite positive error from the unweighted-summed CCF.
+        # The per-CCD error comes from the unweighted-summed CCF.
         ccd_rv, ccd_rv_err = rv_loaded.compute_weighted_rvs(
             ["GREEN"], "SCI2", combine_fibers=False, combine_ccds=False
         )["GREEN"]
@@ -367,7 +359,7 @@ class TestComputeRVPublic:
 
     def test_per_ccd_rv_sums_science_fibers(self, rv_loaded):
         # combine_fibers=True sums the three science fibers' cached CCFs before
-        # fitting (the SCI-combined per-CCD RV); still recovers the injected velocity.
+        # fitting, giving the SCI-combined per-CCD RV.
         ccd_rv, ccd_rv_err = rv_loaded.compute_weighted_rvs(
             ["GREEN"], ["SCI1", "SCI2", "SCI3"], combine_fibers=True, combine_ccds=False
         )["GREEN"]
@@ -375,8 +367,7 @@ class TestComputeRVPublic:
         assert np.isfinite(ccd_rv_err) and ccd_rv_err > 0
 
     def test_combine_ccds_returns_tuple_and_recovers_injected(self, rv_loaded):
-        # combine_ccds=True returns a single (rv, rv_err) tuple from the RV-level
-        # cross-chip combine.
+        # combine_ccds=True combines at the RV level, not the CCF level.
         out = rv_loaded.compute_weighted_rvs(
             ["GREEN", "RED"], "SCI2", combine_fibers=False, combine_ccds=True
         )
@@ -415,8 +406,8 @@ class TestComputeRVPublic:
         assert np.all(np.isfinite(rv_err)) and np.all(rv_err > 0)
 
     def test_nonphysical_order_degrades_to_nan(self, rv_loaded):
-        # A single order whose CCF window is non-physical (here, negative variance)
-        # degrades to NaN instead of aborting the frame; other orders are unaffected.
+        # One bad order (negative variance) degrades to NaN instead of aborting
+        # the whole frame.
         bad = 5
         rv_loaded._ccf_var["GREEN_SCI2"][bad] = -1.0
         res = rv_loaded.compute_order_by_order_rvs("GREEN", "SCI2")
@@ -451,7 +442,7 @@ class TestPerform:
             table = l4.data[f"{fiber}_RV"]
             assert len(table) == NORDER
             assert np.any(np.isfinite(np.asarray(table["RV"], dtype=float)))
-            # The CrossCorrelation-seeded metadata columns survive the fill.
+            # The CrossCorrelation-seeded metadata columns survive the RV fill.
             assert set(table.columns) >= {
                 "ORDER_INDEX",
                 "ORDER_ID",
@@ -486,8 +477,8 @@ class TestPerform:
         assert l4.headers["PRIMARY"]["RVMETHOD"] == "CCF"
 
     def test_per_ccd_rv_keywords(self, rv_module):
-        # Per-orderlet legacy RVs are registered KPF keywords routed to their RV#
-        # table header (CCD<n>RV<sfx>; CCD1=GREEN, CCD2=RED; SCI2 suffix '2' -> RV3).
+        # Per-orderlet legacy RVs route to their RV# table header as CCD<n>RV<sfx>
+        # (CCD1=GREEN, CCD2=RED; SCI2 has suffix '2' and lives on RV3).
         l4 = rv_module.perform()
         rv_hdr = l4.headers["RV3"]
         assert rv_hdr["CCD1RV2"] == pytest.approx(_V_INJECT, abs=0.1)
@@ -506,7 +497,6 @@ class TestPerform:
         assert prim["RV"] == pytest.approx(_V_INJECT, abs=0.1)
         assert prim["RVERR"] > 0
         assert prim["RVMETHOD"] == "CCF"
-        # The combined-RV keywords are not duplicated onto the RV3 table.
         assert "CCD1RV" not in l4.headers["RV3"]
         assert "RV" not in l4.headers["RV3"]
 
@@ -524,9 +514,9 @@ class TestPerform:
 
     def test_primary_berv_bjdtdb_from_per_order(self, rv_module):
         # PRIMARY BERV/BJDTDB are the WEIGHT-weighted mean of the rep SCI fiber's
-        # per-order BERV/BJD_TDB (RVn). Constant per-order values -> that value.
-        # berv/bjd only seed the RV-table metadata columns (never the CCF compute),
-        # so overwrite them on the shared L4 rather than rebuild it via _make_l4.
+        # per-order columns, so constant per-order values reproduce that value.
+        # These columns never feed the CCF compute, so overwriting them on the
+        # shared L4 is cheaper than rebuilding it via _make_l4.
         l4 = rv_module.l4_obj
         table = l4.data["SCI1_RV"]
         table["BERV"] = -12.3
@@ -537,8 +527,8 @@ class TestPerform:
         assert prim["BJDTDB"] == pytest.approx(2460123.5)
 
     def test_primary_berv_undefined_when_berv_nan(self, rv_module):
-        # A rep-fiber BERV column that is all-NaN -> BERV UNDEFINED, while BJDTDB
-        # (from the still-finite BJD_TDB column) stays defined.
+        # An all-NaN BERV column leaves BERV UNDEFINED while BJDTDB, from the
+        # still-finite BJD_TDB column, stays defined.
         l4 = rv_module.l4_obj
         table = l4.data["SCI1_RV"]
         table["BERV"] = np.nan
@@ -548,15 +538,14 @@ class TestPerform:
         assert prim["BJDTDB"] is not None
 
     def test_no_science_illuminated_raises(self, monkeypatch):
-        # SCI requested (default fibers) but the L4 carries no SCI CCFs -> fail loudly.
+        # SCI requested by default, but the L4 carries no SCI CCFs -> fail loudly.
         l4 = _make_l4(monkeypatch, sci_obj="None")
         rv = RadialVelocity(l4, config={"rv_window": _RANGE_KMS})
         with pytest.raises(ValueError, match="none illuminated"):
             rv.perform()
 
     def test_cal_only_run_skips_combine(self, monkeypatch, caplog):
-        # A calibration-only run (no SCI requested) does not raise; PRIMARY RV is
-        # left UNDEFINED and a note is logged.
+        # A calibration-only run must not raise: PRIMARY RV is left UNDEFINED.
         l4 = _make_l4(monkeypatch, sci_obj="None", sky_obj="None", cal_obj="Th_gold")
         with caplog.at_level(logging.INFO, logger="kpfpipe"):
             prim = (
@@ -568,8 +557,7 @@ class TestPerform:
         assert "no science orderlet requested" in caplog.text
 
     def test_single_chip_combine_warns(self, rv_module, caplog):
-        # One chip present: the combined RV uses it alone (== CCD1RV) and a
-        # note is logged.
+        # With one chip present the combined RV is that chip's RV alone.
         with caplog.at_level(logging.INFO, logger="kpfpipe"):
             l4 = rv_module.perform(chips=["GREEN"])
         prim = l4.headers["PRIMARY"]
@@ -577,28 +565,26 @@ class TestPerform:
         assert "only chip GREEN present" in caplog.text
 
     def test_l4_serializes_to_fits(self, rv_module, tmp_path):
-        # The filled RV columns and RV headers survive to_fits. SCI2 -> RV3.
+        # SCI2's per-orderlet RVs land on the RV3 table.
         l4 = rv_module.perform(fibers=["SCI1", "SCI2", "SCI3"])
         path = tmp_path / "kpf_SL4_20240405T000000.fits"
         l4.to_fits(str(path))
         with fits.open(path) as hdul:
             rv = hdul["RV3"].header
             assert rv["RVMETHOD"] == "CCF"
-            # Per-orderlet legacy RV lives on its RV# table header, not PRIMARY.
             assert rv["CCD1RV2"] == pytest.approx(_V_INJECT, abs=0.1)
             assert "CCD1RV2" not in hdul["PRIMARY"].header
-            # The EPRV combined RV survives on PRIMARY.
+            # Only the EPRV combined RV belongs on PRIMARY.
             assert hdul["PRIMARY"].header["RV"] == pytest.approx(_V_INJECT, abs=0.1)
             assert hdul["PRIMARY"].header["RVERR"] > 0
-            # The seeded ORDER_ID / ECHELLE_ORDER columns round-trip alongside RV.
             rv_table = hdul["RV3"].data
             assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_0"
             assert rv_table["ECHELLE_ORDER"][0] == 137
             assert np.all(np.isfinite(rv_table["RV"]))
 
     def test_failed_combined_fit_written_as_undefined(self, rv_module, monkeypatch):
-        # A non-finite fit (failed fit) is written as a FITS UNDEFINED card
-        # (present, value None), never a bare NaN.
+        # A failed fit is written as a FITS UNDEFINED card (present, value None),
+        # never a bare NaN.
         monkeypatch.setattr(
             rv_module, "_compute_rv_1d", lambda *args, **kwargs: (np.nan, np.nan)
         )

--- a/tests/regression/test_radial_velocity.py
+++ b/tests/regression/test_radial_velocity.py
@@ -11,7 +11,6 @@ import logging
 
 import numpy as np
 import pytest
-from astropy.constants import c
 from astropy.io import fits
 
 from kpfpipe.data_models.level2 import KPF2, NORDER_GREEN, NORDER_RED
@@ -19,56 +18,27 @@ from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.modules.cross_correlation import CrossCorrelation
 from kpfpipe.modules.radial_velocity import RadialVelocity
 
+from ._catalog import seed_sci2_cards
 from ._dtype_policy import RV_FLOAT, assert_dtype
+from ._science import (
+    MASK_CENTERS,
+    NCOL,
+    RANGE_KMS,
+    SPEED_OF_LIGHT_KMS,
+    V_INJECT,
+    absorption_spectrum,
+    make_mask,
+)
 
 NORDER = NORDER_GREEN + NORDER_RED
-SPEED_OF_LIGHT_KMS = np.float64(c.to("km/s").value)
+# Fiber order is the module's own config-overridable default, not the canonical
+# slicer order -- spelled out so a reordering in production shows up here.
 _FIBERS = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]
-
-# Narrow CCF grid for fast integration tests; wide enough for the second-pass
-# +/-3 sigma window (sigma ~ 4 km/s) to stay on-grid: +/-15 km/s at 0.25 km/s.
-_RANGE_KMS = [-15.0, 15.0]
-_STEP_KMS = 0.25  # matches the module default
-_NVEL = round((_RANGE_KMS[1] - _RANGE_KMS[0]) / _STEP_KMS) + 1
-_V_INJECT = 1.5  # injected RV [km/s], on the grid
-_MASK_CENTERS = np.linspace(5015.0, 5035.0, 30)  # vacuum line centers [Angstrom]
-# Wide enough that the default CCF clip (clip_edge_pixels=(500, 500)) trims the
-# order edges but leaves the mask lines well inside.
-NCOL = 2000
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _make_mask(centers, weights=None, width=1.0):
-    """Build a line-mask dict matching CrossCorrelation._build_line_mask."""
-    centers = np.asarray(centers, dtype=np.float64)
-    if weights is None:
-        weights = np.ones_like(centers)
-    half_width = centers * (width / 2.0 / SPEED_OF_LIGHT_KMS)
-    return {
-        "center": centers,
-        "weight": np.asarray(weights, dtype=np.float64),
-        "start": centers - half_width,
-        "end": centers + half_width,
-    }
-
-
-def _absorption_spectrum(wave, centers, weights=None, depth=0.6, sigma_kms=4.0):
-    """Unit continuum with Gaussian absorption lines at `centers`."""
-    if weights is None:
-        weights = np.ones_like(centers)
-    flux = np.ones_like(wave)
-    for center, weight in zip(centers, weights, strict=False):
-        sigma_a = center * sigma_kms / SPEED_OF_LIGHT_KMS
-        flux -= (
-            depth
-            * (weight / np.max(weights))
-            * np.exp(-0.5 * ((wave - center) / sigma_a) ** 2)
-        )
-    return flux
 
 
 def _make_l4(
@@ -80,19 +50,14 @@ def _make_l4(
     bjd=0.0,
     perform_fibers=None,
 ):
-    """Synthetic KPF2 (absorption at _MASK_CENTERS, shifted by _V_INJECT) run
+    """Synthetic KPF2 (absorption at MASK_CENTERS, shifted by V_INJECT) run
     through CrossCorrelation (mask stubbed, narrow grid) into a KPF4."""
     kpf2 = KPF2()
-    kpf2.headers["PRIMARY"]["CCLR3"] = 0.823  # G2V -> 5770 K
-    kpf2.headers["PRIMARY"]["CCLRN3"] = "Gaia BP-RP"
-    kpf2.headers["PRIMARY"]["CRV3"] = 0.0
-    kpf2.headers["INSTRUMENT_HEADER"]["SCI-OBJ"] = sci_obj
-    kpf2.headers["INSTRUMENT_HEADER"]["SKY-OBJ"] = sky_obj
-    kpf2.headers["INSTRUMENT_HEADER"]["CAL-OBJ"] = cal_obj
+    seed_sci2_cards(kpf2, sci_obj=sci_obj, sky_obj=sky_obj, cal_obj=cal_obj)
 
     wave_1d = np.linspace(5000.0, 5050.0, NCOL)
-    lam_obs = _MASK_CENTERS * (1.0 + _V_INJECT / SPEED_OF_LIGHT_KMS)
-    flux_1d = _absorption_spectrum(wave_1d, lam_obs)
+    lam_obs = MASK_CENTERS * (1.0 + V_INJECT / SPEED_OF_LIGHT_KMS)
+    flux_1d = absorption_spectrum(wave_1d, lam_obs)
     for chip, n in [("GREEN", NORDER_GREEN), ("RED", NORDER_RED)]:
         for fiber in _FIBERS:
             kpf2.set_data(
@@ -108,13 +73,13 @@ def _make_l4(
     kpf2.set_data("BARYCORR_KMS", np.full(NORDER, berv))
     kpf2.set_data("BJD_TDB", np.full(NORDER, bjd))
 
-    mask = _make_mask(_MASK_CENTERS)
+    mask = make_mask(MASK_CENTERS)
     monkeypatch.setattr(
         CrossCorrelation,
         "_build_line_mask",
         lambda self, chip, fiber, mask_width=None: mask,
     )
-    return CrossCorrelation(kpf2, config={"ccf_window": _RANGE_KMS}).perform(
+    return CrossCorrelation(kpf2, config={"ccf_window": RANGE_KMS}).perform(
         fibers=perform_fibers
     )
 
@@ -324,7 +289,7 @@ def rv_module(rv_l4):
     ``rv_l4``. The copy is a memcpy -- the ~1s cost was the CCF compute, not the
     data -- so isolation is cheap while the CCFs are still built only once.
     """
-    return RadialVelocity(copy.deepcopy(rv_l4), config={"rv_window": _RANGE_KMS})
+    return RadialVelocity(copy.deepcopy(rv_l4), config={"rv_window": RANGE_KMS})
 
 
 @pytest.fixture
@@ -347,14 +312,14 @@ class TestComputeRVPublic:
 
     def test_recovers_injected_rv(self, rv_loaded):
         rv = rv_loaded.compute_order_by_order_rvs("GREEN", "SCI2")["rv"]
-        np.testing.assert_allclose(rv, _V_INJECT, atol=0.1)
+        np.testing.assert_allclose(rv, V_INJECT, atol=0.1)
 
     def test_per_ccd_rv_recovers_injected(self, rv_loaded):
         # The per-CCD error comes from the unweighted-summed CCF.
         ccd_rv, ccd_rv_err = rv_loaded.compute_weighted_rvs(
             ["GREEN"], "SCI2", combine_fibers=False, combine_ccds=False
         )["GREEN"]
-        assert ccd_rv == pytest.approx(_V_INJECT, abs=0.1)
+        assert ccd_rv == pytest.approx(V_INJECT, abs=0.1)
         assert np.isfinite(ccd_rv_err) and ccd_rv_err > 0
 
     def test_per_ccd_rv_sums_science_fibers(self, rv_loaded):
@@ -363,7 +328,7 @@ class TestComputeRVPublic:
         ccd_rv, ccd_rv_err = rv_loaded.compute_weighted_rvs(
             ["GREEN"], ["SCI1", "SCI2", "SCI3"], combine_fibers=True, combine_ccds=False
         )["GREEN"]
-        assert ccd_rv == pytest.approx(_V_INJECT, abs=0.1)
+        assert ccd_rv == pytest.approx(V_INJECT, abs=0.1)
         assert np.isfinite(ccd_rv_err) and ccd_rv_err > 0
 
     def test_combine_ccds_returns_tuple_and_recovers_injected(self, rv_loaded):
@@ -372,7 +337,7 @@ class TestComputeRVPublic:
             ["GREEN", "RED"], "SCI2", combine_fibers=False, combine_ccds=True
         )
         assert isinstance(out, tuple) and len(out) == 2
-        assert out[0] == pytest.approx(_V_INJECT, abs=0.1)
+        assert out[0] == pytest.approx(V_INJECT, abs=0.1)
         assert np.isfinite(out[1]) and out[1] > 0
 
     def test_combine_fibers_requires_three_sci(self, rv_loaded):
@@ -466,7 +431,7 @@ class TestPerform:
         l4 = rv_module.perform()
         for fiber in self._ILLUMINATED:
             rv = np.asarray(l4.data[f"{fiber}_RV"]["RV"])
-            np.testing.assert_allclose(rv, _V_INJECT, atol=0.1)
+            np.testing.assert_allclose(rv, V_INJECT, atol=0.1)
 
     def test_rv_headers(self, rv_module):
         l4 = rv_module.perform()
@@ -481,8 +446,8 @@ class TestPerform:
         # (CCD1=GREEN, CCD2=RED; SCI2 has suffix '2' and lives on RV3).
         l4 = rv_module.perform()
         rv_hdr = l4.headers["RV3"]
-        assert rv_hdr["CCD1RV2"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert rv_hdr["CCD2RV2"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert rv_hdr["CCD1RV2"] == pytest.approx(V_INJECT, abs=0.1)
+        assert rv_hdr["CCD2RV2"] == pytest.approx(V_INJECT, abs=0.1)
         assert rv_hdr["CCD1ERV2"] > 0 and rv_hdr["CCD2ERV2"] > 0
         # The per-orderlet keywords do not leak onto PRIMARY.
         assert "CCD1RV2" not in l4.headers["PRIMARY"]
@@ -491,10 +456,10 @@ class TestPerform:
         # PRIMARY: EPRV RV/RVERR plus the KPF SCI-combined per-CCD CCD1RV/CCD2RV.
         l4 = rv_module.perform()
         prim = l4.headers["PRIMARY"]
-        assert prim["CCD1RV"] == pytest.approx(_V_INJECT, abs=0.1)
-        assert prim["CCD2RV"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert prim["CCD1RV"] == pytest.approx(V_INJECT, abs=0.1)
+        assert prim["CCD2RV"] == pytest.approx(V_INJECT, abs=0.1)
         assert prim["CCD1ERV"] > 0 and prim["CCD2ERV"] > 0
-        assert prim["RV"] == pytest.approx(_V_INJECT, abs=0.1)
+        assert prim["RV"] == pytest.approx(V_INJECT, abs=0.1)
         assert prim["RVERR"] > 0
         assert prim["RVMETHOD"] == "CCF"
         assert "CCD1RV" not in l4.headers["RV3"]
@@ -540,7 +505,7 @@ class TestPerform:
     def test_no_science_illuminated_raises(self, monkeypatch):
         # SCI requested by default, but the L4 carries no SCI CCFs -> fail loudly.
         l4 = _make_l4(monkeypatch, sci_obj="None")
-        rv = RadialVelocity(l4, config={"rv_window": _RANGE_KMS})
+        rv = RadialVelocity(l4, config={"rv_window": RANGE_KMS})
         with pytest.raises(ValueError, match="none illuminated"):
             rv.perform()
 
@@ -549,7 +514,7 @@ class TestPerform:
         l4 = _make_l4(monkeypatch, sci_obj="None", sky_obj="None", cal_obj="Th_gold")
         with caplog.at_level(logging.INFO, logger="kpfpipe"):
             prim = (
-                RadialVelocity(l4, config={"rv_window": _RANGE_KMS})
+                RadialVelocity(l4, config={"rv_window": RANGE_KMS})
                 .perform(fibers=["CAL"])
                 .headers["PRIMARY"]
             )
@@ -572,10 +537,10 @@ class TestPerform:
         with fits.open(path) as hdul:
             rv = hdul["RV3"].header
             assert rv["RVMETHOD"] == "CCF"
-            assert rv["CCD1RV2"] == pytest.approx(_V_INJECT, abs=0.1)
+            assert rv["CCD1RV2"] == pytest.approx(V_INJECT, abs=0.1)
             assert "CCD1RV2" not in hdul["PRIMARY"].header
             # Only the EPRV combined RV belongs on PRIMARY.
-            assert hdul["PRIMARY"].header["RV"] == pytest.approx(_V_INJECT, abs=0.1)
+            assert hdul["PRIMARY"].header["RV"] == pytest.approx(V_INJECT, abs=0.1)
             assert hdul["PRIMARY"].header["RVERR"] > 0
             rv_table = hdul["RV3"].data
             assert rv_table["ORDER_ID"][0] == "GREEN_SCI2_0"

--- a/tests/regression/test_reduce_script.py
+++ b/tests/regression/test_reduce_script.py
@@ -1,13 +1,9 @@
 """Tests for scripts/processing/reduce.py: the ``kpfpipe run`` leaf.
 
-reduce.py is the single-recipe, single-unit runner relocated out of the old
-tools/cli.py. These cover the shortcut/`-r`/`-c` resolution and the recipe-kind
-guards, and that ``--masters``/``--science`` set a default config an explicit
-``-c`` overrides. Each test drives ``main(argv)`` against a tiny stub recipe
+Covers the shortcut/`-r`/`-c` resolution, the recipe-kind guards, and
+clear_stale_outputs. Each test drives ``main(argv)`` against a tiny stub recipe
 (which records the resolved config) with logging stubbed out, so no real
-reduction runs.
-
-(``resolve_logging`` itself is unit-tested in test_logger.py.)
+reduction runs. (``resolve_logging`` itself is unit-tested in test_logger.py.)
 """
 
 import argparse
@@ -33,7 +29,7 @@ def _stub_recipe(tmp_path, sentinel):
 
 
 def _run(monkeypatch, argv):
-    # Keep the real logging stack untouched; we only assert config resolution.
+    # Only config resolution is asserted; keep the real logging stack untouched.
     monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
     red.main(argv)
 
@@ -88,7 +84,6 @@ class TestDirShortcuts:
         assert data_input == "/aliased/in"
 
     def test_output_dir_sets_every_output_dir(self, monkeypatch, tmp_path):
-        # --output_dir fills masters/science output + log dir; input keeps the config.
         cfg = _base_cfg(tmp_path)
         sentinel = tmp_path / "seen.txt"
         recipe = _dirs_stub_recipe(tmp_path, sentinel)
@@ -108,14 +103,12 @@ class TestDirShortcuts:
         )
         data_input, masters, science, log_dir = sentinel.read_text().split("|")
         assert data_input == "/cfg/in"  # untouched by --output_dir
-        # masters/science outputs take the root; the log dir gets its subdir.
         assert masters == "/out" and science == "/out" and log_dir == "/out/logs"
 
 
 class TestShortcutOverride:
     def test_c_and_r_override_are_accepted(self, monkeypatch, tmp_path):
-        # A temp config with a distinctive data dir; --science supplies the kind,
-        # -r/-c override its defaults. This combination is allowed (not an error).
+        # --science supplies the kind; -r/-c override its defaults rather than erroring.
         cfg = tmp_path / "custom.toml"
         cfg.write_text(
             "[DATA_DIRS]\n"
@@ -169,8 +162,6 @@ class TestClearStaleOutputs:
 
     def test_science_removes_l1_l2_l4_for_obs_id(self, tmp_path):
         science_root = str(tmp_path / "sci")
-        # Create the three deterministic per-obs_id products (plus a stray file
-        # in the same tree that must survive).
         targets = []
         for level in ("L1", "L2", "L4"):
             p = red.kpf_filepath(self._OID, level, data_root=science_root)
@@ -188,19 +179,18 @@ class TestClearStaleOutputs:
         assert os.path.exists(stray)  # a different obs_id's product is untouched
 
     def test_science_raises_when_output_root_unset(self, tmp_path):
-        # No KPF_SCIENCE_OUTPUT -> can't know what to clear; fail loud, matching
-        # the recipe's required data_dirs["KPF_SCIENCE_OUTPUT"] read.
+        # No KPF_SCIENCE_OUTPUT -> can't know what to clear; fail loud.
         with pytest.raises(KeyError, match="KPF_SCIENCE_OUTPUT"):
             red.clear_stale_outputs(_Config({}), _args(obs_id=self._OID))
 
     def test_masters_raises_when_output_root_unset(self, tmp_path):
-        # Same for the masters branch: absent KPF_MASTERS_OUTPUT fails loud.
+        # Same for the masters branch.
         with pytest.raises(KeyError, match="KPF_MASTERS_OUTPUT"):
             red.clear_stale_outputs(_Config({}), _args(datecode="20240405"))
 
     def test_science_noop_for_invalid_obs_id(self, tmp_path):
-        # A malformed obs_id can't build a path; skip rather than raise (the recipe
-        # reports the real error). This mirrors the -o KP.x guard-test case.
+        # A malformed obs_id can't build a path; skip rather than raise -- the
+        # recipe reports the real error.
         red.clear_stale_outputs(
             _Config({"KPF_SCIENCE_OUTPUT": str(tmp_path)}), _args(obs_id="KP.x")
         )
@@ -222,8 +212,8 @@ class TestClearStaleOutputs:
         for name in removed + kept:
             open(os.path.join(night, name), "w").close()
 
-        # The WLS thar_L2/ subdir: per-frame ThAr L2s + the diagnostics HDF5, all
-        # removed wholesale with the thar master.
+        # The thar_L2/ subdir (per-frame ThAr L2s + diagnostics HDF5) goes
+        # wholesale with the thar master.
         stack_subdir = os.path.join(night, "thar_L2")
         os.makedirs(stack_subdir)
         stack_files = [
@@ -240,7 +230,7 @@ class TestClearStaleOutputs:
 
         for name in removed:
             assert not os.path.exists(os.path.join(night, name)), name
-        assert not os.path.exists(stack_subdir)  # entire subdir gone
+        assert not os.path.exists(stack_subdir)
         for name in kept:
             assert os.path.exists(os.path.join(night, name)), name
 

--- a/tests/regression/test_reduce_script.py
+++ b/tests/regression/test_reduce_script.py
@@ -128,15 +128,15 @@ class TestShortcutOverride:
 
 
 class TestGuards:
-    def test_masters_rejects_obs_id(self, monkeypatch):
+    def test_masters_rejects_obs_id(self):
         with pytest.raises(SystemExit):
             red.main(["--masters", "-o", "KP.x"])
 
-    def test_science_rejects_datecode(self, monkeypatch):
+    def test_science_rejects_datecode(self):
         with pytest.raises(SystemExit):
             red.main(["--science", "-d", "20240405"])
 
-    def test_missing_recipe_and_config_errors(self, monkeypatch):
+    def test_missing_recipe_and_config_errors(self):
         # No --masters/--science and no explicit -r/-c pair.
         with pytest.raises(SystemExit):
             red.main(["-o", "KP.x"])
@@ -178,12 +178,12 @@ class TestClearStaleOutputs:
         assert not any(os.path.exists(p) for p in targets)
         assert os.path.exists(stray)  # a different obs_id's product is untouched
 
-    def test_science_raises_when_output_root_unset(self, tmp_path):
+    def test_science_raises_when_output_root_unset(self):
         # No KPF_SCIENCE_OUTPUT -> can't know what to clear; fail loud.
         with pytest.raises(KeyError, match="KPF_SCIENCE_OUTPUT"):
             red.clear_stale_outputs(_Config({}), _args(obs_id=self._OID))
 
-    def test_masters_raises_when_output_root_unset(self, tmp_path):
+    def test_masters_raises_when_output_root_unset(self):
         # Same for the masters branch.
         with pytest.raises(KeyError, match="KPF_MASTERS_OUTPUT"):
             red.clear_stale_outputs(_Config({}), _args(datecode="20240405"))

--- a/tests/regression/test_reduce_script.py
+++ b/tests/regression/test_reduce_script.py
@@ -7,6 +7,7 @@ reduction runs. (``resolve_logging`` itself is unit-tested in test_logger.py.)
 """
 
 import argparse
+import logging
 import os
 
 import pytest
@@ -128,18 +129,95 @@ class TestShortcutOverride:
 
 
 class TestGuards:
-    def test_masters_rejects_obs_id(self):
-        with pytest.raises(SystemExit):
+    # main() raises SystemExit with two different meanings -- argparse's 2 for a
+    # usage error, and a string payload (exit 1) for a bad recipe -- so a bare
+    # `raises(SystemExit)` cannot tell a rejected flag from a crash. Every case
+    # here pins the code and the specific message.
+
+    def test_masters_rejects_obs_id(self, capsys):
+        with pytest.raises(SystemExit) as exc:
             red.main(["--masters", "-o", "KP.x"])
+        assert exc.value.code == 2
+        assert "masters recipe takes -d/--datecode" in capsys.readouterr().err
 
-    def test_science_rejects_datecode(self):
-        with pytest.raises(SystemExit):
+    def test_science_rejects_datecode(self, capsys):
+        with pytest.raises(SystemExit) as exc:
             red.main(["--science", "-d", "20240405"])
+        assert exc.value.code == 2
+        assert "science recipe takes -o/--obs_id" in capsys.readouterr().err
 
-    def test_missing_recipe_and_config_errors(self):
+    def test_missing_recipe_and_config_errors(self, capsys):
         # No --masters/--science and no explicit -r/-c pair.
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc:
             red.main(["-o", "KP.x"])
+        assert exc.value.code == 2
+        assert "must specify --masters, --science" in capsys.readouterr().err
+
+    def test_masters_and_science_are_mutually_exclusive(self, capsys):
+        with pytest.raises(SystemExit) as exc:
+            red.main(["--masters", "--science", "-d", "20240405"])
+        assert exc.value.code == 2
+        assert "not allowed with argument" in capsys.readouterr().err
+
+    def test_datecode_and_obs_id_are_mutually_exclusive(self, capsys):
+        # The guard against running a masters recipe on a science target.
+        with pytest.raises(SystemExit) as exc:
+            red.main(["--science", "-d", "20240405", "-o", "KP.x"])
+        assert exc.value.code == 2
+        assert "not allowed with argument" in capsys.readouterr().err
+
+
+class TestRecipeLoading:
+    """reduce.py's recipe-loading failure branches. All in-process via main(),
+    no subprocess. None of these asserts anything about clear_stale_outputs,
+    which runs earlier at reduce.py:149 -- see the note in that module."""
+
+    def test_missing_recipe_file_exits(self, monkeypatch, tmp_path):
+        cfg = _base_cfg(tmp_path)
+        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        with pytest.raises(SystemExit, match="Recipe file not found"):
+            red.main(["-r", str(tmp_path / "absent.py"), "-c", str(cfg), "-o", "KP.x"])
+
+    def test_recipe_without_main_exits(self, monkeypatch, tmp_path):
+        cfg = _base_cfg(tmp_path)
+        recipe = tmp_path / "nomain.py"
+        recipe.write_text("VALUE = 1\n")
+        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        with pytest.raises(SystemExit, match="has no main"):
+            red.main(["-r", str(recipe), "-c", str(cfg), "-o", "KP.x"])
+
+    def test_recipe_exception_is_logged_before_reraise(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        # reduce.py's one sanctioned catch-log-reraise: the only place a
+        # traceback is guaranteed to reach the log before the nonzero exit
+        # (DRP-RUN-08). A bare `raise` here would lose the logged traceback.
+        cfg = _base_cfg(tmp_path)
+        recipe = tmp_path / "boom.py"
+        recipe.write_text("def main(config, args):\n    raise RuntimeError('boom')\n")
+        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        caplog.set_level(logging.CRITICAL)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            red.main(["-r", str(recipe), "-c", str(cfg), "-o", "KP.x"])
+
+        assert "uncaught exception; pipeline aborted" in caplog.text
+
+    def test_missing_log_dir_is_a_usage_error(self, monkeypatch, tmp_path):
+        # resolve_logging's ValueError must surface as a clean usage error
+        # (DRP-RUN-07), not a traceback out of main().
+        cfg = tmp_path / "nolog.toml"
+        cfg.write_text(
+            "[DATA_DIRS]\n"
+            'KPF_DATA_INPUT = "/cfg/in"\n'
+            'KPF_MASTERS_OUTPUT = "/cfg/m"\n'
+            'KPF_SCIENCE_OUTPUT = "/cfg/s"\n'
+            "[LOGGER]\n"
+        )
+        recipe = _stub_recipe(tmp_path, tmp_path / "seen.txt")
+        with pytest.raises(SystemExit) as exc:
+            red.main(["-r", str(recipe), "-c", str(cfg), "-o", "KP.x"])
+        assert exc.value.code == 2
 
 
 class _Config:

--- a/tests/regression/test_scan_script.py
+++ b/tests/regression/test_scan_script.py
@@ -1,12 +1,8 @@
 """Tests for scripts/processing/_scan.py: up-front L0 mini-db cache warming.
 
-_scan owns the in-process, parallel-by-datecode header scan the masters and
-science orchestrators run before their fan-out, so the fanned-out reduces read the
-mini-db cache read-only. These cover the per-night primitive, the generic parallel
-dispatcher (including the per-thread-FileHandler no-contamination invariant), and
-the fail-soft warm entry point.
-
-Unit tests use synthetic FITS frames in temp trees -- no real testdata needed.
+_scan owns the parallel-by-datecode header scan the masters and science
+orchestrators run before their fan-out, so the fanned-out reduces read the mini-db
+cache read-only. Frames are synthetic FITS in temp trees; no testdata is needed.
 """
 
 from pathlib import Path
@@ -56,11 +52,10 @@ class TestScanNightToCache:
 
         assert df is not None
         assert len(df) == 2
-        assert _cache_path(str(tmp_path), "20240101").is_file()  # cache="rw" wrote it
+        assert _cache_path(str(tmp_path), "20240101").is_file()  # default cache="rw"
 
     def test_read_only_mode_does_not_write(self, tmp_path):
-        # cache="r" scans in-process but writes no cache CSV (recipes read the
-        # cache; only the scripts layer writes it).
+        # Recipes read the cache; only the scripts layer writes it.
         _write_l0(str(tmp_path), "20240101", 3600)
 
         df = _scan.scan_night_to_cache(str(tmp_path), "20240101", cache="r")
@@ -69,8 +64,8 @@ class TestScanNightToCache:
         assert not _cache_path(str(tmp_path), "20240101").exists()
 
     def test_empty_night_returns_none(self, tmp_path):
-        # A datecode dir with no FITS files -> ValueError inside build_mini_database,
-        # swallowed here: returns None, no cache written, no raise.
+        # An empty datecode dir raises ValueError inside build_mini_database; _scan
+        # swallows it and returns None rather than aborting the batch.
         (Path(tmp_path) / "L0" / "20240101").mkdir(parents=True)
         assert _scan.scan_night_to_cache(str(tmp_path), "20240101") is None
         assert not _cache_path(str(tmp_path), "20240101").exists()
@@ -88,7 +83,7 @@ class TestScanDatecodes:
     def test_returns_per_night_results(self, tmp_path):
         datecodes = ["20240101", "20240102", "20240103"]
         results = _scan.scan_datecodes(datecodes, jobs=3, worker=lambda dc: (dc, ""))
-        assert sorted(results) == datecodes  # one result per night, order-agnostic
+        assert sorted(results) == datecodes  # order-agnostic: the pool is unordered
 
     def test_tolerates_jobs_exceeding_datecodes(self, tmp_path):
         results = _scan.scan_datecodes(["20240101"], jobs=8, worker=lambda dc: (dc, ""))
@@ -99,9 +94,8 @@ class TestScanDatecodes:
 
     def test_threaded_scan_no_contamination(self, tmp_path):
         # Each night gets its own FileHandler inside scan_night_to_cache, so a pooled
-        # scan never collapses nights via a shared self._mini_db. Worker returns each
-        # night's obs_id set; assert every night is exact under an 8-wide pool.
-        nights = [f"202401{d:02d}" for d in range(1, 7)]  # six nights
+        # scan never collapses nights via a shared self._mini_db.
+        nights = [f"202401{d:02d}" for d in range(1, 7)]
         expected = {}
         for dc in nights:
             ids = {_write_l0(str(tmp_path), dc, 3600 + j * 100) for j in range(4)}
@@ -134,8 +128,7 @@ class TestWarmMiniDbCaches:
             assert _cache_path(str(tmp_path), dc).is_file()
 
     def test_read_only_mode_skips_prescan(self, tmp_path):
-        # A read-only mode warms nothing: no cache is written and every night is
-        # reported skipped, without even scanning.
+        # A read-only mode warms nothing: every night is reported skipped, unscanned.
         nights = ["20240101", "20240102"]
         for dc in nights:
             _write_l0(str(tmp_path), dc, 3600)
@@ -159,8 +152,8 @@ class TestWarmMiniDbCaches:
         assert (written, skipped) == (1, 1)
 
     def test_fail_soft_on_pool_error(self, tmp_path, monkeypatch):
-        # A pool-level surprise must never abort the batch: warm swallows it and
-        # reports every night as skipped so the reduces fall back to in-process scans.
+        # A pool-level failure must never abort the batch: warm reports every night
+        # skipped so the reduces fall back to in-process scans.
         def _boom(datecodes, jobs, worker, *, label="scanning"):
             raise RuntimeError("pool exploded")
 

--- a/tests/regression/test_scan_script.py
+++ b/tests/regression/test_scan_script.py
@@ -8,30 +8,13 @@ cache read-only. Frames are synthetic FITS in temp trees; no testdata is needed.
 from pathlib import Path
 
 import pytest
-from astropy.io import fits
 
 from scripts.processing import _scan
 
+from ._scripts import write_l0_tree
+
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
 pytestmark = pytest.mark.cli
-
-
-def _write_l0(data_input, datecode, seconds, obj="10700", imtype="Object"):
-    """Write one L0 frame under {data_input}/L0/{datecode}; return its obs_id."""
-    l0_dir = Path(data_input) / "L0" / datecode
-    l0_dir.mkdir(parents=True, exist_ok=True)
-    obs_id = f"KP.{datecode}.{seconds:05d}.00"
-    header = fits.Header(
-        {
-            "OBJECT": obj,
-            "IMTYPE": imtype,
-            "TARGNAME": obj,
-            "EXPTIME": 60.0,
-            "ELAPSED": 60.0,
-        }
-    )
-    fits.PrimaryHDU(header=header).writeto(l0_dir / f"{obs_id}.fits")
-    return obs_id
 
 
 def _cache_path(data_input, datecode):
@@ -45,8 +28,8 @@ def _cache_path(data_input, datecode):
 
 class TestScanNightToCache:
     def test_scans_and_writes_cache(self, tmp_path):
-        _write_l0(str(tmp_path), "20240101", 3600)
-        _write_l0(str(tmp_path), "20240101", 3700)
+        write_l0_tree(str(tmp_path), "20240101", 3600)
+        write_l0_tree(str(tmp_path), "20240101", 3700)
 
         df = _scan.scan_night_to_cache(str(tmp_path), "20240101")
 
@@ -56,7 +39,7 @@ class TestScanNightToCache:
 
     def test_read_only_mode_does_not_write(self, tmp_path):
         # Recipes read the cache; only the scripts layer writes it.
-        _write_l0(str(tmp_path), "20240101", 3600)
+        write_l0_tree(str(tmp_path), "20240101", 3600)
 
         df = _scan.scan_night_to_cache(str(tmp_path), "20240101", cache="r")
 
@@ -98,7 +81,7 @@ class TestScanDatecodes:
         nights = [f"202401{d:02d}" for d in range(1, 7)]
         expected = {}
         for dc in nights:
-            ids = {_write_l0(str(tmp_path), dc, 3600 + j * 100) for j in range(4)}
+            ids = {write_l0_tree(str(tmp_path), dc, 3600 + j * 100) for j in range(4)}
             expected[dc] = ids
 
         def _worker(dc):
@@ -119,7 +102,7 @@ class TestWarmMiniDbCaches:
     def test_writes_all_and_counts(self, tmp_path):
         nights = ["20240101", "20240102"]
         for dc in nights:
-            _write_l0(str(tmp_path), dc, 3600)
+            write_l0_tree(str(tmp_path), dc, 3600)
 
         written, skipped = _scan.warm_mini_db_caches(str(tmp_path), nights, jobs=2)
 
@@ -131,7 +114,7 @@ class TestWarmMiniDbCaches:
         # A read-only mode warms nothing: every night is reported skipped, unscanned.
         nights = ["20240101", "20240102"]
         for dc in nights:
-            _write_l0(str(tmp_path), dc, 3600)
+            write_l0_tree(str(tmp_path), dc, 3600)
 
         written, skipped = _scan.warm_mini_db_caches(
             str(tmp_path), nights, jobs=2, cache="r"
@@ -142,7 +125,7 @@ class TestWarmMiniDbCaches:
             assert not _cache_path(str(tmp_path), dc).exists()
 
     def test_empty_night_counted_skipped(self, tmp_path):
-        _write_l0(str(tmp_path), "20240101", 3600)  # good
+        write_l0_tree(str(tmp_path), "20240101", 3600)  # good
         (Path(tmp_path) / "L0" / "20240102").mkdir(parents=True)  # empty
 
         written, skipped = _scan.warm_mini_db_caches(

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -16,9 +16,12 @@ import pytest
 
 from kpfpipe import DETECTOR
 from kpfpipe.data_models.level2 import KPF2
+from kpfpipe.data_models.level4 import KPF4
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import kpf_filepath
 from recipes._logging import science_run_summary
+
+from ._dtype_policy import CCF, RV_FLOAT, assert_dtype
 
 # ---------------------------------------------------------------------------
 # Test data paths and constants
@@ -42,6 +45,126 @@ def _load_recipe():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+# ---------------------------------------------------------------------------
+# Frozen catalog capture (stands in for the live SIMBAD/Gaia query)
+# ---------------------------------------------------------------------------
+#
+# The four CATALOG_RECORD rows AstroQuery returned for OBS_ID on 2026-08-20,
+# captured verbatim from one live query (Gaia DR3, SIMBAD). The frame's target
+# is 47 UMa / HD 95128; a row reading RA 01:44 / Dec -15:56 is tau Ceti, i.e.
+# the wrong star, and would corrupt the barycentric correction by tens of km/s.
+#
+# This is an oracle -- a recording of what production emits -- not a rebuild of
+# it: the rows go in through AstroQuery's own writer, and merge_catalog_records
+# is what produced the 'kpf-drp' row, so a merge change disagrees with this
+# capture rather than silently agreeing with a reimplementation.
+#
+# To recapture: run AstroQuery(KPF0.from_fits(<L0>), config).perform() in a
+# plain python script (NOT under pytest, whose conftest blocks outbound
+# sockets) and dump l0.data["CATALOG_RECORD"] row by row.
+_CATALOG_CAPTURE = {
+    "wmko": {
+        "object": "95128",
+        "radec_src": "wmko",
+        "plx_src": "wmko",
+        "rv_src": "wmko",
+        "ra": "10:59:27.4994",
+        "dec": "+40:25:50.0140",
+        "pmra": 0.0,
+        "pmdec": 0.0,
+        "parallax": 72.0,
+        "rv": 11.1,
+        "frame": "icrs",
+        "epoch": 2000.0,
+        "equinox": 2000.0,
+        "color": 0.9100000000000001,
+        "color_name": "G-J",
+    },
+    "gaia": {
+        "object": "Gaia DR3 777254360337133312",
+        "radec_src": "gaia",
+        "plx_src": "gaia",
+        "rv_src": "gaia",
+        "ra": "10:59:27.5287",
+        "dec": "+40:25:49.8035",
+        "pmra": -0.3168498990963689,
+        "pmdec": 0.05518040036976814,
+        "parallax": 72.00696109116399,
+        "rv": 11.23812198638916,
+        "frame": "icrs",
+        "epoch": 2016.0,
+        "equinox": 2000.0,
+        "color": 0.7958617210388184,
+        "color_name": "Gaia BP-RP",
+    },
+    "simbad": {
+        "object": "HD 95128",
+        "radec_src": "simbad",
+        "plx_src": "simbad",
+        "rv_src": "simbad",
+        "ra": "10:59:27.9728",
+        "dec": "+40:25:48.9206",
+        "pmra": -0.31685,
+        "pmdec": 0.05518,
+        "parallax": 72.007,
+        "rv": 11.142,
+        "frame": "icrs",
+        "epoch": 2000.0,
+        "equinox": 2000.0,
+        "color": None,
+        "color_name": "",
+    },
+    "kpf-drp": {
+        "object": "Gaia DR3 777254360337133312",
+        "radec_src": "gaia",
+        "plx_src": "gaia",
+        "rv_src": "gaia",
+        "ra": "10:59:27.5287",
+        "dec": "+40:25:49.8035",
+        "pmra": -0.3168498990963689,
+        "pmdec": 0.05518040036976814,
+        "parallax": 72.00696109116399,
+        "rv": 11.23812198638916,
+        "frame": "icrs",
+        "epoch": 2016.0,
+        "equinox": 2000.0,
+        "color": 0.7958617210388184,
+        "color_name": "Gaia BP-RP",
+    },
+}
+
+
+class _FrozenAstroQuery:
+    """AstroQuery stand-in that replays _CATALOG_CAPTURE instead of querying.
+
+    Writes the frozen rows through the real module's own writer and header
+    setter, so the L0 this hands back carries the same CATALOG_RECORD schema,
+    presence flags and receipt entry a live run produces -- without the
+    network. AstroQuery's own contract (queries, merge, schema) is tested in
+    test_astro_query.py with Gaia and SIMBAD mocked.
+    """
+
+    def __init__(self, l0_obj, config=None):
+        # Imported here, not at module scope: astro_query pulls in
+        # astroquery/astropy (~2 s) and opens a connection at import.
+        from kpfpipe.modules.astro_query import AstroQuery
+
+        self._aq = AstroQuery(l0_obj, config)
+
+    def perform(self):
+        aq = self._aq
+        for source, record in _CATALOG_CAPTURE.items():
+            aq._write_catalog_record(source, dict(record))
+        # _set_headers reads these to write the per-source presence flags.
+        aq._wmko = _CATALOG_CAPTURE["wmko"]
+        aq._gaia = _CATALOG_CAPTURE["gaia"]
+        aq._simbad = _CATALOG_CAPTURE["simbad"]
+        aq._canonical = _CATALOG_CAPTURE["kpf-drp"]
+        aq._set_headers(aq.l0_obj)
+        aq.l0_obj.receipt_add_entry("astro_query", "", "PASS")
+        return aq.l0_obj
 
 
 # ---------------------------------------------------------------------------
@@ -69,10 +192,29 @@ class TestScienceRecipe:
         args = argparse.Namespace(obs_id=OBS_ID)
 
         recipe = _load_recipe()
+        # The recipe module object is built fresh by _load_recipe() and dropped
+        # with this fixture, so swapping the stage in place needs no patcher.
+        # This is the suite's only live-network call site; see _CATALOG_CAPTURE.
+        recipe.AstroQuery = _FrozenAstroQuery
         recipe.main(config, args)
 
         out_path = kpf_filepath(OBS_ID, "L2", data_root=str(tmp_path))
         return out_path
+
+    @pytest.fixture(scope="class")
+    def l2(self, recipe_output):
+        """The written L2, read once and shared read-only across the class."""
+        return KPF2.from_fits(recipe_output)
+
+    @pytest.fixture(scope="class")
+    def l4(self, recipe_output):
+        """The L4 the same recipe run wrote, read once for the class.
+
+        Keyed off recipe_output so the recipe still runs exactly once; the
+        data root is the L2 path's grandparent (as the QLP tests below do).
+        """
+        data_root = str(Path(recipe_output).parents[2])
+        return KPF4.from_fits(kpf_filepath(OBS_ID, "L4", data_root=data_root))
 
     def test_output_file_exists(self, recipe_output):
         assert os.path.isfile(recipe_output), (
@@ -82,17 +224,23 @@ class TestScienceRecipe:
     def test_output_filename_format(self, recipe_output):
         assert os.path.basename(recipe_output) == "kpf_SL2_20240405T110833.fits"
 
-    def test_output_is_valid_kpf2(self, recipe_output):
-        l2 = KPF2.from_fits(recipe_output)
-        assert isinstance(l2, KPF2)
+    def test_output_is_valid_kpf2(self, l2):
+        # isinstance() would only restate from_fits' return type; the level and
+        # the extracted-spectrum extensions are what the L2 write must carry.
+        assert l2.level == 2
+        for ext in (
+            "GREEN_SCI2_FLUX",
+            "GREEN_SCI2_WAVE",
+            "RED_SCI2_FLUX",
+            "RED_SCI2_WAVE",
+        ):
+            assert np.asarray(l2.data[ext]).ndim == 2, f"{ext} is not a 2-D trace"
 
-    def test_flux_positive(self, recipe_output):
-        l2 = KPF2.from_fits(recipe_output)
+    def test_flux_positive(self, l2):
         assert np.nanmedian(l2.data["GREEN_SCI2_FLUX"]) > 0
         assert np.nanmedian(l2.data["RED_SCI2_FLUX"]) > 0
 
-    def test_receipt_chain(self, recipe_output):
-        l2 = KPF2.from_fits(recipe_output)
+    def test_receipt_chain(self, l2):
         modules = l2.receipt["FUNCTION"].values
         assert "image_assembly" in modules
         assert "calibration_association" in modules
@@ -100,16 +248,14 @@ class TestScienceRecipe:
         assert "wavelength_calibration" in modules
         assert "barycentric_correction" in modules
 
-    def test_barycorr_extensions_populated(self, recipe_output):
-        l2 = KPF2.from_fits(recipe_output)
+    def test_barycorr_extensions_populated(self, l2):
         norder = NORDER_GREEN + NORDER_RED
         for ext in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
             arr = np.asarray(l2.data[ext])
             assert arr.shape == (norder,), f"{ext} shape {arr.shape} != ({norder},)"
             assert np.all(np.isfinite(arr)), f"{ext} has non-finite values"
 
-    def test_per_ccd_barycorr_keywords(self, recipe_output):
-        l2 = KPF2.from_fits(recipe_output)
+    def test_per_ccd_barycorr_keywords(self, l2):
         homes = {
             "CCD1BJD": "BJD_TDB",
             "CCD2BJD": "BJD_TDB",
@@ -123,9 +269,8 @@ class TestScienceRecipe:
             assert key in hdr, f"{key} missing from {ext}"
             assert np.isfinite(float(hdr.get(key))), f"{key} not finite"
 
-    def test_calibration_headers_set(self, recipe_output):
+    def test_calibration_headers_set(self, l2):
         # Master paths land on RECEIPT, ages on QUALITY_CONTROL (registry homes).
-        l2 = KPF2.from_fits(recipe_output)
         receipt = l2.headers["RECEIPT"]
         qc = l2.headers["QUALITY_CONTROL"]
         # bias/dark use a full-path FILE + float AGE (no DIR). Flat association
@@ -142,10 +287,9 @@ class TestScienceRecipe:
         assert receipt.get("WLSFILE").endswith("_master_thar_L2.fits")
         assert isinstance(qc.get("WLSAGE"), float)
 
-    def test_provenance_keywords_set(self, recipe_output):
+    def test_provenance_keywords_set(self, l2):
         # DRPTAG stays on the L2 PRIMARY; the other provenance cards live on
         # the L2 RECEIPT.
-        l2 = KPF2.from_fits(recipe_output)
         prim = l2.headers["PRIMARY"]
         receipt = l2.headers["RECEIPT"]
         version = importlib.metadata.version("kpfpipe")
@@ -157,10 +301,45 @@ class TestScienceRecipe:
         # BarycentricCorrection is the last module to run before the L2 write.
         assert receipt.get("DRPSTATU") == "Barycentric Correction module complete"
 
-    def test_wave_arrays_populated(self, recipe_output):
-        l2 = KPF2.from_fits(recipe_output)
-        assert np.any(l2.data["GREEN_SCI2_WAVE"] != 0)
-        assert np.any(l2.data["RED_SCI2_WAVE"] != 0)
+    @pytest.mark.parametrize(
+        "ext, blue_end, red_end",
+        [
+            ("GREEN_SCI2_WAVE", (4450, 4470), (5990, 6010)),
+            ("RED_SCI2_WAVE", (5980, 5995), (8690, 8710)),
+        ],
+    )
+    def test_wave_arrays_populated(self, l2, ext, blue_end, red_end):
+        # A single non-zero element would pass on a WLS copied from the wrong
+        # fiber or chip. Every order must instead run blue->red and the chip's
+        # coverage must land where the detector actually sees.
+        wave = np.asarray(l2.data[ext])
+        assert np.all(np.diff(wave, axis=1) > 0), f"{ext} is not strictly ascending"
+        assert blue_end[0] < wave.min() < blue_end[1]
+        assert red_end[0] < wave.max() < red_end[1]
+
+    def test_l4_output_filename_format(self, recipe_output):
+        path = kpf_filepath(OBS_ID, "L4", data_root=str(Path(recipe_output).parents[2]))
+        assert os.path.isfile(path), f"Expected L4 output not found: {path}"
+        assert os.path.basename(path) == "kpf_SL4_20240405T110833.fits"
+
+    def test_l4_receipt_chain(self, l4):
+        # The L2's receipt stops at barycentric_correction, so these two entries
+        # are what distinguishes the final product from the intermediate one.
+        modules = l4.receipt["FUNCTION"].values
+        assert "cross_correlation" in modules
+        assert "radial_velocity" in modules
+
+    def test_l4_rv_products_present(self, l4):
+        # Structural only, by decision: the RV extensions exist, name their
+        # method, and are born in the dtypes the EPRV standard requires. No
+        # radial-velocity VALUE is pinned anywhere in this suite.
+        assert l4.headers["PRIMARY"].get("RVMETHOD") == "CCF"
+        for fiber in ("SCI1", "SCI2", "SCI3"):
+            assert_dtype(l4.data[f"{fiber}_CCF"], CCF, f"{fiber}_CCF")
+            table = l4.data[f"{fiber}_RV"]
+            assert set(table.colnames) >= {"RV", "RV_ERR", "BJD_TDB", "BERV"}
+            for col in ("RV", "RV_ERR", "BJD_TDB", "BERV"):
+                assert_dtype(np.asarray(table[col]), RV_FLOAT, f"{fiber}_RV[{col}]")
 
     def test_qlp_l0_pngs_exist(self, recipe_output):
         qlp_dir = Path(recipe_output).parents[2] / "QLP" / "20240405" / OBS_ID / "L0"
@@ -184,6 +363,171 @@ class TestScienceRecipe:
 
 
 # ---------------------------------------------------------------------------
+# Recipe wiring (no testdata: every collaborator stubbed, real main() called)
+# ---------------------------------------------------------------------------
+
+
+def _wire_science_recipe(tmp_path, monkeypatch):
+    """Load the real recipe with every collaborator replaced by a recorder.
+
+    Returns ``(recipe, config, args, record)``. ``record["calls"]`` holds one
+    ``(stage, input_tag, args)`` tuple per collaborator in call order -- the
+    list order IS the ordering assertion -- alongside the products written
+    (``record["written"]``) and the object handed to the run summary.
+
+    Stubs return tagged sentinels rather than real products, so each stage's
+    input identifies which stage produced it.
+    """
+    recipe = _load_recipe()
+    record = {"calls": [], "written": [], "summary": None}
+
+    class Product:
+        def __init__(self, tag):
+            self.tag = tag
+
+        def to_fits(self, path):
+            record["written"].append((self.tag, path))
+
+    def _tag(obj):
+        return getattr(obj, "tag", obj)
+
+    def _stage(name, produces):
+        class StubStage:
+            def __init__(self, obj, config=None, **kwargs):
+                self._obj = obj
+
+            def perform(self, *args, **kwargs):
+                record["calls"].append((name, _tag(self._obj), args))
+                return Product(produces)
+
+        return StubStage
+
+    def _checkpoint(name):
+        class StubCheckpoint:
+            def __init__(self, obj):
+                self._obj = obj
+
+            def run(self):
+                record["calls"].append((name, _tag(self._obj), ()))
+
+        return StubCheckpoint
+
+    def _plot(name):
+        class StubPlot:
+            def __init__(self, obj, output_dir=None, obs_id=None):
+                record["calls"].append((name, _tag(obj), (output_dir,)))
+
+            def run(self, which):
+                pass
+
+        return StubPlot
+
+    class StubKPF0:
+        @staticmethod
+        def from_fits(path):
+            record["calls"].append(("from_fits", path, ()))
+            return Product("l0")
+
+    monkeypatch.setattr(recipe, "KPF0", StubKPF0)
+    for name, produces in [
+        ("AstroQuery", "l0"),
+        ("ImageAssembly", "l1"),
+        ("CalibrationAssociation", "l1"),
+        ("ImageProcessing", "l1"),
+        ("SpectralExtraction", "l2"),
+        ("WavelengthCalibration", "l2"),
+        ("BarycentricCorrection", "l2"),
+        ("CrossCorrelation", "l4"),
+        ("RadialVelocity", "l4"),
+    ]:
+        monkeypatch.setattr(recipe, name, _stage(name, produces))
+    for name in ("CheckpointL0", "CheckpointL1", "CheckpointL2", "CheckpointL4"):
+        monkeypatch.setattr(recipe, name, _checkpoint(name))
+    for name in ("PlotL0", "PlotL1", "PlotL2", "PlotL4"):
+        monkeypatch.setattr(recipe, name, _plot(name))
+
+    def capture_summary(l4, elapsed):
+        record["summary"] = _tag(l4)
+        return ""
+
+    monkeypatch.setattr(recipe, "science_run_summary", capture_summary)
+
+    config = ConfigHandler(
+        str(CONFIG_PATH),
+        overrides={
+            "DATA_DIRS": {
+                "KPF_DATA_INPUT": str(tmp_path),
+                "KPF_MASTERS_OUTPUT": str(tmp_path),
+                "KPF_SCIENCE_OUTPUT": str(tmp_path),
+            }
+        },
+    )
+    return recipe, config, argparse.Namespace(obs_id=OBS_ID), record
+
+
+class TestScienceRecipeWiring:
+    """The stage hand-off chain, driven without testdata or FITS I/O."""
+
+    @pytest.fixture
+    def run(self, tmp_path, monkeypatch):
+        recipe, config, args, record = _wire_science_recipe(tmp_path, monkeypatch)
+        recipe.main(config, args)
+        record["tmp_path"] = tmp_path
+        return record
+
+    def test_stages_run_in_order(self, run):
+        # CheckpointL0 runs BEFORE ImageAssembly on purpose: QCL0 writes the L0
+        # QC flags that to_kpf1 propagates into the L1/L2/L4 products.
+        assert [call[0] for call in run["calls"]] == [
+            "from_fits",
+            "AstroQuery",
+            "PlotL0",
+            "CheckpointL0",
+            "ImageAssembly",
+            "CalibrationAssociation",
+            "ImageProcessing",
+            "PlotL1",
+            "CheckpointL1",
+            "SpectralExtraction",
+            "WavelengthCalibration",
+            "BarycentricCorrection",
+            "PlotL2",
+            "CheckpointL2",
+            "CrossCorrelation",
+            "RadialVelocity",
+            "PlotL4",
+            "CheckpointL4",
+        ]
+
+    def test_each_stage_receives_the_previous_product(self, run):
+        # A mis-wired hand-off (SpectralExtraction fed the L0, RadialVelocity fed
+        # the pre-CCF L2) is invisible to a pass/fail run on real data.
+        inputs = {call[0]: call[1] for call in run["calls"]}
+        assert inputs["ImageAssembly"] == "l0"
+        assert inputs["SpectralExtraction"] == "l1"
+        assert inputs["BarycentricCorrection"] == "l2"
+        assert inputs["CrossCorrelation"] == "l2"
+        assert inputs["RadialVelocity"] == "l4"
+
+    def test_calibration_masters_requested(self, run):
+        # Flat association is deliberately absent until flat processing exists.
+        calls = {call[0]: call[2] for call in run["calls"]}
+        assert calls["CalibrationAssociation"] == (["bias", "dark", "thar"],)
+
+    def test_products_written_to_their_convention_paths(self, run):
+        data_root = str(run["tmp_path"])
+        assert run["written"] == [
+            ("l2", kpf_filepath(OBS_ID, "L2", data_root=data_root)),
+            ("l4", kpf_filepath(OBS_ID, "L4", data_root=data_root)),
+        ]
+
+    def test_summary_reads_the_l4(self, run):
+        # The end-of-run verdict quotes the combined RV, so it must be handed the
+        # L4 and not the L2 written a few lines earlier.
+        assert run["summary"] == "l4"
+
+
+# ---------------------------------------------------------------------------
 # Science recipe error paths
 # ---------------------------------------------------------------------------
 
@@ -202,7 +546,12 @@ class TestScienceRecipeErrors:
         )
         args = argparse.Namespace(obs_id=OBS_ID)
         recipe = _load_recipe()
-        with pytest.raises((FileNotFoundError, IOError, OSError)):
+        # The old three-way tuple was just OSError three times over (IOError *is*
+        # OSError, FileNotFoundError subclasses it), so any OSError from the
+        # recipe's directory creation or FITS writes satisfied it. rvdata raises
+        # a bare IOError here, so match= on the obs_id is what pins the failure
+        # to the L0 read this test is named for.
+        with pytest.raises(OSError, match=OBS_ID):
             recipe.main(config, args)
 
     def test_missing_obs_id_raises(self, tmp_path):

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -1,6 +1,6 @@
 """Tests for the kpf_drp_science recipe.
 
-Integration tests run the full recipe (L0 -> L1 -> L2) against a real star
+Integration tests run the full recipe (L0 -> L1 -> L2 -> L4) against a real star
 observation from tests/testdata/L0/20240405/.
 """
 
@@ -52,8 +52,6 @@ def _load_recipe():
 @pytest.mark.slow
 @pytest.mark.requires_testdata
 class TestScienceRecipe:
-    """End-to-end recipe test: KPF0 → ImageAssembly → SpectralExtraction → KPF2."""
-
     @pytest.fixture(scope="class")
     def recipe_output(self, tmp_path_factory):
         tmp_path = tmp_path_factory.mktemp("science_out")
@@ -89,7 +87,6 @@ class TestScienceRecipe:
         assert isinstance(l2, KPF2)
 
     def test_flux_positive(self, recipe_output):
-        """Star flux should be positive after extraction."""
         l2 = KPF2.from_fits(recipe_output)
         assert np.nanmedian(l2.data["GREEN_SCI2_FLUX"]) > 0
         assert np.nanmedian(l2.data["RED_SCI2_FLUX"]) > 0
@@ -104,8 +101,6 @@ class TestScienceRecipe:
         assert "barycentric_correction" in modules
 
     def test_barycorr_extensions_populated(self, recipe_output):
-        """BarycentricCorrection should populate the EPRV-standard extensions
-        per-order, with finite values."""
         l2 = KPF2.from_fits(recipe_output)
         norder = NORDER_GREEN + NORDER_RED
         for ext in ("BJD_TDB", "BARYCORR_KMS", "BARYCORR_Z"):
@@ -114,7 +109,6 @@ class TestScienceRecipe:
             assert np.all(np.isfinite(arr)), f"{ext} has non-finite values"
 
     def test_per_ccd_barycorr_keywords(self, recipe_output):
-        """Per-CCD scalar summaries land on their barycentric extension headers."""
         l2 = KPF2.from_fits(recipe_output)
         homes = {
             "CCD1BJD": "BJD_TDB",
@@ -130,36 +124,32 @@ class TestScienceRecipe:
             assert np.isfinite(float(hdr.get(key))), f"{key} not finite"
 
     def test_calibration_headers_set(self, recipe_output):
-        """CalibrationAssociation's writes survive onto the L2 product: master
-        paths on RECEIPT, ages on QUALITY_CONTROL (their registry homes)."""
+        # Master paths land on RECEIPT, ages on QUALITY_CONTROL (registry homes).
         l2 = KPF2.from_fits(recipe_output)
         receipt = l2.headers["RECEIPT"]
         qc = l2.headers["QUALITY_CONTROL"]
-        # bias/dark use full-path FILE + float AGE (no DIR). Flat association is
-        # not part of the basic runnable path until flat processing is
-        # implemented.
+        # bias/dark use a full-path FILE + float AGE (no DIR). Flat association
+        # is not wired up until flat processing exists.
         for prefix in ("BIAS", "DARK"):
             assert f"{prefix}FILE" in receipt
             assert f"{prefix}DIR" not in receipt
             assert f"{prefix}AGE" in qc
         assert "FLATFILE" not in receipt
         assert "FLATAGE" not in qc
-        # thar uses the same convention: WLSFILE = full path (no WLSDIR),
-        # WLSAGE = float days
+        # thar follows the same convention; WLSAGE is in days.
         assert "WLSFILE" in receipt
         assert "WLSDIR" not in receipt
         assert receipt.get("WLSFILE").endswith("_master_thar_L2.fits")
         assert isinstance(qc.get("WLSAGE"), float)
 
     def test_provenance_keywords_set(self, recipe_output):
-        """DRPTAG (EPRV) stays on the L2 PRIMARY; the WMKO DRP-RUN provenance cards
-        live on the L2 RECEIPT."""
+        # DRPTAG stays on the L2 PRIMARY; the other provenance cards live on
+        # the L2 RECEIPT.
         l2 = KPF2.from_fits(recipe_output)
         prim = l2.headers["PRIMARY"]
         receipt = l2.headers["RECEIPT"]
         version = importlib.metadata.version("kpfpipe")
         assert prim.get("DRPTAG") == version
-        # The four provenance cards moved off PRIMARY onto RECEIPT.
         assert all(k not in prim for k in ("DRPVERNO", "DRPSTATU", "PROGID", "KOAID"))
         assert receipt.get("DRPVERNO") == version
         assert "PROGID" in receipt
@@ -168,8 +158,6 @@ class TestScienceRecipe:
         assert receipt.get("DRPSTATU") == "Barycentric Correction module complete"
 
     def test_wave_arrays_populated(self, recipe_output):
-        """WavelengthCalibration wiring: the per-fiber WAVE extensions are
-        populated (nonzero) after the real run."""
         l2 = KPF2.from_fits(recipe_output)
         assert np.any(l2.data["GREEN_SCI2_WAVE"] != 0)
         assert np.any(l2.data["RED_SCI2_WAVE"] != 0)
@@ -235,7 +223,7 @@ class TestScienceRecipeErrors:
 
 
 class _FakeL4:
-    """Minimal stand-in for a finished KPF4: the attributes _summary reads."""
+    """Minimal stand-in for a finished KPF4: what science_run_summary reads."""
 
     def __init__(self, obs_id, headers, receipt):
         self.obs_id = obs_id
@@ -244,7 +232,7 @@ class _FakeL4:
 
 
 class TestScienceSummary:
-    """Unit tests for the science_run_summary() run-verdict formatter."""
+    """Unit tests for the science_run_summary() formatter."""
 
     def _l4(self):
         headers = {

--- a/tests/regression/test_science_script.py
+++ b/tests/regression/test_science_script.py
@@ -165,14 +165,22 @@ class TestCliTask:
 
 
 class TestMainExitCode:
-    def _patch(self, s, monkeypatch, failed):
+    def _patch(self, s, monkeypatch, failed, calls=None):
         # Skip the runtime setup, config resolution and subprocess fan-out (and
-        # any real batch log file); assert only run_stage's failure set -> exit code.
+        # any real batch log file). ``calls`` collects run_stage's arguments for
+        # the fan-out contract tests below; the rest assert only its failure set
+        # -> exit code.
         monkeypatch.setattr(s, "configure_runtime", lambda: None)
         monkeypatch.setattr(s, "ConfigHandler", _FakeConfig)
         monkeypatch.setattr(s, "setup_batch_logging", lambda *a, **k: "/l/x.log")
         monkeypatch.setattr(s, "warm_mini_db_caches", lambda *a, **k: (0, 0))
-        monkeypatch.setattr(s, "run_stage", lambda *a, **k: set(failed))
+
+        def fake_run_stage(*args, **kwargs):
+            if calls is not None:
+                calls.append((args, kwargs))
+            return set(failed)
+
+        monkeypatch.setattr(s, "run_stage", fake_run_stage)
 
     def test_derives_datecodes_for_prescan(self, s, monkeypatch):
         # The pre-scan gets the unique-sorted nights the frames span, not the raw
@@ -200,6 +208,34 @@ class TestMainExitCode:
         with pytest.raises(SystemExit) as exc:
             s.main(["--obs_ids", _OID1])
         assert exc.value.code == 1
+
+    def test_fan_out_is_fail_soft(self, s, monkeypatch):
+        # This driver reduces a whole night: one bad frame must not abort the
+        # rest. Its sibling drivers assert the same contract for themselves.
+        calls = []
+        self._patch(s, monkeypatch, failed=[], calls=calls)
+        s.main(["--obs_ids", _OID1, _OID2])
+        assert calls[0][1]["abort_on_failure"] is False
+
+    def test_fan_out_paces_launches(self, s, monkeypatch):
+        # Every reduction resolves catalog astrometry, so the launches are spaced
+        # to stay inside the SIMBAD/Gaia rate limits.
+        calls = []
+        self._patch(s, monkeypatch, failed=[], calls=calls)
+        s.main(["--obs_ids", _OID1, "--job_timeout", "42"])
+        assert calls[0][1]["launch_interval"] == s._LAUNCH_INTERVAL > 0
+        assert calls[0][1]["job_timeout"] == 42
+
+    def test_output_dir_reaches_the_per_frame_argv(self, s, monkeypatch):
+        # Parsing --kpf_science_output is not enough: dropping it from `forward`
+        # sends every product to the config's data root with a green suite.
+        calls = []
+        self._patch(s, monkeypatch, failed=[], calls=calls)
+        s.main(["--obs_ids", _OID1, "--kpf_science_output", "/out"])
+        tasks = calls[0][0][1]
+        _, argv = tasks[0]
+        assert "--kpf_science_output" in argv
+        assert argv[argv.index("--kpf_science_output") + 1] == "/out"
 
     def test_errors_when_log_dir_unset(self, s, monkeypatch):
         # A missing log_dir is fatal before any fan-out.

--- a/tests/regression/test_science_script.py
+++ b/tests/regression/test_science_script.py
@@ -12,28 +12,13 @@ import pytest
 
 from scripts.processing import science as _science
 
+from ._scripts import _FakeConfig, _NoLogDirConfig
+
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
 pytestmark = pytest.mark.cli
 
 _OID1 = "KP.20240405.40113.57"
 _OID2 = "KP.20240405.40237.36"
-
-
-class _FakeConfig:
-    """Stand-in for ConfigHandler in the exit-code tests: no real file read."""
-
-    def __init__(self, path):
-        pass
-
-    def get_params(self, keys):
-        return {"KPF_DATA_INPUT": "/in", "log_dir": "/l"}
-
-
-class _NoLogDirConfig(_FakeConfig):
-    """A config with a resolvable data input but no configured log_dir."""
-
-    def get_params(self, keys):
-        return {"KPF_DATA_INPUT": "/in"}
 
 
 @pytest.fixture(scope="module")

--- a/tests/regression/test_science_script.py
+++ b/tests/regression/test_science_script.py
@@ -1,11 +1,9 @@
 """Tests for scripts/processing/science.py: the science-reduction driver.
 
-Cover the driver's own surface: arg parsing and obs_id validation, the
+Covers the driver's own surface: arg parsing and obs_id validation, the
 ``_cli_task`` argv it fans out, and the ``main`` exit-code contract (nonzero iff
-at least one frame failed). The shared fan-out engine (``run_stage``, the
-cores-based job sizing) lives in ``_dispatch`` and is tested in test_dispatch_script.py.
-
-Unit tests use trivial subprocess stubs -- no real testdata needed.
+at least one frame failed). The shared fan-out engine lives in ``_dispatch`` and
+is tested in test_dispatch_script.py. Stubs only -- no real testdata needed.
 """
 
 import sys
@@ -22,7 +20,7 @@ _OID2 = "KP.20240405.40237.36"
 
 
 class _FakeConfig:
-    """Stand-in for ConfigHandler in the exit-code tests (no real file read)."""
+    """Stand-in for ConfigHandler in the exit-code tests: no real file read."""
 
     def __init__(self, path):
         pass
@@ -35,12 +33,11 @@ class _NoLogDirConfig(_FakeConfig):
     """A config with a resolvable data input but no configured log_dir."""
 
     def get_params(self, keys):
-        return {"KPF_DATA_INPUT": "/in"}  # no log_dir
+        return {"KPF_DATA_INPUT": "/in"}
 
 
 @pytest.fixture(scope="module")
 def s():
-    """The science driver module (a normal package import)."""
     return _science
 
 
@@ -184,9 +181,8 @@ class TestCliTask:
 
 class TestMainExitCode:
     def _patch(self, s, monkeypatch, failed):
-        # Skip the runtime setup and the real dir/config resolution + subprocess
-        # fan-out; assert only the exit-code contract from run_stage's failure set.
-        # setup_batch_logging is stubbed so main() writes no real batch log file.
+        # Skip the runtime setup, config resolution and subprocess fan-out (and
+        # any real batch log file); assert only run_stage's failure set -> exit code.
         monkeypatch.setattr(s, "configure_runtime", lambda: None)
         monkeypatch.setattr(s, "ConfigHandler", _FakeConfig)
         monkeypatch.setattr(s, "setup_batch_logging", lambda *a, **k: "/l/x.log")
@@ -195,8 +191,7 @@ class TestMainExitCode:
 
     def test_derives_datecodes_for_prescan(self, s, monkeypatch):
         # The pre-scan gets the unique-sorted nights the frames span, not the raw
-        # obs_ids: two 20240405 frames collapse to one datecode. It warms up front
-        # (the science default cache="rw").
+        # obs_ids: two 20240405 frames collapse to one datecode.
         warm_args = {}
         self._patch(s, monkeypatch, failed=[])
         monkeypatch.setattr(
@@ -222,7 +217,7 @@ class TestMainExitCode:
         assert exc.value.code == 1
 
     def test_errors_when_log_dir_unset(self, s, monkeypatch):
-        # A missing log_dir is fatal before any fan-out (DRP-RUN-07).
+        # A missing log_dir is fatal before any fan-out.
         monkeypatch.setattr(s, "configure_runtime", lambda: None)
         monkeypatch.setattr(s, "ConfigHandler", _NoLogDirConfig)
         with pytest.raises(SystemExit) as exc:

--- a/tests/regression/test_spectral_extraction.py
+++ b/tests/regression/test_spectral_extraction.py
@@ -4,6 +4,7 @@ Extraction-algorithm and perform() tests run on synthetic arrays, the latter wit
 extract_ffi monkeypatched; the real-L0 regression class is marked slow.
 """
 
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -151,12 +152,12 @@ class TestDtypeProvenance:
 class TestUnimplementedExtraction:
     def test_optimal_raises(self):
         D = V = np.ones((5, 10))
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match="[Oo]ptimal"):
             SpectralExtraction._optimal_extraction(D, V)
 
     def test_flat_relative_raises(self):
         D = V = np.ones((5, 10))
-        with pytest.raises(NotImplementedError):
+        with pytest.raises(NotImplementedError, match="[Ff]lat"):
             SpectralExtraction._flat_relative_extraction(D, V)
 
 
@@ -182,30 +183,11 @@ class TestPerformShapes:
                 arrays[f"{chip}_{fiber}_VAR"] = np.ones((n, NCOL), dtype=np.float32)
         return arrays
 
-    def test_returns_kpf2(self, minimal_l1, mock_ffi_arrays, monkeypatch):
-        monkeypatch.setattr(
-            SpectralExtraction,
-            "extract_ffi",
-            lambda self, chip, fibers, extraction_method, **kwargs: {
-                k: v for k, v in mock_ffi_arrays.items() if k.startswith(chip)
-            },
-        )
-        se = SpectralExtraction(minimal_l1)
-        l2 = se.perform()
-        assert isinstance(l2, KPF2)
-        assert l2.level == 2
-
-    @pytest.mark.parametrize(
-        "key, expected_rows",
-        [
-            ("GREEN_SCI2_FLUX", NORDER_GREEN),
-            ("RED_SCI2_FLUX", NORDER_RED),
-            ("SCI2_FLUX", NORDER_GREEN + NORDER_RED),
-        ],
-    )
-    def test_trace_shape(
-        self, minimal_l1, mock_ffi_arrays, monkeypatch, key, expected_rows
+    def test_whole_trace_concatenates_green_then_red(
+        self, minimal_l1, mock_ffi_arrays, monkeypatch
     ):
+        # Per-chip shapes would only restate the arrays the mock handed in; the
+        # concatenation is the part perform() actually computes.
         monkeypatch.setattr(
             SpectralExtraction,
             "extract_ffi",
@@ -213,23 +195,32 @@ class TestPerformShapes:
                 k: v for k, v in mock_ffi_arrays.items() if k.startswith(chip)
             },
         )
-        se = SpectralExtraction(minimal_l1)
-        l2 = se.perform()
-        assert l2.data[key].shape == (expected_rows, NCOL)
+        l2 = SpectralExtraction(minimal_l1).perform()
+        assert l2.level == 2
+        assert l2.data["SCI2_FLUX"].shape == (NORDER_GREEN + NORDER_RED, NCOL)
 
-    def test_all_fibers_populated(self, minimal_l1, mock_ffi_arrays, monkeypatch):
-        monkeypatch.setattr(
-            SpectralExtraction,
-            "extract_ffi",
-            lambda self, chip, fibers, extraction_method, **kwargs: {
-                k: v for k, v in mock_ffi_arrays.items() if k.startswith(chip)
-            },
-        )
-        se = SpectralExtraction(minimal_l1)
-        l2 = se.perform()
-        for fiber in ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]:
-            assert l2.data[f"{fiber}_FLUX"].shape == (NORDER_GREEN + NORDER_RED, NCOL)
-            assert l2.data[f"{fiber}_VAR"].shape == (NORDER_GREEN + NORDER_RED, NCOL)
+    def test_every_fiber_lands_on_its_own_trace(self, minimal_l1, monkeypatch):
+        # One fill value per fiber, so this sees a fiber written over another's
+        # trace -- which a shape assertion cannot.
+        fills = {"CAL": 1.0, "SCI1": 2.0, "SCI2": 3.0, "SCI3": 4.0, "SKY": 5.0}
+        norder = {"GREEN": NORDER_GREEN, "RED": NORDER_RED}
+
+        def mock_extract(self, chip, fibers, extraction_method, **kwargs):
+            return {
+                f"{chip}_{fiber}_{quantity}": np.full(
+                    (norder[chip], NCOL), fill, dtype=np.float32
+                )
+                for fiber, fill in fills.items()
+                for quantity in ("FLUX", "VAR")
+            }
+
+        monkeypatch.setattr(SpectralExtraction, "extract_ffi", mock_extract)
+        l2 = SpectralExtraction(minimal_l1).perform()
+        for fiber, fill in fills.items():
+            for quantity in ("FLUX", "VAR"):
+                array = l2.data[f"{fiber}_{quantity}"]
+                assert array.shape == (NORDER_GREEN + NORDER_RED, NCOL)
+                np.testing.assert_array_equal(array, fill)
 
     def test_green_red_slices_independent(self, minimal_l1, monkeypatch):
         def mock_extract(self, chip, fibers, extraction_method, **kwargs):
@@ -506,6 +497,21 @@ class TestValidColumnSpan:
 
         assert np.all(np.isfinite(flux_1d))
 
+    @pytest.mark.parametrize("center", [50.0, 50.5])
+    def test_aperture_weights_sum_to_the_aperture_height(self, center):
+        # TopEdge = BottomEdge = 5.0 is a 10-pixel aperture, so on a uniform
+        # detector every carried column must weigh exactly 10 -- whole pixels
+        # inside plus the two fractional edge rows. Existing tests assert only
+        # WHERE W is non-zero; an off-by-one in edge_pixel_top/bottom or an
+        # inverted frac_bot is a ~10% photometric error they all tolerate.
+        se = self._make_se(center, x1=0.0, x2=99.0)
+
+        _, _, W = se._get_orderlet_pixels("GREEN", "SCI1", 0)
+        np.testing.assert_allclose(W.sum(axis=0), 10.0, atol=1e-5)
+
+        flux_1d, _ = se.extract_orderlet("GREEN", "SCI1", 0)
+        np.testing.assert_allclose(flux_1d, 10.0 * 1234.0, rtol=1e-5)
+
     def test_the_box_is_sized_from_the_carried_columns_alone(self):
         # This trace climbs a row per column, so past X2 its extrapolation runs
         # off the top of the detector and would size a box of rows the orderlet
@@ -520,6 +526,92 @@ class TestValidColumnSpan:
         assert (row_min, row_max) == (5, 54)
         assert W[:, :40].any(axis=0).all()
         assert not W[:, 40:].any()
+
+
+# ---------------------------------------------------------------------------
+# extract_ffi's missing-trace tolerance, and the extraction-method guard
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFfiFailureTolerance:
+    """One missing trace degrades to a NaN row; two or more fail loudly.
+
+    The single-failure tolerance exists because in some KPF eras one trace does
+    not fall on the detector. Widening it would let a systematically broken
+    order trace produce an all-NaN L2 that only surfaces far downstream, as a
+    zero CCF.
+    """
+
+    def _make_se(self, n_traced):
+        """SpectralExtraction over 2 GREEN orders with only ``n_traced`` traced."""
+
+        class StubL1:
+            data = {
+                "GREEN_CCD": np.full((100, 100), 1.0, dtype=np.float32),
+                "GREEN_VAR": np.ones((100, 100), dtype=np.float32),
+            }
+            headers = {"PRIMARY": {}}
+
+        rows = [
+            {
+                "Fiber": "SCI1",
+                "Order": order,
+                "TopEdge": 5.0,
+                "BottomEdge": 5.0,
+                "X1": 0.0,
+                "X2": 99.0,
+                "Coeff0": 20.0 + 20.0 * order,
+                "Coeff1": 0.0,
+                "Coeff2": 0.0,
+                "Coeff3": 0.0,
+            }
+            for order in range(n_traced)
+        ]
+        trace = pd.DataFrame(
+            rows,
+            columns=[
+                "Fiber",
+                "Order",
+                "TopEdge",
+                "BottomEdge",
+                "X1",
+                "X2",
+                "Coeff0",
+                "Coeff1",
+                "Coeff2",
+                "Coeff3",
+            ],
+        ).set_index(["Fiber", "Order"])
+        se = SpectralExtraction(StubL1())
+        se._order_trace = {"GREEN": trace}
+        se._order_trace_path = "<stub>"
+        # Rebind rather than mutate: self.norder is the shared DETECTOR dict, so
+        # an item assignment here would resize every later test's detector.
+        se.norder = dict(se.norder, GREEN=2)
+        return se
+
+    def test_one_missing_trace_leaves_a_nan_row(self, caplog):
+        se = self._make_se(n_traced=1)
+        with caplog.at_level(logging.WARNING):
+            arrays = se.extract_ffi("GREEN", ["SCI1"])
+        flux = arrays["GREEN_SCI1_FLUX"]
+        assert np.all(np.isfinite(flux[0]))
+        assert np.all(np.isnan(flux[1]))
+        assert "1 orderlet failed" in caplog.text
+
+    def test_two_missing_traces_raise(self):
+        se = self._make_se(n_traced=0)
+        with pytest.raises(LookupError, match="Failed to extract 2"):
+            se.extract_ffi("GREEN", ["SCI1"])
+
+
+class TestExtractionMethodGuard:
+    def test_unsupported_method_names_itself(self):
+        # Dispatch is getattr(self, f"_{extraction_method}_extraction"), so a
+        # config typo must not surface as a bare AttributeError mid-loop.
+        se = TestValidColumnSpan()._make_se(50.0, x1=0.0, x2=99.0)
+        with pytest.raises(AttributeError, match="Unsupported extraction"):
+            se.extract_orderlet("GREEN", "SCI1", 0, extraction_method="boxx")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/regression/test_spectral_extraction.py
+++ b/tests/regression/test_spectral_extraction.py
@@ -1,10 +1,7 @@
-"""
-Tests for the SpectralExtraction module (L1 → L2).
+"""Tests for the SpectralExtraction module (L1 -> L2).
 
-Unit tests for extraction algorithms use synthetic arrays and require no
-real data. Integration tests (perform()) monkeypatch extract_ffi so they
-also require no real data. Regression tests using real L1 FITS files are
-skipped if KPF_TESTDATA is not set.
+Extraction-algorithm and perform() tests run on synthetic arrays, the latter with
+extract_ffi monkeypatched; the real-L0 regression class is marked slow.
 """
 
 from pathlib import Path
@@ -39,7 +36,7 @@ L0_FILE = str(TESTDATA_L0_DIR / "KP.20240405.00020.86.fits")
 
 @pytest.fixture
 def minimal_l1(tmp_path):
-    """Minimal KPF1 object sufficient for to_kpf2() and SpectralExtraction init."""
+    """Minimal KPF1 sufficient for to_kpf2() and SpectralExtraction init."""
     fn = str(tmp_path / "kpf_L1_20240101T000000.fits")
     primary = fits.PrimaryHDU()
     primary.header["INSTRUME"] = "KPF"
@@ -71,7 +68,6 @@ class TestBoxExtraction:
         np.testing.assert_allclose(flux, 5.0)
 
     def test_with_weights(self):
-        """Weights < 1 at edges should reduce total flux."""
         D = np.ones((5, 10), dtype=np.float32)
         V = np.ones((5, 10), dtype=np.float32)
         W = np.ones((5, 10), dtype=np.float32)
@@ -89,20 +85,19 @@ class TestBoxExtraction:
         np.testing.assert_allclose(flux, 5 * (10.0 - 3.0))
 
     def test_with_mask(self):
-        """Masking a pixel should redistribute weight via M normalisation."""
         D = np.ones((5, 10), dtype=np.float32)
         V = np.ones((5, 10), dtype=np.float32)
         M = np.ones((5, 10), dtype=np.float32)
-        M[2, :] = 0  # mask centre row
+        M[2, :] = 0
         flux, _ = SpectralExtraction._box_extraction(D, V, M=M)
-        # Sum should still equal nrow (mask re-normalises)
+        # M is renormalised to nrow, so masking a row redistributes its weight.
         np.testing.assert_allclose(flux, 5.0)
 
     def test_fully_masked_column_raises(self):
         D = np.ones((5, 10), dtype=np.float32)
         V = np.ones((5, 10), dtype=np.float32)
         M = np.ones((5, 10), dtype=np.float32)
-        M[:, 3] = 0  # fully mask column 3
+        M[:, 3] = 0
         with pytest.raises(ValueError, match="Fully masked"):
             SpectralExtraction._box_extraction(D, V, M=M)
 
@@ -171,12 +166,11 @@ class TestUnimplementedExtraction:
 
 
 class TestPerformShapes:
-    """Verify perform() assembles GREEN and RED arrays into correctly shaped
-    KPF2 traces. extract_ffi is monkeypatched to return pre-built arrays."""
+    """perform() assembles GREEN and RED arrays into correctly shaped KPF2 traces."""
 
     @pytest.fixture
     def mock_ffi_arrays(self):
-        """Return pre-built (chip, fiber) arrays matching real detector dims."""
+        """Pre-built (chip, fiber) arrays matching real detector dimensions."""
         chips = ["GREEN", "RED"]
         fibers = ["CAL", "SCI1", "SCI2", "SCI3", "SKY"]
         norder = {"GREEN": NORDER_GREEN, "RED": NORDER_RED}
@@ -238,8 +232,6 @@ class TestPerformShapes:
             assert l2.data[f"{fiber}_VAR"].shape == (NORDER_GREEN + NORDER_RED, NCOL)
 
     def test_green_red_slices_independent(self, minimal_l1, monkeypatch):
-        """GREEN and RED slices should contain distinct values."""
-
         def mock_extract(self, chip, fibers, extraction_method, **kwargs):
             fill = 1.0 if chip == "GREEN" else 2.0
             n = NORDER_GREEN if chip == "GREEN" else NORDER_RED
@@ -257,11 +249,8 @@ class TestPerformShapes:
         np.testing.assert_array_equal(l2.data["RED_SCI2_FLUX"], 2.0)
 
     def test_each_order_lands_on_its_own_row(self, monkeypatch):
-        """Order n occupies row n of the L2 array.
-
-        The reference numbers its orders from zero, so the loop index is the row
-        index. Shape alone cannot see a rebase: every row stays populated while
-        the spectra rotate."""
+        # The reference numbers orders from zero, so order n must land on row n.
+        # Shape alone cannot see a rebase: every row stays populated either way.
 
         def mock_orderlet(self, chip, fiber, order, extraction_method=None):
             spectrum = np.full(100, order, dtype=np.float32)
@@ -293,7 +282,7 @@ class TestPerformShapes:
 
 
 # ---------------------------------------------------------------------------
-# Regression tests (real L0 data → assemble L1 → extract)
+# Regression tests (real L0 data -> assemble L1 -> extract)
 # ---------------------------------------------------------------------------
 
 
@@ -324,14 +313,12 @@ class TestSpectralExtractionRealData:
         assert l2.data[key].shape == (expected_rows, NCOL)
 
     def test_flux_positive(self, l2_from_flat):
-        """Flat lamp flux should be positive after extraction."""
         l2, _ = l2_from_flat
         assert np.nanmedian(l2.data["GREEN_SCI2_FLUX"]) > 0
         assert np.nanmedian(l2.data["RED_SCI2_FLUX"]) > 0
 
     def test_variance_positive(self, l2_from_flat):
-        """Variance is non-negative wherever it exists; a column outside its
-        trace's valid span is NaN by design, not negative."""
+        # A column outside its trace's valid span is NaN by design, not negative.
         l2, _ = l2_from_flat
         for key in ("GREEN_SCI2_VAR", "RED_SCI2_VAR"):
             var = l2.data[key]
@@ -501,10 +488,8 @@ class TestValidColumnSpan:
 
     @pytest.mark.parametrize("center", [3.0, 96.0])
     def test_columns_beyond_the_span_are_nan(self, center):
-        """A trace clipped at either edge NaNs its extrapolated columns.
-
-        The bottom edge is the one that used to leak: a clamped aperture still
-        lands inside the box and would carry detector row 0 off as flux."""
+        # The bottom edge is the one that used to leak: a clamped aperture still
+        # lands inside the box and would carry detector row 0 off as flux.
         se = self._make_se(center, x1=0.0, x2=59.0)
 
         flux_1d, var_1d = se.extract_orderlet("GREEN", "SCI1", 0)
@@ -557,7 +542,7 @@ _STUB_TRACE = (
 
 
 def _stub_reference_tree(tmp_path, monkeypatch):
-    """Stub the repo reference tree: three instrument eras, three traces."""
+    """Stub the repo reference tree: three instrument eras, three order traces."""
     traces = tmp_path / "reference" / "order_traces"
     traces.mkdir(parents=True)
     (tmp_path / "reference" / "instrument_eras.csv").write_text(_STUB_ERAS)
@@ -633,8 +618,8 @@ class TestOrderTraceSelection:
         self, tmp_path, monkeypatch
     ):
         # extract_ffi catches LookupError to NaN-fill an absent orderlet. An era
-        # that cannot be inferred must not arrive disguised as one -- and must
-        # abort on the first orderlet rather than be retried 175 times.
+        # that cannot be inferred must not arrive disguised as one -- it must
+        # abort on the first orderlet rather than be retried for every order.
         _stub_reference_tree(tmp_path, monkeypatch)
         se = SpectralExtraction(_StubL1(None, "2.0"))
 

--- a/tests/regression/test_spectral_extraction.py
+++ b/tests/regression/test_spectral_extraction.py
@@ -287,6 +287,7 @@ class TestPerformShapes:
 
 
 @pytest.mark.slow
+@pytest.mark.requires_testdata
 class TestSpectralExtractionRealData:
     @pytest.fixture(scope="class")
     def l2_from_flat(self):

--- a/tests/regression/test_stats.py
+++ b/tests/regression/test_stats.py
@@ -118,6 +118,27 @@ class TestFlagOutliers:
         out = flag_outliers(x, sigma=5.0, kernel_size=5, method="trend")
         assert out[25]
 
+    def test_trend_restricted_to_dispersion_axis(self):
+        """The flat-master rejection path: masters/base.py calls this with
+        axis=1 so the blaze along dispersion is smoothed away while structure
+        ACROSS orders is not. Without the axis restriction the cross-order step
+        dominates the residual scale and the real spike goes unflagged -- a
+        silent change to a flat's rejection mask, which is RV-relevant."""
+        cols = np.linspace(0.0, 10.0, 40)  # smooth blaze along dispersion
+        x = np.stack([cols + (100.0 if r % 2 else 0.0) for r in range(8)])
+        x[3, 20] += 50.0  # one hot pixel
+
+        restricted = flag_outliers(x, sigma=5.0, axis=1, kernel_size=5, method="trend")
+        assert restricted[3, 20]
+        assert restricted.sum() == 1  # the blaze itself is not flagged
+
+        # Smoothing across orders too: the row-to-row step inflates the spread
+        # so far that the spike no longer stands out at all.
+        unrestricted = flag_outliers(
+            x, sigma=5.0, axis=None, kernel_size=5, method="trend"
+        )
+        assert not unrestricted[3, 20]
+
     def test_unsupported_method_raises(self):
         with pytest.raises(ValueError, match="method must be 'median' or 'trend'"):
             flag_outliers(np.arange(10.0), sigma=5.0, method="bogus")

--- a/tests/regression/test_stats.py
+++ b/tests/regression/test_stats.py
@@ -66,7 +66,7 @@ class TestInterpolateBadPixels:
         mask[2, 2] = False
         data[2, 2] = 1e6
         out = interpolate_bad_pixels(data, mask)
-        # 8 neighbors all = 2.0 → interpolated value should be ~2.0
+        # 8 neighbors all = 2.0 -> interpolated value should be ~2.0
         assert np.isclose(out[2, 2], 2.0, atol=1e-5)
 
     def test_good_pixels_unchanged(self):

--- a/tests/regression/test_timeseries_script.py
+++ b/tests/regression/test_timeseries_script.py
@@ -1,13 +1,10 @@
 """Tests for scripts/processing/timeseries.py: the RV-timeseries wrapper.
 
 timeseries is a thin discovery + dispatch wrapper: it combs the L0 tree for a
-target's science frames over a datecode range (steps 1-2), then runs one masters
-orchestrator, one science orchestrator, and one plotter subprocess (steps 3-5).
-The robust fan-out engine lives in _dispatch (tested in test_dispatch.py) and the
-orchestrators own their own arg parsing (test_masters_script.py /
-test_science_script.py). These cover only what timeseries owns: arg parsing, the
-threaded L0 discovery, the orchestrator argv it builds, and the main() dispatch
-order.
+target's science frames over a datecode range, then runs one masters
+orchestrator, one science orchestrator, and one plotter subprocess. These cover
+only what timeseries owns: arg parsing, the threaded L0 discovery, the
+orchestrator argv it builds, and the main() dispatch order.
 
 Unit tests use synthetic FITS frames in temp trees -- no real testdata needed.
 """
@@ -29,7 +26,6 @@ _BASE_ARGS = ["--target", "10700", "--date_range", "20240101", "20240131"]
 
 @pytest.fixture(scope="module")
 def ts():
-    """The timeseries wrapper module (a normal package import)."""
     return _ts
 
 
@@ -105,7 +101,6 @@ class TestParseArgs:
         assert ns.science_recipe == "/s.py" and ns.science_config == "/s.toml"
 
     def test_stage_toggles_default_on(self, ts):
-        # All three stages run unless explicitly opted out.
         ns = ts.parse_args(_BASE_ARGS)
         assert ns.masters is True and ns.science is True and ns.plots is True
 
@@ -118,7 +113,7 @@ class TestParseArgs:
         assert ns.kpf_data_input == "/in"
 
     def test_output_dir_fans_out_including_plot_dir(self, ts):
-        # timeseries has all four output slots: masters/science output, log, plot.
+        # --output_dir fans out to all four slots: masters, science, log, plot.
         ns = ts.parse_args(_BASE_ARGS + ["--output_dir", "/out"])
         assert ns.kpf_masters_output == "/out"
         assert ns.kpf_science_output == "/out"
@@ -130,7 +125,7 @@ class TestParseArgs:
         assert ns.plot_dir == "/p" and ns.kpf_science_output == "/out"
 
     def test_jobs_unset_stays_none(self, ts):
-        # Unset --jobs is left None so each stage picks its own default; the
+        # Unset --jobs stays None so each stage picks its own default; the
         # discovery scan falls back to _default_science_jobs() in main().
         assert ts.parse_args(_BASE_ARGS).jobs is None
 
@@ -169,7 +164,6 @@ class TestParseArgs:
         ],  # fmt: skip
     )
     def test_removed_flags_rejected(self, ts, flag):
-        # Every flag dropped in the rewrite is no longer accepted.
         with pytest.raises(SystemExit):
             ts.parse_args(_BASE_ARGS + [flag, "x"])
 
@@ -215,8 +209,7 @@ class TestOrchestratorArgv:
 
 class TestDiscoverScienceObsIds:
     def _build_tree(self, data_input, nights, per_night, target="10700"):
-        """One target burst per night (plus a decoy non-target frame); return the
-        expected sorted obs_id set."""
+        """One target burst per night plus a decoy; return the expected obs_ids."""
         expected = set()
         for i, dc in enumerate(nights):
             for j in range(per_night):
@@ -225,8 +218,8 @@ class TestDiscoverScienceObsIds:
         return expected
 
     def test_threaded_discovery_matches_expected(self, ts, tmp_path):
-        # Six nights scanned by a pool: with a shared FileHandler this raced and
-        # collapsed nights via duplicate obs_ids; per-thread handlers keep it exact.
+        # A shared FileHandler raced here and collapsed nights into duplicate
+        # obs_ids; per-thread handlers keep the scan exact.
         nights = [
             "20240101", "20240102", "20240103", "20240104", "20240105", "20240106",
         ]  # fmt: skip
@@ -238,8 +231,7 @@ class TestDiscoverScienceObsIds:
         assert len(got) == len(set(got)) == 24  # no duplicates, none dropped
 
     def test_discovery_writes_mini_db_cache(self, ts, tmp_path):
-        # Discovery scans cache="rw" through the shared primitive, so it still
-        # writes each night's on-disk CSV as a side effect.
+        # Discovery scans with cache="rw", so each night's CSV is a side effect.
         self._build_tree(str(tmp_path), ["20240101"], per_night=2)
         ts.discover_science_obs_ids(
             str(tmp_path), "10700", "20240101", "20240131", jobs=2
@@ -248,7 +240,6 @@ class TestDiscoverScienceObsIds:
         assert cache.is_file()
 
     def test_matches_serial_result(self, ts, tmp_path):
-        # The discovery is deterministic: jobs=8 equals jobs=1.
         nights = ["20240101", "20240102", "20240103", "20240104"]
         self._build_tree(str(tmp_path), nights, per_night=3)
         common = dict(target="10700", start="20240101", end="20240131")
@@ -332,8 +323,8 @@ class TestMainDispatch:
         return calls
 
     def test_masters_science_plots_dispatch(self, ts, monkeypatch, tmp_path):
-        # All three stages run in order: masters, then science with every discovered
-        # frame (no gating), then plots handed the same frames (no rescan).
+        # Stages run in order: masters, then science over every discovered frame,
+        # then plots handed the same frames (no rescan).
         a = _write_l0(str(tmp_path), "20240101", 3600, "10700")
         b = _write_l0(str(tmp_path), "20240102", 3600, "10700")
         calls = self._patch(ts, monkeypatch, tmp_path)
@@ -345,18 +336,18 @@ class TestMainDispatch:
         assert "20240101" in calls[0] and "20240102" in calls[0]  # both nights
         assert "scripts.processing.science" in calls[1]
         assert a in calls[1] and b in calls[1]  # every frame reduced
-        # timeseries owns what runs: it routes each stage's default recipe+config
-        # explicitly (not left to the orchestrator's own default).
+        # Each stage's default recipe+config is routed explicitly rather than
+        # left to the orchestrator's own default.
         assert ts.DEFAULT_MASTERS_RECIPE in calls[0]
         assert ts.DEFAULT_MASTERS_CONFIG in calls[0]
         assert ts.DEFAULT_SCIENCE_RECIPE in calls[1]
         assert ts.DEFAULT_SCIENCE_CONFIG in calls[1]
-        # Discovery is the sole mini-db writer; both launched stages are forced
-        # read-only (--cache r) so they don't redundantly re-warm the caches.
+        # Discovery is the sole mini-db writer, so both stages are forced
+        # read-only (--cache r) rather than re-warming the caches.
         for stage in (calls[0], calls[1]):
             assert stage[stage.index("--cache") + 1] == "r"
-        # Plot stage: the discovered frames (no rescan), reading from the science
-        # output root, writing to its default {KPF_SCIENCE_OUTPUT}/QLP/timeseries.
+        # The plot stage reads the science output root and writes to its default
+        # {KPF_SCIENCE_OUTPUT}/QLP/timeseries.
         assert "scripts.plots.plot_timeseries" in calls[2]
         assert a in calls[2] and b in calls[2]
         assert "/sci" in calls[2]
@@ -373,8 +364,7 @@ class TestMainDispatch:
 
     def test_jobs_rides_science_not_masters(self, ts, monkeypatch, tmp_path):
         # --jobs sizes only the science fan-out; forwarding it to masters would
-        # defeat the fixed _MASTERS_JOBS concurrency cap, so it must not reach the
-        # masters argv.
+        # defeat that stage's fixed _MASTERS_JOBS concurrency cap.
         _write_l0(str(tmp_path), "20240101", 3600, "10700")
         calls = self._patch(ts, monkeypatch, tmp_path)
 
@@ -386,7 +376,6 @@ class TestMainDispatch:
         assert "--jobs" in calls[1] and "8" in calls[1]  # science gets it
 
     def test_no_masters_skips_masters_stage(self, ts, monkeypatch, tmp_path):
-        # --no-masters runs the science and plots stages only.
         a = _write_l0(str(tmp_path), "20240101", 3600, "10700")
         calls = self._patch(ts, monkeypatch, tmp_path)
 
@@ -398,7 +387,7 @@ class TestMainDispatch:
         assert not any("scripts.processing.masters" in c for c in calls)
 
     def test_no_science_still_plots(self, ts, monkeypatch, tmp_path):
-        # --no-science runs masters, then plots the L4 already on disk.
+        # --no-science still plots, from the L4 already on disk.
         _write_l0(str(tmp_path), "20240101", 3600, "10700")
         calls = self._patch(ts, monkeypatch, tmp_path)
 
@@ -410,7 +399,6 @@ class TestMainDispatch:
         assert not any("scripts.processing.science" in c for c in calls)
 
     def test_no_plots_skips_plot_stage(self, ts, monkeypatch, tmp_path):
-        # --no-plots runs masters + science but no plotter.
         _write_l0(str(tmp_path), "20240101", 3600, "10700")
         calls = self._patch(ts, monkeypatch, tmp_path)
 
@@ -420,7 +408,6 @@ class TestMainDispatch:
         assert not any("scripts.plots.plot_timeseries" in c for c in calls)
 
     def test_all_stages_skipped_runs_nothing(self, ts, monkeypatch, tmp_path):
-        # Skipping every stage dispatches no subprocess and exits cleanly.
         _write_l0(str(tmp_path), "20240101", 3600, "10700")
         calls = self._patch(ts, monkeypatch, tmp_path)
 
@@ -429,7 +416,7 @@ class TestMainDispatch:
         assert calls == []
 
     def test_no_skip_logs_written(self, ts, monkeypatch, tmp_path):
-        # The gate is gone: no stand-in per-frame skip logs are ever written.
+        # No stand-in per-frame skip logs are written any more.
         _write_l0(str(tmp_path), "20240101", 3600, "10700")
         self._patch(ts, monkeypatch, tmp_path)
 

--- a/tests/regression/test_timeseries_script.py
+++ b/tests/regression/test_timeseries_script.py
@@ -134,30 +134,36 @@ class TestParseArgs:
             ["--job_timeout", "0"],  # below 1
         ],
     )
-    def test_invalid_args_exit(self, ts, extra):
+    def test_invalid_args_exit(self, ts, capsys, extra):
         argv = ["--target", "10700"]
         if "--date_range" not in extra:
             argv += ["--date_range", "20240101", "20240131"]
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as exc:
             ts.parse_args(argv + extra)
+        assert exc.value.code == 2
+        # Four different validators; without this the flag name never appears.
+        assert extra[0] in capsys.readouterr().err
 
-    def test_target_required(self, ts):
-        with pytest.raises(SystemExit):
+    def test_target_required(self, ts, capsys):
+        with pytest.raises(SystemExit) as exc:
             ts.parse_args(["--date_range", "20240101", "20240131"])
+        assert exc.value.code == 2
+        assert "the following arguments are required: --target" in (
+            capsys.readouterr().err
+        )
 
-    @pytest.mark.parametrize(
-        "flag",
-        [
-            "--file_limit",
-            "--plots_only",
-            "--group_bursts",
-            "--skip_existing_masters",
-            "--skip_existing_science",
-        ],  # fmt: skip
-    )
-    def test_removed_flags_rejected(self, ts, flag):
-        with pytest.raises(SystemExit):
-            ts.parse_args(_BASE_ARGS + [flag, "x"])
+    def test_removed_flags_have_no_dest(self, ts):
+        # The real contract is that the flags' *dests* are gone. Asserting only
+        # that argparse exits tests argparse: "--nonsense x" passes identically,
+        # and a flag quietly re-added as a no-op alias would still pass.
+        removed = {
+            "file_limit",
+            "plots_only",
+            "group_bursts",
+            "skip_existing_masters",
+            "skip_existing_science",
+        }
+        assert removed & set(vars(ts.parse_args(_BASE_ARGS))) == set()
 
 
 # ---------------------------------------------------------------------------
@@ -257,13 +263,15 @@ class TestDiscoverScienceObsIds:
 
     def test_no_matches_exits(self, ts, tmp_path):
         _write_l0(str(tmp_path), "20240101", 3600, "99999")  # no target frames
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit, match="no science frames for target"):
             ts.discover_science_obs_ids(
                 str(tmp_path), "10700", "20240101", "20240131", jobs=2
             )
 
     def test_missing_l0_root_exits(self, ts, tmp_path):
-        with pytest.raises(SystemExit):
+        # A distinct diagnostic from "no matches": without the match= the tmp
+        # tree yields no frames either way and this duplicates its neighbour.
+        with pytest.raises(SystemExit, match="L0 input directory not found"):
             ts.discover_science_obs_ids(
                 str(tmp_path), "10700", "20240101", "20240131", jobs=2
             )
@@ -313,6 +321,17 @@ class TestMainDispatch:
 
         monkeypatch.setattr(ts.subprocess, "run", _run)
         return calls
+
+    def test_missing_log_dir_exits(self, ts, monkeypatch, tmp_path):
+        # _FakeConfig hands every other dispatch test a hardcoded log_dir, so
+        # this DRP-RUN-07 guard is unreachable from all of them. Losing it means
+        # a ValueError from deep in build_log_path, after the batch has started.
+        _write_l0(str(tmp_path), "20240101", 3600, "10700")
+        monkeypatch.setattr(
+            ts, "ConfigHandler", lambda path: _FakeConfig(path, str(tmp_path), None)
+        )
+        with pytest.raises(SystemExit, match="no log directory configured"):
+            ts.main(_BASE_ARGS)
 
     def test_masters_science_plots_dispatch(self, ts, monkeypatch, tmp_path):
         # Stages run in order: masters, then science over every discovered frame,

--- a/tests/regression/test_timeseries_script.py
+++ b/tests/regression/test_timeseries_script.py
@@ -13,9 +13,10 @@ import sys
 from pathlib import Path
 
 import pytest
-from astropy.io import fits
 
 from scripts.processing import timeseries as _ts
+
+from ._scripts import write_l0_tree
 
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
 pytestmark = pytest.mark.cli
@@ -35,20 +36,11 @@ def ts():
 
 
 def _write_l0(data_input, datecode, seconds, obj, imtype="Object", junk=False):
-    """Write one L0 frame under {data_input}/L0/{datecode}; return its obs_id."""
-    l0_dir = Path(data_input) / "L0" / datecode
-    l0_dir.mkdir(parents=True, exist_ok=True)
-    obs_id = f"KP.{datecode}.{seconds:05d}.00"
-    header = fits.Header(
-        {
-            "OBJECT": obj,
-            "IMTYPE": imtype,
-            "TARGNAME": obj,
-            "EXPTIME": 60.0,
-            "ELAPSED": 60.0,
-        }
-    )
-    fits.PrimaryHDU(header=header).writeto(l0_dir / f"{obs_id}.fits")
+    """Write one L0 frame under {data_input}/L0/{datecode}; return its obs_id.
+
+    Thin wrapper over the shared writer for the junk-list hook, which only the
+    timeseries discovery tests need."""
+    obs_id = write_l0_tree(data_input, datecode, seconds, obj=obj, imtype=imtype)
     if junk:
         _add_junk(data_input, obs_id)
     return obs_id

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -252,7 +252,7 @@ class TestPerform:
             master.data[f"{chip}_SCI2_WAVE"] = rng.uniform(
                 4000.0, 8000.0, size=(norder, NCOL)
             ).astype(np.float64)  # WAVE is born-64 (EPRV / dtype policy)
-        master_path = str(tmp_path / "partial_master.fits")
+        master_path = str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
         master.to_fits(master_path)
 
         l2 = _make_science_l2(wls_path=master_path)

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -196,7 +196,8 @@ class TestPerform:
         WavelengthCalibration(l2).perform()
         for chip in _CHIPS:
             for fiber in _FIBERS:
-                assert l2.data[f"{chip}_{fiber}_WAVE"].dtype == np.float64
+                ext = f"{chip}_{fiber}_WAVE"
+                assert_dtype(l2.data[ext], WAVE, ext)
 
     def test_explicit_path_bypasses_header(self, master_wls_path):
         # The WLSFILE header is bogus; the valid wls_path override wins.
@@ -230,7 +231,7 @@ class TestPerform:
         assert not np.any(l2.data["GREEN_SCI1_WAVE"])
         assert not np.any(l2.data["RED_SCI2_WAVE"])
 
-    def test_raises_when_wlsfile_missing(self):
+    def test_perform_raises_when_wlsfile_missing(self):
         l2 = _make_science_l2()  # no WLSFILE
         with pytest.raises(KeyError, match="WLSFILE"):
             WavelengthCalibration(l2).perform()

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -41,8 +41,8 @@ NCOL = 32
 def _make_master_l2(seed=42):
     """Build a KPFMasterL2 with deterministic, distinct per-fiber WAVE arrays.
 
-    Each (chip, fiber) gets its own random-but-reproducible block so we can
-    later confirm that exactly the right block lands on the science L2.
+    Each (chip, fiber) block differs, so tests can confirm that exactly the right
+    one lands on the science L2.
     """
     master = KPFMasterL2(kind="wls")
     master.headers["PRIMARY"]["INSTRUME"] = "KPF"
@@ -53,8 +53,8 @@ def _make_master_l2(seed=42):
     for chip in _CHIPS:
         norder = NORDER_GREEN if chip == "GREEN" else NORDER_RED
         for fiber in _FIBERS:
-            # WAVE is born-64 (EPRV / dtype policy); rvdata's MinBitDepth would
-            # otherwise upcast-and-warn a float32 WAVE on read.
+            # WAVE is born-64; rvdata's MinBitDepth would otherwise
+            # upcast-and-warn a float32 WAVE on read.
             arr = rng.uniform(4000.0, 8000.0, size=(norder, NCOL)).astype(np.float64)
             master.data[f"{chip}_{fiber}_WAVE"] = arr
     return master
@@ -66,19 +66,19 @@ def _make_science_l2(wls_path=None):
     l2.headers["PRIMARY"]["INSTRUME"] = "KPF"
     l2.headers["PRIMARY"]["DATE-OBS"] = "2024-04-05T11:08:33"
     if wls_path is not None:
-        # WLSFILE is a registered KPF-pipeline keyword routed to the RECEIPT
-        # header (written by CalibrationAssociation on the L1 RECEIPT and carried
-        # through by to_kpf2); set_keyword places it on RECEIPT.
+        # set_keyword routes WLSFILE to RECEIPT, where CalibrationAssociation
+        # writes it on the L1 and to_kpf2 carries it through.
         l2.set_keyword("WLSFILE", wls_path)
     return l2
 
 
 @pytest.fixture(scope="module")
 def master_wls_path(tmp_path_factory):
-    """Write a synthetic KPFMasterL2 to disk and return its path.
+    """Path to a synthetic KPFMasterL2 on disk.
 
-    Module-scoped read-only source: perform()/load_wls() only read the master (they
-    copy WAVE onto a fresh science L2), so the write happens once per module."""
+    Module-scoped: perform()/load_wls() only read the master, so one write serves
+    every test.
+    """
     master = _make_master_l2()
     path = str(
         tmp_path_factory.mktemp("wls") / "KP.20240405.03637.00_master_thar_L2.fits"
@@ -177,7 +177,6 @@ class TestPerform:
         assert mod.fibers == _FIBERS
 
     def test_copies_all_wave_arrays(self, master_wls_path):
-        # Every (chip, fiber) WAVE array on the science L2 should match the master.
         l2 = _make_science_l2(wls_path=master_wls_path)
         WavelengthCalibration(l2).perform()
 
@@ -188,9 +187,8 @@ class TestPerform:
                 np.testing.assert_array_equal(l2.data[key], master.data[key])
 
     def test_wave_arrays_are_float64(self, master_wls_path):
-        # WAVE is born-64 everywhere (EPRV / dtype policy; rvdata MinBitDepth also
-        # enforces 64-bit WAVE on read). Both the master and the science WAVE it is
-        # copied onto must be float64.
+        # WAVE is born-64 everywhere, so both the master and the science arrays
+        # it is copied onto must be float64.
         master = KPFMasterL2.from_fits(master_wls_path)
         # from_fits yields big-endian (>f8); compare precision, not byte order.
         assert_dtype(master.data["GREEN_SCI2_WAVE"], WAVE, "master GREEN_SCI2_WAVE")
@@ -201,7 +199,7 @@ class TestPerform:
                 assert l2.data[f"{chip}_{fiber}_WAVE"].dtype == np.float64
 
     def test_explicit_path_bypasses_header(self, master_wls_path):
-        # WLSFILE header is bogus, but wls_path override is valid → perform() succeeds.
+        # The WLSFILE header is bogus; the valid wls_path override wins.
         l2 = _make_science_l2(wls_path="/tmp/bogus.fits")
         WavelengthCalibration(l2).perform(wls_path=master_wls_path)
 
@@ -220,9 +218,8 @@ class TestPerform:
         )
 
     def test_subset_chips_and_fibers(self, master_wls_path):
-        # Only the requested (chip, fiber) blocks are copied; everything
-        # else stays zero -- both un-requested fibers within the requested
-        # chip, and un-requested chips entirely.
+        # Only the requested (chip, fiber) blocks are copied; every other fiber
+        # and chip stays zero.
         l2 = _make_science_l2(wls_path=master_wls_path)
         WavelengthCalibration(l2).perform(chips=["GREEN"], fibers=["SCI2"])
 
@@ -230,9 +227,7 @@ class TestPerform:
         np.testing.assert_array_equal(
             l2.data["GREEN_SCI2_WAVE"], master.data["GREEN_SCI2_WAVE"]
         )
-        # Un-requested fiber within the requested chip stays zero.
         assert not np.any(l2.data["GREEN_SCI1_WAVE"])
-        # Un-requested chip stays zero.
         assert not np.any(l2.data["RED_SCI2_WAVE"])
 
     def test_raises_when_wlsfile_missing(self):
@@ -241,7 +236,7 @@ class TestPerform:
             WavelengthCalibration(l2).perform()
 
     def test_raises_when_master_missing_requested_fiber(self, tmp_path):
-        # Master only has SCI2; config asks for all 5 fibers → fail loudly.
+        # The master only has SCI2, but all 5 fibers are requested.
         master = KPFMasterL2(kind="wls")
         master.headers["PRIMARY"]["INSTRUME"] = "KPF"
         master.headers["PRIMARY"]["DATE-OBS"] = "2024-04-05T01:00:37"
@@ -251,7 +246,7 @@ class TestPerform:
             norder = NORDER_GREEN if chip == "GREEN" else NORDER_RED
             master.data[f"{chip}_SCI2_WAVE"] = rng.uniform(
                 4000.0, 8000.0, size=(norder, NCOL)
-            ).astype(np.float64)  # WAVE is born-64 (EPRV / dtype policy)
+            ).astype(np.float64)  # WAVE is born-64
         master_path = str(tmp_path / "KP.20240113.23249.10_master_thar_L2.fits")
         master.to_fits(master_path)
 
@@ -266,15 +261,13 @@ class TestPerform:
 #
 # Once WavelengthCalibration assigns the master WLS, the extracted flux must be
 # co-oriented with that wavelength axis: a strong stellar absorption line has to
-# land at its catalog wavelength, NOT at the mirror-image wavelength that a
-# flux/wave flip would produce. We test this with deep Fraunhofer lines, whose
-# rest wavelengths are textbook-known.
+# land at its catalog wavelength, NOT at the mirror-image wavelength a flux/wave
+# flip would produce. Deep Fraunhofer lines, whose rest wavelengths are
+# textbook-known, are the probe.
 #
-# Fraunhofer absorption lines, AIR wavelengths [Angstrom]:
-#   https://en.wikipedia.org/wiki/Fraunhofer_lines
-# KPF covers ~4457-8700 A, so only H-beta, the Na D doublet, and H-alpha are
-# actually observable; the bluer Ca II H&K and H-gamma/H-delta fall below the
-# blue cutoff and are skipped automatically (kept here for documentation).
+# Fraunhofer absorption lines, AIR wavelengths [Angstrom]. KPF covers
+# ~4457-8700 A, so only H-beta, the Na D doublet, and H-alpha are observable;
+# the bluer lines fall below the blue cutoff and are skipped automatically.
 
 _FRAUNHOFER_AIR = {
     "Ca II K": 3933.66,
@@ -297,10 +290,9 @@ def _trough_depth(wave_order, flux_order, lambda_air, halfwin=3.0):
     ``lambda_air``, or None if the line is not covered by this order or the
     window holds no finite flux. The window is centered between the air and
     vacuum line wavelengths, so it absorbs both the air<->vacuum offset (~1.5 A)
-    and the stellar+barycentric Doppler shift (~0.3 A) without needing to know
-    which frame the WLS is in. Continuum is the window's 90th percentile -- over
-    this narrow a span the blaze is locally flat, so its curvature is
-    negligible.
+    and the stellar+barycentric Doppler shift (~0.3 A) without knowing which
+    frame the WLS is in. Continuum is the window's 90th percentile -- the blaze
+    is locally flat over this narrow a span.
     """
     lambda_vac = float(air_to_vac(np.array([lambda_air]))[0])
     center = 0.5 * (lambda_air + lambda_vac)
@@ -319,21 +311,20 @@ def _trough_depth(wave_order, flux_order, lambda_air, halfwin=3.0):
 @pytest.mark.slow
 @pytest.mark.requires_testdata
 class TestSpectrumOrientation:
-    """Discriminator: the WLS-calibrated L2 must have its flux co-oriented with
-    the assigned wavelength axis.
+    """The WLS-calibrated L2 must have its flux co-oriented with its wave axis.
 
     For every in-coverage Fraunhofer anchor on every science fiber, the native
-    ``(wave, flux)`` pairing must show a DEEPER absorption trough at the catalog
-    wavelength than the reversed ``(wave, flux[::-1])`` pairing. A flux/wave flip
-    inverts that relationship and fails the test.
+    ``(wave, flux)`` pairing must show a deeper absorption trough at the catalog
+    wavelength than the reversed ``(wave, flux[::-1])`` pairing; a flux/wave flip
+    inverts that relationship.
     """
 
     @pytest.fixture(scope="class")
     def science_l2(self):
         # Build the real L0->L2 chain just far enough to get extracted flux with
-        # the master WLS assigned. Restricted to the SCI fibers because the truth
-        # WLS master only carries those. Upstream modules are imported here, not
-        # at module scope, to keep this WLS-application test file's surface small.
+        # the master WLS assigned, restricted to the SCI fibers because the truth
+        # WLS master only carries those. Upstream modules are imported here to
+        # keep this file's module-level surface small.
         from kpfpipe.data_models import KPF0
         from kpfpipe.modules.calibration_association import CalibrationAssociation
         from kpfpipe.modules.image_assembly import ImageAssembly
@@ -356,8 +347,7 @@ class TestSpectrumOrientation:
         return WavelengthCalibration(l2, config).perform()
 
     def _anchor_cases(self, l2):
-        """List in-coverage anchors as
-        (name, chip, fiber, order, wave, flux, lambda_air)."""
+        """In-coverage anchors: (name, chip, fiber, order, wave, flux, lambda_air)."""
         cases = []
         for name, lambda_air in _FRAUNHOFER_AIR.items():
             for chip in _CHIPS:
@@ -373,20 +363,14 @@ class TestSpectrumOrientation:
         return cases
 
     def test_expected_anchors_in_coverage(self, science_l2):
-        """The observable Fraunhofer lines are found; the bluer ones are out of
-        range."""
         names = {c[0] for c in self._anchor_cases(science_l2)}
         assert {"H-beta", "Na D2", "Na D1", "H-alpha"} <= names
         assert names.isdisjoint({"Ca II K", "Ca II H", "H-delta", "H-gamma"})
 
     def test_flux_co_oriented_with_wave(self, science_l2):
-        """Anchors sit in deeper troughs in the native pairing than reversed.
-
-        Orientation is a single global property of the FFI, so the verdict is
-        aggregate: the mean native trough depth must clearly exceed the mean
-        reversed depth. (A per-anchor comparison is brittle for lines near an
-        order center, where the mirror wavelength falls back onto the line.)
-        """
+        # Orientation is a single global property of the FFI, so the verdict is
+        # aggregate. A per-anchor comparison would be brittle for lines near an
+        # order center, where the mirror wavelength falls back onto the line.
         cases = self._anchor_cases(science_l2)
         assert cases, "no Fraunhofer anchor lines found in coverage"
 
@@ -411,8 +395,8 @@ class TestSpectrumOrientation:
         )
 
     def test_strong_anchor_is_deep(self, science_l2):
-        """Floor check: the Na D doublet must be a deep trough in the native
-        pairing, so the discriminator cannot pass trivially on near-zero flux."""
+        # Floor check: the Na D doublet must be a deep trough in the native
+        # pairing, so the discriminator cannot pass trivially on near-zero flux.
         deepest = 0.0
         for name, _chip, _fiber, _o, wave, flux, lambda_air in self._anchor_cases(
             science_l2

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -215,7 +215,9 @@ class TestPerform:
         l2 = _make_science_l2(wls_path=master_wls_path)
         WavelengthCalibration(l2).perform()
         assert_dtype(l2.data["TRACE3_WAVE"], WAVE, "L2 TRACE3_WAVE")
-        assert_roundtrip_dtype(KPF2, l2, "TRACE3_WAVE", WAVE, tmp_path)
+        assert_roundtrip_dtype(
+            KPF2, l2, "TRACE3_WAVE", WAVE, tmp_path, name="kpf_SL2_20240101T000000.fits"
+        )
 
     def test_subset_chips_and_fibers(self, master_wls_path):
         # Only the requested (chip, fiber) blocks are copied; everything

--- a/tests/regression/test_wavelength_calibration.py
+++ b/tests/regression/test_wavelength_calibration.py
@@ -113,7 +113,7 @@ class TestConstructor:
         assert mod.fibers == _FIBERS
 
     def test_invalid_config_type(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError, match="config must be"):
             WavelengthCalibration(_make_science_l2(), config="not a dict")
 
     def test_wls_path_is_none_before_load(self):
@@ -394,6 +394,32 @@ class TestSpectrumOrientation:
             f"mean native depth {mean_native:.3f} <= mean reversed {mean_reverse:.3f} "
             f"(flux flipped relative to WLS?)\n" + "\n".join(rows)
         )
+
+    def test_wavelength_solution_is_vacuum(self, science_l2):
+        # EPRV_DATA_STANDARD: all wavelengths are vacuum, never air. The
+        # orientation discriminator above deliberately centers its window
+        # BETWEEN the two frames, so nothing else here can tell them apart --
+        # yet a dropped air->vac conversion is ~1.6 A at Na D, i.e. ~80 m/s.
+        # The two frames differ by far more than the ~0.6 A stellar+barycentric
+        # shift, so the nearer catalog wavelength identifies the frame.
+        checked = 0
+        for name, chip, fiber, o, wave, flux, lambda_air in self._anchor_cases(
+            science_l2
+        ):
+            if name not in ("Na D1", "Na D2", "H-beta"):
+                continue
+            lambda_vac = float(air_to_vac(np.array([lambda_air]))[0])
+            window = np.abs(wave - 0.5 * (lambda_air + lambda_vac)) < 3.0
+            if np.count_nonzero(window) < 5 or not np.any(np.isfinite(flux[window])):
+                continue
+            trough = wave[window][np.nanargmin(flux[window])]
+            checked += 1
+            assert abs(trough - lambda_vac) < 0.5 * abs(trough - lambda_air), (
+                f"{name} {chip} {fiber} order {o}: absorption at {trough:.3f} A is "
+                f"nearer the AIR wavelength {lambda_air:.3f} than the vacuum "
+                f"{lambda_vac:.3f} -- the WLS looks like it is in the air frame"
+            )
+        assert checked, "no anchor usable for the air/vacuum discriminant"
 
     def test_strong_anchor_is_deep(self, science_l2):
         # Floor check: the Na D doublet must be a deep trough in the native


### PR DESCRIPTION
  # Make the regression suite trustworthy

  The suite passed before this branch. That was not the same as it being trustworthy: it
  tolerated warnings, reached the live network on every run, and in several places asserted
  things that could not fail. This PR closes that gap. It is large but single-themed — 9
  commits, almost entirely under `tests/`.

  ## What changed, thematically

  **Warnings now fail.** `filterwarnings = ["error"]`, with two documented exemptions rather
  than a blanket ignore. The EPRV filename-convention suppression is *retired* rather than
  widened — the fixtures that tripped it were fixed instead.

  **The suite no longer reaches the network.** `astroquery.gaia` opens a connection to ESA at
  import, and the science-recipe fixture issued live Gaia/SIMBAD queries — measured between
  **6.1 s and 122.4 s** across runs. `tests/conftest.py` now blocks outbound sockets at module
  scope (the connect happens during *collection*, so a fixture is too late), and the science
  fixture replays a frozen capture of the truth frame's own catalog row through `AstroQuery`'s
  own writer. Frozen BERV agrees with live to 6e-8 km/s.

  **Fictions removed.** The most expensive masters-recipe test never ran the masters recipe — it
  hand-rolled a copy and re-stacked frames another class already stacked. Its assertions moved
  to `test_master_bias.py` (four of them strengthened), and both recipe suites now drive the real
  `main()` through a shared stub. That stub used to model "nothing to stack" as `return []`, a
  value production never produces — it raises.

  **Coverage for things that were silently untested.** The science recipe writes an L4 no test
  opened. `BARYCORR_Z` was zero in both CCF/RV fixtures, so a non-zero barycentric correction
  never flowed through the chain. Nothing pinned the filename generator against its validator —
  and they had already drifted. QC read-noise checks could only fail high, so a broken estimator
  returning ~0 passed. The stacking gates, `CheckpointL0/L2.run()`, and the DiagL2→QCL2 seam were
  unasserted.

  **Cost.** ~68 s of serial CPU removed — mostly by converting 9 of 11 CLI subprocess spawns to
  in-process calls, shrinking eleven full-detector renders that asserted nothing about size, and
  memoizing a rough-WLS build that ran 62 times. Two subprocess spawns are kept deliberately:
  they are the only witnesses that these scripts are invocable *as programs*.

  ## The one production change — please review this closely

  `kpfpipe/quality_control/qc_flags/level0.py` — `radec_consistent` now returns `True`
  unconditionally for non-`Object` frames. Pointing is only meaningful for a science frame; a
  calibration frame has no target, `AstroQuery` never runs on it, and `DiagL0` therefore leaves
  `TARGOFF` blank, which failed the required-branch check. **This changes RADECOK behaviour for
  calibration frames.**

  Everything else is `tests/` plus `pyproject.toml`.

  ## Results

  | | |
  |---|---|
  | `make test` | **1805 passed, 0 failed, 0 warnings** |
  | wall clock | **67.3 / 67.2 / 66.9 s** (three consecutive runs) |
  | determinism | run-to-run **sd 1.8 → 0.2 s** after de-networking |
  | production files changed | **1** (above) |

  The spread matters more than the median. The suite's previously-quoted "~90 s baseline" was one
  sample of a network-dependent distribution and never reproduced.

  ## What this deliberately does *not* do

  **No numeric RV pin.** The recipe's L4 is now read back and asserted structurally — `kpf_SL4_`
  basename, receipt entries, `RVMETHOD`, extensions, dtypes — but no value it carries is checked.
  That was a considered call; the end-to-end RV tripwire remains an open item.

  **No test blesses a known bug.** Six production defects were confirmed during the audit and
  left untouched; two proposed tests that would have pinned buggy behaviour as correct were
  withdrawn rather than written.

  1. **`scripts/processing/reduce.py:149`** — `clear_stale_outputs` runs *before* the recipe path
     is validated. Every recipe-loading failure (bad path, exec error, missing `main()`) destroys
     the previous run's L1/L2/L4 and then exits. A typo'd `-r` is sufficient. **Data loss.**
  2. **`kpfpipe/modules/masters/base.py:616`** (and `wls.py:831`) — `INPUT_FILES` records the
     *requested* frames, not the *stacked* ones, contradicting the data model's own docstring.
     Because `generate_standard_filename()` derives the WMKO DRP-RUN-05 name from
     `INPUT_FILES[0]`, a master whose first frame failed QC is named after a frame that
     contributed nothing.
  3. **`kpfpipe/modules/astro_query.py:27`** — live TCP connect at import. Contained test-side
     here; three subprocess tests still reach ESA because a spawned interpreter loads no conftest.
  4. **`kpfpipe/utils/network.py:13-15`** — retry ladder with no per-attempt timeout (~55 s of
     sleep on top of unbounded block time). The mechanism behind the 20× runtime range.
  5. **`kpfpipe/modules/cross_correlation.py:511-512`** — unreachable branch; the module already
     raises on descending `WAVE`.
  6. **`kpfpipe/data_models/aliased_dict.py:33`** — `unregister_alias` has no caller.

  (1) and (2) have archive/provenance consequences and are worth scheduling before the next
  release. (3) and (4) already have an implementation plan in `notes/network_fixes.md`.

  ## Reviewing this

  The commits are individually coherent and land in dependency order; reading them in sequence is
  easier than reading the combined diff. If you only read two:

  - `a9e2b4f4` — the audit's substance (de-networking, fictions removed, coverage added)
  - `3b4df2e2` — the shared-helper structure everything else builds on

  Test-count deltas were declared per file before the work ran and reconciled exactly against
  collection (1805), so no test was lost silently — the failure mode a green run cannot detect.