### PR TITLE
Stop querying ESA at import, bound the queries we make, and fix subprocess teardown

### DIFF
--- a/configs/kpf_drp_science.toml
+++ b/configs/kpf_drp_science.toml
@@ -16,6 +16,7 @@ fibers = ["SKY", "SCI1", "SCI2", "SCI3", "CAL"]
 do_gaia_query = true
 do_simbad_query = true
 astrometry_priority = ["gaia", "simbad"]  # can include gaia/simbad/wmko
+query_timeout = 30  # seconds per HTTP round trip; retried up to 5 times
 
 [MODULE_IMAGE_ASSEMBLY]
 overscan_method = "rowmedian"

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -24,13 +24,11 @@ import numpy as np
 from astropy.coordinates import FK5, ICRS, Angle, SkyCoord
 from astropy.table import Table
 from astropy.time import Time
-from astroquery.gaia import Gaia
-from astroquery.simbad import Simbad
 
 from kpfpipe import DEFAULTS
 from kpfpipe.utils.astro import compute_redshift
 from kpfpipe.utils.config import ConfigHandler
-from kpfpipe.utils.network import retry_request
+from kpfpipe.utils.network import gaia_client, retry_request, simbad_client
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +37,7 @@ _DEFAULTS = {
     "do_gaia_query": True,
     "do_simbad_query": True,
     "astrometry_priority": ("gaia", "simbad"),
+    "query_timeout": 30,
 }
 
 # Sources that can supply a CATALOG_RECORD row, highest catalog priority first.
@@ -72,6 +71,11 @@ _SIMBAD_UNITS = {
     "B": None,
     "V": None,
 }
+
+# Votable fields asked of SIMBAD, beyond the ra/dec every query returns. Deliberately
+# spelled out beside _SIMBAD_UNITS rather than derived from it, so the two can be seen
+# to diverge; test_astro_query guards the pair against drift.
+_SIMBAD_FIELDS = ("pmra", "pmdec", "plx_value", "rvz_radvel", "B", "V")
 
 # Queryable Gaia release -> its gaia_source table, newest last. DR1 and EDR3 are
 # excluded (no radial_velocity or BP/RP photometry, and superseded, respectively).
@@ -156,7 +160,7 @@ class AstroQuery:
         OBJECT, TARG*) is read but never modified.
     config : None | dict | ConfigHandler
         Module configuration. Recognized keys: do_gaia_query, do_simbad_query,
-        astrometry_priority.
+        astrometry_priority, query_timeout.
     """
 
     def __init__(self, l0_obj, config=None):
@@ -266,7 +270,9 @@ class AstroQuery:
             )
             try:
                 found = retry_request(
-                    lambda q=query: Gaia.launch_job(q).get_results(), f"Gaia {release}"
+                    lambda q=query: gaia_client().launch_job(q).get_results(),
+                    f"Gaia {release}",
+                    timeout=self.query_timeout,
                 )
             except Exception as e:
                 logger.warning(
@@ -455,7 +461,9 @@ class AstroQuery:
         logger.info("querying Gaia %s for source_id %s", release, gaia_id)
         try:
             results = retry_request(
-                lambda: Gaia.launch_job(query).get_results(), f"Gaia {release}"
+                lambda: gaia_client().launch_job(query).get_results(),
+                f"Gaia {release}",
+                timeout=self.query_timeout,
             )
         except Exception as e:
             logger.warning(
@@ -523,11 +531,13 @@ class AstroQuery:
             return None
         logger.info("querying SIMBAD for %r", name)
         try:
-            simbad = Simbad()
-            simbad.add_votable_fields(
-                "pmra", "pmdec", "plx_value", "rvz_radvel", "B", "V"
+            result = retry_request(
+                lambda: simbad_client(_SIMBAD_FIELDS, self.query_timeout).query_object(
+                    name
+                ),
+                "SIMBAD",
+                timeout=self.query_timeout,
             )
-            result = retry_request(lambda: simbad.query_object(name), "SIMBAD")
         except Exception as e:
             logger.warning(
                 "SIMBAD query failed (%s: %s); SIMBAD astrometry unavailable",

--- a/kpfpipe/modules/astro_query.py
+++ b/kpfpipe/modules/astro_query.py
@@ -72,9 +72,8 @@ _SIMBAD_UNITS = {
     "V": None,
 }
 
-# Votable fields asked of SIMBAD, beyond the ra/dec every query returns. Deliberately
-# spelled out beside _SIMBAD_UNITS rather than derived from it, so the two can be seen
-# to diverge; test_astro_query guards the pair against drift.
+# Votable fields asked of SIMBAD, beyond the ra/dec every query returns. Spelled out
+# rather than derived from _SIMBAD_UNITS, so the two can be seen to diverge.
 _SIMBAD_FIELDS = ("pmra", "pmdec", "plx_value", "rvz_radvel", "B", "V")
 
 # Queryable Gaia release -> its gaia_source table, newest last. DR1 and EDR3 are

--- a/kpfpipe/utils/network.py
+++ b/kpfpipe/utils/network.py
@@ -2,17 +2,19 @@
 
 import logging
 import random
+import socket
 import time
 
 from astroquery.exceptions import RemoteServiceError
 from astroquery.exceptions import TimeoutError as AstroqueryTimeoutError
 from pyvo.dal import DALServiceError
+from requests.adapters import HTTPAdapter
 
 logger = logging.getLogger(__name__)
 
 # Nominal seconds to wait before each retry; len() sets the retry count, so a call
-# is attempted len(_RETRY_WAITS) + 1 times (~55 s of waiting worst case).
-_RETRY_WAITS = (1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 30.0)
+# is attempted len(_RETRY_WAITS) + 1 = 5 times (~18 s of waiting worst case).
+_RETRY_WAITS = (1.0, 2.0, 5.0, 10.0)
 
 # Transient failures worth another attempt. OSError covers the builtin
 # ConnectionError/TimeoutError and every requests exception (RequestException
@@ -22,24 +24,38 @@ _RETRY_WAITS = (1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 30.0)
 _RETRYABLE = (OSError, AstroqueryTimeoutError, RemoteServiceError, DALServiceError)
 
 
-def retry_request(func, description):
+def retry_request(func, description, timeout=None):
     """Call ``func``, retrying transient network failures with backoff.
 
     Waits follow ``_RETRY_WAITS`` with equal jitter. A non-transient exception, or the
     last attempt's, propagates to the caller unchanged -- the AstroQuery callers turn
     that into their fail-soft warning + None.
 
-    There is no per-attempt timeout: astroquery 0.4.11 exposes no socket timeout for
-    either client (``Gaia.launch_job`` takes none and its TAP transport builds an
-    ``http.client`` connection without one; SIMBAD's ``timeout`` is a server-side
-    execution duration), so a hung connection is not bounded here.
+    ``timeout`` bounds each HTTP request, not the call as a whole: one attempt makes
+    several round trips, so the ceiling is ``timeout`` per round trip over 5 attempts
+    plus the backoff -- minutes at the 30 s default, but finite.
+
+    It covers only Gaia. Gaia's TAP transport is ``http.client``, which honours the
+    process-wide socket default set here; SIMBAD's is ``requests`` via pyvo, which
+    passes an explicit ``timeout=None`` down to ``sock.settimeout`` and so *overrides*
+    that default. SIMBAD is bounded instead by the adapter ``simbad_client`` installs.
+    Do not collapse the two -- dropping that adapter leaves SIMBAD unbounded.
+
+    ``socket.setdefaulttimeout`` is process-global and not thread-safe; the
+    ``try/finally`` and the tight window around ``func()`` are what make it acceptable.
+    Queries run single-threaded inside each child process today (``_dispatch.py``
+    threads supervise child *processes*, not queries); revisit this if that changes.
 
     Parameters
     ----------
     func : callable
-        Zero-argument callable performing the request.
+        Zero-argument callable performing the request. Build the service client inside
+        it: both clients reach the network while being constructed, and only what runs
+        inside ``func`` is bounded.
     description : str
         Service name used in the retry log messages.
+    timeout : float, optional
+        Seconds to bound each request. None leaves the process default untouched.
 
     Returns
     -------
@@ -50,11 +66,21 @@ def retry_request(func, description):
     ------
     Exception
         Whatever ``func`` raises, once retries are exhausted or immediately if the
-        failure is not transient.
+        failure is not transient. A tripped socket timeout is a ``TimeoutError``, which
+        ``_RETRYABLE`` covers via OSError, so it retries like any other.
     """
-    for wait in _RETRY_WAITS:
+
+    def attempt():
+        previous = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(timeout)
         try:
             return func()
+        finally:
+            socket.setdefaulttimeout(previous)
+
+    for wait in _RETRY_WAITS:
+        try:
+            return attempt()
         except _RETRYABLE as e:
             # Equal jitter -- half the nominal wait plus a random half -- so parallel
             # workers that failed together do not retry in lockstep.
@@ -67,4 +93,58 @@ def retry_request(func, description):
                 delay,
             )
             time.sleep(delay)
-    return func()
+    return attempt()
+
+
+class _TimeoutAdapter(HTTPAdapter):
+    """requests adapter supplying a default timeout when the caller passes none."""
+
+    def __init__(self, timeout, **kwargs):
+        self._timeout = timeout
+        super().__init__(**kwargs)
+
+    def send(self, request, stream=False, timeout=None, **kwargs):
+        if timeout is None:
+            timeout = self._timeout
+        return super().send(request, stream=stream, timeout=timeout, **kwargs)
+
+
+def gaia_client():
+    """Return a Gaia TAP client that does not fetch server status messages.
+
+    ``astroquery.gaia`` reaches ESA twice: once building its module-level
+    ``Gaia = GaiaClass()``, whose constructor fetches status messages, and again per
+    query. ``show_server_messages=False`` kills the second. The first is not gone, only
+    moved out of the pipeline's import graph -- importing the module still triggers
+    it -- so call this inside the callable handed to ``retry_request``, where it is
+    bounded.
+    """
+    # Deferred: this import *is* the connection to ESA, so it must not run until a
+    # caller has decided to query Gaia.
+    from astroquery.gaia import GaiaClass
+
+    return GaiaClass(show_server_messages=False)
+
+
+def simbad_client(fields, timeout=None):
+    """Return a SIMBAD client requesting ``fields``, bounded by ``timeout``.
+
+    A session-level default rather than a socket one, because SIMBAD is reached through
+    pyvo over ``requests`` -- see ``retry_request``. It goes on before
+    ``add_votable_fields``, which validates the names server-side and is itself a
+    network call.
+
+    ``SimbadClass()`` is constructed explicitly because astroquery's ``Simbad`` is an
+    instance, not a class; calling it works only via ``BaseQuery.__call__``.
+    """
+    # Deferred: import cost, and to keep astroquery off the paths that never query a
+    # catalog.
+    from astroquery.simbad import SimbadClass
+
+    client = SimbadClass()
+    if timeout is not None:
+        adapter = _TimeoutAdapter(timeout)
+        client._session.mount("https://", adapter)
+        client._session.mount("http://", adapter)
+    client.add_votable_fields(*fields)
+    return client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,16 +54,11 @@ testpaths = ["tests"]
 # Quiet output; re-run a single failure with --tb=long for full frame context.
 addopts = "-q --no-header --tb=short"
 # Exempt only warnings that are expected *and* handled, and prefer
-# @pytest.mark.filterwarnings on the one test over widening this list. The
-# exception is a warning raised during garbage collection: it surfaces at an
-# arbitrary later test, so no single test owns it and only a global rule works.
+# @pytest.mark.filterwarnings on the one test over widening this list.
 filterwarnings = [
     "error",
     # masters INPUT_FILES deliberately round-trips long paths.
     "ignore:Card is too long, comment will be truncated:astropy.io.fits.verify.VerifyWarning",
-    # astroquery.gaia opens a connection to ESA at import (astro_query.py:27) and
-    # never closes it. Print the leak; do not fail on GC timing.
-    "default::ResourceWarning",
 ]
 # Markers are registered in tests/conftest.py (pytest_configure).
 

--- a/scripts/processing/_dispatch.py
+++ b/scripts/processing/_dispatch.py
@@ -96,16 +96,18 @@ def _handle_termination_signal(signum, frame):
 
 
 def configure_runtime():
-    """Install the SIGTERM handler and pin subprocess BLAS/OpenMP to one thread.
+    """Install the SIGTERM handler, pin BLAS/OpenMP to one thread, select Agg.
 
     Call once at the start of an orchestrator's main(), not at import, so importing
     never mutates signal handlers or the environment. Routes SIGTERM through the
     KeyboardInterrupt path so `kill` tears down children like Ctrl+C. Caps the
     BLAS/OpenMP pools at 1 (via setdefault, so an explicit caller wins): we already
     run one process per job, so an inner OpenBLAS pool would be jobs x cores threads
-    and thrash.
+    and thrash. Pins matplotlib to Agg the same way: children run headless, and an
+    unset backend resolves to macosx.
     """
     signal.signal(signal.SIGTERM, _handle_termination_signal)
+    os.environ.setdefault("MPLBACKEND", "Agg")
     for var in (
         "OMP_NUM_THREADS",
         "OPENBLAS_NUM_THREADS",
@@ -169,6 +171,7 @@ def _run_one(argv, timeout=None, launch_interval=0.0):
     proc = subprocess.Popen(
         argv,
         cwd=kpfpipe.REPO_ROOT,
+        stdin=subprocess.DEVNULL,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
         text=True,
@@ -217,9 +220,11 @@ def run_stage(
     the rest in a pool of `jobs` workers. Returns the set of failed tags.
 
     The canary runs alone (bounded by `canary_timeout`) before any fan-out, warming
-    the shared on-disk caches every job lazily builds (barycorrpy leap-seconds,
-    astropy IERS, matplotlib fonts, bytecode) so the parallel jobs don't stampede a
-    cold cache. Each fanned-out job is bounded by the shorter `job_timeout`; on
+    the shared on-disk caches the jobs lazily build so they don't stampede a cold
+    one. How much that is depends on the stage: the science recipe pulls in
+    barycorrpy leap-seconds, astropy IERS and matplotlib fonts; the masters recipe
+    imports none of them, so there it warms bytecode alone.
+    Each fanned-out job is bounded by the shorter `job_timeout`; on
     overrun (a stalled NFS read, a runaway recipe) its process group is killed and
     it returns 124, counted as a failure, so one stuck unit can't hang the batch.
 

--- a/scripts/processing/_dispatch.py
+++ b/scripts/processing/_dispatch.py
@@ -242,7 +242,16 @@ def run_stage(
     desynchronize the lockstep disk-read phase); the canary, running first, is
     unaffected. On SIGINT/SIGTERM, cancel the queue and terminate every running
     child before exiting 130, so an interrupt leaves no orphaned subprocesses.
+
+    The module-level state is reset on entry: a leftover `_interrupted` would make
+    every `_run_one` return (130, "") without launching, so a second call in this
+    process would do nothing at all.
     """
+    _interrupted.clear()
+    with _live_lock:
+        _live_procs.clear()
+    _last_launch[0] = 0.0
+
     if not tasks:
         return set()
     logger.info(

--- a/scripts/processing/masters.py
+++ b/scripts/processing/masters.py
@@ -17,11 +17,11 @@ within [START, END].
 Builds run in a bounded process pool. The L0 mini-database caches are warmed up
 front by a parallel per-datecode pre-scan (``--cache``, ``rw`` by default; ``r``
 skips the pre-scan and leaves each reduce to read-only); the first night then runs
-alone as a canary to warm the *other* shared caches (barycorrpy leap-seconds,
-astropy IERS, matplotlib fonts, bytecode) before the rest fan out. The run is
-fail-soft (a night
-that fails to build is reported and the others continue) but exits nonzero if any
-night failed.
+alone as a canary before the rest fan out. The masters recipe imports neither
+barycorrpy, astropy IERS nor matplotlib, so that canary warms only bytecode; the
+reference-data caches it warms for the science stage have no counterpart here. The
+run is fail-soft (a night that fails to build is reported and the others continue)
+but exits nonzero if any night failed.
 """
 
 import argparse

--- a/scripts/processing/reduce.py
+++ b/scripts/processing/reduce.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """Run one recipe on one unit (the ``kpfpipe run`` leaf).
 
-Reads the config, applies CLI overrides, configures logging, clears the unit's
-stale L1/L2/L4 products (see ``clear_stale_outputs``), and execs the recipe's
-``main(config, args)``. It is both the in-process target of ``kpfpipe run`` and
-the leaf the orchestrators (``masters.py``/``science.py``) fan out as
-``python -m scripts.processing.reduce`` subprocesses.
+Reads the config, applies CLI overrides, configures logging, loads the recipe,
+clears the unit's stale L1/L2/L4 products (see ``clear_stale_outputs``), and execs
+the recipe's ``main(config, args)``. It is both the in-process target of
+``kpfpipe run`` and the leaf the orchestrators (``masters.py``/``science.py``) fan
+out as ``python -m scripts.processing.reduce`` subprocesses.
 
 Recipe + config come from ``--masters``/``--science`` (repo-relative shortcuts,
 usable from any cwd) or an explicit ``-r/-c`` pair; the shortcuts supply defaults
@@ -55,6 +55,10 @@ logger = logging.getLogger("kpfpipe.cli")
 
 
 def main(argv=None):
+    # Before the recipe is exec'd and pulls matplotlib in: this runs headless, and an
+    # unset backend resolves to macosx.
+    os.environ.setdefault("MPLBACKEND", "Agg")
+
     parser = argparse.ArgumentParser(
         prog="kpfpipe run",
         description=__doc__,
@@ -145,9 +149,6 @@ def main(argv=None):
     logger.info("data dirs: %s", config.get_params(["DATA_DIRS"]))
     logger.info("log file: %s", log_path)
 
-    # Clear prior L1/L2/L4 products so this run's outputs stand alone.
-    clear_stale_outputs(config, args)
-
     if not os.path.isfile(args.recipe):
         raise SystemExit(f"Recipe file not found: {args.recipe}")
 
@@ -156,6 +157,10 @@ def main(argv=None):
     spec.loader.exec_module(recipe)
     if not hasattr(recipe, "main"):
         raise SystemExit(f"Recipe {args.recipe!r} has no main() function")
+
+    # Clear prior L1/L2/L4 products so this run's outputs stand alone. After the load,
+    # never before: a mistyped -r must not destroy a night's products on its way out.
+    clear_stale_outputs(config, args)
 
     try:
         recipe.main(config, args)

--- a/scripts/processing/timeseries.py
+++ b/scripts/processing/timeseries.py
@@ -240,12 +240,6 @@ def _orchestrator_argv(module, unit_flag, units, forward, recipe=None, config=No
     return argv
 
 
-# Longer than the orchestrator's own teardown (_terminate_all_children waits 5 s
-# before escalating), so we don't SIGKILL a stage mid-cleanup and orphan the very
-# fan-out it was reaping.
-_STAGE_GRACE = 10.0
-
-
 def _run_stage(argv):
     """Run one stage subprocess to completion, tearing it down on an interrupt.
 
@@ -253,6 +247,11 @@ def _run_stage(argv):
     orchestrators means dying before their own teardown runs and orphaning their
     fan-out. SIGTERM instead: ``configure_runtime`` routes it through the same
     KeyboardInterrupt path, so the orchestrator reaps its children first.
+
+    The stage then gets 10 s before we escalate to SIGKILL -- longer than the
+    orchestrator's own teardown (``_terminate_all_children`` waits 5 s before
+    escalating), so we don't kill a stage mid-cleanup and orphan the very fan-out
+    it was reaping.
     """
     proc = subprocess.Popen(argv, cwd=kpfpipe.REPO_ROOT, stdin=subprocess.DEVNULL)
     try:
@@ -261,9 +260,9 @@ def _run_stage(argv):
         logger.warning("interrupted; terminating the running stage")
         proc.terminate()
         try:
-            proc.wait(timeout=_STAGE_GRACE)
+            proc.wait(timeout=10.0)
         except subprocess.TimeoutExpired:
-            logger.warning("stage did not exit in %.0fs; killing it", _STAGE_GRACE)
+            logger.warning("stage did not exit in 10s; killing it")
             proc.kill()
             proc.wait()
         sys.exit(130)

--- a/scripts/processing/timeseries.py
+++ b/scripts/processing/timeseries.py
@@ -56,7 +56,7 @@ from scripts.processing._argparse import (
     pool_parser,
     resolve_dir_shortcuts,
 )
-from scripts.processing._dispatch import _default_science_jobs
+from scripts.processing._dispatch import _default_science_jobs, configure_runtime
 from scripts.processing._scan import scan_datecodes, scan_night_to_cache
 
 logger = logging.getLogger(__name__)
@@ -240,7 +240,37 @@ def _orchestrator_argv(module, unit_flag, units, forward, recipe=None, config=No
     return argv
 
 
+# Longer than the orchestrator's own teardown (_terminate_all_children waits 5 s
+# before escalating), so we don't SIGKILL a stage mid-cleanup and orphan the very
+# fan-out it was reaping.
+_STAGE_GRACE = 10.0
+
+
+def _run_stage(argv):
+    """Run one stage subprocess to completion, tearing it down on an interrupt.
+
+    ``subprocess.run`` would SIGKILL the stage on KeyboardInterrupt, which for the
+    orchestrators means dying before their own teardown runs and orphaning their
+    fan-out. SIGTERM instead: ``configure_runtime`` routes it through the same
+    KeyboardInterrupt path, so the orchestrator reaps its children first.
+    """
+    proc = subprocess.Popen(argv, cwd=kpfpipe.REPO_ROOT, stdin=subprocess.DEVNULL)
+    try:
+        return proc.wait()
+    except KeyboardInterrupt:
+        logger.warning("interrupted; terminating the running stage")
+        proc.terminate()
+        try:
+            proc.wait(timeout=_STAGE_GRACE)
+        except subprocess.TimeoutExpired:
+            logger.warning("stage did not exit in %.0fs; killing it", _STAGE_GRACE)
+            proc.kill()
+            proc.wait()
+        sys.exit(130)
+
+
 def main(argv=None):
+    configure_runtime()
     args = parse_args(argv)
     start, end = args.date_range
 
@@ -331,7 +361,7 @@ def main(argv=None):
             config=masters_config,
         )
         logger.info("dispatching masters for %d night(s)", len(datecodes))
-        masters_rc = subprocess.run(masters_argv, cwd=kpfpipe.REPO_ROOT).returncode
+        masters_rc = _run_stage(masters_argv)
     else:
         logger.info("skipping masters stage (--no-masters)")
 
@@ -349,7 +379,7 @@ def main(argv=None):
             config=science_config,
         )
         logger.info("dispatching science for %d frame(s)", len(obs_ids))
-        science_rc = subprocess.run(science_argv, cwd=kpfpipe.REPO_ROOT).returncode
+        science_rc = _run_stage(science_argv)
     else:
         logger.info("skipping science stage (--no-science)")
 
@@ -372,7 +402,7 @@ def main(argv=None):
             *obs_ids,
         ]
         logger.info("dispatching plots for %d frame(s) -> %s", len(obs_ids), plot_dir)
-        plots_rc = subprocess.run(plot_argv, cwd=kpfpipe.REPO_ROOT).returncode
+        plots_rc = _run_stage(plot_argv)
     else:
         logger.info("skipping plots stage (--no-plots)")
 

--- a/scripts/quality_control/qlp.py
+++ b/scripts/quality_control/qlp.py
@@ -15,13 +15,20 @@ import sys
 
 from kpfpipe.data_models.level0 import KPF0
 from kpfpipe.data_models.level1 import KPF1
-from kpfpipe.quality_control.quicklook.level0 import PlotL0
-from kpfpipe.quality_control.quicklook.level1 import PlotL1
 from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import kpf_directory, kpf_filepath
 
 
 def main():
+    # Before anything imports matplotlib: this runs headless, and an unset backend
+    # resolves to macosx.
+    os.environ.setdefault("MPLBACKEND", "Agg")
+
+    # Deferred for that reason: these pull matplotlib in, so at module scope they
+    # would import it before the line above ran.
+    from kpfpipe.quality_control.quicklook.level0 import PlotL0
+    from kpfpipe.quality_control.quicklook.level1 import PlotL1
+
     parser = argparse.ArgumentParser(description="KPF Quicklook Plot Generator")
     parser.add_argument(
         "--obs_id", type=str, help="Observation ID (e.g. KP.20240405.03637.74)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,36 +16,89 @@ from astropy.io import fits
 from astropy.table import Table
 
 # ---------------------------------------------------------------------------
-# Offline guard -- deliberately module-scope, not a fixture
+# Network guard -- deliberately module-scope, not a fixture
 # ---------------------------------------------------------------------------
 #
-# The regression suite is offline by contract: every external query is mocked.
-# This makes that a rule the suite enforces rather than a claim its docstrings
-# make -- a test that reaches for the wire now fails loudly, naming the address.
+# Every catalog query the pipeline makes is mocked, and this makes that a rule
+# the suite enforces rather than a claim its docstrings make: a test that loses
+# its patch fails loudly, naming the host.
 #
-# It must run at import, not in a fixture: astroquery.gaia opens a connection to
-# the ESA archive when `kpfpipe.modules.astro_query` is imported
-# (astro_query.py:27, a filed production defect), and that import happens during
-# COLLECTION, before any fixture -- even a session-scoped autouse one -- can run.
-# Blocking it there is worth 1.4-2.7 s per worker process; astroquery survives
-# the refusal, printing "Status messages could not be retrieved" and carrying on
-# with the real `Gaia` object the tests patch.
+# It must run at import, not in a fixture. `import barycorrpy` fetches IERS_B and
+# leap seconds before it finishes executing, and that import happens during
+# COLLECTION -- before any fixture, even a session-scoped autouse one, can run.
 #
-# Loopback stays open so pytest-xdist, execnet and any local-socket test are
-# unaffected.
+# The suite is NOT strictly offline. Reference data is allowed through, because
+# there is no local cache to fall back on and no configuration that suppresses
+# the fetch. A cold machine therefore downloads ~120 MB on its first run. That is
+# the accepted price of not carrying a cache; it is paid by CI and by every fresh
+# checkout.
+
+# Mocked by every test that touches them. A connect here is a lost patch.
+_CATALOG_HOSTS = (
+    "gea.esac.esa.int",  # ESA Gaia TAP
+    "simbad.cds.unistra.fr",  # SIMBAD, and its Harvard mirror below
+    "simbad.harvard.edu",
+)
+
+# Reference data with no local alternative. Each entry is here because something
+# fetches it unconditionally at import or first use -- not for convenience.
+_REFERENCE_HOSTS = (
+    "hpiers.obspm.fr",  # IERS_B + leap seconds; barycorrpy fetches at import
+    "datacenter.iers.org",  # astropy IERS_A (Earth orientation)
+    "maia.usno.navy.mil",  # IERS_A mirror, also barycorrpy's own
+    "naif.jpl.nasa.gov",  # JPL solar-system ephemeris
+    "data.astropy.org",  # astropy's data server, and its mirror below
+    "www.astropy.org",
+)
+
+_real_getaddrinfo = socket.getaddrinfo
 _real_connect = socket.socket.connect
 
+# IPs that came back from resolving an allowed host. connect() is handed an
+# address, not a name, so this is the only way it can tell them apart.
+_allowed_addresses = set()
 
-def _no_outbound_connect(self, address, *args, **kwargs):
+
+def _is_local(host):
+    # host is None when binding; loopback must stay open or xdist/execnet die.
+    if host is None:
+        return True
+    if isinstance(host, bytes):
+        host = host.decode("ascii", "replace")
+    return isinstance(host, str) and (
+        host.startswith("127.") or host in ("::1", "localhost", "0.0.0.0", "")
+    )
+
+
+def _blocked(host):
+    why = (
+        "the suite mocks this catalog -- a test lost its patch"
+        if host in _CATALOG_HOSTS
+        else f"not a known reference-data host; allowed: {', '.join(_REFERENCE_HOSTS)}"
+    )
+    return OSError(f"tests/conftest.py blocked a connection to {host!r}: {why}")
+
+
+def _guarded_getaddrinfo(host, *args, **kwargs):
+    if _is_local(host):
+        return _real_getaddrinfo(host, *args, **kwargs)
+    if host not in _REFERENCE_HOSTS:
+        raise _blocked(host)
+    infos = _real_getaddrinfo(host, *args, **kwargs)
+    _allowed_addresses.update(info[4][0] for info in infos)
+    return infos
+
+
+def _guarded_connect(self, address, *args, **kwargs):
+    # The backstop: catches anything that reaches a bare IP without resolving it.
     host = address[0] if isinstance(address, tuple) else address
-    if isinstance(host, str) and (
-        host.startswith("127.") or host in ("::1", "localhost")
-    ):
+    if _is_local(host) or host in _allowed_addresses:
         return _real_connect(self, address, *args, **kwargs)
-    raise OSError(f"the regression suite is offline; blocked connect to {address!r}")
+    raise _blocked(host)
 
 
-socket.socket.connect = _no_outbound_connect
+socket.getaddrinfo = _guarded_getaddrinfo
+socket.socket.connect = _guarded_connect
 
 # Fixed seed so every synthetic-FITS fixture is byte-stable across runs.
 _SEED = 20240113
@@ -129,16 +182,16 @@ def _catalog_record_hdu():
     AstroQuery(l0)._write_catalog_record(
         "kpf-drp",
         {
-            "object": "Gaia_HD10700",
+            "object": "Gaia DR3 12345",
             "radec_src": "gaia",
             "plx_src": "gaia",
             "rv_src": "gaia",
-            "ra": "01:44:04.0000",
-            "dec": "-15:56:14.900",
-            "pmra": -1.7,
-            "pmdec": 0.85,
-            "parallax": 273.8,
-            "rv": -16.6,
+            "ra": "12:00:00.0000",
+            "dec": "+40:00:00.000",
+            "pmra": 0.5,
+            "pmdec": -0.3,
+            "parallax": 50.0,
+            "rv": 10.0,
             "frame": "icrs",
             "epoch": 2016.0,
             "equinox": 2000.0,
@@ -160,7 +213,7 @@ def synthetic_l0_file(tmp_path_factory):
     primary.header["MJD-OBS"] = 60322.43537  # JD_UTC source (full JD = + 2400000.5)
     primary.header["EXPTIME"] = 300.0
     primary.header["ELAPSED"] = 300.0
-    primary.header["OBJECT"] = "HD_10700"
+    primary.header["OBJECT"] = "10700"
     primary.header["IMTYPE"] = "Object"
     primary.header["GROBSERV"] = "Smith"
     primary.header["PROGNAME"] = "K123"

--- a/tests/regression/_catalog.py
+++ b/tests/regression/_catalog.py
@@ -11,26 +11,26 @@ from astropy.table import Table
 SOURCES = ("gaia", "kpf-drp")
 
 _STR_CELLS = {
-    "object": "12345",
+    "object": "Gaia DR3 12345",
     "radec_src": "gaia",
     "plx_src": "gaia",
     "rv_src": "gaia",
-    "ra": "01:44:04.0000",
-    "dec": "-15:56:14.900",
+    "ra": "12:00:00.0000",
+    "dec": "+40:00:00.000",
     "frame": "icrs",
     "color_name": "Gaia BP-RP",
 }
 _FLOAT_CELLS = {
-    "pmra": -1.7,
-    "pmdec": 0.85,
-    "parallax": 273.8,
+    "pmra": 0.5,
+    "pmdec": -0.3,
+    "parallax": 50.0,
     "epoch": 2016.0,
     "equinox": 2000.0,
     "color": 1.2,
 }
 
 
-def catalog_record_table(rv=-16.6):
+def catalog_record_table(rv=10.0):
     """A two-row CATALOG_RECORD table: a 'gaia' source row + the merged 'kpf-drp'.
 
     Carries the full write schema, since KPF0.to_kpf1 reads every canonical column
@@ -46,7 +46,7 @@ def catalog_record_table(rv=-16.6):
         table[column] = np.array([value] * 2, dtype=float)
     missing = rv is None
     table["rv"] = np.array([np.nan if missing else rv] * 2, dtype=float)
-    table["z"] = np.array([np.nan if missing else -5.5e-5] * 2, dtype=float)
+    table["z"] = np.array([np.nan if missing else 3.3357e-5] * 2, dtype=float)
     return table
 
 

--- a/tests/regression/_scripts.py
+++ b/tests/regression/_scripts.py
@@ -24,13 +24,14 @@ CHILD_WARNINGS = ",".join(
     (
         "error",
         "ignore:Card is too long",
-        "default::ResourceWarning",
     )
 )
 
-# A child that reaches the network (AstroQuery, astropy's IERS auto-download) can
-# block forever, so cap every run: a hang becomes a loud TimeoutExpired instead of
-# a stalled suite. Generous enough for a slow-but-working run.
+# AstroQuery is bounded now (kpfpipe.utils.network's per-request timeouts) and
+# stdin=DEVNULL below rules out a tty stop, but astropy's and barycorrpy's
+# reference-data downloads still have no bound we control. Cap every run anyway:
+# a hang becomes a loud TimeoutExpired instead of a stalled suite, which is how
+# both of the bugs above were found. Generous enough for a slow-but-working run.
 CHILD_TIMEOUT = 120
 
 
@@ -46,6 +47,10 @@ def run_script(script, *argv, timeout=CHILD_TIMEOUT):
         [sys.executable, script, *map(str, argv)],
         cwd=REPO_ROOT,
         env=env,
+        # Without this the child inherits the terminal's stdin, and a read from a
+        # background process group raises SIGTTIN -- which *stops* the process at
+        # 0% CPU, indistinguishable from a hang.
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/tests/regression/test_astro_query.py
+++ b/tests/regression/test_astro_query.py
@@ -2,14 +2,16 @@
 
 Covers ``merge_catalog_records`` (gaia/simbad/wmko -> the canonical ``kpf-drp``
 row), ``read_wmko_header`` off synthetic L0 PRIMARY TARG*, and the external query
-contract. The network is never touched: ``Gaia.launch_job``/``Simbad`` are mocked
-with one-row result Tables, so parsing, the fail-soft None+warning paths, and the
-``_verify_units`` schema-drift guard all run offline. That is enforced, not just
-intended -- tests/conftest.py blocks outbound connect() for the whole suite.
+contract. The network is never touched: the ``gaia_client``/``simbad_client``
+factories are mocked to hand back one-row result Tables, so parsing, the fail-soft
+None+warning paths, and the ``_verify_units`` schema-drift guard all run offline.
+That is enforced, not just intended -- tests/conftest.py blocks connects to the
+catalog hosts for the whole suite.
 """
 
 import logging
 import re
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -522,11 +524,25 @@ def _l0_for_query(**primary):
     return l0
 
 
+@contextmanager
 def _patch_gaia(job_or_exc):
-    target = "kpfpipe.modules.astro_query.Gaia.launch_job"
+    """Patch the Gaia client factory, yielding the ``launch_job`` mock to assert on.
+
+    Production builds a client per attempt (``gaia_client().launch_job(...)``); one
+    mock client answers every call, so call_count accumulates across retries.
+    """
+    client = MagicMock()
     if isinstance(job_or_exc, Exception):
-        return patch(target, side_effect=job_or_exc)
-    return patch(target, return_value=job_or_exc)
+        client.launch_job.side_effect = job_or_exc
+    else:
+        client.launch_job.return_value = job_or_exc
+    with patch("kpfpipe.modules.astro_query.gaia_client", return_value=client):
+        yield client.launch_job
+
+
+def _patch_simbad(instance):
+    """Patch the SIMBAD client factory to return ``instance``."""
+    return patch("kpfpipe.modules.astro_query.simbad_client", return_value=instance)
 
 
 class TestExternalQueries:
@@ -673,10 +689,7 @@ class TestExternalQueries:
     def test_query_simbad_parses_and_writes(self):
         l0 = _l0_for_query(OBJECT="10700")
         aq = AstroQuery(l0)
-        with patch(
-            "kpfpipe.modules.astro_query.Simbad",
-            return_value=_simbad_instance(_simbad_table()),
-        ):
+        with _patch_simbad(_simbad_instance(_simbad_table())):
             rec = aq.query_simbad()
         assert rec is not None
         exp_ra, exp_dec = AstroQuery._sexagesimal_radec(
@@ -698,10 +711,7 @@ class TestExternalQueries:
         # A color needs both magnitudes; one unmeasured -> no color.
         l0 = _l0_for_query(OBJECT="10700")
         aq = AstroQuery(l0)
-        with patch(
-            "kpfpipe.modules.astro_query.Simbad",
-            return_value=_simbad_instance(_simbad_table({"V": float("nan")})),
-        ):
+        with _patch_simbad(_simbad_instance(_simbad_table({"V": float("nan")}))):
             rec = aq.query_simbad()
         assert rec["color"] is None and rec["color_name"] is None
 
@@ -717,7 +727,7 @@ class TestExternalQueries:
         inst = MagicMock()
         inst.query_object.side_effect = ConnectionError("simbad down")
         with (
-            patch("kpfpipe.modules.astro_query.Simbad", return_value=inst),
+            _patch_simbad(inst),
             patch("kpfpipe.utils.network.time.sleep"),
             caplog.at_level(logging.WARNING),
         ):
@@ -728,10 +738,7 @@ class TestExternalQueries:
     def test_query_simbad_no_match_returns_none(self, caplog):
         aq = AstroQuery(_l0_for_query(OBJECT="NotARealStar"))
         with (
-            patch(
-                "kpfpipe.modules.astro_query.Simbad",
-                return_value=_simbad_instance(None),
-            ),
+            _patch_simbad(_simbad_instance(None)),
             caplog.at_level(logging.WARNING),
         ):
             assert aq.query_simbad() is None
@@ -739,9 +746,8 @@ class TestExternalQueries:
 
     def test_query_simbad_unit_mismatch_raises(self):
         aq = AstroQuery(_l0_for_query(OBJECT="tau Cet"))
-        with patch(
-            "kpfpipe.modules.astro_query.Simbad",
-            return_value=_simbad_instance(_simbad_table(units={"plx_value": u.arcsec})),
+        with _patch_simbad(
+            _simbad_instance(_simbad_table(units={"plx_value": u.arcsec}))
         ):
             with pytest.raises(ValueError, match="unexpected column units"):
                 aq.query_simbad()
@@ -795,10 +801,9 @@ class TestRequestMatchesParse:
     def test_simbad_votable_fields_match_parsed_columns(self):
         # ra/dec arrive in SIMBAD's default basic set, so they are not requested.
         aq = AstroQuery(_l0_for_query(OBJECT="tau Cet"))
-        inst = _simbad_instance(_simbad_table())
-        with patch("kpfpipe.modules.astro_query.Simbad", return_value=inst):
+        with _patch_simbad(_simbad_instance(_simbad_table())) as simbad_client:
             aq.query_simbad()
-        requested = set(inst.add_votable_fields.call_args.args)
+        requested = set(simbad_client.call_args.args[0])
         assert requested == set(_SIMBAD_UNITS) - {"ra", "dec"}
 
 
@@ -833,10 +838,9 @@ class TestBareGaiaIdResolution:
     @staticmethod
     def _query(**kwargs):
         aq = AstroQuery(_l0_for_query(GAIAID="12345"))  # bare: no release prefix
-        with patch(
-            "kpfpipe.modules.astro_query.Gaia.launch_job",
-            side_effect=_release_aware_launch_job(**kwargs),
-        ):
+        client = MagicMock()
+        client.launch_job.side_effect = _release_aware_launch_job(**kwargs)
+        with patch("kpfpipe.modules.astro_query.gaia_client", return_value=client):
             return aq.query_gaia()
 
     def test_newest_matching_release_wins(self, caplog):
@@ -885,10 +889,7 @@ def _perform(**config):
     aq = AstroQuery(l0, config or None)
     with (
         _patch_gaia(_gaia_job(_gaia_table({"ra": 10.0}))),
-        patch(
-            "kpfpipe.modules.astro_query.Simbad",
-            return_value=_simbad_instance(_simbad_table({"ra": 20.0})),
-        ),
+        _patch_simbad(_simbad_instance(_simbad_table({"ra": 20.0}))),
     ):
         aq.perform()
     return aq, aq.l0_obj.data["CATALOG_RECORD"]

--- a/tests/regression/test_barycentric_correction.py
+++ b/tests/regression/test_barycentric_correction.py
@@ -273,14 +273,17 @@ class TestGetNormalizedFlux:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.slow
 class TestComputeBarycorrReference:
     """The real barycorrpy handoff, pinned to a golden value.
 
     Every perform() test stubs _compute_barycorr, so this is the only guard on
     the real wiring: ICRS ra/dec/pm/parallax, the J2000 epoch, UTC->JD, the Keck
-    site, and the m/s units and sign. It may download JPL ephemeris on first run,
-    hence @slow. Golden values are pinned to barycorrpy==0.4.4.
+    site, and the m/s units and sign. Golden values are pinned to
+    barycorrpy==0.4.4.
+
+    Unmarked: it reads no truth frames, which is what ``slow`` means here. It
+    carried the marker as a hedge against a cold-cache ephemeris download, which
+    tests/conftest.py now allows through rather than blocking.
     """
 
     def test_matches_barycorrpy_reference(self):

--- a/tests/regression/test_data_models_l0.py
+++ b/tests/regression/test_data_models_l0.py
@@ -254,8 +254,8 @@ class TestCatalogRecordMissingValues:
         assert np.isnan(row["rv"])
 
     def test_present_value_reads_back_unchanged(self, tmp_path):
-        row = self._l0_written_and_read(tmp_path, rv=-16.6).data["CATALOG_RECORD"][0]
-        assert row["rv"] == pytest.approx(-16.6)
+        row = self._l0_written_and_read(tmp_path, rv=10.0).data["CATALOG_RECORD"][0]
+        assert row["rv"] == pytest.approx(10.0)
 
     def test_missing_value_leaves_catalog_card_blank(self, tmp_path):
         # The regression the normalization exists for: a masked cell defeats the
@@ -264,7 +264,7 @@ class TestCatalogRecordMissingValues:
         l0 = self._l0_written_and_read(tmp_path, rv=None)
         l1 = l0.to_kpf1()
         assert not l1.headers["PRIMARY"].get("CRV2")
-        assert l1.headers["PRIMARY"]["CRA2"] == "01:44:04.0000"
+        assert l1.headers["PRIMARY"]["CRA2"] == "12:00:00.0000"
         l1.to_fits(str(tmp_path / "kpf_L1_20240405T000000.fits"))
 
 

--- a/tests/regression/test_data_models_l1.py
+++ b/tests/regression/test_data_models_l1.py
@@ -286,11 +286,11 @@ class TestToKpf1:
         l1 = l0.to_kpf1()
         assert l1.headers["PRIMARY"]["INSTRUME"] == "KPF"
         assert l1.headers["PRIMARY"]["DATE-OBS"] == "2024-01-13T10:26:56"
-        assert l1.headers["PRIMARY"]["OBJECT"] == "HD_10700"
+        assert l1.headers["PRIMARY"]["OBJECT"] == "10700"
 
     # Canonical CATALOG_RECORD row (EPRV C*# format) overlaid onto the SCI cards.
     _KPF_DRP = {
-        "object": "Gaia123",
+        "object": "Gaia DR3 12345",
         "radec_src": "gaia",
         "plx_src": "gaia",
         "rv_src": "gaia",
@@ -324,7 +324,7 @@ class TestToKpf1:
         # Direct copy of the canonical row onto every SCI fiber (2,3,4), no conversion.
         p = self._l0_with_catalog(dict(self._KPF_DRP)).to_kpf1().headers["PRIMARY"]
         for i in (2, 3, 4):
-            assert p[f"CID{i}"] == "Gaia123"
+            assert p[f"CID{i}"] == "Gaia DR3 12345"
             assert p[f"CSRC{i}"] == "gaia"
             assert p[f"CRA{i}"] == "12:00:00.0000"
             assert p[f"CDEC{i}"] == "+40:00:00.000"
@@ -519,7 +519,7 @@ class TestCatalogRecordPassthrough:
     """
 
     @staticmethod
-    def _l0_with_catalog_table(rv=-16.6):
+    def _l0_with_catalog_table(rv=10.0):
         l0 = KPF0()
         l0.headers["PRIMARY"]["IMTYPE"] = "Object"
         l0.set_data("CATALOG_RECORD", catalog_record_table(rv=rv))

--- a/tests/regression/test_data_models_l2.py
+++ b/tests/regression/test_data_models_l2.py
@@ -106,7 +106,7 @@ class TestCatalogRecordPassthrough:
     """
 
     @staticmethod
-    def _l1_with_catalog(rv=-16.6):
+    def _l1_with_catalog(rv=10.0):
         # KPF1 creates CATALOG_RECORD only on the L0 pass-through or a read (it is
         # Required=False in L1-extensions.csv), so a bare L1 makes it explicitly.
         l1 = KPF1()

--- a/tests/regression/test_data_models_l4.py
+++ b/tests/regression/test_data_models_l4.py
@@ -32,10 +32,10 @@ class TestToKPF4:
     def test_to_kpf4_forwards_primary_header(self):
         kpf2 = KPF2()
         kpf2.headers["PRIMARY"]["INSTRUME"] = "KPF"
-        kpf2.headers["PRIMARY"]["OBJECT"] = "HD_10700"
+        kpf2.headers["PRIMARY"]["OBJECT"] = "10700"
         kpf4 = kpf2.to_kpf4()
         assert kpf4.headers["PRIMARY"]["INSTRUME"] == "KPF"
-        assert kpf4.headers["PRIMARY"]["OBJECT"] == "HD_10700"
+        assert kpf4.headers["PRIMARY"]["OBJECT"] == "10700"
 
     def test_to_kpf4_sets_datalvl(self):
         kpf2 = KPF2()

--- a/tests/regression/test_dispatch_script.py
+++ b/tests/regression/test_dispatch_script.py
@@ -27,7 +27,11 @@ _SLEEP = [sys.executable, "-c", "import time; time.sleep(30)"]  # a wedged job
 
 @pytest.fixture(autouse=True)
 def _clear_interrupted():
-    """Keep the module-global interrupt flag clean around each test."""
+    """Keep the module-global interrupt flag clean around each test.
+
+    run_stage resets its own state now; the tests that set the flag and call
+    `_run_one` directly still need this.
+    """
     f._interrupted.clear()
     yield
     f._interrupted.clear()
@@ -263,6 +267,16 @@ class TestRunStageInterrupt:
         assert exc.value.code == 130
         assert f._interrupted.is_set()  # stops the pool launching anything more
         assert torn_down == [1]
+
+    def test_stale_interrupt_flag_is_cleared_on_entry(self, tmp_path):
+        # `_interrupted` is module state that outlives a run, so without the reset
+        # a second run_stage in this process launches nothing at all: every
+        # _run_one short-circuits to 130 and every task is reported failed.
+        f._interrupted.set()
+        failed = f.run_stage(
+            "job", [("a", _OK), ("b", _OK)], 2, str(tmp_path), abort_on_failure=False
+        )
+        assert failed == set()
 
     def test_terminate_escalates_sigterm_then_sigkill(self, monkeypatch):
         # A child that dies on SIGTERM is left alone; one still alive after the

--- a/tests/regression/test_network.py
+++ b/tests/regression/test_network.py
@@ -1,16 +1,29 @@
-"""Tests for the network retry helper in kpfpipe.utils.network.
+"""Tests for the network helpers in kpfpipe.utils.network.
 
-The network is never touched: every test drives ``retry_request`` with a mock
-callable and patches ``time.sleep``, so the backoff is inspected, not waited out.
+No external host is contacted. The retry tests drive ``retry_request`` with a mock
+callable and patch ``time.sleep``, so the backoff is inspected, not waited out. The
+timeout tests need a real socket that stalls, so they use a loopback listener --
+which the conftest guard allows, and which no amount of mocking could stand in for.
 """
 
+import http.client
+import json
 import logging
+import socket
+import subprocess
+import sys
+import threading
+import time
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from pyvo.dal import DALQueryError, DALServiceError
 
-from kpfpipe.utils.network import _RETRY_WAITS, retry_request
+from kpfpipe.utils.network import _RETRY_WAITS, _RETRYABLE, retry_request, simbad_client
+
+from ._scripts import REPO_ROOT
 
 
 def _patch_sleep():
@@ -92,3 +105,191 @@ class TestRetryRequest:
         assert "Gaia DR3 request failed" in caplog.text
         assert "ConnectionError" in caplog.text
         assert "retrying in" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Import purity -- witnessed in a child, because this suite's conftest hides it
+# ---------------------------------------------------------------------------
+
+# Records every outbound connect, imports the module, and reports what it saw.
+# Run through `python -c` so no conftest loads: the suite's own network guard
+# would mask exactly the connection this is here to detect.
+_IMPORT_PROBE = """
+import json, socket, sys
+hits = []
+socket.socket.connect = lambda self, addr, *a, **k: hits.append(addr)
+socket.create_connection = lambda addr, *a, **k: hits.append(addr)
+import kpfpipe.modules.astro_query
+print(json.dumps({
+    "hits": [str(h) for h in hits],
+    "astroquery": sorted(m for m in sys.modules if m.startswith("astroquery")),
+}))
+"""
+
+
+@pytest.mark.cli
+def test_importing_astro_query_touches_no_network():
+    """Importing the module must not open a connection, nor pull in a client.
+
+    ``astroquery.gaia`` builds a module-level ``GaiaClass()`` whose constructor
+    fetches ESA status messages, so importing it *is* a connection. Both client
+    imports are deferred into the factories to keep that off every code path that
+    never queries a catalog -- this is the only thing that witnesses it.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _IMPORT_PROBE],
+        cwd=REPO_ROOT,
+        env={"PYTHONPATH": REPO_ROOT, "PATH": "/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    seen = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    assert seen["hits"] == []
+    # astroquery.exceptions is imported at module scope for the retryable-error
+    # tuple; it is cheap and reaches nothing. The two client modules are what must
+    # stay out, so name them rather than the package.
+    assert "astroquery.gaia" not in seen["astroquery"]
+    assert "astroquery.simbad" not in seen["astroquery"]
+
+
+# ---------------------------------------------------------------------------
+# Timeouts -- two transports, two seams
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _stalled_listener():
+    """A loopback address that accepts a connection and then never answers.
+
+    The listen backlog completes the TCP handshake without anyone calling
+    ``accept``, so the client blocks on the read -- the shape of the hang these
+    timeouts exist to bound.
+    """
+    server = socket.socket()
+    server.bind(("127.0.0.1", 0))
+    server.listen(1)
+    try:
+        yield server.getsockname()
+    finally:
+        server.close()
+
+
+def _raises_within(seconds, func):
+    """Run ``func`` in a daemon thread; return the exception it raised.
+
+    Both seams fail by *not returning*, so calling ``func`` inline would hang the
+    suite instead of failing it. The thread is abandoned on timeout -- it is stuck
+    on a loopback read and dies with the interpreter.
+    """
+    outcome = []
+    thread = threading.Thread(
+        target=lambda: outcome.append(_capture(func)), daemon=True
+    )
+    started = time.monotonic()
+    thread.start()
+    thread.join(seconds)
+    assert not thread.is_alive(), (
+        f"still blocked after {seconds:.0f}s: nothing bounds it"
+    )
+    assert time.monotonic() - started < seconds
+    return outcome[0]
+
+
+def _capture(func):
+    try:
+        func()
+    except BaseException as exc:  # noqa: BLE001 -- the exception is the result
+        return exc
+    return None
+
+
+class _FakeSimbadClass:
+    """SimbadClass stand-in: the real one validates fields over the network.
+
+    Carries the one attribute ``simbad_client`` touches, so the adapter it mounts
+    is exercised on a genuine requests.Session.
+    """
+
+    def __init__(self):
+        self._session = requests.Session()
+
+    def add_votable_fields(self, *fields):
+        pass
+
+
+class TestTimeoutBounds:
+    """The two transports are bounded by two different seams -- assert both.
+
+    ``socket.setdefaulttimeout`` bounds Gaia's ``http.client`` transport but not
+    SIMBAD's, which goes through pyvo over ``requests`` and passes an explicit
+    ``timeout=None`` down to ``sock.settimeout``. Covering only the Gaia path would
+    let the SIMBAD half regress in silence.
+    """
+
+    def test_timeout_bounds_the_http_client_transport(self):
+        with _stalled_listener() as (host, port):
+
+            def request():
+                conn = http.client.HTTPConnection(host, port)
+                try:
+                    conn.request("GET", "/")
+                    conn.getresponse()
+                finally:
+                    conn.close()
+
+            with _patch_sleep():
+                raised = _raises_within(
+                    0.5 * (len(_RETRY_WAITS) + 1) + 10,
+                    lambda: retry_request(request, "stall", timeout=0.5),
+                )
+
+        # Classification matters as much as the bound: a timeout the retry loop
+        # did not recognise would escape on the first attempt instead of retrying.
+        assert isinstance(raised, _RETRYABLE)
+
+    def test_simbad_timeout_bounds_a_requests_call(self):
+        with _stalled_listener() as (host, port):
+            with patch("astroquery.simbad.SimbadClass", _FakeSimbadClass):
+                client = simbad_client(("B",), timeout=0.5)
+
+            # The point of the separate seam: nothing here is holding a socket
+            # default, so only the mounted adapter can end this call.
+            assert socket.getdefaulttimeout() is None
+            raised = _raises_within(
+                10, lambda: client._session.get(f"http://{host}:{port}/")
+            )
+
+        assert isinstance(raised, requests.exceptions.Timeout)
+
+    def test_socket_default_restored_after_success(self):
+        socket.setdefaulttimeout(7.0)
+        try:
+            retry_request(lambda: "ok", "Service", timeout=1.0)
+            assert socket.getdefaulttimeout() == 7.0
+        finally:
+            socket.setdefaulttimeout(None)
+
+    def test_socket_default_restored_after_failure(self):
+        # The non-transient path: one attempt, then the raise escapes the loop.
+        socket.setdefaulttimeout(7.0)
+        try:
+            with pytest.raises(ValueError):
+                retry_request(_raise(ValueError("bad")), "Service", timeout=1.0)
+            assert socket.getdefaulttimeout() == 7.0
+        finally:
+            socket.setdefaulttimeout(None)
+
+    def test_none_timeout_leaves_the_default_alone(self):
+        assert socket.getdefaulttimeout() is None
+        retry_request(lambda: "ok", "Service")
+        assert socket.getdefaulttimeout() is None
+
+
+def _raise(exc):
+    def func():
+        raise exc
+
+    return func

--- a/tests/regression/test_qc_flags.py
+++ b/tests/regression/test_qc_flags.py
@@ -608,8 +608,8 @@ class TestQCL0:
         l0 = _make_kpf0(tmp_path)
         record = {
             "object": "test",
-            "ra": "01:44:04.08",
-            "dec": "-15:56:14.9",
+            "ra": "12:00:00.00",
+            "dec": "+40:00:00.0",
             "pmra": 0.1,
             "pmdec": -0.2,
             "parallax": 100.0,

--- a/tests/regression/test_qlp_script.py
+++ b/tests/regression/test_qlp_script.py
@@ -6,6 +6,7 @@ and lets each case assert the message as well as the exit code.
 """
 
 import os
+import subprocess
 import sys
 
 import pytest
@@ -14,7 +15,7 @@ from kpfpipe.utils.io import kpf_directory
 from scripts.quality_control import qlp
 
 from ._data_models import write_amp_l0
-from ._scripts import run_script, write_config
+from ._scripts import CHILD_TIMEOUT, REPO_ROOT, run_script, write_config
 
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
 pytestmark = pytest.mark.cli
@@ -128,3 +129,47 @@ class TestQLPScript:
             _main(monkeypatch)
         assert exc.value.code == 2
         assert "--level" in capsys.readouterr().err
+
+
+# Drives main() the way a shell would, then reports what matplotlib settled on.
+# main() must import the renderers *after* it sets MPLBACKEND, so anything qlp.py
+# pulls in at module scope that already touches matplotlib will show up here.
+_BACKEND_PROBE = """
+import sys
+from scripts.quality_control.qlp import main
+sys.argv = ["qlp.py", "--input", sys.argv[1], "--level", "L0",
+            "--output_dir", sys.argv[2]]
+main()
+import matplotlib
+print("BACKEND", matplotlib.get_backend())
+"""
+
+
+def test_entry_point_selects_a_headless_backend(tmp_path):
+    """qlp.py must resolve matplotlib to Agg, not to a windowing backend.
+
+    The pipeline runs headless. With MPLBACKEND unset this machine resolves to
+    macosx, which needs a display -- so the entry point sets it before the first
+    matplotlib import rather than leaving it to the environment.
+
+    MPLBACKEND is scrubbed deliberately: tests/regression/conftest.py sets it, and
+    run_script hands the child a copy of os.environ, so a child that inherited it
+    would pass whether or not qlp.py did anything at all.
+    """
+    fixture = tmp_path / f"{_OBS_ID}.fits"
+    _write_l0_image_fixture(str(fixture))
+
+    env = {k: v for k, v in os.environ.items() if k != "MPLBACKEND"}
+    env["PYTHONPATH"] = REPO_ROOT
+    proc = subprocess.run(
+        [sys.executable, "-c", _BACKEND_PROBE, str(fixture), str(tmp_path / "out")],
+        cwd=REPO_ROOT,
+        env=env,
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=CHILD_TIMEOUT,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "BACKEND Agg" in proc.stdout, proc.stdout

--- a/tests/regression/test_reduce_script.py
+++ b/tests/regression/test_reduce_script.py
@@ -169,8 +169,7 @@ class TestGuards:
 
 class TestRecipeLoading:
     """reduce.py's recipe-loading failure branches. All in-process via main(),
-    no subprocess. None of these asserts anything about clear_stale_outputs,
-    which runs earlier at reduce.py:149 -- see the note in that module."""
+    no subprocess."""
 
     def test_missing_recipe_file_exits(self, monkeypatch, tmp_path):
         cfg = _base_cfg(tmp_path)
@@ -202,6 +201,30 @@ class TestRecipeLoading:
             red.main(["-r", str(recipe), "-c", str(cfg), "-o", "KP.x"])
 
         assert "uncaught exception; pipeline aborted" in caplog.text
+
+    def test_bad_recipe_leaves_prior_products_alone(self, monkeypatch, tmp_path):
+        # A mistyped -r must not cost a night's L1/L2/L4: clearing is destructive and
+        # unconditional, so it runs only once the recipe is known to load.
+        cfg = tmp_path / "sci.toml"
+        science_root = tmp_path / "sci"
+        cfg.write_text(
+            "[DATA_DIRS]\n"
+            'KPF_DATA_INPUT = "/cfg/in"\n'
+            'KPF_MASTERS_OUTPUT = "/cfg/m"\n'
+            f'KPF_SCIENCE_OUTPUT = "{science_root}"\n'
+            "[LOGGER]\n"
+            'log_dir = "/cfg/l"\n'
+        )
+        oid = "KP.20240405.40113.57"
+        product = red.kpf_filepath(oid, "L1", data_root=str(science_root))
+        os.makedirs(os.path.dirname(product), exist_ok=True)
+        open(product, "w").close()
+
+        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        with pytest.raises(SystemExit, match="Recipe file not found"):
+            red.main(["-r", str(tmp_path / "absent.py"), "-c", str(cfg), "-o", oid])
+
+        assert os.path.exists(product)
 
     def test_missing_log_dir_is_a_usage_error(self, monkeypatch, tmp_path):
         # resolve_logging's ValueError must surface as a clean usage error

--- a/tests/regression/test_science_recipe.py
+++ b/tests/regression/test_science_recipe.py
@@ -52,9 +52,7 @@ def _load_recipe():
 # ---------------------------------------------------------------------------
 #
 # The four CATALOG_RECORD rows AstroQuery returned for OBS_ID on 2026-08-20,
-# captured verbatim from one live query (Gaia DR3, SIMBAD). The frame's target
-# is 47 UMa / HD 95128; a row reading RA 01:44 / Dec -15:56 is tau Ceti, i.e.
-# the wrong star, and would corrupt the barycentric correction by tens of km/s.
+# captured verbatim from one live query (Gaia DR3, SIMBAD).
 #
 # This is an oracle -- a recording of what production emits -- not a rebuild of
 # it: the rows go in through AstroQuery's own writer, and merge_catalog_records
@@ -62,8 +60,8 @@ def _load_recipe():
 # capture rather than silently agreeing with a reimplementation.
 #
 # To recapture: run AstroQuery(KPF0.from_fits(<L0>), config).perform() in a
-# plain python script (NOT under pytest, whose conftest blocks outbound
-# sockets) and dump l0.data["CATALOG_RECORD"] row by row.
+# plain python script (NOT under pytest, whose conftest blocks the catalog
+# hosts) and dump l0.data["CATALOG_RECORD"] row by row.
 _CATALOG_CAPTURE = {
     "wmko": {
         "object": "95128",
@@ -194,7 +192,8 @@ class TestScienceRecipe:
         recipe = _load_recipe()
         # The recipe module object is built fresh by _load_recipe() and dropped
         # with this fixture, so swapping the stage in place needs no patcher.
-        # This is the suite's only live-network call site; see _CATALOG_CAPTURE.
+        # AstroQuery is the recipe's one live-network stage; _FrozenAstroQuery
+        # replays a recording of it rather than querying. See _CATALOG_CAPTURE.
         recipe.AstroQuery = _FrozenAstroQuery
         recipe.main(config, args)
 
@@ -286,6 +285,55 @@ class TestScienceRecipe:
         assert "WLSDIR" not in receipt
         assert receipt.get("WLSFILE").endswith("_master_thar_L2.fits")
         assert isinstance(qc.get("WLSAGE"), float)
+
+    def test_catalog_record_reaches_the_science_cards(self, l2):
+        """The merged catalog row is copied onto every science fiber's C*# cards.
+
+        Expectations come from the capture itself, so this checks the overlay
+        wiring -- each canonical column landing on its keyword, for all three
+        science traces -- and stays indifferent to what the record contains.
+
+        The pairs are spelled out rather than read from _CATALOG_CARD_BASES: a
+        test that imported the mapping would agree with a renamed keyword
+        instead of catching it.
+        """
+        prim = l2.headers["PRIMARY"]
+        expected = _CATALOG_CAPTURE["kpf-drp"]
+        # SCI1-3 are traces 2-4 and carry identical astrometry.
+        for column, base in (
+            ("object", "CID"),
+            ("radec_src", "CSRC"),
+            ("ra", "CRA"),
+            ("dec", "CDEC"),
+            ("pmra", "CPMR"),
+            ("pmdec", "CPMD"),
+            ("parallax", "CPLX"),
+            ("rv", "CRV"),
+            ("epoch", "CEPCH"),
+            ("equinox", "CEQNX"),
+            ("color", "CCLR"),
+            ("color_name", "CCLRN"),
+        ):
+            for trace in (2, 3, 4):
+                card = f"{base}{trace}"
+                assert prim[card] == expected[column], card
+
+    def test_l4_rv_products_are_deterministic(self, l4):
+        """The same frames and masters must reproduce the same numbers.
+
+        A reproducibility pin on the pipeline, not a claim about the target: it
+        catches numerical drift and any loss of run-to-run determinism through
+        the barycentric and CCF chain.
+
+        These values are the only ones here coupled to what goes in: the truth
+        frames, the masters, and _CATALOG_CAPTURE. If this goes red, confirm all
+        three are unchanged before reading it as a pipeline regression --
+        different input needs a deliberate re-pin, not a fix.
+        """
+        prim = l4.headers["PRIMARY"]
+        assert prim["RV"] == pytest.approx(11.29034877686747, abs=1e-6)
+        assert prim["BERV"] == pytest.approx(-18.507963847544822, abs=1e-6)
+        assert prim["BJDTDB"] == pytest.approx(2460405.9689188506, abs=1e-9)
 
     def test_provenance_keywords_set(self, l2):
         # DRPTAG stays on the L2 PRIMARY; the other provenance cards live on

--- a/tests/regression/test_timeseries_script.py
+++ b/tests/regression/test_timeseries_script.py
@@ -312,14 +312,11 @@ class TestMainDispatch:
         monkeypatch.setattr(ts, "setup_batch_logging", lambda *a, **k: "/logs/x.log")
         calls = []
 
-        class _Result:
-            returncode = 0
-
-        def _run(argv, **kwargs):
+        def _run_stage(argv):
             calls.append(argv)
-            return _Result()
+            return 0
 
-        monkeypatch.setattr(ts.subprocess, "run", _run)
+        monkeypatch.setattr(ts, "_run_stage", _run_stage)
         return calls
 
     def test_missing_log_dir_exits(self, ts, monkeypatch, tmp_path):
@@ -439,10 +436,7 @@ class TestMainDispatch:
         _write_l0(str(tmp_path), "20240101", 3600, "10700")
         self._patch(ts, monkeypatch, tmp_path)
 
-        class _Fail:
-            returncode = 1
-
-        monkeypatch.setattr(ts.subprocess, "run", lambda *a, **k: _Fail())
+        monkeypatch.setattr(ts, "_run_stage", lambda argv: 1)
         with pytest.raises(SystemExit) as exc:
             ts.main(_BASE_ARGS)
         assert exc.value.code == 1


### PR DESCRIPTION
# Stop querying ESA at import, bound the queries we make, and fix subprocess teardown

Four commits into `kpf-next`. 25 files, +690/−163. No science numbers change.

## Why

`kpfpipe/modules/astro_query.py` imported `astroquery.gaia` at module scope. That
import runs a constructor which opens a socket to ESA with no timeout, so **every**
process importing the module — every `qc.py` child, every science recipe, every xdist
worker — paid 1.5–3.3 s and inherited a connection that hangs forever if the server
accepts but never answers. `do_gaia_query` never gated it; the connect happens long
before config is read.

Pulling on that surfaced a data-loss bug and a family of subprocess-teardown defects in
the same call paths.

## What changed

**`reduce.py` no longer deletes a night's products on a typo.** `clear_stale_outputs`
ran upstream of every recipe-loading failure, so `kpfpipe run -r recipes/kpf_drp_scince.py`
destroyed that unit's L1/L2/L4 and *then* exited on the typo. It now runs only after the
recipe is known to load.

**Import-time network call removed.** `kpfpipe/utils/network.py` owns two client
factories. `gaia_client()` defers the astroquery import and passes
`show_server_messages=False`; `simbad_client(fields, timeout)` constructs `SimbadClass()`
explicitly. Both are built inside the retried callable — loading `astroquery.gaia` builds
its module-level `Gaia = GaiaClass()`, so deferring the import *relocates* the connect
rather than removing it, and only a process that actually queries Gaia now pays it.

**Every attempt is bounded — via two mechanisms, not one.** Gaia's TAP transport is
`http.client` and honours `socket.setdefaulttimeout`. SIMBAD goes through pyvo over
`requests`, which passes an explicit `timeout=None` down to `sock.settimeout` and
overrides that default; it is bounded by an adapter mounted on the client's session.
Measured against an accept-and-stall listener, `setdefaulttimeout(2.0)` raises at 2.01 s
on the first and is still blocked past 25 s on the second. Collapsing the two would
silently un-bound SIMBAD.

**Subprocesses are torn down instead of orphaned.** `timeseries.py` never called
`configure_runtime()`, so SIGTERM killed the wrapper and left its stages running. Its
three stages now go through `_run_stage`, which SIGTERMs (routed through the same
KeyboardInterrupt path, so an orchestrator reaps its own fan-out first) and escalates to
SIGKILL only after 10 s. `_dispatch.run_stage` also resets its module-level state on
entry — a leftover `_interrupted` made every subsequent `_run_one` return `(130, "")`
without launching.

**Headless matplotlib.** No entry point selected a backend, so `plt.get_backend()`
resolved to `macosx` in headless children while `quicklook/base.py` documents its render
path as the Agg buffer's RGB channels. `MPLBACKEND` is now set via `setdefault` (an
explicit caller wins) in `qlp.main()`, `reduce.main()` and `configure_runtime()`.

**Smaller:** children get `stdin=DEVNULL`; the canary docstrings no longer claim a
warm-up that only happens for the science stage.

## Operator-visible

- New `[MODULE_ASTRO_QUERY] query_timeout` (default 30 s) in
  `configs/kpf_drp_science.toml`.
- Retry ladder drops from 8 attempts to 5 — attempts are bounded now and no longer wait
  on a hung socket.

## Review point: the test suite is no longer strictly offline

The old guard blocked every non-loopback connect. That cannot hold: `barycorrpy` fetches
IERS_B and leap seconds *at import*, before `import barycorrpy` returns, and no
configuration suppresses it. With a cold `HOME` the old guard turned this into a
collection-time `OSError`.

`tests/conftest.py` now hooks `socket.getaddrinfo` with a **catalog denylist** (ESA TAP,
SIMBAD and its Harvard mirror — anything the suite mocks) plus a **reference-data
allowlist**, each entry naming what fetches it, with `connect()` as a backstop for bare
IPs. A cold machine pulls ~123 MB on its first run. That is the cost of carrying no local
cache, and it is contained rather than fixed.

## Verification

- `make test`: **1816 passed, 70.1 s**. `make test-cli`: 264 passed. Full suite also
  green from an empty `HOME` (cold cache, serial, zero skips).
- Every new guard was checked by mutating the production fix and confirming the test goes
  red — import purity, both timeout seams, the socket-default restore, the headless
  backend, the catalog-card overlay, and the dispatcher state reset.
- Runtime spread, not median, is the durable result: sd 1.8 → 0.2 across three runs.
