### PR TITLE
Kpf next bugfixes 20260821

### DIFF
--- a/kpfpipe/modules/cross_correlation.py
+++ b/kpfpipe/modules/cross_correlation.py
@@ -496,8 +496,9 @@ class CrossCorrelation:
         var = np.asarray(self.l2_obj.data[f"{chip}_{fiber}_VAR"], dtype=np.float64)
 
         # Drop the blaze-faint, low-S/N order edges (they inject CCF noise).
-        # clip_edge_pixels is [short_wavelength_end, long_wavelength_end]; map to
-        # the pixel axis via the measured dispersion direction.
+        # clip_edge_pixels is [short_wavelength_end, long_wavelength_end]; WAVE is
+        # ascending (blue->red), enforced in _compute_ccf_1d, so pixel 0 is the
+        # short-wavelength end.
         n_short, n_long = int(clip_edge_pixels[0]), int(clip_edge_pixels[1])
         if n_short or n_long:
             ncol = flux.shape[1]
@@ -506,10 +507,7 @@ class CrossCorrelation:
                     f"clip_edge_pixels {list(clip_edge_pixels)} removes all "
                     f"{ncol} pixels of {chip}_{fiber}"
                 )
-            if np.nanmedian(np.diff(wave, axis=1)) >= 0:  # pixel 0 = short wavelength
-                cols = slice(n_short, ncol - n_long)
-            else:
-                cols = slice(n_long, ncol - n_short)
+            cols = slice(n_short, ncol - n_long)
             flux = flux[:, cols]
             wave = wave[:, cols]
             var = var[:, cols]

--- a/kpfpipe/modules/masters/base.py
+++ b/kpfpipe/modules/masters/base.py
@@ -120,6 +120,9 @@ class BaseMasterModule:
         # populated by subclass make_master_l2(); used by save_master('L2', ...)
         self.ml2_obj = None
 
+        # L0 files that actually stacked; recorded as the master's INPUT_FILES.
+        self._stacked_files = []
+
         # Per-chip stack statistics cached by _populate_stack_info() (dict);
         # consumed by the subclass _track_info() when it builds the info() text.
         self._stack_info = None
@@ -342,6 +345,7 @@ class BaseMasterModule:
 
         i = 0
         failure_count = 0
+        self._stacked_files = []
 
         for fn in l0_file_list:
             l1_obj = self._load_frame(fn, cache=cache)
@@ -353,6 +357,7 @@ class BaseMasterModule:
                 )
                 continue
 
+            self._stacked_files.append(fn)
             l1_obj = self._process_frame(l1_obj)
 
             exptime[i] = l1_obj.headers["PRIMARY"]["EXPTIME"]
@@ -501,6 +506,7 @@ class BaseMasterModule:
 
         failure = 0
         clipping_mask = np.ones((nrow, ncol), dtype=bool)
+        self._stacked_files = []
 
         for fn in l0_file_list:
             # The first ``ndirect`` frames are cache hits from the approximation
@@ -514,6 +520,7 @@ class BaseMasterModule:
                 )
                 continue
 
+            self._stacked_files.append(fn)
             l1_obj = self._process_frame(l1_obj)
 
             exptime = l1_obj.headers["PRIMARY"]["EXPTIME"]
@@ -593,12 +600,12 @@ class BaseMasterModule:
     # Private helpers for building outputs and tracking results.
     # ------------------------------------------------------------------
 
-    def _build_ml1_obj(self, l1_arrays, l0_file_list, *, master_type):
+    def _build_ml1_obj(self, l1_arrays, *, master_type):
         """
         Assemble a KPFMasterL1 from finalized per-chip '{chip}_IMG/_SNR/_MASK'
         arrays. ``master_type`` ('bias'/'dark'/'flat') drives the WMKO filename
         token, the receipt key (``master_{master_type}``), and the BUNIT units
-        (``_BUNIT_BY_TYPE``).
+        (``_BUNIT_BY_TYPE``). INPUT_FILES records ``self._stacked_files``.
         """
         receipt_key = f"master_{master_type}"
         bunit = self._BUNIT_BY_TYPE.get(master_type)
@@ -613,7 +620,7 @@ class BaseMasterModule:
             if bunit is not None:
                 ml1_obj.headers[f"{chip}_IMG"]["BUNIT"] = bunit
 
-        ml1_obj.set_input_files(l0_file_list, master_type)
+        ml1_obj.set_input_files(self._stacked_files, master_type)
         ml1_obj.receipt_add_entry(receipt_key, "", "PASS")
 
         return ml1_obj

--- a/kpfpipe/modules/masters/bias.py
+++ b/kpfpipe/modules/masters/bias.py
@@ -91,7 +91,7 @@ class Bias(BaseMasterModule):
             cal_type="bias",
         )
 
-        self.ml1_obj = self._build_ml1_obj(l1_arrays, l0_file_list, master_type="bias")
+        self.ml1_obj = self._build_ml1_obj(l1_arrays, master_type="bias")
         self._populate_stack_info(l1_arrays)
         self._track_info()
 

--- a/kpfpipe/modules/masters/dark.py
+++ b/kpfpipe/modules/masters/dark.py
@@ -107,7 +107,7 @@ class Dark(BaseMasterModule):
         # Dark current is a rate: stack_frames normalizes each frame by its
         # exposure time, so the master dark IMG is in electrons/sec (BUNIT is
         # derived from master_type in _build_ml1_obj).
-        self.ml1_obj = self._build_ml1_obj(l1_arrays, l0_file_list, master_type="dark")
+        self.ml1_obj = self._build_ml1_obj(l1_arrays, master_type="dark")
         self._populate_stack_info(l1_arrays)
         self._track_info()
 

--- a/kpfpipe/modules/masters/flat.py
+++ b/kpfpipe/modules/masters/flat.py
@@ -108,7 +108,7 @@ class Flat(BaseMasterModule):
             cal_type="flat",
         )
 
-        self.ml1_obj = self._build_ml1_obj(l1_arrays, l0_file_list, master_type="flat")
+        self.ml1_obj = self._build_ml1_obj(l1_arrays, master_type="flat")
         self._populate_stack_info(l1_arrays)
         self._track_info()
 

--- a/kpfpipe/modules/masters/wls.py
+++ b/kpfpipe/modules/masters/wls.py
@@ -195,6 +195,7 @@ class WLS(BaseMasterModule):
             raise ValueError("Empty l0_file_list; must supply at least one valid file")
 
         self._l2_obj_cache = []
+        self._stacked_files = []
         failure = 0
 
         for fn in l0_file_list:
@@ -207,6 +208,7 @@ class WLS(BaseMasterModule):
                 )
                 continue
 
+            self._stacked_files.append(fn)
             l1_obj = self._process_frame(l1_obj)
             l2_obj = self._extract_frame(l1_obj)
             self._l2_obj_cache.append(l2_obj)
@@ -828,7 +830,7 @@ class WLS(BaseMasterModule):
                 self.ml2_obj.create_extension(coeffs_ext, "ImageHDU")
             self.ml2_obj.set_data(coeffs_ext, coeffs_mean)
 
-        self.ml2_obj.set_input_files(l0_file_list, "thar")
+        self.ml2_obj.set_input_files(self._stacked_files, "thar")
 
         # WLS metadata is out of EPRV scope but registered in ML2-wls-headers.csv,
         # so it routes through set_keyword (-> PRIMARY, registry comments).

--- a/tests/regression/_masters.py
+++ b/tests/regression/_masters.py
@@ -47,7 +47,16 @@ def mocked_stack(module, arrays=None):
     ``save_master`` on it); otherwise prefer ``make_mocked_master``.
     """
     value = make_l1_arrays() if arrays is None else arrays
-    with patch.object(module, "stack_frames", return_value=value):
+
+    # Real stacking records its survivors in _stacked_files (the master's
+    # INPUT_FILES); the mock stands in for that too.
+    def _stack(l0_file_list=None, **kwargs):
+        module._stacked_files = list(
+            module.l0_file_list if l0_file_list is None else l0_file_list
+        )
+        return value
+
+    with patch.object(module, "stack_frames", side_effect=_stack):
         yield module
 
 

--- a/tests/regression/test_cross_correlation.py
+++ b/tests/regression/test_cross_correlation.py
@@ -525,11 +525,9 @@ class TestComputeCCFPublic:
         assert not np.allclose(full, clipped)
 
     def test_clip_edge_pixels_ends_are_distinguished(self, cc_module):
-        # clip_edge_pixels is [short_wavelength_end, long_wavelength_end]; on this
-        # ascending fixture pixel 0 is the short end, so clipping one end must not
-        # produce the same CCF as clipping the other. (The descending branch at
-        # cross_correlation.py:512 is unreachable in production and is not covered
-        # here -- see the dead-code defect report.)
+        # clip_edge_pixels is [short_wavelength_end, long_wavelength_end]; WAVE is
+        # ascending, so pixel 0 is the short end and clipping one end must not
+        # produce the same CCF as clipping the other.
         blue = cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[800, 0])["ccf"]
         red = cc_module.compute_ccfs("GREEN", "SCI2", clip_edge_pixels=[0, 800])["ccf"]
         assert not np.allclose(blue, red)

--- a/tests/regression/test_master_base.py
+++ b/tests/regression/test_master_base.py
@@ -1044,12 +1044,31 @@ class TestInputFilesProvenance:
         # INPUT_FILES and MASTYPE are the master's provenance anchor, and
         # MASTYPE is what generate_standard_filename() needs to build a
         # DRP-RUN-05 name after a round trip.
-        #
-        # NOTE: production records the *requested* L0 list, not the frames that
-        # survived stacking -- _build_ml1_obj passes l0_file_list straight to
-        # set_input_files, while _load_frame may drop QC failures within the
-        # tolerated budget. No frame is dropped here, so this assertion holds
-        # under either semantic; it is deliberately silent on which is intended.
         ml1 = make_mocked_master(Bias)
         assert ml1.data["INPUT_FILES"]["FILENAME"].tolist() == FILE_LIST
         assert ml1.headers["PRIMARY"]["MASTYPE"] == "bias"
+
+    def test_records_only_the_frames_that_stacked(self):
+        # A frame _load_frame drops contributed nothing to the master, so it
+        # must not appear in INPUT_FILES -- and, dropped first, must not name
+        # the master via generate_standard_filename()'s INPUT_FILES[0].
+        # Eight frames, so one drop stays inside the tolerated failure budget.
+        dark = Dark(sorted(f"f{i}.fits" for i in range(8)))
+        dark.chips = ["GREEN"]
+        dark.ccd = {"nrow": 2, "ncol": 2}
+
+        dropped = dark.l0_file_list[0]
+        with (
+            patch.object(
+                dark,
+                "_load_frame",
+                lambda fn, **k: (
+                    None if fn == dropped else _stack_frame(10.0, 100.0, 1.0)
+                ),
+            ),
+            patch.object(dark, "_process_frame", lambda l1: l1),
+        ):
+            l1_arrays = dark.stack_frames()
+
+        ml1 = dark._build_ml1_obj(l1_arrays, master_type="dark")
+        assert ml1.data["INPUT_FILES"]["FILENAME"].tolist() == dark.l0_file_list[1:]


### PR DESCRIPTION
## Summary

Two small, unrelated bugfixes:

1. Masters now record the frames that were *actually* stacked, rather than the full list of requested frames
2. Dropped an extraneous guard on WAVE array ordering (all arrays are oriented blue -> red across the pipeline)