### PR TITLE
run.json run-record sidecar for every kpfpipe invocation

### DIFF
--- a/kpfpipe/utils/run_record.py
+++ b/kpfpipe/utils/run_record.py
@@ -1,0 +1,258 @@
+"""Per-invocation ``run.json`` run records.
+
+Every ``kpfpipe`` invocation -- the ``run`` leaf and the ``masters``/``science``
+batch orchestrators -- writes one machine-readable record beside its log file
+(same directory, same stem, ``.run.json`` instead of ``.log``). The record is
+written at start with ``status: running`` and rewritten at exit, so a crash
+leaves an honest partial record rather than nothing. It exists so operations
+tooling (KPF-Ops) and shell users can answer "what ran, from which pipeline
+commit, and how did it end" without parsing log text.
+
+Stdlib only, and independent of the logging stack: the record must still be
+written when logging setup itself has failed.
+"""
+
+import atexit
+import glob
+import json
+import logging
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import time
+
+import kpfpipe
+
+logger = logging.getLogger(__name__)
+
+SCHEMA = 1
+
+# Environment variables that link records together. An orchestrator exports
+# PARENT_ENV (its own run.json path) before fanning out; each child records it as
+# ``parent``. FLOW_RUN_ENV is set by KPF-Ops flows so a record can be joined to the
+# Prefect flow run that launched it; absent outside KPF-Ops.
+PARENT_ENV = "KPFPIPE_PARENT_RUN"
+FLOW_RUN_ENV = "KPFOPS_FLOW_RUN_ID"
+
+# ``x.log`` -> ``x.run.json``; a collision-suffixed ``x.log.3`` -> ``x.3.run.json``.
+_LOG_SUFFIX = re.compile(r"\.log(?:\.(\d+))?$")
+
+_GIT_TIMEOUT_S = 5
+
+
+def run_json_path(log_path):
+    """Return the sidecar path for a log file path.
+
+    Parameters
+    ----------
+    log_path : str
+        A log path produced by ``kpfpipe.utils.logger.setup_logging`` (ending in
+        ``.log`` or a collision-suffixed ``.log.N``).
+
+    Returns
+    -------
+    str
+
+    Raises
+    ------
+    ValueError
+        If ``log_path`` does not end in ``.log`` / ``.log.N``.
+    """
+    m = _LOG_SUFFIX.search(log_path)
+    if m is None:
+        raise ValueError(f"not a kpfpipe log path (no .log suffix): {log_path!r}")
+    stem = log_path[: m.start()]
+    suffix = f".{m.group(1)}" if m.group(1) else ""
+    return f"{stem}{suffix}.run.json"
+
+
+def git_sha(repo_root=kpfpipe.REPO_ROOT):
+    """Return the HEAD commit sha of ``repo_root``, or None if unavailable.
+
+    Never raises: a missing ``git`` binary, a damaged or absent ``.git``, or a
+    timeout all yield None, which the record stores as ``null``. A null sha is an
+    honest "unknown"; it is never replaced with a guess.
+    """
+    if shutil.which("git") is None:
+        return None
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if out.returncode != 0:
+        return None
+    sha = out.stdout.strip()
+    return sha or None
+
+
+def write_json_atomic(path, data):
+    """Write ``data`` as JSON to ``path`` atomically (temp file + ``os.replace``).
+
+    Creates the parent directory as needed. A reader never observes a partial
+    file: it sees either the previous complete record or the new one.
+    """
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, indent=2, sort_keys=True)
+        fh.write("\n")
+    os.replace(tmp, path)
+
+
+def read_run_record(path):
+    """Load a run record, validating its ``schema`` field.
+
+    Raises
+    ------
+    ValueError
+        If the file's ``schema`` is not the one this module writes.
+    """
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    if data.get("schema") != SCHEMA:
+        raise ValueError(
+            f"{path}: run record schema {data.get('schema')!r}, expected {SCHEMA}"
+        )
+    return data
+
+
+def _utc_now():
+    """ISO-8601 UT timestamp with a trailing Z, second resolution."""
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+class RunRecord:
+    """The run.json record for one invocation: start now, finish at exit.
+
+    ``start`` writes the record with ``status: running`` and registers an
+    ``atexit`` hook; if the process exits without ``finish`` (``sys.exit(130)``
+    on Ctrl-C, an unhandled SystemExit) the hook rewrites it as ``interrupted``.
+    A SIGKILL leaves the ``running`` record in place -- an honest partial record.
+    """
+
+    def __init__(self, path, record):
+        self.path = path
+        self.record = record
+        self._finished = False
+
+    @classmethod
+    def start(cls, log_path, *, kind, recipe, target, config, argv=None):
+        """Create and write the ``running`` record for this invocation.
+
+        Parameters
+        ----------
+        log_path : str
+            The invocation's log file (from ``setup_logging``); the record is
+            written beside it (``run_json_path``).
+        kind : {'run', 'batch'}
+            ``run`` for the single-unit leaf, ``batch`` for an orchestrator.
+        recipe : str
+            Short recipe/orchestrator name, e.g. ``science``/``masters``.
+        target : str
+            obs_id, datecode, or ``batch``.
+        config : str
+            Path of the TOML config in force.
+        argv : list of str or None
+            The command line; ``None`` means ``sys.argv``.
+        """
+        if kind not in ("run", "batch"):
+            raise ValueError(f"kind must be 'run' or 'batch', got {kind!r}")
+        argv = list(sys.argv if argv is None else argv)
+        record = {
+            "schema": SCHEMA,
+            "kind": kind,
+            "status": "running",
+            "recipe": recipe,
+            "target": target,
+            "command": " ".join(argv),
+            "argv": argv,
+            "config": config,
+            "git_sha": git_sha(),
+            "drptag": kpfpipe.__version__,
+            "host": socket.gethostname(),
+            "pid": os.getpid(),
+            "cwd": os.getcwd(),
+            "started_utc": _utc_now(),
+            "ended_utc": None,
+            "exit_status": None,
+            "counts": {"done": 0, "failed": 0, "skipped": 0},
+            "log_path": log_path,
+            "parent": os.environ.get(PARENT_ENV),
+            "flow_run_id": os.environ.get(FLOW_RUN_ENV),
+            "children": [],
+        }
+        self = cls(run_json_path(log_path), record)
+        write_json_atomic(self.path, self.record)
+        atexit.register(self._on_exit)
+        return self
+
+    def finish(self, exit_status, *, done=0, failed=0, skipped=0, children=None):
+        """Finalize the record: ``succeeded`` for exit 0, else ``failed``.
+
+        Raises
+        ------
+        RuntimeError
+            If called twice.
+        """
+        if self._finished:
+            raise RuntimeError(f"run record already finished: {self.path}")
+        self.record["status"] = "succeeded" if exit_status == 0 else "failed"
+        self.record["exit_status"] = int(exit_status)
+        self.record["ended_utc"] = _utc_now()
+        self.record["counts"] = {"done": done, "failed": failed, "skipped": skipped}
+        if children is not None:
+            self.record["children"] = list(children)
+        self._finished = True
+        write_json_atomic(self.path, self.record)
+
+    def is_finished(self):
+        return self._finished
+
+    def _on_exit(self):
+        """atexit hook: mark a still-running record ``interrupted``."""
+        if self._finished:
+            return
+        self.record["status"] = "interrupted"
+        self.record["ended_utc"] = _utc_now()
+        self._finished = True
+        write_json_atomic(self.path, self.record)
+
+
+def collect_child_records(log_dir, parent_path):
+    """List the child run records under ``log_dir`` that name ``parent_path``.
+
+    Scans ``{log_dir}/*/*.run.json`` (the one-level date layout ``setup_logging``
+    writes). Files that are not valid run records are skipped with a WARNING
+    rather than aborting the batch's own bookkeeping. Returned entries carry the
+    child's ``target`` as ``tag`` and are sorted by it.
+    """
+    children = []
+    for path in glob.glob(os.path.join(log_dir, "*", "*.run.json")):
+        try:
+            data = read_run_record(path)
+        except (OSError, ValueError) as exc:
+            # json.JSONDecodeError is a ValueError subclass.
+            logger.warning("skipping unreadable run record %s: %s", path, exc)
+            continue
+        if data.get("parent") != parent_path:
+            continue
+        children.append(
+            {
+                "tag": data.get("target"),
+                "exit_status": data.get("exit_status"),
+                "status": data.get("status"),
+                "run_json": path,
+            }
+        )
+    children.sort(key=lambda c: str(c["tag"]))
+    return children

--- a/scripts/processing/masters.py
+++ b/scripts/processing/masters.py
@@ -34,6 +34,7 @@ from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import datecode_dirs_in_range, read_token_file
 from kpfpipe.utils.kpf import is_datecode
 from kpfpipe.utils.logger import setup_batch_logging
+from kpfpipe.utils.run_record import PARENT_ENV, RunRecord, collect_child_records
 from scripts.processing import DEFAULT_MASTERS_CONFIG, DEFAULT_MASTERS_RECIPE
 from scripts.processing._argparse import (
     cache_parser,
@@ -214,6 +215,16 @@ def main(argv=None):
     # echoed live to stdout, alongside each night's per-reduction log.
     level = args.log_level or logger_params.get("log_level", "INFO")
     log_path = setup_batch_logging(log_dir, "masters", level=level)
+    # The batch run.json sidecar; see science.py for why the path is exported.
+    record = RunRecord.start(
+        log_path,
+        kind="batch",
+        recipe="masters",
+        target="batch",
+        config=args.config or DEFAULT_MASTERS_CONFIG,
+    )
+    prior_parent = os.environ.get(PARENT_ENV)
+    os.environ[PARENT_ENV] = record.path
 
     forward = []
     for value, flag in (
@@ -232,6 +243,7 @@ def main(argv=None):
     logger.info("data input: %s", data_input)
     logger.info("jobs: %s", args.jobs)
     logger.info("batch log: %s", log_path)
+    logger.info("run record: %s", record.path)
 
     datecodes = resolve_datecodes(args, data_input)
     logger.info(
@@ -256,8 +268,19 @@ def main(argv=None):
         launch_interval=_LAUNCH_INTERVAL,
     )
 
+    if prior_parent is None:
+        os.environ.pop(PARENT_ENV, None)
+    else:
+        os.environ[PARENT_ENV] = prior_parent
+
     built = len(datecodes) - len(failed)
     logger.info("done: built masters for %d/%d night(s)", built, len(datecodes))
+    record.finish(
+        1 if failed else 0,
+        done=built,
+        failed=len(failed),
+        children=collect_child_records(log_dir, record.path),
+    )
     if failed:
         sys.exit(1)
 

--- a/scripts/processing/reduce.py
+++ b/scripts/processing/reduce.py
@@ -38,6 +38,7 @@ from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import kpf_directory, kpf_filepath
 from kpfpipe.utils.kpf import is_obs_id
 from kpfpipe.utils.logger import setup_logging
+from kpfpipe.utils.run_record import RunRecord
 from scripts.processing import (
     DEFAULT_MASTERS_CONFIG,
     DEFAULT_MASTERS_RECIPE,
@@ -141,6 +142,16 @@ def main(argv=None):
         parser.error(str(e))
     log_path = setup_logging(**log_params)
 
+    # The run.json sidecar: started now (status running), finished below. It is
+    # the machine-readable twin of this log for operations tooling.
+    record = RunRecord.start(
+        log_path,
+        kind="run",
+        recipe=log_params["recipe_name"],
+        target=log_params["target"],
+        config=args.config,
+    )
+
     # Invocation banner: the start of the DRP-RUN-08 reduction-step trail.
     logger.info("kpfpipe %s starting", kpfpipe.__version__)
     logger.info("argv: %s", " ".join(sys.argv))
@@ -148,6 +159,7 @@ def main(argv=None):
     logger.info("config: %s", args.config)
     logger.info("data dirs: %s", config.get_params(["DATA_DIRS"]))
     logger.info("log file: %s", log_path)
+    logger.info("run record: %s", record.path)
 
     if not os.path.isfile(args.recipe):
         raise SystemExit(f"Recipe file not found: {args.recipe}")
@@ -169,7 +181,9 @@ def main(argv=None):
         # ensure the traceback reaches the log before the nonzero exit. The
         # SystemExit usage errors above bypass this on purpose.
         logger.critical("uncaught exception; pipeline aborted", exc_info=True)
+        record.finish(1, failed=1)
         raise
+    record.finish(0, done=1)
     logger.info("pipeline completed successfully")
 
 

--- a/scripts/processing/science.py
+++ b/scripts/processing/science.py
@@ -31,6 +31,7 @@ from kpfpipe.utils.config import ConfigHandler
 from kpfpipe.utils.io import read_token_file
 from kpfpipe.utils.kpf import get_datecode, is_obs_id
 from kpfpipe.utils.logger import setup_batch_logging
+from kpfpipe.utils.run_record import PARENT_ENV, RunRecord, collect_child_records
 from scripts.processing import DEFAULT_SCIENCE_CONFIG, DEFAULT_SCIENCE_RECIPE
 from scripts.processing._argparse import (
     cache_parser,
@@ -162,6 +163,18 @@ def main(argv=None):
     # echoed live to stdout, alongside each frame's per-reduction log.
     level = args.log_level or logger_params.get("log_level", "INFO")
     log_path = setup_batch_logging(log_dir, "science", level=level)
+    # The batch run.json sidecar. Exporting its path lets every fanned-out reduce
+    # child (which inherits our environment) record this batch as its parent, so
+    # the two levels of records link both ways.
+    record = RunRecord.start(
+        log_path,
+        kind="batch",
+        recipe="science",
+        target="batch",
+        config=args.config or DEFAULT_SCIENCE_CONFIG,
+    )
+    prior_parent = os.environ.get(PARENT_ENV)
+    os.environ[PARENT_ENV] = record.path
 
     forward = []
     for value, flag in (
@@ -182,6 +195,7 @@ def main(argv=None):
     logger.info("config: %s", args.config or DEFAULT_SCIENCE_CONFIG)
     logger.info("jobs: %s", args.jobs)
     logger.info("batch log: %s", log_path)
+    logger.info("run record: %s", record.path)
     logger.info("reducing %d science frame(s): %s", len(obs_ids), ", ".join(obs_ids))
 
     # Warm the L0 mini-db caches up front, one thread per night (--cache, rw
@@ -202,8 +216,19 @@ def main(argv=None):
         launch_interval=_LAUNCH_INTERVAL,
     )
 
+    if prior_parent is None:
+        os.environ.pop(PARENT_ENV, None)
+    else:
+        os.environ[PARENT_ENV] = prior_parent
+
     reduced = len(obs_ids) - len(failed)
     logger.info("done: reduced %d/%d frame(s)", reduced, len(obs_ids))
+    record.finish(
+        1 if failed else 0,
+        done=reduced,
+        failed=len(failed),
+        children=collect_child_records(log_dir, record.path),
+    )
     if failed:
         sys.exit(1)
 

--- a/tests/regression/test_masters_script.py
+++ b/tests/regression/test_masters_script.py
@@ -9,10 +9,13 @@ test_io.py.
 Unit tests use synthetic dir trees in tmp_path -- no real testdata needed.
 """
 
+import os
 import sys
+import tempfile
 
 import pytest
 
+from kpfpipe.utils import run_record as rr
 from scripts.processing import masters as _masters
 
 from ._scripts import _FakeConfig, _NoLogDirConfig
@@ -24,6 +27,19 @@ pytestmark = pytest.mark.cli
 @pytest.fixture(scope="module")
 def m():
     return _masters
+
+
+def _stub_batch_log(monkeypatch, mod):
+    """Stub setup_batch_logging with a real-looking .log path in a temp dir.
+
+    The batch run.json sidecar is written beside the log, so the stub must return
+    a writable path ending in .log (never a placeholder like /l/x.log).
+    """
+    base = tempfile.mkdtemp()
+    fake_log = os.path.join(base, "logs", "20240405", "kpf_batch_x_20240405T000000.log")
+    os.makedirs(os.path.dirname(fake_log), exist_ok=True)
+    monkeypatch.setattr(mod, "setup_batch_logging", lambda *a, **k: fake_log)
+    return fake_log
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +232,7 @@ class TestMainExitCode:
         # run_stage's kwargs for wiring assertions.
         monkeypatch.setattr(m, "configure_runtime", lambda: None)
         monkeypatch.setattr(m, "ConfigHandler", _FakeConfig)
-        monkeypatch.setattr(m, "setup_batch_logging", lambda *a, **k: "/l/x.log")
+        _stub_batch_log(monkeypatch, m)
         monkeypatch.setattr(m, "resolve_datecodes", lambda args, di: ["20240405"])
         monkeypatch.setattr(m, "warm_mini_db_caches", lambda *a, **k: (0, 0))
 
@@ -302,3 +318,51 @@ class TestMainExitCode:
         with pytest.raises(SystemExit) as exc:
             m.main(["--dates", "20240405"])
         assert "log directory" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# batch run.json sidecar
+# ---------------------------------------------------------------------------
+
+
+class TestBatchRunRecord:
+    def test_batch_record_written_with_counts_and_children(
+        self, m, monkeypatch, tmp_path
+    ):
+        log_dir = tmp_path / "logs"
+        fake_log = log_dir / "20240405" / "kpf_masters_batch_20240405T000000.log"
+        fake_log.parent.mkdir(parents=True)
+        monkeypatch.setattr(m, "configure_runtime", lambda: None)
+        monkeypatch.setattr(m, "ConfigHandler", _FakeConfig)
+        monkeypatch.setattr(m, "setup_batch_logging", lambda *a, **k: str(fake_log))
+        monkeypatch.setattr(m, "warm_mini_db_caches", lambda *a, **k: (0, 0))
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: None)
+        monkeypatch.delenv(rr.PARENT_ENV, raising=False)
+
+        def fake_run_stage(label, tasks, jobs, log_dir_arg, **kw):
+            child = os.path.join(
+                log_dir_arg, "20240405", "kpf_masters_20240406_x.run.json"
+            )
+            rr.write_json_atomic(
+                child,
+                {
+                    "schema": rr.SCHEMA,
+                    "kind": "run",
+                    "status": "succeeded",
+                    "target": "20240406",
+                    "exit_status": 0,
+                    "parent": os.environ.get(rr.PARENT_ENV),
+                },
+            )
+            return set()
+
+        monkeypatch.setattr(m, "run_stage", fake_run_stage)
+        m.main(["--dates", "20240405", "20240406", "--log_dir", str(log_dir)])
+
+        data = rr.read_run_record(rr.run_json_path(str(fake_log)))
+        assert data["kind"] == "batch"
+        assert data["recipe"] == "masters"
+        assert data["status"] == "succeeded"
+        assert data["counts"] == {"done": 2, "failed": 0, "skipped": 0}
+        assert [c["tag"] for c in data["children"]] == ["20240406"]
+        assert os.environ.get(rr.PARENT_ENV) is None

--- a/tests/regression/test_reduce_script.py
+++ b/tests/regression/test_reduce_script.py
@@ -7,11 +7,15 @@ reduction runs. (``resolve_logging`` itself is unit-tested in test_logger.py.)
 """
 
 import argparse
+import glob
 import logging
 import os
+import tempfile
 
 import pytest
 
+from kpfpipe.utils import run_record as rr
+from kpfpipe.utils.logger import teardown_logging
 from scripts.processing import reduce as red
 
 # scripts/CLI/tools-layer suite: excluded from `make test-fast`.
@@ -29,9 +33,22 @@ def _stub_recipe(tmp_path, sentinel):
     return recipe
 
 
+def _stub_logging(monkeypatch):
+    """Stub setup_logging: no real handlers, but a real-looking .log path.
+
+    The run.json sidecar is written beside the log, so the stub must return a
+    path ending in .log inside a writable temp dir (never /dev/null).
+    """
+    base = tempfile.mkdtemp()
+    fake_log = os.path.join(base, "logs", "20240405", "kpf_rec_x_20240405T000000.log")
+    os.makedirs(os.path.dirname(fake_log), exist_ok=True)
+    monkeypatch.setattr(red, "setup_logging", lambda **kw: fake_log)
+    return fake_log
+
+
 def _run(monkeypatch, argv):
     # Only config resolution is asserted; keep the real logging stack untouched.
-    monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+    _stub_logging(monkeypatch)
     red.main(argv)
 
 
@@ -173,7 +190,7 @@ class TestRecipeLoading:
 
     def test_missing_recipe_file_exits(self, monkeypatch, tmp_path):
         cfg = _base_cfg(tmp_path)
-        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        _stub_logging(monkeypatch)
         with pytest.raises(SystemExit, match="Recipe file not found"):
             red.main(["-r", str(tmp_path / "absent.py"), "-c", str(cfg), "-o", "KP.x"])
 
@@ -181,7 +198,7 @@ class TestRecipeLoading:
         cfg = _base_cfg(tmp_path)
         recipe = tmp_path / "nomain.py"
         recipe.write_text("VALUE = 1\n")
-        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        _stub_logging(monkeypatch)
         with pytest.raises(SystemExit, match="has no main"):
             red.main(["-r", str(recipe), "-c", str(cfg), "-o", "KP.x"])
 
@@ -194,7 +211,7 @@ class TestRecipeLoading:
         cfg = _base_cfg(tmp_path)
         recipe = tmp_path / "boom.py"
         recipe.write_text("def main(config, args):\n    raise RuntimeError('boom')\n")
-        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        _stub_logging(monkeypatch)
         caplog.set_level(logging.CRITICAL)
 
         with pytest.raises(RuntimeError, match="boom"):
@@ -220,7 +237,7 @@ class TestRecipeLoading:
         os.makedirs(os.path.dirname(product), exist_ok=True)
         open(product, "w").close()
 
-        monkeypatch.setattr(red, "setup_logging", lambda **kw: "/dev/null")
+        _stub_logging(monkeypatch)
         with pytest.raises(SystemExit, match="Recipe file not found"):
             red.main(["-r", str(tmp_path / "absent.py"), "-c", str(cfg), "-o", oid])
 
@@ -340,3 +357,74 @@ class TestClearStaleOutputs:
         red.clear_stale_outputs(
             _Config({"KPF_MASTERS_OUTPUT": str(tmp_path)}), _args(datecode="20240405")
         )
+
+
+# ---------------------------------------------------------------------------
+# run.json sidecar
+# ---------------------------------------------------------------------------
+
+
+def _record_cfg(tmp_path):
+    cfg = tmp_path / "rec.toml"
+    cfg.write_text(
+        "[DATA_DIRS]\n"
+        f'KPF_DATA_INPUT = "{tmp_path / "in"}"\n'
+        f'KPF_MASTERS_OUTPUT = "{tmp_path / "m"}"\n'
+        f'KPF_SCIENCE_OUTPUT = "{tmp_path / "s"}"\n'
+        "[LOGGER]\n"
+        f'log_dir = "{tmp_path / "logs"}"\n'
+        "console = false\n"
+    )
+    return cfg
+
+
+class TestRunRecordSidecar:
+    """reduce.py writes a run.json beside its log: succeeded on a clean recipe,
+    failed (and still re-raised) when the recipe throws. These run the real
+    logging stack so the sidecar lands next to a real log file."""
+
+    _OID = "KP.20240405.40113.57"
+
+    def _run_real_logging(self, monkeypatch, argv):
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: "deadbeef")
+        try:
+            red.main(argv)
+        finally:
+            teardown_logging()
+
+    def _records(self, tmp_path):
+        return sorted(glob.glob(str(tmp_path / "logs" / "*" / "*.run.json")))
+
+    def test_success_writes_succeeded_record(self, monkeypatch, tmp_path):
+        cfg = _record_cfg(tmp_path)
+        recipe = _stub_recipe(tmp_path, tmp_path / "seen.txt")
+        self._run_real_logging(
+            monkeypatch, ["-r", str(recipe), "-c", str(cfg), "-o", self._OID]
+        )
+        (path,) = self._records(tmp_path)
+        data = rr.read_run_record(path)
+        assert data["kind"] == "run"
+        assert data["status"] == "succeeded"
+        assert data["recipe"] == "rec"
+        assert data["target"] == self._OID
+        assert data["config"] == str(cfg)
+        assert data["git_sha"] == "deadbeef"
+        assert data["counts"] == {"done": 1, "failed": 0, "skipped": 0}
+        assert data["log_path"].endswith(".log")
+        assert path == rr.run_json_path(data["log_path"])
+
+    def test_recipe_exception_writes_failed_record_and_reraises(
+        self, monkeypatch, tmp_path
+    ):
+        cfg = _record_cfg(tmp_path)
+        recipe = tmp_path / "boom.py"
+        recipe.write_text("def main(config, args):\n    raise RuntimeError('boom')\n")
+        with pytest.raises(RuntimeError, match="boom"):
+            self._run_real_logging(
+                monkeypatch, ["-r", str(recipe), "-c", str(cfg), "-o", self._OID]
+            )
+        (path,) = self._records(tmp_path)
+        data = rr.read_run_record(path)
+        assert data["status"] == "failed"
+        assert data["exit_status"] == 1
+        assert data["counts"]["failed"] == 1

--- a/tests/regression/test_run_record.py
+++ b/tests/regression/test_run_record.py
@@ -84,3 +84,172 @@ class TestAtomicJson:
         path.write_text(json.dumps({"schema": 99}))
         with pytest.raises(ValueError):
             rr.read_run_record(str(path))
+
+
+def _log(tmp_path):
+    d = tmp_path / "20240405"
+    d.mkdir(exist_ok=True)
+    return str(d / "kpf_science_KP.20240405.1_20240405T010203.log")
+
+
+class TestRunRecordStart:
+    def test_writes_running_record_beside_log(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: "abc123")
+        monkeypatch.delenv(rr.PARENT_ENV, raising=False)
+        monkeypatch.delenv(rr.FLOW_RUN_ENV, raising=False)
+        rec = rr.RunRecord.start(
+            _log(tmp_path),
+            kind="run",
+            recipe="science",
+            target="KP.20240405.1",
+            config="/c/s.toml",
+            argv=["kpfpipe", "run"],
+        )
+        assert rec.path == rr.run_json_path(_log(tmp_path))
+        data = rr.read_run_record(rec.path)
+        assert data["schema"] == rr.SCHEMA
+        assert data["kind"] == "run"
+        assert data["status"] == "running"
+        assert data["recipe"] == "science"
+        assert data["target"] == "KP.20240405.1"
+        assert data["config"] == "/c/s.toml"
+        assert data["argv"] == ["kpfpipe", "run"]
+        assert data["command"] == "kpfpipe run"
+        assert data["git_sha"] == "abc123"
+        assert data["drptag"] == rr.kpfpipe.__version__
+        assert data["host"] == rr.socket.gethostname()
+        assert data["pid"] == os.getpid()
+        assert data["log_path"] == _log(tmp_path)
+        assert data["parent"] is None
+        assert data["flow_run_id"] is None
+        assert data["ended_utc"] is None
+        assert data["exit_status"] is None
+        assert data["counts"] == {"done": 0, "failed": 0, "skipped": 0}
+        assert data["children"] == []
+        assert data["started_utc"].endswith("Z")
+        rec.finish(0)  # detach atexit
+
+    def test_records_parent_and_flow_run_from_env(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: None)
+        monkeypatch.setenv(rr.PARENT_ENV, "/l/d/kpf_science_batch_x.run.json")
+        monkeypatch.setenv(rr.FLOW_RUN_ENV, "flow-uuid")
+        rec = rr.RunRecord.start(
+            _log(tmp_path), kind="run", recipe="science", target="t", config="c"
+        )
+        data = rr.read_run_record(rec.path)
+        assert data["parent"] == "/l/d/kpf_science_batch_x.run.json"
+        assert data["flow_run_id"] == "flow-uuid"
+        assert data["git_sha"] is None
+        rec.finish(0)
+
+    def test_argv_defaults_to_sys_argv(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: None)
+        monkeypatch.setattr(rr.sys, "argv", ["prog", "-o", "x"])
+        rec = rr.RunRecord.start(
+            _log(tmp_path), kind="run", recipe="science", target="t", config="c"
+        )
+        assert rr.read_run_record(rec.path)["argv"] == ["prog", "-o", "x"]
+        rec.finish(0)
+
+    def test_bad_kind_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            rr.RunRecord.start(
+                _log(tmp_path), kind="nope", recipe="science", target="t", config="c"
+            )
+
+
+class TestRunRecordFinish:
+    def _start(self, tmp_path, monkeypatch, kind="run"):
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: None)
+        return rr.RunRecord.start(
+            _log(tmp_path), kind=kind, recipe="science", target="t", config="c"
+        )
+
+    def test_exit_zero_is_succeeded_with_counts(self, tmp_path, monkeypatch):
+        rec = self._start(tmp_path, monkeypatch)
+        rec.finish(0, done=1)
+        data = rr.read_run_record(rec.path)
+        assert data["status"] == "succeeded"
+        assert data["exit_status"] == 0
+        assert data["counts"] == {"done": 1, "failed": 0, "skipped": 0}
+        assert data["ended_utc"] is not None
+        assert rec.is_finished()
+
+    def test_nonzero_is_failed(self, tmp_path, monkeypatch):
+        rec = self._start(tmp_path, monkeypatch)
+        rec.finish(1, failed=1)
+        assert rr.read_run_record(rec.path)["status"] == "failed"
+
+    def test_children_recorded_for_batch(self, tmp_path, monkeypatch):
+        rec = self._start(tmp_path, monkeypatch, kind="batch")
+        kids = [{"tag": "KP.1", "exit_status": 0, "run_json": "/l/d/a.run.json"}]
+        rec.finish(0, done=1, children=kids)
+        assert rr.read_run_record(rec.path)["children"] == kids
+
+    def test_finish_twice_raises(self, tmp_path, monkeypatch):
+        rec = self._start(tmp_path, monkeypatch)
+        rec.finish(0)
+        with pytest.raises(RuntimeError):
+            rec.finish(0)
+
+    def test_atexit_marks_unfinished_record_interrupted(self, tmp_path, monkeypatch):
+        registered = []
+        monkeypatch.setattr(rr.atexit, "register", lambda fn: registered.append(fn))
+        rec = self._start(tmp_path, monkeypatch)
+        assert len(registered) == 1
+        registered[0]()  # simulate interpreter exit without finish()
+        data = rr.read_run_record(rec.path)
+        assert data["status"] == "interrupted"
+        assert data["exit_status"] is None
+        assert data["ended_utc"] is not None
+
+    def test_atexit_is_noop_after_finish(self, tmp_path, monkeypatch):
+        registered = []
+        monkeypatch.setattr(rr.atexit, "register", lambda fn: registered.append(fn))
+        rec = self._start(tmp_path, monkeypatch)
+        rec.finish(0)
+        before = rr.read_run_record(rec.path)
+        registered[0]()
+        assert rr.read_run_record(rec.path) == before
+
+
+class TestCollectChildRecords:
+    def _child(self, log_dir, night, tag, parent, status="succeeded", rc=0):
+        p = os.path.join(log_dir, night, f"kpf_science_{tag}_20240405T000000.run.json")
+        rr.write_json_atomic(
+            p,
+            {
+                "schema": rr.SCHEMA,
+                "kind": "run",
+                "status": status,
+                "target": tag,
+                "exit_status": rc,
+                "parent": parent,
+            },
+        )
+        return p
+
+    def test_returns_children_pointing_at_parent_sorted(self, tmp_path):
+        log_dir = str(tmp_path)
+        parent = os.path.join(log_dir, "20240405", "kpf_science_batch_x.run.json")
+        b = self._child(log_dir, "20240405", "KP.2", parent, "failed", 1)
+        a = self._child(log_dir, "20240405", "KP.1", parent)
+        self._child(log_dir, "20240405", "KP.9", "/elsewhere/other.run.json")
+        self._child(log_dir, "20240406", "KP.3", None)
+        assert rr.collect_child_records(log_dir, parent) == [
+            {"tag": "KP.1", "exit_status": 0, "status": "succeeded", "run_json": a},
+            {"tag": "KP.2", "exit_status": 1, "status": "failed", "run_json": b},
+        ]
+
+    def test_skips_unreadable_or_foreign_json(self, tmp_path):
+        log_dir = str(tmp_path)
+        parent = "/l/p.run.json"
+        (tmp_path / "20240405").mkdir()
+        (tmp_path / "20240405" / "junk.run.json").write_text("{not json")
+        (tmp_path / "20240405" / "other.run.json").write_text('{"schema": 99}')
+        good = self._child(log_dir, "20240405", "KP.1", parent)
+        got = rr.collect_child_records(log_dir, parent)
+        assert [c["run_json"] for c in got] == [good]
+
+    def test_missing_log_dir_returns_empty(self, tmp_path):
+        assert rr.collect_child_records(str(tmp_path / "nope"), "/l/p.run.json") == []

--- a/tests/regression/test_run_record.py
+++ b/tests/regression/test_run_record.py
@@ -1,0 +1,86 @@
+"""Tests for kpfpipe/utils/run_record.py: the per-invocation run.json sidecar.
+
+The sidecar sits beside the log file (same directory, same stem) so a log and its
+run record are always found together; writes are atomic so a reader never sees a
+half-written file; git_sha never raises (a damaged or absent .git records null).
+"""
+
+import json
+import os
+import subprocess
+
+import pytest
+
+from kpfpipe.utils import run_record as rr
+
+
+class TestRunJsonPath:
+    def test_replaces_log_suffix(self):
+        assert (
+            rr.run_json_path("/l/20240405/kpf_science_KP.1_20240405T010203.log")
+            == "/l/20240405/kpf_science_KP.1_20240405T010203.run.json"
+        )
+
+    def test_keeps_collision_suffix(self):
+        assert (
+            rr.run_json_path("/l/d/kpf_masters_batch_x.log.3")
+            == "/l/d/kpf_masters_batch_x.3.run.json"
+        )
+
+    def test_rejects_non_log_path(self):
+        with pytest.raises(ValueError):
+            rr.run_json_path("/l/d/notalog.txt")
+
+
+class TestGitSha:
+    def test_returns_head_sha_of_a_repo(self, tmp_path):
+        subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(tmp_path),
+                "-c",
+                "user.name=t",
+                "-c",
+                "user.email=t@t",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                "x",
+            ],
+            check=True,
+        )
+        sha = rr.git_sha(tmp_path)
+        assert isinstance(sha, str) and len(sha) == 40
+
+    def test_returns_none_outside_a_repo(self, tmp_path):
+        assert rr.git_sha(tmp_path) is None
+
+    def test_returns_none_when_git_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(rr.shutil, "which", lambda name: None)
+        assert rr.git_sha(tmp_path) is None
+
+
+class TestAtomicJson:
+    def test_write_then_read_roundtrip(self, tmp_path):
+        path = str(tmp_path / "a.run.json")
+        rr.write_json_atomic(path, {"schema": 1, "status": "running"})
+        assert rr.read_run_record(path) == {"schema": 1, "status": "running"}
+
+    def test_creates_parent_dir(self, tmp_path):
+        path = str(tmp_path / "sub" / "a.run.json")
+        rr.write_json_atomic(path, {"x": 1})
+        assert os.path.isfile(path)
+
+    def test_no_tmp_file_left_behind(self, tmp_path):
+        path = str(tmp_path / "a.run.json")
+        rr.write_json_atomic(path, {"x": 1})
+        assert os.listdir(tmp_path) == ["a.run.json"]
+
+    def test_read_rejects_wrong_schema(self, tmp_path):
+        path = tmp_path / "a.run.json"
+        path.write_text(json.dumps({"schema": 99}))
+        with pytest.raises(ValueError):
+            rr.read_run_record(str(path))

--- a/tests/regression/test_science_script.py
+++ b/tests/regression/test_science_script.py
@@ -6,10 +6,13 @@ at least one frame failed). The shared fan-out engine lives in ``_dispatch`` and
 is tested in test_dispatch_script.py. Stubs only -- no real testdata needed.
 """
 
+import os
 import sys
+import tempfile
 
 import pytest
 
+from kpfpipe.utils import run_record as rr
 from scripts.processing import science as _science
 
 from ._scripts import _FakeConfig, _NoLogDirConfig
@@ -24,6 +27,19 @@ _OID2 = "KP.20240405.40237.36"
 @pytest.fixture(scope="module")
 def s():
     return _science
+
+
+def _stub_batch_log(monkeypatch, mod):
+    """Stub setup_batch_logging with a real-looking .log path in a temp dir.
+
+    The batch run.json sidecar is written beside the log, so the stub must return
+    a writable path ending in .log (never a placeholder like /l/x.log).
+    """
+    base = tempfile.mkdtemp()
+    fake_log = os.path.join(base, "logs", "20240405", "kpf_batch_x_20240405T000000.log")
+    os.makedirs(os.path.dirname(fake_log), exist_ok=True)
+    monkeypatch.setattr(mod, "setup_batch_logging", lambda *a, **k: fake_log)
+    return fake_log
 
 
 # ---------------------------------------------------------------------------
@@ -172,7 +188,7 @@ class TestMainExitCode:
         # -> exit code.
         monkeypatch.setattr(s, "configure_runtime", lambda: None)
         monkeypatch.setattr(s, "ConfigHandler", _FakeConfig)
-        monkeypatch.setattr(s, "setup_batch_logging", lambda *a, **k: "/l/x.log")
+        _stub_batch_log(monkeypatch, s)
         monkeypatch.setattr(s, "warm_mini_db_caches", lambda *a, **k: (0, 0))
 
         def fake_run_stage(*args, **kwargs):
@@ -244,3 +260,65 @@ class TestMainExitCode:
         with pytest.raises(SystemExit) as exc:
             s.main(["--obs_ids", _OID1])
         assert "log directory" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# batch run.json sidecar
+# ---------------------------------------------------------------------------
+
+
+class TestBatchRunRecord:
+    def test_batch_record_written_with_counts_and_children(
+        self, s, monkeypatch, tmp_path
+    ):
+        log_dir = tmp_path / "logs"
+        fake_log = log_dir / "20240405" / "kpf_science_batch_20240405T000000.log"
+        fake_log.parent.mkdir(parents=True)
+        monkeypatch.setattr(s, "configure_runtime", lambda: None)
+        monkeypatch.setattr(s, "ConfigHandler", _FakeConfig)
+        monkeypatch.setattr(s, "setup_batch_logging", lambda *a, **k: str(fake_log))
+        monkeypatch.setattr(s, "warm_mini_db_caches", lambda *a, **k: (0, 0))
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: None)
+        monkeypatch.delenv(rr.PARENT_ENV, raising=False)
+
+        seen_env = {}
+        child = os.path.join(
+            str(log_dir), "20240405", f"kpf_science_{_OID2}_x.run.json"
+        )
+
+        def fake_run_stage(label, tasks, jobs, log_dir_arg, **kw):
+            # Children inherit the environment: the parent pointer must be set
+            # by the time the fan-out starts.
+            seen_env["parent"] = os.environ.get(rr.PARENT_ENV)
+            # Simulate one child having written its record.
+            rr.write_json_atomic(
+                child,
+                {
+                    "schema": rr.SCHEMA,
+                    "kind": "run",
+                    "status": "failed",
+                    "target": _OID2,
+                    "exit_status": 1,
+                    "parent": seen_env["parent"],
+                },
+            )
+            return {_OID2}
+
+        monkeypatch.setattr(s, "run_stage", fake_run_stage)
+
+        with pytest.raises(SystemExit) as ei:
+            s.main(["--obs_ids", _OID1, _OID2, "--log_dir", str(log_dir)])
+        assert ei.value.code == 1
+
+        path = rr.run_json_path(str(fake_log))
+        data = rr.read_run_record(path)
+        assert data["kind"] == "batch"
+        assert data["recipe"] == "science"
+        assert data["target"] == "batch"
+        assert data["status"] == "failed"
+        assert data["counts"] == {"done": 1, "failed": 1, "skipped": 0}
+        assert seen_env["parent"] == path
+        assert data["children"] == [
+            {"tag": _OID2, "exit_status": 1, "status": "failed", "run_json": child}
+        ]
+        assert os.environ.get(rr.PARENT_ENV) is None  # restored after the batch


### PR DESCRIPTION
## Summary
Every `kpfpipe run` / `science` / `masters` invocation now writes a `run.json` beside its log
(`kpf_<recipe>_<target>_<stamp>.run.json`): command, argv, config, git sha, drptag, host, pid, cwd,
UT start/end, exit status, done/failed/skipped counts, log path, parent batch (via the
`KPFPIPE_PARENT_RUN` env var the orchestrators export), optional `KPFOPS_FLOW_RUN_ID`, and for
batches the list of child records. Written at start (`running`), finalized at exit; an `atexit`
hook marks unfinished records `interrupted` (Ctrl-C, SystemExit). Stdlib only; no change to any
reduction.

Motivation: pipeline-side prerequisite for the KPF-Ops operations console (spec lives in the
future KPF-Ops repo; summary: an ingester tails these records instead of parsing log text).
Useful standalone: `python -m json.tool <log>.run.json` answers "what ran, from which commit, how
did it end".

New module: `kpfpipe/utils/run_record.py` (`RunRecord`, `run_json_path`, `git_sha`,
`collect_child_records`). Integration points: `reduce.py` (leaf), `science.py`/`masters.py`
(batch). Test stubs that returned `/dev/null` / `/l/x.log` as the log path now return a real
`.log` path in a temp dir, since the sidecar is written beside the log.

## Behaviour notes
- Recipe-load usage errors (`Recipe file not found`, `has no main()`) exit before the record is
  finished, so those records end `interrupted` with `exit_status: null` rather than `failed`.
- A SIGKILL leaves the `running` record in place: an honest partial record by design.
- `git_sha` is `null` when git or `.git` is unavailable; never guessed.

## Follow-ups (need a human OK, not done here)
- Architecture guide: document the sidecar under the logging/diagnostics layer.
- `pytest-xdist` is not in the local `kpfpipe` env, so `make test*` targets fail with
  `unrecognized arguments: -n`; suites were run serially for this PR.

## Test plan
- [x] Full suite serial: all passed (testdata-gated tests skipped as usual)
- [x] `ruff format --check` / `ruff check` clean
- [x] Real invocation from the clone: `kpfpipe science --obs_ids KP.20240923.33129.48 ...` on local
      data. The frame fails for a data reason (no dark master for 20240923), which exercised the
      failure path end to end: batch record `failed` with the child listed, child record `failed`
      with `parent` pointing back, both carrying git sha 9aebfc82 and drptag 3.0.0.
- [x] Ctrl-C (SIGINT) during a slow stub recipe under `kpfpipe run`: record ends `interrupted`.
- [ ] Success path on real data: not possible on this laptop (no night has a complete vNext
      masters set); covered by the in-process tests in `test_reduce_script.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
