### PR TITLE
kpfpipe realtime: DRP-RUN-14 continuous-mode L0 watcher with heartbeat

### DIFF
--- a/kpfpipe/utils/run_record.py
+++ b/kpfpipe/utils/run_record.py
@@ -30,6 +30,9 @@ logger = logging.getLogger(__name__)
 
 SCHEMA = 1
 
+# Record kinds: the single-unit leaf, a batch orchestrator, the realtime watcher.
+KINDS = ("run", "batch", "realtime")
+
 # Environment variables that link records together. An orchestrator exports
 # PARENT_ENV (its own run.json path) before fanning out; each child records it as
 # ``parent``. FLOW_RUN_ENV is set by KPF-Ops flows so a record can be joined to the
@@ -154,8 +157,9 @@ class RunRecord:
         log_path : str
             The invocation's log file (from ``setup_logging``); the record is
             written beside it (``run_json_path``).
-        kind : {'run', 'batch'}
-            ``run`` for the single-unit leaf, ``batch`` for an orchestrator.
+        kind : {'run', 'batch', 'realtime'}
+            ``run`` for the single-unit leaf, ``batch`` for an orchestrator,
+            ``realtime`` for the continuous-mode watcher.
         recipe : str
             Short recipe/orchestrator name, e.g. ``science``/``masters``.
         target : str
@@ -165,8 +169,8 @@ class RunRecord:
         argv : list of str or None
             The command line; ``None`` means ``sys.argv``.
         """
-        if kind not in ("run", "batch"):
-            raise ValueError(f"kind must be 'run' or 'batch', got {kind!r}")
+        if kind not in KINDS:
+            raise ValueError(f"kind must be one of {KINDS}, got {kind!r}")
         argv = list(sys.argv if argv is None else argv)
         record = {
             "schema": SCHEMA,

--- a/scripts/processing/realtime.py
+++ b/scripts/processing/realtime.py
@@ -1,0 +1,533 @@
+#!/usr/bin/env python3
+"""Continuous-mode L0 watcher (``kpfpipe realtime``): reduce frames as they land.
+
+The WMKO DRP-RUN-14 "real-time script": started once, it runs unattended, polling
+the current and previous UT night directories under ``{KPF_DATA_INPUT}/L0`` for
+newly landed raw frames and reducing each science frame end-to-end (L0 -> L4) via
+the ``kpfpipe run`` leaf, exactly once, in a bounded process pool:
+
+    kpfpipe realtime                     # watch tonight + last night, forever
+    kpfpipe realtime --once              # one scan pass, reduce what is new, exit
+    kpfpipe realtime --poll_interval 30 --settle 120 --jobs 4
+
+It reimplements no pipeline logic and builds no masters; it only decides *which
+frames to hand to the leaf and when*. Three mechanisms make that safe on a live
+NFS mount:
+
+* **Polling, not inotify.** The L0 tree is an NFS mount, where kernel file events
+  do not fire, so the watcher rescans every ``--poll_interval`` seconds with plain
+  ``os.scandir``. No third-party dependency.
+* **Settle time.** A frame is dispatched only once its mtime is at least
+  ``--settle`` seconds old, so a file still being written is never reduced.
+* **A persisted ledger.** Every frame seen is recorded in a JSON ledger keyed on
+  ``(path, mtime, size)``; restarts and rescans are harmless, and a re-delivered
+  frame (new mtime) is treated as a new frame.
+
+Only science frames (PRIMARY ``IMTYPE == 'Object'``, the same test the timeseries
+wrapper uses) are reduced; calibration frames are recorded as ``skipped``. A
+heartbeat status file (``--status_file``, default ``{log_dir}/realtime_status.json``)
+is rewritten every pass so operations tooling can see the watcher is alive and what
+it has done. The daemon's own run.json (kind ``realtime``) is the parent of every
+child reduction's record.
+"""
+
+import argparse
+import concurrent.futures
+import json
+import logging
+import os
+import signal
+import sys
+import time
+
+from astropy.io import fits
+
+import kpfpipe
+from kpfpipe.utils.config import ConfigHandler
+from kpfpipe.utils.kpf import get_obs_id
+from kpfpipe.utils.logger import setup_batch_logging
+from kpfpipe.utils.run_record import (
+    PARENT_ENV,
+    RunRecord,
+    collect_child_records,
+    write_json_atomic,
+)
+from scripts.processing import DEFAULT_SCIENCE_CONFIG
+from scripts.processing._argparse import (
+    data_dirs_parser,
+    logging_parser,
+    pool_parser,
+    recipe_and_config_parser,
+    resolve_dir_shortcuts,
+)
+from scripts.processing._dispatch import (
+    _default_science_jobs,
+    _run_one,
+    _terminate_all_children,
+    configure_runtime,
+)
+from scripts.processing.science import _cli_task
+
+logger = logging.getLogger(__name__)
+
+STATUS_SCHEMA = 1
+LEDGER_SCHEMA = 1
+
+# Launch spacing for the pool (same reason as science.py: the per-frame L0 pointing
+# QC queries SIMBAD/Gaia at startup).
+_LAUNCH_INTERVAL = 1.0
+
+# Seconds to wait for in-flight reductions after a stop request before killing them.
+_SHUTDOWN_GRACE = 30.0
+
+_JOBS_HELP = (
+    "max concurrent reductions; left unset, defaults to a cores-based value "
+    "(~25%% of CPUs, but up to 16)"
+)
+
+
+def parse_args(argv=None):
+    ap = argparse.ArgumentParser(
+        prog="kpfpipe realtime",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        parents=[
+            recipe_and_config_parser(),
+            data_dirs_parser(science_output=True),
+            logging_parser(),
+            pool_parser(jobs_help=_JOBS_HELP),
+        ],
+    )
+    ap.add_argument(
+        "--poll_interval",
+        type=float,
+        default=15.0,
+        help="seconds between L0 directory scans (default: %(default)s)",
+    )
+    ap.add_argument(
+        "--settle",
+        type=float,
+        default=60.0,
+        help="a frame is dispatched only once its mtime is at least this many "
+        "seconds old, so a file still being written is never reduced "
+        "(default: %(default)s)",
+    )
+    ap.add_argument(
+        "--nights",
+        type=int,
+        default=2,
+        help="how many UT night directories to watch, counting back from today "
+        "(default: %(default)s, i.e. tonight and last night)",
+    )
+    ap.add_argument(
+        "--once",
+        action="store_true",
+        help="scan once, reduce whatever is new, wait for it, and exit (nonzero if "
+        "any frame failed); for cron-style use and tests",
+    )
+    ap.add_argument(
+        "--status_file",
+        default=None,
+        help="heartbeat JSON path (default: {log_dir}/realtime_status.json)",
+    )
+    ap.add_argument(
+        "--ledger",
+        default=None,
+        help="exactly-once ledger JSON path (default: {log_dir}/realtime_ledger.json)",
+    )
+    args = ap.parse_args(argv)
+    if args.poll_interval <= 0:
+        ap.error("--poll_interval must be > 0")
+    if args.settle < 0:
+        ap.error("--settle must be >= 0")
+    if args.nights < 1:
+        ap.error("--nights must be >= 1")
+    if args.job_timeout < 1:
+        ap.error("--job_timeout must be >= 1")
+    if args.jobs is None:
+        args.jobs = _default_science_jobs()
+    elif args.jobs < 1:
+        ap.error("--jobs must be >= 1")
+    return resolve_dir_shortcuts(args)
+
+
+def watch_datecodes(now=None, nights=2):
+    """UT datecodes to watch: today first, then ``nights - 1`` earlier nights.
+
+    Parameters
+    ----------
+    now : float or None
+        Epoch seconds; ``None`` means ``time.time()``.
+    nights : int
+        Number of consecutive UT dates, newest first.
+    """
+    now = time.time() if now is None else now
+    return [
+        time.strftime("%Y%m%d", time.gmtime(now - 86400 * i)) for i in range(nights)
+    ]
+
+
+def scan_settled_frames(l0_dirs, settle, now=None):
+    """Regular ``KP.*.fits`` files under ``l0_dirs`` whose mtime is >= ``settle`` s old.
+
+    Missing directories are skipped silently (a night dir appears with its first
+    frame). Returns ``(path, mtime, size)`` tuples sorted by path.
+    """
+    now = time.time() if now is None else now
+    found = []
+    for d in l0_dirs:
+        try:
+            entries = list(os.scandir(d))
+        except FileNotFoundError:
+            continue
+        for e in entries:
+            if not (e.name.startswith("KP.") and e.name.endswith(".fits")):
+                continue
+            try:
+                st = e.stat()
+            except FileNotFoundError:
+                continue
+            if not e.is_file():
+                continue
+            if now - st.st_mtime < settle:
+                continue
+            found.append((e.path, st.st_mtime, st.st_size))
+    found.sort()
+    return found
+
+
+def classify_frame(path):
+    """Return ``('science', None)`` for an ``IMTYPE == 'Object'`` frame, else
+    ``('cal', reason)``.
+
+    A header that cannot be read is classified ``cal`` with the error as the
+    reason, so a corrupt or partial file is recorded and skipped rather than
+    dispatched to fail loudly later -- the ledger keeps the reason.
+    """
+    try:
+        imtype = str(fits.getheader(path, 0).get("IMTYPE", "")).strip()
+    except Exception as exc:  # astropy raises a zoo of types for a bad file
+        return "cal", f"unreadable header: {exc}"
+    if imtype == "Object":
+        return "science", None
+    return "cal", f"IMTYPE={imtype or '<missing>'}"
+
+
+def _utc_now():
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+class Ledger:
+    """The exactly-once ledger: one entry per ``(path, mtime, size)`` ever seen.
+
+    States: ``skipped`` (calibration frame or unreadable), ``running``
+    (dispatched, not yet reaped), ``succeeded``, ``failed``. Persisted atomically
+    after every change so a restart resumes where it left off.
+    """
+
+    def __init__(self, path):
+        self.path = path
+        self.entries = {}
+
+    def load(self):
+        if not os.path.isfile(self.path):
+            return self
+        with open(self.path, encoding="utf-8") as fh:
+            data = json.load(fh)
+        if data.get("schema") != LEDGER_SCHEMA:
+            raise ValueError(
+                f"{self.path}: ledger schema {data.get('schema')!r}, "
+                f"expected {LEDGER_SCHEMA}"
+            )
+        self.entries = data.get("entries", {})
+        return self
+
+    def save(self):
+        write_json_atomic(self.path, {"schema": LEDGER_SCHEMA, "entries": self.entries})
+
+    @staticmethod
+    def key(path, mtime, size):
+        return f"{path}|{mtime:.6f}|{size}"
+
+    def seen(self, key):
+        return key in self.entries
+
+    def mark(self, key, **fields):
+        entry = self.entries.setdefault(key, {})
+        entry.update(fields)
+        self.save()
+        return entry
+
+    def counts(self):
+        out = {"skipped": 0, "running": 0, "succeeded": 0, "failed": 0}
+        for e in self.entries.values():
+            state = e.get("state")
+            if state in out:
+                out[state] += 1
+        out["dispatched"] = out["running"] + out["succeeded"] + out["failed"]
+        return out
+
+
+class Realtime:
+    """The watcher: scan -> classify -> dispatch -> reap -> heartbeat, on a loop."""
+
+    def __init__(self, args, config, *, log_dir, log_path):
+        self.args = args
+        self.log_dir = log_dir
+        self.data_input = (
+            args.kpf_data_input or config.get_params(["DATA_DIRS"])["KPF_DATA_INPUT"]
+        )
+        self.l0_root = os.path.join(self.data_input, "L0")
+        self.status_file = args.status_file or os.path.join(
+            log_dir, "realtime_status.json"
+        )
+        self.ledger = Ledger(
+            args.ledger or os.path.join(log_dir, "realtime_ledger.json")
+        ).load()
+        self.forward = []
+        for value, flag in (
+            (args.kpf_data_input, "--kpf_data_input"),
+            (args.kpf_masters_output, "--kpf_masters_output"),
+            (args.kpf_science_output, "--kpf_science_output"),
+            (args.log_dir, "--log_dir"),
+            (args.log_level, "--log_level"),
+        ):
+            if value:
+                self.forward += [flag, value]
+        self.record = RunRecord.start(
+            log_path,
+            kind="realtime",
+            recipe="science",
+            target="realtime",
+            config=args.config or DEFAULT_SCIENCE_CONFIG,
+        )
+        self._prior_parent = os.environ.get(PARENT_ENV)
+        os.environ[PARENT_ENV] = self.record.path
+        self.pool = concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs)
+        self.futures = {}  # future -> ledger key
+        self.stop = False
+        self.started_utc = _utc_now()
+        self.files_seen = 0
+        self.last_scan_utc = None
+        self.last_dispatch_utc = None
+
+    # -- one pass -----------------------------------------------------------
+
+    def watched_dirs(self, now=None):
+        return [
+            os.path.join(self.l0_root, dc)
+            for dc in watch_datecodes(now, self.args.nights)
+        ]
+
+    def tick(self, now=None):
+        """One pass: scan, dispatch new frames, reap finished ones, heartbeat."""
+        dirs = self.watched_dirs(now)
+        frames = scan_settled_frames(dirs, self.args.settle, now)
+        self.files_seen = len(frames)
+        self.last_scan_utc = _utc_now()
+        for path, mtime, size in frames:
+            if self.stop:
+                break
+            key = Ledger.key(path, mtime, size)
+            if self.ledger.seen(key):
+                continue
+            self._admit(key, path, mtime, size)
+        self._reap()
+        self.write_status(dirs)
+
+    def _admit(self, key, path, mtime, size):
+        try:
+            obs_id = get_obs_id(path)
+        except ValueError as exc:
+            logger.warning("skipping %s: %s", path, exc)
+            self.ledger.mark(
+                key, path=path, mtime=mtime, size=size, state="skipped", reason=str(exc)
+            )
+            return
+        kind, reason = classify_frame(path)
+        if kind != "science":
+            logger.info("skip %s (%s)", obs_id, reason)
+            self.ledger.mark(
+                key,
+                path=path,
+                obs_id=obs_id,
+                mtime=mtime,
+                size=size,
+                state="skipped",
+                reason=reason,
+            )
+            return
+        _tag, argv = _cli_task(
+            obs_id, self.forward, config=self.args.config, recipe=self.args.recipe
+        )
+        logger.info("dispatch %s", obs_id)
+        self.ledger.mark(
+            key,
+            path=path,
+            obs_id=obs_id,
+            mtime=mtime,
+            size=size,
+            state="running",
+            dispatched_utc=_utc_now(),
+        )
+        self.last_dispatch_utc = _utc_now()
+        future = self.pool.submit(
+            _run_one, argv, self.args.job_timeout, _LAUNCH_INTERVAL
+        )
+        self.futures[future] = key
+
+    def _reap(self):
+        for future in [f for f in self.futures if f.done()]:
+            key = self.futures.pop(future)
+            rc, _stderr = future.result()
+            state = "succeeded" if rc == 0 else "failed"
+            entry = self.ledger.mark(
+                key, state=state, exit_status=rc, ended_utc=_utc_now()
+            )
+            log = logger.info if rc == 0 else logger.warning
+            log("%s %s (exit %d)", state, entry.get("obs_id"), rc)
+
+    def write_status(self, dirs):
+        c = self.ledger.counts()
+        write_json_atomic(
+            self.status_file,
+            {
+                "schema": STATUS_SCHEMA,
+                "pid": os.getpid(),
+                "host": self.record.record["host"],
+                "started_utc": self.started_utc,
+                "updated_utc": _utc_now(),
+                "last_scan_utc": self.last_scan_utc,
+                "last_dispatch_utc": self.last_dispatch_utc,
+                "watched_dirs": dirs,
+                "poll_interval": self.args.poll_interval,
+                "settle": self.args.settle,
+                "jobs": self.args.jobs,
+                "files_seen": self.files_seen,
+                "dispatched": c["dispatched"],
+                "skipped": c["skipped"],
+                "running": sum(1 for f in self.futures if f.running()),
+                "queued": sum(1 for f in self.futures if not f.running()),
+                "succeeded": c["succeeded"],
+                "failed": c["failed"],
+                "ledger": self.ledger.path,
+                "run_json": self.record.path,
+            },
+        )
+
+    # -- lifecycle ----------------------------------------------------------
+
+    def wait_for_inflight(self, timeout=None):
+        """Block until every dispatched reduction has been reaped (or ``timeout``)."""
+        deadline = None if timeout is None else time.monotonic() + timeout
+        while self.futures:
+            remaining = (
+                None if deadline is None else max(0.0, deadline - time.monotonic())
+            )
+            done, _ = concurrent.futures.wait(
+                list(self.futures),
+                timeout=remaining,
+                return_when=concurrent.futures.FIRST_COMPLETED,
+            )
+            self._reap()
+            if not done and deadline is not None and time.monotonic() >= deadline:
+                return False
+        return True
+
+    def finish(self):
+        """Reap, restore the environment, finalize the record; return exit status."""
+        self._reap()
+        if self._prior_parent is None:
+            os.environ.pop(PARENT_ENV, None)
+        else:
+            os.environ[PARENT_ENV] = self._prior_parent
+        self.pool.shutdown(wait=False, cancel_futures=True)
+        c = self.ledger.counts()
+        self.write_status(self.watched_dirs())
+        exit_status = 0 if c["failed"] == 0 else 1
+        self.record.finish(
+            exit_status,
+            done=c["succeeded"],
+            failed=c["failed"],
+            skipped=c["skipped"],
+            children=collect_child_records(self.log_dir, self.record.path),
+        )
+        logger.info(
+            "done: %d succeeded, %d failed, %d skipped",
+            c["succeeded"],
+            c["failed"],
+            c["skipped"],
+        )
+        return exit_status
+
+    def run(self):
+        """The main loop; returns the process exit status."""
+        if self.args.once:
+            self.tick()
+            self.wait_for_inflight()
+            return self.finish()
+        logger.info(
+            "watching %s every %.0fs (settle %.0fs, jobs %d); SIGINT/SIGTERM to stop",
+            self.l0_root,
+            self.args.poll_interval,
+            self.args.settle,
+            self.args.jobs,
+        )
+        while not self.stop:
+            self.tick()
+            # Sleep in short slices so a stop request is honoured promptly.
+            deadline = time.monotonic() + self.args.poll_interval
+            while not self.stop and time.monotonic() < deadline:
+                time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
+        logger.warning(
+            "stop requested; waiting up to %.0fs for %d in-flight reduction(s)",
+            _SHUTDOWN_GRACE,
+            len(self.futures),
+        )
+        if not self.wait_for_inflight(timeout=_SHUTDOWN_GRACE):
+            logger.warning("grace period over; terminating remaining children")
+            _terminate_all_children()
+            self.wait_for_inflight(timeout=5.0)
+        return self.finish()
+
+
+def main(argv=None):
+    configure_runtime()
+    args = parse_args(argv)
+
+    config = ConfigHandler(args.config or DEFAULT_SCIENCE_CONFIG)
+    logger_params = config.get_params(["LOGGER"])
+    log_dir = args.log_dir or logger_params.get("log_dir")
+    if not log_dir:
+        sys.exit(
+            "error: no log directory configured; set [LOGGER] log_dir in the "
+            "config file or pass --log_dir"
+        )
+    level = args.log_level or logger_params.get("log_level", "INFO")
+    log_path = setup_batch_logging(log_dir, "realtime", level=level)
+
+    logger.info("kpfpipe %s realtime starting", kpfpipe.__version__)
+    logger.info("argv: %s", " ".join(sys.argv))
+    logger.info("config: %s", args.config or DEFAULT_SCIENCE_CONFIG)
+    logger.info("log: %s", log_path)
+
+    rt = Realtime(args, config, log_dir=log_dir, log_path=log_path)
+    logger.info("run record: %s", rt.record.path)
+    logger.info("status file: %s", rt.status_file)
+    logger.info("ledger: %s", rt.ledger.path)
+
+    def _request_stop(signum, frame):
+        rt.stop = True
+
+    # configure_runtime routed SIGTERM to KeyboardInterrupt (the batch drivers'
+    # teardown path); the watcher instead stops gracefully on both signals.
+    signal.signal(signal.SIGTERM, _request_stop)
+    signal.signal(signal.SIGINT, _request_stop)
+
+    exit_status = rt.run()
+    if exit_status:
+        sys.exit(exit_status)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regression/test_cli.py
+++ b/tests/regression/test_cli.py
@@ -42,6 +42,16 @@ class TestUsage:
         assert "usage: kpfpipe <command>" in capsys.readouterr().out
 
 
+class TestRealtimeCommand:
+    def test_realtime_is_routed_and_listed(self, monkeypatch, capsys):
+        seen = []
+        monkeypatch.setitem(cli._COMMANDS, "realtime", lambda rest: seen.append(rest))
+        cli.main(["realtime", "--once"])
+        assert seen == [["--once"]]
+        cli.main([])
+        assert "  realtime    " in capsys.readouterr().out
+
+
 class TestUnknownCommand:
     def test_unknown_command_exits_two(self, capsys):
         with pytest.raises(SystemExit) as exc:

--- a/tests/regression/test_realtime_script.py
+++ b/tests/regression/test_realtime_script.py
@@ -1,0 +1,295 @@
+"""Tests for scripts/processing/realtime.py: the continuous-mode L0 watcher.
+
+Covers arg parsing, UT night selection, the settled-frame scan, IMTYPE
+classification, the exactly-once ledger, and one-pass (``--once``) runs with the
+subprocess launcher stubbed: what gets dispatched, what gets skipped, what the
+heartbeat status file and the run.json say, and that a second pass over the same
+tree dispatches nothing. Synthetic L0 trees only -- no real reduction runs.
+"""
+
+import json
+import os
+
+import pytest
+
+from kpfpipe.utils import run_record as rr
+from scripts.processing import realtime as rt
+
+from ._scripts import write_l0_tree
+
+# scripts/CLI/tools-layer suite: excluded from `make test-fast`.
+pytestmark = pytest.mark.cli
+
+_NIGHT = "20240405"
+# 2024-04-05 00:30 UT, so "today" is _NIGHT and yesterday is 20240404.
+_NOW = 1712277000.0
+
+
+# ---------------------------------------------------------------------------
+# parse_args / watch_datecodes
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_defaults(self, monkeypatch):
+        monkeypatch.setattr(rt, "_default_science_jobs", lambda: 3)
+        ns = rt.parse_args([])
+        assert ns.poll_interval == 15.0
+        assert ns.settle == 60.0
+        assert ns.nights == 2
+        assert ns.once is False
+        assert ns.jobs == 3
+        assert ns.job_timeout == 1200
+        assert ns.status_file is None and ns.ledger is None
+
+    @pytest.mark.parametrize(
+        "argv",
+        [
+            ["--poll_interval", "0"],
+            ["--settle", "-1"],
+            ["--nights", "0"],
+            ["--jobs", "0"],
+            ["--job_timeout", "0"],
+        ],
+    )
+    def test_invalid_values_exit_two(self, argv):
+        with pytest.raises(SystemExit) as exc:
+            rt.parse_args(argv)
+        assert exc.value.code == 2
+
+    def test_output_dir_fans_out_to_log_dir(self):
+        ns = rt.parse_args(["--output_dir", "/out"])
+        assert ns.log_dir == "/out/logs"
+
+
+class TestWatchDatecodes:
+    def test_today_then_yesterday_ut(self):
+        assert rt.watch_datecodes(_NOW, nights=2) == ["20240405", "20240404"]
+
+    def test_single_night(self):
+        assert rt.watch_datecodes(_NOW, nights=1) == ["20240405"]
+
+
+# ---------------------------------------------------------------------------
+# scan_settled_frames / classify_frame
+# ---------------------------------------------------------------------------
+
+
+def _age(path, seconds, now=_NOW):
+    os.utime(path, (now - seconds, now - seconds))
+
+
+class TestScanSettledFrames:
+    def test_only_settled_kp_fits_files(self, tmp_path):
+        oid_old = write_l0_tree(tmp_path, _NIGHT, 100)
+        oid_new = write_l0_tree(tmp_path, _NIGHT, 200)
+        night = tmp_path / "L0" / _NIGHT
+        _age(night / f"{oid_old}.fits", 120)
+        _age(night / f"{oid_new}.fits", 10)
+        (night / "notes.txt").write_text("x")
+        (night / "KP.junk.fits").mkdir()  # a directory, not a file
+        got = rt.scan_settled_frames([str(night)], settle=60, now=_NOW)
+        assert [os.path.basename(p) for p, _m, _s in got] == [f"{oid_old}.fits"]
+        assert got[0][2] > 0  # size recorded
+
+    def test_missing_dir_is_empty(self, tmp_path):
+        assert rt.scan_settled_frames([str(tmp_path / "nope")], 60, _NOW) == []
+
+    def test_zero_settle_takes_everything(self, tmp_path):
+        oid = write_l0_tree(tmp_path, _NIGHT, 100)
+        night = tmp_path / "L0" / _NIGHT
+        _age(night / f"{oid}.fits", 0)
+        assert len(rt.scan_settled_frames([str(night)], 0, _NOW)) == 1
+
+
+class TestClassifyFrame:
+    def test_object_is_science(self, tmp_path):
+        oid = write_l0_tree(tmp_path, _NIGHT, 100, imtype="Object")
+        assert rt.classify_frame(str(tmp_path / "L0" / _NIGHT / f"{oid}.fits")) == (
+            "science",
+            None,
+        )
+
+    def test_bias_is_cal_with_reason(self, tmp_path):
+        oid = write_l0_tree(tmp_path, _NIGHT, 100, imtype="Bias", obj="autocal-bias")
+        kind, reason = rt.classify_frame(str(tmp_path / "L0" / _NIGHT / f"{oid}.fits"))
+        assert kind == "cal" and reason == "IMTYPE=Bias"
+
+    def test_unreadable_is_cal_with_reason(self, tmp_path):
+        bad = tmp_path / "KP.20240405.00001.00.fits"
+        bad.write_bytes(b"not a fits file")
+        kind, reason = rt.classify_frame(str(bad))
+        assert kind == "cal" and reason.startswith("unreadable header")
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+
+class TestLedger:
+    def test_roundtrip_and_counts(self, tmp_path):
+        led = rt.Ledger(str(tmp_path / "ledger.json")).load()
+        k1 = rt.Ledger.key("/a", 1.5, 10)
+        k2 = rt.Ledger.key("/b", 2.5, 10)
+        led.mark(k1, state="running")
+        led.mark(k2, state="skipped")
+        led.mark(k1, state="succeeded", exit_status=0)
+        again = rt.Ledger(str(tmp_path / "ledger.json")).load()
+        assert again.seen(k1) and again.seen(k2)
+        assert again.entries[k1]["exit_status"] == 0
+        assert again.counts() == {
+            "skipped": 1,
+            "running": 0,
+            "succeeded": 1,
+            "failed": 0,
+            "dispatched": 1,
+        }
+
+    def test_changed_mtime_is_a_new_key(self):
+        assert rt.Ledger.key("/a", 1.0, 10) != rt.Ledger.key("/a", 2.0, 10)
+
+    def test_wrong_schema_raises(self, tmp_path):
+        p = tmp_path / "ledger.json"
+        p.write_text('{"schema": 99, "entries": {}}')
+        with pytest.raises(ValueError):
+            rt.Ledger(str(p)).load()
+
+
+# ---------------------------------------------------------------------------
+# --once end to end (launcher stubbed)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunOne:
+    """Stand-in for _dispatch._run_one: records argv, returns a scripted rc."""
+
+    def __init__(self, rc_for=None):
+        self.calls = []
+        self.rc_for = rc_for or {}
+
+    def __call__(self, argv, timeout=None, launch_interval=0.0):
+        self.calls.append(argv)
+        obs_id = argv[argv.index("-o") + 1]
+        return self.rc_for.get(obs_id, 0), ""
+
+
+def _setup_tree(tmp_path, now=_NOW):
+    """Two aged Object frames + one aged Bias frame under L0/{tonight}."""
+    data = tmp_path / "data"
+    o1 = write_l0_tree(data, _NIGHT, 100, imtype="Object")
+    o2 = write_l0_tree(data, _NIGHT, 200, imtype="Object")
+    b1 = write_l0_tree(data, _NIGHT, 300, imtype="Bias", obj="autocal-bias")
+    night = data / "L0" / _NIGHT
+    for oid in (o1, o2, b1):
+        _age(night / f"{oid}.fits", 600, now)
+    return data, o1, o2, b1
+
+
+def _once(monkeypatch, tmp_path, data, fake, extra=(), now=_NOW):
+    """Run realtime --once with the launcher stubbed and a temp log dir."""
+    log_dir = tmp_path / "logs"
+    fake_log = log_dir / _NIGHT / "kpf_realtime_batch_x.log"
+    fake_log.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(rt, "configure_runtime", lambda: None)
+    monkeypatch.setattr(rt, "setup_batch_logging", lambda *a, **k: str(fake_log))
+    monkeypatch.setattr(rt, "_run_one", fake)
+    monkeypatch.setattr(rt.time, "time", lambda: now)
+    monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: None)
+    monkeypatch.delenv(rr.PARENT_ENV, raising=False)
+    argv = [
+        "--once",
+        "--input_dir",
+        str(data),
+        "--kpf_masters_output",
+        str(tmp_path / "m"),
+        "--kpf_science_output",
+        str(tmp_path / "s"),
+        "--log_dir",
+        str(log_dir),
+        "--jobs",
+        "2",
+        "--settle",
+        "60",
+        *extra,
+    ]
+    code = 0
+    try:
+        rt.main(argv)
+    except SystemExit as exc:
+        code = exc.code
+    return code, log_dir, str(fake_log)
+
+
+class TestOnce:
+    def test_dispatches_science_skips_cal_writes_status_and_record(
+        self, monkeypatch, tmp_path
+    ):
+        data, o1, o2, b1 = _setup_tree(tmp_path)
+        fake = _FakeRunOne()
+        code, log_dir, fake_log = _once(monkeypatch, tmp_path, data, fake)
+        assert code == 0
+
+        dispatched = sorted(a[a.index("-o") + 1] for a in fake.calls)
+        assert dispatched == sorted([o1, o2])
+        # The leaf is told the same dir overrides the watcher got.
+        assert "--kpf_data_input" in fake.calls[0]
+
+        ledger = rt.Ledger(str(log_dir / "realtime_ledger.json")).load()
+        states = {e["obs_id"]: e["state"] for e in ledger.entries.values()}
+        assert states == {o1: "succeeded", o2: "succeeded", b1: "skipped"}
+
+        with open(log_dir / "realtime_status.json") as fh:
+            status = json.load(fh)
+        assert status["schema"] == rt.STATUS_SCHEMA
+        assert status["files_seen"] == 3
+        assert status["dispatched"] == 2
+        assert status["skipped"] == 1
+        assert status["succeeded"] == 2
+        assert status["failed"] == 0
+        assert status["running"] == 0 and status["queued"] == 0
+        assert status["watched_dirs"][0].endswith(os.path.join("L0", _NIGHT))
+        assert status["last_dispatch_utc"] is not None
+        assert status["run_json"] == rr.run_json_path(fake_log)
+
+        rec = rr.read_run_record(rr.run_json_path(fake_log))
+        assert rec["kind"] == "realtime"
+        assert rec["status"] == "succeeded"
+        assert rec["counts"] == {"done": 2, "failed": 0, "skipped": 1}
+        assert os.environ.get(rr.PARENT_ENV) is None
+
+    def test_second_pass_dispatches_nothing(self, monkeypatch, tmp_path):
+        data, *_ = _setup_tree(tmp_path)
+        first = _FakeRunOne()
+        _once(monkeypatch, tmp_path, data, first)
+        second = _FakeRunOne()
+        code, log_dir, _ = _once(monkeypatch, tmp_path, data, second)
+        assert code == 0
+        assert len(first.calls) == 2
+        assert second.calls == []
+
+    def test_failed_frame_gives_exit_one_and_failed_ledger_state(
+        self, monkeypatch, tmp_path
+    ):
+        data, o1, o2, _b1 = _setup_tree(tmp_path)
+        fake = _FakeRunOne(rc_for={o2: 1})
+        code, log_dir, fake_log = _once(monkeypatch, tmp_path, data, fake)
+        assert code == 1
+        ledger = rt.Ledger(str(log_dir / "realtime_ledger.json")).load()
+        states = {e["obs_id"]: e["state"] for e in ledger.entries.values()}
+        assert states[o1] == "succeeded" and states[o2] == "failed"
+        rec = rr.read_run_record(rr.run_json_path(fake_log))
+        assert rec["status"] == "failed"
+        assert rec["counts"] == {"done": 1, "failed": 1, "skipped": 1}
+
+    def test_unsettled_frame_waits_for_a_later_tick(self, monkeypatch, tmp_path):
+        data, o1, o2, _b1 = _setup_tree(tmp_path)
+        night = data / "L0" / _NIGHT
+        _age(night / f"{o2}.fits", 10)  # landed 10 s ago: not settled yet
+        fake = _FakeRunOne()
+        _once(monkeypatch, tmp_path, data, fake)
+        assert [a[a.index("-o") + 1] for a in fake.calls] == [o1]
+        # 5 minutes later, the same tree: only the newly settled frame goes out.
+        fake2 = _FakeRunOne()
+        _once(monkeypatch, tmp_path, data, fake2, now=_NOW + 300)
+        assert [a[a.index("-o") + 1] for a in fake2.calls] == [o2]

--- a/tests/regression/test_run_record.py
+++ b/tests/regression/test_run_record.py
@@ -151,6 +151,18 @@ class TestRunRecordStart:
         assert rr.read_run_record(rec.path)["argv"] == ["prog", "-o", "x"]
         rec.finish(0)
 
+    def test_realtime_kind_accepted(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(rr, "git_sha", lambda repo_root=None: None)
+        rec = rr.RunRecord.start(
+            _log(tmp_path),
+            kind="realtime",
+            recipe="science",
+            target="realtime",
+            config="c",
+        )
+        assert rr.read_run_record(rec.path)["kind"] == "realtime"
+        rec.finish(0)
+
     def test_bad_kind_raises(self, tmp_path):
         with pytest.raises(ValueError):
             rr.RunRecord.start(

--- a/tools/cli.py
+++ b/tools/cli.py
@@ -9,6 +9,7 @@ its own argument parsing:
     kpfpipe masters     -- build nightly master calibrations for a set of datecodes
     kpfpipe science     -- reduce a set of science frames end-to-end (L0 -> L4)
     kpfpipe timeseries  -- reduce a star's RV timeseries over a datecode range
+    kpfpipe realtime    -- watch the L0 tree and reduce new science frames as they land
 
 Examples:
 
@@ -25,13 +26,14 @@ layer; the scripts never import ``tools`` (see CLAUDE.md, "CLI architecture").
 
 import sys
 
-from scripts.processing import masters, reduce, science, timeseries
+from scripts.processing import masters, realtime, reduce, science, timeseries
 
 _COMMANDS = {
     "run": reduce.main,
     "masters": masters.main,
     "science": science.main,
     "timeseries": timeseries.main,
+    "realtime": realtime.main,
 }
 
 
@@ -43,7 +45,8 @@ def _usage():
         "  run         reduce one recipe on one unit, in-process (the leaf)\n"
         "  masters     build nightly master calibrations for a set of datecodes\n"
         "  science     reduce a set of science frames end-to-end (L0 -> L4)\n"
-        "  timeseries  reduce a star's RV timeseries over a datecode range\n\n"
+        "  timeseries  reduce a star's RV timeseries over a datecode range\n"
+        "  realtime    watch the L0 tree and reduce new science frames as they land\n\n"
         "Run `kpfpipe <command> -h` for a command's own options."
     )
 


### PR DESCRIPTION
## Summary
`kpfpipe realtime` is the DRP-RUN-14 "real-time script": started once, it polls the current and
previous UT night directories under `{KPF_DATA_INPUT}/L0` every `--poll_interval` seconds and
reduces each newly landed science frame (PRIMARY `IMTYPE == 'Object'`) end to end via the
`kpfpipe run` leaf, exactly once, in a bounded pool (`--jobs`, `--job_timeout`). Calibration
frames are recorded as skipped, never dispatched; masters are not built here.

- **Polling, not inotify/watchdog.** L0 is an NFS mount where kernel events do not fire, and this
  adds no dependency (DRP-BLD-01).
- **Settle time** (`--settle`, default 60 s of mtime age) so a file still being written is never
  reduced.
- **Persisted ledger** (`{log_dir}/realtime_ledger.json`, keyed on path+mtime+size) makes
  restarts and rescans harmless; a re-delivered frame with a new mtime is a new frame.
- **Heartbeat** (`{log_dir}/realtime_status.json`) rewritten every pass: pid, host, watched dirs,
  files seen / dispatched / skipped / running / queued / succeeded / failed, last scan and dispatch
  times, ledger and run.json paths. This is what operations tooling reads.
- **Graceful stop** on SIGINT/SIGTERM: stop scanning, wait up to 30 s for in-flight reductions,
  then terminate them; `--once` does a single pass and exits nonzero if any frame failed.
- Its own run.json has the new kind `realtime` (additive; `SCHEMA` unchanged) and is the `parent`
  of every child reduction's record.

Stacked on #1545 (`kpf-next-run-json`); GitHub will retarget to `kpf-next` when that merges.

## Test plan
- [x] `tests/regression/test_realtime_script.py`: arg validation, UT night selection, settle scan,
      IMTYPE classification (incl. unreadable file), ledger round-trip/idempotency, and `--once`
      end to end with the launcher stubbed: dispatch set, skip set, status fields, run.json counts,
      second pass dispatches nothing, failed frame -> exit 1, unsettled frame waits for a later tick.
- [x] CLI-layer suite and fast subset serial: all passed. `ruff` clean.
- [x] Real `--once` from the clone against a temp data root holding one real L0 frame
      (`KP.20240923.33129.48`, `--nights 800` to reach that night): frame dispatched and reaped as
      failed for the known data reason ("No 'dark' master found for 2024-09-23"); ledger, heartbeat,
      and both run.json records (realtime parent, child back-link) correct.
- [ ] Long-running soak (24 h unattended, DRP-RUN-14) not yet done; needs a live L0 feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
